### PR TITLE
fix(security): patch bundled npm in runner image (CVE-2026-42338)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -92,6 +92,13 @@ ARG GIT_SHA=""
 
 WORKDIR /app
 
+# Patch npm to a version whose bundled dependencies clear the latest
+# CVE round (ip-address < 10.1.1 / CVE-2026-42338, etc.). Pinning the
+# version keeps the build reproducible; bump this line when a newer
+# bundle becomes available. The npm cache is wiped afterwards so the
+# layer does not grow.
+RUN npm install -g npm@11.14.1 && npm cache clean --force
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV GIT_SHA=${GIT_SHA}


### PR DESCRIPTION
## Summary

Closes the last CVE alert (#567) on the project: `ip-address` < 10.1.1 / CVE-2026-42338, surfacing because Node 26-alpine still ships an older npm bundle.

Pins npm to **11.14.1** in the runner stage. The newer bundle includes `ip-address` 10.1.1+ and refreshed `picomatch` / `brace-expansion` revisions, so this is also defensive against future Trivy rounds on the same family of CVEs.

## Why runner only

The runner stage is the image Trivy scans on push. `deps` and `builder` are intermediate stages that never ship.

## Why pinned

Reproducible builds. When a newer bundle is needed (next CVE round, next major), bump the pinned version in this single line.

## Test plan
- [ ] CI green (test, CodeQL, Trivy Frontend Image)
- [ ] After merge: CVE #567 closes on the next Trivy scan