### PR TITLE
fix(quality): close remaining Sonar bugs and vulnerability

### DIFF
--- a/frontend/src/app/(dashboard)/automation/drs/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/drs/page.tsx
@@ -1613,7 +1613,7 @@ return Object.entries(metricsData as any)
   // All clusters collapsed by default — no auto-expand
 
   // Detect PVE HA groups / affinity rules that may conflict with DRS
-  const clusterIds = useMemo(() => clusters.map(c => c.id).sort().join(','), [clusters])
+  const clusterIds = useMemo(() => clusters.map(c => c.id).sort((a, b) => a.localeCompare(b)).join(','), [clusters])
 
   const { data: haDataMap } = useSWR(
     clusterIds ? `ha-check:${clusterIds}` : null,
@@ -1686,7 +1686,7 @@ return Object.entries(metricsData as any)
 
   // IDs des migrations actives (string stable pour la dépendance)
   const activeMigrationIds = useMemo(() =>
-    activeMigrations.map(m => m.id).sort().join(','),
+    activeMigrations.map(m => m.id).sort((a, b) => a.localeCompare(b)).join(','),
     [activeMigrations]
   )
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
@@ -351,7 +351,7 @@ return
       const score = (node.cpuPct || 0) + (node.memPct || 0)
       const bestScore = (best.cpuPct || 0) + (best.memPct || 0)
       return score < bestScore ? node : best
-    })
+    }, onlineNodes[0])
 
     return bestNode.node
   }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -694,7 +694,7 @@ return
       const score = (node.cpuPct || 0) + (node.memPct || 0)
       const bestScore = (best.cpuPct || 0) + (best.memPct || 0)
       return score < bestScore ? node : best
-    })
+    }, onlineNodes[0])
 
     return bestNode.node
   }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -2367,7 +2367,7 @@ return favorites.has(vmKey)
   const fetchNetworks = useCallback(() => {
     const connIds = clusters.map(c => c.connId).filter(Boolean)
     if (connIds.length === 0) return
-    const cacheKey = connIds.sort().join(',')
+    const cacheKey = connIds.sort((a, b) => a.localeCompare(b)).join(',')
     if (networkCacheRef.current?.connIds === cacheKey) {
       setNetworkData(networkCacheRef.current.data)
       return

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsNotesTab.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsNotesTab.tsx
@@ -103,7 +103,7 @@ export default function PbsNotesTab({ pbsId }: PbsNotesTabProps) {
     }
   }, [dirty, saving, pbsId, value, t])
 
-  saveRef.current = handleSave
+  saveRef.current = () => { void handleSave() }
 
   const handleReset = useCallback(() => {
     setValue(original)

--- a/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
+++ b/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
@@ -435,7 +435,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
                 <Typography variant='caption' color='text.secondary'>{t('siteRecovery.snapshots.image')}</Typography>
                 <Typography variant='body2' sx={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{detail.pool}/{detail.image}</Typography>
               </Box>
-              {detail.vmid && (
+              {!!detail.vmid && (
                 <Box>
                   <Typography variant='caption' color='text.secondary'>{t('siteRecovery.snapshots.vm')}</Typography>
                   <Typography variant='body2'>{detail.vmid}{vmNameMap?.[detail.vmid] ? ` · ${vmNameMap[detail.vmid]}` : ''}</Typography>

--- a/frontend/src/components/hardware/CloneVmDialog.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.tsx
@@ -403,7 +403,7 @@ return currentScore > bestScore ? current : best
                           sx={{ height: 16, fontSize: '0.6rem', '& .MuiChip-label': { px: 0.5 } }}
                         />
                       </Box>
-                      {s.total && (
+                      {!!s.total && (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                           <Box sx={{ flex: 1, height: 3, bgcolor: 'action.hover', borderRadius: 0.5, overflow: 'hidden' }}>
                             <Box sx={{

--- a/frontend/src/components/storage/StorageContentBrowser.tsx
+++ b/frontend/src/components/storage/StorageContentBrowser.tsx
@@ -268,7 +268,7 @@ function ContentGroupCard({ group, connId, node, storage, readOnly, onDeleted, o
             </strong>{' '}
             ?
           </DialogContentText>
-          {deleteTarget?.size && (
+          {!!deleteTarget?.size && (
             <Typography variant="caption" sx={{ opacity: 0.6, mt: 1, display: 'block' }}>
               Size: {formatBytes(deleteTarget.size)}
             </Typography>

--- a/weasyprint/Dockerfile
+++ b/weasyprint/Dockerfile
@@ -24,7 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir \
+# --only-binary :all: blocks running setup scripts during install
+# (sonar docker:S8541): wheels exist on PyPI for weasyprint, flask and
+# gunicorn on linux/amd64, so the build still succeeds.
+RUN pip install --no-cache-dir --only-binary :all: \
         weasyprint==66.0 \
         flask==3.1.0 \
         gunicorn==23.0.0


### PR DESCRIPTION
## Summary

Brings Reliability + Security ratings to **A** by clearing the 9 long-standing bugs and the 1 vulnerability that Sonar reports on main today.

Once this lands, the public badges should read AAA across the board.

### Bugs (9)
- **3x typescript:S2871** (Array.sort without locale-aware compare) — `drs/page.tsx` clusterIds + activeMigrationIds, `InventoryTree.tsx` network cache key. Switched to `localeCompare` for the joined id strings used as cache keys.
- **2x typescript:S6959** (reduce without initial value) — `CreateLxcDialog.tsx`, `CreateVmDialog.tsx`. Pass `onlineNodes[0]` as the initial accumulator. Empty-array case was already guarded one line above.
- **3x typescript:S6439** (conditional with leaked falsy value) — `SnapshotsTab.tsx` (detail.vmid), `CloneVmDialog.tsx` (s.total), `StorageContentBrowser.tsx` (deleteTarget?.size). Coerce to boolean with `!!` so a `0` / empty string can't render verbatim.
- **1x typescript:S6544** (Promise-returning function in void slot) — `PbsNotesTab.tsx`. Wrap the `handleSave` ref assignment in a void-returning arrow.

### Vulnerability (1)
- **1x docker:S8541** (pip install can execute setup scripts) — `weasyprint/Dockerfile`. Pinned `--only-binary :all:` so install resolves through wheels only. Wheels exist on PyPI for weasyprint, flask and gunicorn on linux/amd64.

### Why this matters
The Sonar PR gate prevents new debt from landing, but it doesn't retroactively fix pre-existing issues. These 9 bugs + 1 vuln have been on main for a while and the CI scan revealed them after we replaced autoscan. This PR clears the slate so the gate's baseline is genuinely clean going forward.

## Test plan
- [ ] Build succeeds (Dockerfile change validated by docker build in CI)
- [ ] Existing UI features still work (no behaviour change expected, but worth a quick smoke test)
- [ ] Sonar QG on this PR passes
- [ ] After merge: overall ratings on main show A for Reliability and Security