### PR TITLE
chore(sonar): exclude globalThemesConfig.js from CPD

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -36,6 +36,7 @@ sonar.coverage.exclusions=\
 # Create / Delete / Detach dialogs all follow MUI Dialog + Form patterns with
 # near-identical structure — duplication is by intent, not by laziness.
 sonar.cpd.exclusions=frontend/src/lib/templates/cloudImages.ts,\
+  frontend/src/configs/globalThemesConfig.js,\
   frontend/src/components/dashboard/widgets/**/*,\
   frontend/src/components/ClusterFirewallTab.tsx,\
   frontend/src/components/hardware/DetachConfirmDialog.tsx,\


### PR DESCRIPTION
## Summary

Adds `frontend/src/configs/globalThemesConfig.js` to `sonar.cpd.exclusions` alongside the other by-design repetitive files (`cloudImages.ts`, dashboard widgets, dialog skeletons).

The file is a theme registry — each variant declares the same property shape (palette, typography, breakpoints) with different values. Keeping them side-by-side is the whole point; a generator would hide the data from IDE jump-to-definition without any maintenance benefit.

Drops overall duplication from **6.3% → ~5%** on the project.

## Scope discipline

This **only** excludes the theme config. Per the audit:

- **Kept visible** as standing debt: `InventoryDialogs.tsx`, `InventoryTree.tsx`, `InventoryDetails.tsx`, `ClusterTabs.tsx`, `RootInventoryView.tsx`, `security/rbac/page.tsx`. These have real refactoring opportunities (sub-components, render helpers, config-driven tables) but aren't priority.
- **Tracked as real metier debt**: `migration/pipeline.ts` vs `migration/xcpng-pipeline.ts`. Plan is to add characterization tests first, then extract a `migration/shared-steps.ts`. Not in this PR.

## Test plan
- [ ] Sonar QG on this PR passes
- [ ] After merge: overall duplication metric drops on main
- [ ] Nothing else changes (this is a one-line config update)