### PR TITLE
fix(ai): repair Test connection for Ollama (#314)

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.jsx
+++ b/frontend/src/app/(dashboard)/settings/page.jsx
@@ -2053,7 +2053,9 @@ function AITab() {
               {settings.provider === 'ollama' && (
                 <Box>
                   <Alert severity='info' sx={{ mb: 2 }}>
-                    <Typography variant='body2' dangerouslySetInnerHTML={{ __html: t('settings.ollamaInfo') }} />
+                    <Typography variant='body2'>
+                      {t.rich('settings.ollamaInfo', { b: chunks => <b>{chunks}</b> })}
+                    </Typography>
                   </Alert>
 
                   <TextField

--- a/frontend/src/app/api/v1/ai/test/route.test.ts
+++ b/frontend/src/app/api/v1/ai/test/route.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' },
+}))
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+async function importHandler() {
+  const mod = await import('./route')
+
+  return mod.POST
+}
+
+function jsonOk(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('POST /api/v1/ai/test', () => {
+  it('honours an RBAC denial from checkPermission', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+
+    checkPermissionMock.mockResolvedValueOnce(denied as any)
+
+    const handler = await importHandler()
+    const res = await callRoute(handler, { body: { provider: 'ollama', ollamaUrl: 'http://localhost:11434' } })
+
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  describe('ollama provider', () => {
+    it('forwards the prompt to /api/generate and returns the model reply', async () => {
+      fetchMock.mockResolvedValueOnce(jsonOk({ response: 'Oui, je suis fonctionnel.' }))
+
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'ollama', ollamaUrl: 'http://localhost:11434', ollamaModel: 'mistral:7b' },
+      })
+
+      expect(res.status).toBe(200)
+      const json = await readJson<any>(res)
+
+      expect(json).toMatchObject({
+        success: true,
+        provider: 'ollama',
+        model: 'mistral:7b',
+        response: 'Oui, je suis fonctionnel.',
+      })
+
+      const [calledUrl, init] = fetchMock.mock.calls[0]
+
+      expect(calledUrl).toBe('http://localhost:11434/api/generate')
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        model: 'mistral:7b',
+        stream: false,
+      })
+    })
+
+    // Regression: a CodeQL SSRF fix dropped the trailing-slash trim, which
+    // turned the default `http://localhost:11434` into `http://localhost:11434/`
+    // and the forged URL into `http://localhost:11434//api/generate`. Ollama
+    // 301s the double slash, fetch follows as GET, Ollama replies 405.
+    it('never produces a double slash even when the base URL has trailing slashes', async () => {
+      fetchMock.mockResolvedValueOnce(jsonOk({ response: 'ok' }))
+
+      const handler = await importHandler()
+
+      await callRoute(handler, {
+        body: { provider: 'ollama', ollamaUrl: 'http://localhost:11434///', ollamaModel: 'mistral:7b' },
+      })
+
+      const [calledUrl] = fetchMock.mock.calls[0]
+
+      expect(calledUrl).toBe('http://localhost:11434/api/generate')
+      expect(calledUrl).not.toMatch(/\/\/api\//)
+    })
+
+    it('rejects a non-http(s) Ollama URL with a 500 and a descriptive error', async () => {
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'ollama', ollamaUrl: 'file:///etc/passwd', ollamaModel: 'mistral:7b' },
+      })
+
+      expect(res.status).toBe(500)
+      expect((await readJson<any>(res)).error).toMatch(/Only http and https/i)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('propagates upstream Ollama errors as a 500 with the response body', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('model not found', { status: 404 }))
+
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'ollama', ollamaUrl: 'http://localhost:11434', ollamaModel: 'nope:1b' },
+      })
+
+      expect(res.status).toBe(500)
+      expect((await readJson<any>(res)).error).toMatch(/Ollama error: model not found/)
+    })
+  })
+
+  describe('openai provider', () => {
+    it('calls /chat/completions on the default base URL with a Bearer token', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonOk({ choices: [{ message: { content: 'Yes, I am functional.' } }] }),
+      )
+
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'openai', openaiKey: 'sk-test', openaiModel: 'gpt-4.1-nano' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(await readJson<any>(res)).toMatchObject({
+        success: true,
+        provider: 'openai',
+        response: 'Yes, I am functional.',
+      })
+
+      const [calledUrl, init] = fetchMock.mock.calls[0]
+
+      expect(calledUrl).toBe('https://api.openai.com/v1/chat/completions')
+      expect((init.headers as Record<string, string>).Authorization).toBe('Bearer sk-test')
+    })
+
+    it('honours a custom openaiBaseUrl', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonOk({ choices: [{ message: { content: 'hi' } }] }),
+      )
+
+      const handler = await importHandler()
+
+      await callRoute(handler, {
+        body: {
+          provider: 'openai',
+          openaiKey: 'sk-test',
+          openaiModel: 'gpt-4.1-nano',
+          openaiBaseUrl: 'https://openai.proxy.lan/v1/',
+        },
+      })
+
+      expect(fetchMock.mock.calls[0][0]).toBe('https://openai.proxy.lan/v1/chat/completions')
+    })
+
+    it('surfaces a structured OpenAI error message when the upstream call fails', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Invalid API key' } }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'openai', openaiKey: 'bad', openaiModel: 'gpt-4.1-nano' },
+      })
+
+      expect(res.status).toBe(500)
+      expect((await readJson<any>(res)).error).toBe('Invalid API key')
+    })
+  })
+
+  describe('anthropic provider', () => {
+    it('calls /v1/messages with the x-api-key header', async () => {
+      fetchMock.mockResolvedValueOnce(
+        jsonOk({ content: [{ text: 'Yes, I am functional.' }] }),
+      )
+
+      const handler = await importHandler()
+
+      const res = await callRoute(handler, {
+        body: { provider: 'anthropic', anthropicKey: 'sk-ant-test', anthropicModel: 'claude-opus-4-7' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(await readJson<any>(res)).toMatchObject({
+        success: true,
+        provider: 'anthropic',
+        response: 'Yes, I am functional.',
+      })
+
+      const [calledUrl, init] = fetchMock.mock.calls[0]
+      const headers = init.headers as Record<string, string>
+
+      expect(calledUrl).toBe('https://api.anthropic.com/v1/messages')
+      expect(headers['x-api-key']).toBe('sk-ant-test')
+      expect(headers['anthropic-version']).toBe('2023-06-01')
+    })
+  })
+
+  it('returns 500 for an unknown provider', async () => {
+    const handler = await importHandler()
+
+    const res = await callRoute(handler, { body: { provider: 'bedrock' } })
+
+    expect(res.status).toBe(500)
+    expect((await readJson<any>(res)).error).toMatch(/Provider inconnu: bedrock/)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/ai/test/route.ts
+++ b/frontend/src/app/api/v1/ai/test/route.ts
@@ -13,7 +13,9 @@ function validateAIUrl(input) {
   // Trim trailing slashes so callers can safely append a sub-path
   // (e.g. `${base}/api/generate`) without producing `//api/...` which
   // Ollama 301-redirects to a GET and breaks POST endpoints.
-  return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '')
+  let url = `${parsed.origin}${parsed.pathname}`
+  while (url.endsWith('/')) url = url.slice(0, -1)
+  return url
 }
 
 /** Sanitize a string for safe logging (strip newlines/control chars) */

--- a/frontend/src/app/api/v1/ai/test/route.ts
+++ b/frontend/src/app/api/v1/ai/test/route.ts
@@ -9,8 +9,11 @@ function validateAIUrl(input) {
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error('Only http and https URLs are allowed')
   }
-  // Return origin + pathname to cut taint flow from user input
-  return `${parsed.origin}${parsed.pathname}`
+  // Return origin + pathname to cut taint flow from user input.
+  // Trim trailing slashes so callers can safely append a sub-path
+  // (e.g. `${base}/api/generate`) without producing `//api/...` which
+  // Ollama 301-redirects to a GET and breaks POST endpoints.
+  return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, '')
 }
 
 /** Sanitize a string for safe logging (strip newlines/control chars) */


### PR DESCRIPTION
## Summary

Restore the **Settings > Artificial Intelligence > Test connection** flow, which was completely broken on 1.4.0 for Ollama users (issue #314 — reported by @hichsoft).

Three independent problems on the same screen:

- **Route mismatch**: client calls `POST /api/v1/ai/test` but the handler was registered at `/api/v1/ai`. Next.js returned its default 404 HTML, the client tried `res.json()` on it, hence the user-visible `Unexpected token '<', "<!DOCTYPE "...`. Move the handler into a `test/` subfolder so the registered URL matches the client.
- **Double-slash regression from CodeQL fix `e89f1909`**: `validateAIUrl` now returns `${origin}${pathname}`; for `http://localhost:11434`, `pathname === "/"`, so the test forged `http://localhost:11434//api/generate`. Ollama 301s the double slash, fetch follows as GET, and Ollama replies `405 Method Not Allowed`. Re-add the trailing-slash trim that the sibling `models` route already had.
- **i18n crash**: `settings.ollamaInfo` contains `<b>...</b>` and was rendered through `dangerouslySetInnerHTML`, which made `next-intl` parse `<b>` as a tag placeholder and throw `FORMATTING_ERROR`, hiding the whole AI panel. Switch to `t.rich(...)` with a `b` chunk renderer (same pattern as `ConnectionDialog.tsx`).

## Test plan

- [x] Reproduced `Unexpected token '<', "<!DOCTYPE "...` against 1.4.0
- [x] Reproduced `FORMATTING_ERROR: The intl string context variable "b" was not provided` once the route is fixed
- [x] Reproduced `Ollama error: 405 method not allowed` once the i18n crash is fixed
- [x] After all three fixes, **Test connection** against a local Ollama `mistral:7b` returns the model's reply
- [ ] Reviewer: try the same against OpenAI and Anthropic providers (URL forging logic shared, no behavioural change beyond the trailing-slash trim)

Fixes #314