### PR TITLE
feat(drs): per-cluster + target inflow caps in DRS settings, tidier Advanced section

### DIFF
--- a/frontend/src/app/api/v1/orchestrator/drs/settings/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/drs/settings/route.ts
@@ -5,6 +5,7 @@ import { getOrchestratorClient } from '@/lib/orchestrator/client'
 import { getSetting, setSetting } from '@/lib/db/settings'
 import { getCurrentTenantId } from '@/lib/tenant'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { defaultDRSSettings } from '@/components/automation/drs/drsSettings'
 
 export const runtime = "nodejs"
 
@@ -31,41 +32,10 @@ async function saveFrontendSettings(data: Record<string, any>): Promise<void> {
   } catch (e) { console.error('[drs/settings] Failed to save frontend settings:', e) }
 }
 
-// Default settings that match the frontend DRSSettings interface
-const defaultSettings = {
-  enabled: true,
-  mode: 'manual',
-  balancing_method: 'memory',
-  balancing_mode: 'used',
-  balance_types: ['vm', 'ct'],
-  maintenance_nodes: [],
-  excluded_clusters: [],
-  excluded_nodes: {},
-  cluster_modes: {},
-  cpu_high_threshold: 80,
-  cpu_low_threshold: 20,
-  memory_high_threshold: 85,
-  memory_low_threshold: 25,
-  storage_high_threshold: 90,
-  imbalance_threshold: 5,
-  homogenization_enabled: true,
-  max_load_spread: 10,
-  cpu_weight: 1.0,
-  memory_weight: 1.0,
-  storage_weight: 0.5,
-  max_concurrent_migrations: 2, // Legacy, unused by the engine. Kept for back-compat.
-  max_concurrent_migrations_per_cluster: 2,
-  max_target_inflow_per_cycle: 0,
-  migration_cooldown: '5m',
-  max_pending_recommendations: 10,
-  balance_larger_first: false,
-  prevent_overprovisioning: true,
-  enable_affinity_rules: true,
-  enforce_affinity: false,
-  rebalance_schedule: 'interval',
-  rebalance_interval: '15m',
-  rebalance_time: '10:00',
-}
+// Default settings come from the shared module so the client panel and the
+// API route can't drift. The legacy alias `defaultSettings` is kept inline
+// for the rest of this file's existing references.
+const defaultSettings = defaultDRSSettings
 
 // GET /api/v1/orchestrator/drs/settings
 export async function GET() {

--- a/frontend/src/app/api/v1/orchestrator/drs/settings/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/drs/settings/route.ts
@@ -53,7 +53,9 @@ const defaultSettings = {
   cpu_weight: 1.0,
   memory_weight: 1.0,
   storage_weight: 0.5,
-  max_concurrent_migrations: 2,
+  max_concurrent_migrations: 2, // Legacy, unused by the engine. Kept for back-compat.
+  max_concurrent_migrations_per_cluster: 2,
+  max_target_inflow_per_cycle: 0,
   migration_cooldown: '5m',
   max_pending_recommendations: 10,
   balance_larger_first: false,

--- a/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
+++ b/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
@@ -74,6 +74,24 @@ const HelpTip = ({ text }: { text: string }) => (
   </Tooltip>
 )
 
+// SubsectionHeader factorises the "icon + bold subtitle (+ optional help
+// tooltip)" pattern used to introduce each block in the Advanced section.
+// Three repeated blocks were tripping SonarCloud's duplication detector.
+interface SubsectionHeaderProps {
+  icon: string
+  label: string
+  help?: string
+  mb?: number
+}
+
+const SubsectionHeader = ({ icon, label, help, mb = 1.5 }: SubsectionHeaderProps) => (
+  <Typography variant="subtitle2" sx={{ mb, fontWeight: 600 }}>
+    <i className={icon} style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
+    {label}
+    {help && <HelpTip text={help} />}
+  </Typography>
+)
+
 // LabeledSlider factorises the "title + ? tooltip + bounded slider" pattern
 // used several times in the Advanced section. Without this, each repeated
 // block was tripping SonarCloud's duplication detector.
@@ -815,10 +833,7 @@ export default function DRSSettingsPanel({
 
   const renderAdvanced = () => (
     <>
-      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
-        <i className="ri-speed-up-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
-        {t('drsPage.sectionMigrationLimits')}
-      </Typography>
+      <SubsectionHeader icon="ri-speed-up-line" label={t('drsPage.sectionMigrationLimits')} />
       <Grid container spacing={2.5} sx={{ mb: 1 }}>
         <Grid size={{ xs: 12, md: 6 }}>
           <LabeledSlider
@@ -847,10 +862,7 @@ export default function DRSSettingsPanel({
 
       <Divider sx={{ my: 2 }} />
 
-      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
-        <i className="ri-tools-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
-        {t('drsPage.sectionMigrationBehavior')}
-      </Typography>
+      <SubsectionHeader icon="ri-tools-line" label={t('drsPage.sectionMigrationBehavior')} />
       <Grid container spacing={2.5} sx={{ mb: 1 }}>
         <Grid size={{ xs: 12, md: 6 }}>
           <LabeledSlider
@@ -890,11 +902,7 @@ export default function DRSSettingsPanel({
 
       <Divider sx={{ my: 2 }} />
 
-      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 600 }}>
-        <i className="ri-scales-3-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
-        {t('drsPage.resourceWeights')}
-        <HelpTip text={t('drsPage.helpResourceWeights')} />
-      </Typography>
+      <SubsectionHeader icon="ri-scales-3-line" label={t('drsPage.resourceWeights')} help={t('drsPage.helpResourceWeights')} mb={0.5} />
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
         {t('drsPage.helpResourceWeightsDesc')}
       </Typography>

--- a/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
+++ b/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
@@ -130,54 +130,12 @@ const LabeledSlider = ({ label, help, value, onChange, min, max, step = 1, marks
 )
 
 // ============================================
-// Types
+// Types (shared with the API route — see ./drsSettings)
 // ============================================
 
-export interface DRSSettings {
-  enabled: boolean
-  mode: 'manual' | 'partial' | 'automatic'
-  balancing_method: 'memory' | 'cpu' | 'disk'
-  balancing_mode: 'used' | 'assigned' | 'psi'
-  balance_types: ('vm' | 'ct')[]
-  maintenance_nodes: string[]
-  excluded_clusters: string[]
-  excluded_nodes: Record<string, string[]>
-  cluster_modes: Record<string, string>
-  cpu_high_threshold: number
-  cpu_low_threshold: number
-  memory_high_threshold: number
-  memory_low_threshold: number
-  storage_high_threshold: number
-  imbalance_threshold: number
-  homogenization_enabled: boolean
-  max_load_spread: number
-  cpu_weight: number
-  memory_weight: number
-  storage_weight: number
-  max_concurrent_migrations: number
-  // 0 = disabled (only the global cap applies). >0 caps how many migrations
-  // can be active for one cluster at once, preventing a single hot cluster
-  // from monopolizing the global slot pool.
-  max_concurrent_migrations_per_cluster: number
-  // 0 = disabled. >0 caps how many migrations may target the same node in
-  // one Rebalance cycle, preventing target flooding.
-  max_target_inflow_per_cycle: number
-  migration_cooldown: string
-  max_pending_recommendations: number
-  balance_larger_first: boolean
-  prevent_overprovisioning: boolean
-  enable_affinity_rules: boolean
-  enforce_affinity: boolean
-  rebalance_schedule: 'interval' | 'daily'
-  rebalance_interval: string
-  rebalance_time: string
-}
-
-export interface ClusterVersionInfo {
-  connectionId: string
-  name: string
-  version: number // Major version (8 or 9)
-}
+import { type DRSSettings, type ClusterVersionInfo, defaultDRSSettings } from './drsSettings'
+// Re-export so existing consumers of DRSSettingsPanel keep working.
+export { type DRSSettings, type ClusterVersionInfo, defaultDRSSettings }
 
 interface DRSSettingsPanelProps {
   settings: DRSSettings
@@ -186,45 +144,6 @@ interface DRSSettingsPanelProps {
   clusterVersions?: ClusterVersionInfo[]
   onSave: (settings: DRSSettings) => Promise<void>
   loading?: boolean
-}
-
-// ============================================
-// Default settings
-// ============================================
-
-export const defaultDRSSettings: DRSSettings = {
-  enabled: true,
-  mode: 'manual',
-  balancing_method: 'memory',
-  balancing_mode: 'used',
-  balance_types: ['vm', 'ct'],
-  maintenance_nodes: [],
-  excluded_clusters: [],
-  excluded_nodes: {},
-  cluster_modes: {},
-  cpu_high_threshold: 80,
-  cpu_low_threshold: 20,
-  memory_high_threshold: 85,
-  memory_low_threshold: 25,
-  storage_high_threshold: 90,
-  imbalance_threshold: 5,
-  homogenization_enabled: true,
-  max_load_spread: 10,
-  cpu_weight: 1.0,
-  memory_weight: 1.0,
-  storage_weight: 0.5,
-  max_concurrent_migrations: 2, // Legacy field, kept for back-compat. Engine ignores it; use per-cluster instead.
-  max_concurrent_migrations_per_cluster: 2,
-  max_target_inflow_per_cycle: 0,
-  migration_cooldown: '5m',
-  max_pending_recommendations: 10,
-  balance_larger_first: false,
-  prevent_overprovisioning: true,
-  enable_affinity_rules: true,
-  enforce_affinity: false,
-  rebalance_schedule: 'interval',
-  rebalance_interval: '1h',
-  rebalance_time: '10:00',
 }
 
 // ============================================

--- a/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
+++ b/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
@@ -74,6 +74,43 @@ const HelpTip = ({ text }: { text: string }) => (
   </Tooltip>
 )
 
+// LabeledSlider factorises the "title + ? tooltip + bounded slider" pattern
+// used several times in the Advanced section. Without this, each repeated
+// block was tripping SonarCloud's duplication detector.
+interface LabeledSliderProps {
+  label: string
+  help: string
+  value: number
+  onChange: (v: number) => void
+  min: number
+  max: number
+  step?: number
+  marks: { value: number; label: string }[]
+  valueLabelFormat?: (v: number) => string
+}
+
+const LabeledSlider = ({ label, help, value, onChange, min, max, step = 1, marks, valueLabelFormat }: LabeledSliderProps) => (
+  <>
+    <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+      {label}
+      <HelpTip text={help} />
+    </Typography>
+    <Box sx={{ px: 1 }}>
+      <Slider
+        value={value}
+        onChange={(_, val) => onChange(val as number)}
+        min={min}
+        max={max}
+        step={step}
+        marks={marks}
+        valueLabelDisplay="auto"
+        valueLabelFormat={valueLabelFormat}
+        size="small"
+      />
+    </Box>
+  </>
+)
+
 // ============================================
 // Types
 // ============================================
@@ -784,41 +821,27 @@ export default function DRSSettingsPanel({
       </Typography>
       <Grid container spacing={2.5} sx={{ mb: 1 }}>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-            {t('drsPage.maxConcurrentPerCluster')}
-            <HelpTip text={t('drsPage.helpMaxConcurrentPerCluster')} />
-          </Typography>
-          <Box sx={{ px: 1 }}>
-            <Slider
-              value={settings.max_concurrent_migrations_per_cluster || 2}
-              onChange={(_, val) => handleChange('max_concurrent_migrations_per_cluster', val as number)}
-              min={1}
-              max={10}
-              step={1}
-              marks={[{ value: 1, label: '1' }, { value: 5, label: '5' }, { value: 10, label: '10' }]}
-              valueLabelDisplay="auto"
-              size="small"
-            />
-          </Box>
+          <LabeledSlider
+            label={t('drsPage.maxConcurrentPerCluster')}
+            help={t('drsPage.helpMaxConcurrentPerCluster')}
+            value={settings.max_concurrent_migrations_per_cluster || 2}
+            onChange={(v) => handleChange('max_concurrent_migrations_per_cluster', v)}
+            min={1}
+            max={10}
+            marks={[{ value: 1, label: '1' }, { value: 5, label: '5' }, { value: 10, label: '10' }]}
+          />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-            {t('drsPage.maxTargetInflowPerCycle')}
-            <HelpTip text={t('drsPage.helpMaxTargetInflow')} />
-          </Typography>
-          <Box sx={{ px: 1 }}>
-            <Slider
-              value={settings.max_target_inflow_per_cycle}
-              onChange={(_, val) => handleChange('max_target_inflow_per_cycle', val as number)}
-              min={0}
-              max={5}
-              step={1}
-              marks={[{ value: 0, label: 'off' }, { value: 1, label: '1' }, { value: 3, label: '3' }, { value: 5, label: '5' }]}
-              valueLabelDisplay="auto"
-              valueLabelFormat={(v) => (v === 0 ? 'off' : String(v))}
-              size="small"
-            />
-          </Box>
+          <LabeledSlider
+            label={t('drsPage.maxTargetInflowPerCycle')}
+            help={t('drsPage.helpMaxTargetInflow')}
+            value={settings.max_target_inflow_per_cycle}
+            onChange={(v) => handleChange('max_target_inflow_per_cycle', v)}
+            min={0}
+            max={5}
+            marks={[{ value: 0, label: 'off' }, { value: 1, label: '1' }, { value: 3, label: '3' }, { value: 5, label: '5' }]}
+            valueLabelFormat={(v) => (v === 0 ? 'off' : String(v))}
+          />
         </Grid>
       </Grid>
 
@@ -830,52 +853,38 @@ export default function DRSSettingsPanel({
       </Typography>
       <Grid container spacing={2.5} sx={{ mb: 1 }}>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-            {t('drsPage.cooldownBetweenMigrations')}
-            <HelpTip text={t('drsPage.helpCooldown')} />
-          </Typography>
-          <Box sx={{ px: 1 }}>
-            <Slider
-              value={(() => {
-                const s = settings.migration_cooldown || '5m'
-                // Parse Go duration format: "5m", "5m0s", "1h30m", "30s"
-                let totalMinutes = 0
-                const hMatch = s.match(/(\d+)h/)
-                const mMatch = s.match(/(\d+)m/)
-                const sMatch = s.match(/^(\d+)s$/)
-                if (hMatch) totalMinutes += Number.parseInt(hMatch[1]) * 60
-                if (mMatch) totalMinutes += Number.parseInt(mMatch[1])
-                if (sMatch) totalMinutes = Math.max(1, Math.round(Number.parseInt(sMatch[1]) / 60))
-                return totalMinutes || 5
-              })()}
-              onChange={(_, val) => handleChange('migration_cooldown', `${val as number}m`)}
-              min={1}
-              max={30}
-              step={1}
-              marks={[{ value: 1, label: '1m' }, { value: 5, label: '5m' }, { value: 15, label: '15m' }, { value: 30, label: '30m' }]}
-              valueLabelDisplay="auto"
-              valueLabelFormat={(v) => `${v}m`}
-              size="small"
-            />
-          </Box>
+          <LabeledSlider
+            label={t('drsPage.cooldownBetweenMigrations')}
+            help={t('drsPage.helpCooldown')}
+            value={(() => {
+              const s = settings.migration_cooldown || '5m'
+              // Parse Go duration format: "5m", "5m0s", "1h30m", "30s"
+              let totalMinutes = 0
+              const hMatch = s.match(/(\d+)h/)
+              const mMatch = s.match(/(\d+)m/)
+              const sMatch = s.match(/^(\d+)s$/)
+              if (hMatch) totalMinutes += Number.parseInt(hMatch[1]) * 60
+              if (mMatch) totalMinutes += Number.parseInt(mMatch[1])
+              if (sMatch) totalMinutes = Math.max(1, Math.round(Number.parseInt(sMatch[1]) / 60))
+              return totalMinutes || 5
+            })()}
+            onChange={(v) => handleChange('migration_cooldown', `${v}m`)}
+            min={1}
+            max={30}
+            marks={[{ value: 1, label: '1m' }, { value: 5, label: '5m' }, { value: 15, label: '15m' }, { value: 30, label: '30m' }]}
+            valueLabelFormat={(v) => `${v}m`}
+          />
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-            {t('drsPage.maxPendingRecommendations')}
-            <HelpTip text={t('drsPage.helpMaxPending')} />
-          </Typography>
-          <Box sx={{ px: 1 }}>
-            <Slider
-              value={settings.max_pending_recommendations}
-              onChange={(_, val) => handleChange('max_pending_recommendations', val as number)}
-              min={1}
-              max={20}
-              step={1}
-              marks={[{ value: 1, label: '1' }, { value: 5, label: '5' }, { value: 10, label: '10' }, { value: 20, label: '20' }]}
-              valueLabelDisplay="auto"
-              size="small"
-            />
-          </Box>
+          <LabeledSlider
+            label={t('drsPage.maxPendingRecommendations')}
+            help={t('drsPage.helpMaxPending')}
+            value={settings.max_pending_recommendations}
+            onChange={(v) => handleChange('max_pending_recommendations', v)}
+            min={1}
+            max={20}
+            marks={[{ value: 1, label: '1' }, { value: 5, label: '5' }, { value: 10, label: '10' }, { value: 20, label: '20' }]}
+          />
         </Grid>
       </Grid>
 

--- a/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
+++ b/frontend/src/components/automation/drs/DRSSettingsPanel.tsx
@@ -40,7 +40,34 @@ const InfoIcon = (props: any) => <i className="ri-information-line" style={{ fon
 
 // Help tooltip component
 const HelpTip = ({ text }: { text: string }) => (
-  <Tooltip title={text} arrow placement="top">
+  <Tooltip
+    title={text}
+    arrow
+    placement="top"
+    slotProps={{
+      tooltip: {
+        sx: {
+          bgcolor: 'background.paper',
+          color: 'text.primary',
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1.5,
+          boxShadow: 3,
+          fontSize: 12,
+          maxWidth: 320,
+        },
+      },
+      arrow: {
+        sx: {
+          color: 'background.paper',
+          '&::before': {
+            border: '1px solid',
+            borderColor: 'divider',
+          },
+        },
+      },
+    }}
+  >
     <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', ml: 0.5, cursor: 'help', opacity: 0.5, '&:hover': { opacity: 1 } }}>
       <i className="ri-question-line" style={{ fontSize: 16 }} />
     </Box>
@@ -73,6 +100,13 @@ export interface DRSSettings {
   memory_weight: number
   storage_weight: number
   max_concurrent_migrations: number
+  // 0 = disabled (only the global cap applies). >0 caps how many migrations
+  // can be active for one cluster at once, preventing a single hot cluster
+  // from monopolizing the global slot pool.
+  max_concurrent_migrations_per_cluster: number
+  // 0 = disabled. >0 caps how many migrations may target the same node in
+  // one Rebalance cycle, preventing target flooding.
+  max_target_inflow_per_cycle: number
   migration_cooldown: string
   max_pending_recommendations: number
   balance_larger_first: boolean
@@ -124,7 +158,9 @@ export const defaultDRSSettings: DRSSettings = {
   cpu_weight: 1.0,
   memory_weight: 1.0,
   storage_weight: 0.5,
-  max_concurrent_migrations: 2,
+  max_concurrent_migrations: 2, // Legacy field, kept for back-compat. Engine ignores it; use per-cluster instead.
+  max_concurrent_migrations_per_cluster: 2,
+  max_target_inflow_per_cycle: 0,
   migration_cooldown: '5m',
   max_pending_recommendations: 10,
   balance_larger_first: false,
@@ -142,7 +178,7 @@ export const defaultDRSSettings: DRSSettings = {
 
 type SectionKey = 'general' | 'thresholds' | 'affinity' | 'advanced'
 
-const validIntervalOptions = ['1h', '2h', '3h', '4h', '6h', '8h', '12h', '24h']
+const validIntervalOptions = ['15m', '30m', '1h', '2h', '3h', '4h', '6h', '8h', '12h', '24h']
 
 const SECTIONS: { key: SectionKey; icon: string; colorKey: string }[] = [
   { key: 'general', icon: 'ri-speed-line', colorKey: 'primary.main' },
@@ -177,7 +213,10 @@ export default function DRSSettingsPanel({
   const pve8Clusters = clusterVersions.filter(v => v.version < 9)
 
   useEffect(() => {
-    // Clamp legacy sub-1h interval values to 1h
+    // Fall back to 1h when the persisted value is not one of the options we
+    // expose. Sub-1h was once clamped here but is now a first-class choice;
+    // this guard now only catches genuinely unknown values (typos, removed
+    // options) so the Select doesn't render with an empty/uncontrolled value.
     const normalized = { ...initialSettings }
     if (!validIntervalOptions.includes(normalized.rebalance_interval)) {
       normalized.rebalance_interval = '1h'
@@ -471,6 +510,8 @@ export default function DRSSettingsPanel({
                   label={t('drsPage.rebalanceEvery')}
                   onChange={(e) => handleChange('rebalance_interval', e.target.value)}
                 >
+                  <MenuItem value="15m">15 min</MenuItem>
+                  <MenuItem value="30m">30 min</MenuItem>
                   <MenuItem value="1h">1 h</MenuItem>
                   <MenuItem value="2h">2 h</MenuItem>
                   <MenuItem value="3h">3 h</MenuItem>
@@ -737,13 +778,20 @@ export default function DRSSettingsPanel({
 
   const renderAdvanced = () => (
     <>
-      <Grid container spacing={2}>
+      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
+        <i className="ri-speed-up-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
+        {t('drsPage.sectionMigrationLimits')}
+      </Typography>
+      <Grid container spacing={2.5} sx={{ mb: 1 }}>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>{t('drsPage.maxConcurrentMigrations')}</Typography>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+            {t('drsPage.maxConcurrentPerCluster')}
+            <HelpTip text={t('drsPage.helpMaxConcurrentPerCluster')} />
+          </Typography>
           <Box sx={{ px: 1 }}>
             <Slider
-              value={settings.max_concurrent_migrations}
-              onChange={(_, val) => handleChange('max_concurrent_migrations', val as number)}
+              value={settings.max_concurrent_migrations_per_cluster || 2}
+              onChange={(_, val) => handleChange('max_concurrent_migrations_per_cluster', val as number)}
               min={1}
               max={10}
               step={1}
@@ -752,10 +800,40 @@ export default function DRSSettingsPanel({
               size="small"
             />
           </Box>
-          <Typography variant="caption" color="text.secondary">{t('drsPage.helpMaxConcurrent')}</Typography>
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>{t('drsPage.cooldownBetweenMigrations')}</Typography>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+            {t('drsPage.maxTargetInflowPerCycle')}
+            <HelpTip text={t('drsPage.helpMaxTargetInflow')} />
+          </Typography>
+          <Box sx={{ px: 1 }}>
+            <Slider
+              value={settings.max_target_inflow_per_cycle}
+              onChange={(_, val) => handleChange('max_target_inflow_per_cycle', val as number)}
+              min={0}
+              max={5}
+              step={1}
+              marks={[{ value: 0, label: 'off' }, { value: 1, label: '1' }, { value: 3, label: '3' }, { value: 5, label: '5' }]}
+              valueLabelDisplay="auto"
+              valueLabelFormat={(v) => (v === 0 ? 'off' : String(v))}
+              size="small"
+            />
+          </Box>
+        </Grid>
+      </Grid>
+
+      <Divider sx={{ my: 2 }} />
+
+      <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 600 }}>
+        <i className="ri-tools-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
+        {t('drsPage.sectionMigrationBehavior')}
+      </Typography>
+      <Grid container spacing={2.5} sx={{ mb: 1 }}>
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+            {t('drsPage.cooldownBetweenMigrations')}
+            <HelpTip text={t('drsPage.helpCooldown')} />
+          </Typography>
           <Box sx={{ px: 1 }}>
             <Slider
               value={(() => {
@@ -780,10 +858,12 @@ export default function DRSSettingsPanel({
               size="small"
             />
           </Box>
-          <Typography variant="caption" color="text.secondary">{t('drsPage.helpCooldown')}</Typography>
         </Grid>
         <Grid size={{ xs: 12, md: 6 }}>
-          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>{t('drsPage.maxPendingRecommendations')}</Typography>
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
+            {t('drsPage.maxPendingRecommendations')}
+            <HelpTip text={t('drsPage.helpMaxPending')} />
+          </Typography>
           <Box sx={{ px: 1 }}>
             <Slider
               value={settings.max_pending_recommendations}
@@ -796,42 +876,20 @@ export default function DRSSettingsPanel({
               size="small"
             />
           </Box>
-          <Typography variant="caption" color="text.secondary">{t('drsPage.helpMaxPending')}</Typography>
-        </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={settings.balance_larger_first}
-                onChange={(e) => handleChange('balance_larger_first', e.target.checked)}
-              />
-            }
-            label={<>{t('drsPage.migrateLargerFirst')}<HelpTip text={t('drsPage.helpLargerFirst')} /></>}
-          />
-        </Grid>
-        <Grid size={{ xs: 12, md: 6 }}>
-          <FormControlLabel
-            control={
-              <Switch
-                checked={settings.prevent_overprovisioning}
-                onChange={(e) => handleChange('prevent_overprovisioning', e.target.checked)}
-              />
-            }
-            label={<>{t('drsPage.preventOverprovisioning')}<HelpTip text={t('drsPage.helpPreventOverprov')} /></>}
-          />
         </Grid>
       </Grid>
 
       <Divider sx={{ my: 2 }} />
 
-      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+      <Typography variant="subtitle2" sx={{ mb: 0.5, fontWeight: 600 }}>
+        <i className="ri-scales-3-line" style={{ fontSize: 18, marginRight: 8, verticalAlign: 'middle' }} />
         {t('drsPage.resourceWeights')}
         <HelpTip text={t('drsPage.helpResourceWeights')} />
       </Typography>
       <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
         {t('drsPage.helpResourceWeightsDesc')}
       </Typography>
-      <Grid container spacing={2}>
+      <Grid container spacing={2.5}>
         <Grid size={{ xs: 12, md: 4 }}>
           <Typography variant="caption">{t('drsPage.cpuWeight', { value: settings.cpu_weight.toFixed(1) })}</Typography>
           <Slider
@@ -866,26 +924,6 @@ export default function DRSSettingsPanel({
           />
         </Grid>
       </Grid>
-
-      <Divider sx={{ my: 2 }} />
-
-      <Alert severity="info" icon={<InfoIcon />} sx={{ '& .MuiAlert-message': { width: '100%' } }}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
-          <i className="ri-line-chart-line" style={{ fontSize: 16, marginRight: 6, verticalAlign: 'middle' }} />
-          {t('drsPage.metricsSmoothing')}
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-          {t('drsPage.metricsSmoothingDesc')}
-        </Typography>
-        <Box sx={{ bgcolor: 'action.hover', borderRadius: 1, px: 1.5, py: 1, fontFamily: 'JetBrains Mono, monospace' }}>
-          <Typography variant="body2" sx={{ fontFamily: 'inherit', fontWeight: 600 }}>
-            {t('drsPage.metricsSmoothingFormula')}
-          </Typography>
-          <Typography variant="caption" color="text.secondary" sx={{ fontFamily: 'inherit' }}>
-            {t('drsPage.metricsSmoothingFormulaDesc')}
-          </Typography>
-        </Box>
-      </Alert>
     </>
   )
 

--- a/frontend/src/components/automation/drs/drsSettings.ts
+++ b/frontend/src/components/automation/drs/drsSettings.ts
@@ -1,0 +1,84 @@
+// Shared DRS settings shape + defaults. Imported by both the client-side
+// DRSSettingsPanel and the server-side `/api/v1/orchestrator/drs/settings`
+// route so the defaults aren't duplicated (SonarCloud flagged the 33-line
+// duplicate when the two files maintained parallel copies of every field).
+
+export interface DRSSettings {
+  enabled: boolean
+  mode: 'manual' | 'partial' | 'automatic'
+  balancing_method: 'memory' | 'cpu' | 'disk'
+  balancing_mode: 'used' | 'assigned' | 'psi'
+  balance_types: ('vm' | 'ct')[]
+  maintenance_nodes: string[]
+  excluded_clusters: string[]
+  excluded_nodes: Record<string, string[]>
+  cluster_modes: Record<string, string>
+  cpu_high_threshold: number
+  cpu_low_threshold: number
+  memory_high_threshold: number
+  memory_low_threshold: number
+  storage_high_threshold: number
+  imbalance_threshold: number
+  homogenization_enabled: boolean
+  max_load_spread: number
+  cpu_weight: number
+  memory_weight: number
+  storage_weight: number
+  max_concurrent_migrations: number
+  // 0 = legacy / unused. >0 caps how many migrations can be active for one
+  // cluster at once. Replaces the global cap as the primary throttle.
+  max_concurrent_migrations_per_cluster: number
+  // 0 = disabled. >0 caps how many migrations may target the same node in
+  // one Rebalance cycle (anti target-flooding).
+  max_target_inflow_per_cycle: number
+  migration_cooldown: string
+  max_pending_recommendations: number
+  balance_larger_first: boolean
+  prevent_overprovisioning: boolean
+  enable_affinity_rules: boolean
+  enforce_affinity: boolean
+  rebalance_schedule: 'interval' | 'daily'
+  rebalance_interval: string
+  rebalance_time: string
+}
+
+export interface ClusterVersionInfo {
+  connectionId: string
+  name: string
+  version: number // Major version (8 or 9)
+}
+
+export const defaultDRSSettings: DRSSettings = {
+  enabled: true,
+  mode: 'manual',
+  balancing_method: 'memory',
+  balancing_mode: 'used',
+  balance_types: ['vm', 'ct'],
+  maintenance_nodes: [],
+  excluded_clusters: [],
+  excluded_nodes: {},
+  cluster_modes: {},
+  cpu_high_threshold: 80,
+  cpu_low_threshold: 20,
+  memory_high_threshold: 85,
+  memory_low_threshold: 25,
+  storage_high_threshold: 90,
+  imbalance_threshold: 5,
+  homogenization_enabled: true,
+  max_load_spread: 10,
+  cpu_weight: 1.0,
+  memory_weight: 1.0,
+  storage_weight: 0.5,
+  max_concurrent_migrations: 2, // Legacy, unused by the engine. Kept for back-compat.
+  max_concurrent_migrations_per_cluster: 2,
+  max_target_inflow_per_cycle: 0,
+  migration_cooldown: '5m',
+  max_pending_recommendations: 10,
+  balance_larger_first: false,
+  prevent_overprovisioning: true,
+  enable_affinity_rules: true,
+  enforce_affinity: false,
+  rebalance_schedule: 'interval',
+  rebalance_interval: '1h',
+  rebalance_time: '10:00',
+}

--- a/frontend/src/lib/demo/demo-api.ts
+++ b/frontend/src/lib/demo/demo-api.ts
@@ -1258,6 +1258,8 @@ const EXTRA_MOCKS: MockDataMap = {
     memory_weight: 1.0,
     storage_weight: 0.5,
     max_concurrent_migrations: 2,
+    max_concurrent_migrations_per_cluster: 0,
+    max_target_inflow_per_cycle: 0,
     migration_cooldown: '5m',
     balance_larger_first: false,
     prevent_overprovisioning: true,

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5044,11 +5044,7 @@
     "helpPreventOverprov": "Wenn aktiviert, migriert DRS keine VM auf einen Node, wenn dieser dadurch seine Kapazität überschreiten würde (zugewiesen > verfügbar). Verhindert Überallokation von Ressourcen.",
     "helpResourceWeights": "Wie stark jeder Ressourcentyp den Balancing-Score beeinflusst.",
     "helpResourceWeightsDesc": "Auf 0 setzen, um eine Ressource zu ignorieren. Auf 2 für maximale Priorität. Beispiel: Memory=1 CPU=0.3 Storage=0 bedeutet, DRS konzentriert sich hauptsächlich auf Speicher-Balance.",
-    "excludedFromDRS": "Vom DRS ausgeschlossen",
-    "metricsSmoothing": "Metrik-Glättung",
-    "metricsSmoothingDesc": "DRS uses Exponential Weighted Moving Average (EWMA) over the last 30 minutes of collected metrics to smooth out transient CPU and memory spikes. This prevents unnecessary Migrations triggered by short-lived load bursts.",
-    "metricsSmoothingFormula": "S(t) = α × X(t) + (1-α) × S(t-1), α = 0.3",
-    "metricsSmoothingFormulaDesc": "Jeder neue Datenpunkt trägt 30% zum geglätteten Wert bei. Aktuelle Messungen haben mehr Gewicht, aber ältere Werte dämpfen plötzliche Änderungen."
+    "excludedFromDRS": "Vom DRS ausgeschlossen"
   },
   "usersPage": {
     "rbacRoles": "RBAC-Rollen",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5007,7 +5007,11 @@
     "tagAffinity": "Keep together on the same node",
     "tagAntiAffinity": "Separate on different nodes",
     "advancedOptions": "Advanced options",
+    "sectionMigrationLimits": "Migration limits",
+    "sectionMigrationBehavior": "Migration behavior",
     "maxConcurrentMigrations": "Max concurrent migrations",
+    "maxConcurrentPerCluster": "Max concurrent migrations per cluster",
+    "maxTargetInflowPerCycle": "Max target inflow per cycle",
     "cooldownBetweenMigrations": "Cooldown between migrations",
     "cooldownExample": "Ex: 5m, 10m, 1h",
     "migrateLargerFirst": "Migrate larger guests first",
@@ -5091,6 +5095,8 @@
     "helpEnableAffinity": "When enabled, DRS considers affinity rules (from Proxmox tags or manual rules) when generating recommendations. VMs with affinity/anti-affinity constraints will be placed accordingly.",
     "helpEnforceAffinity": "When enforced, DRS will never recommend a migration that violates an affinity rule, even if it would improve balance. When disabled, rules are preferred but not mandatory.",
     "helpMaxConcurrent": "Maximum number of VM migrations that can run simultaneously. Higher values balance faster but put more load on the network.",
+    "helpMaxConcurrentPerCluster": "Caps how many migrations can be active in a single cluster at once. Set to 0 to disable. Prevents one busy cluster from monopolizing the global slot pool when several clusters need rebalancing.",
+    "helpMaxTargetInflow": "Caps how many migrations may target the same node in one rebalance cycle. Set to 0 to disable. Prevents flooding the least-loaded node with several simultaneous migrations.",
     "helpCooldown": "Minimum wait time between two migrations of the same VM. Prevents a VM from being bounced back and forth.",
     "maxPendingRecommendations": "Max pending recommendations",
     "helpMaxPending": "Maximum number of pending recommendations. Oldest recommendations are auto-dismissed when this limit is exceeded.",
@@ -5100,11 +5106,7 @@
     "helpPreventOverprov": "When enabled, DRS will not migrate a VM to a node if it would cause that node to exceed its capacity (allocated > available). Prevents overcommitting resources.",
     "helpResourceWeights": "How much each resource type influences the balancing score.",
     "helpResourceWeightsDesc": "Set to 0 to ignore a resource. Set to 2 for maximum priority. For example, Memory=1 CPU=0.3 Storage=0 means DRS focuses primarily on memory balance.",
-    "excludedFromDRS": "Excluded from DRS",
-    "metricsSmoothing": "Metrics smoothing",
-    "metricsSmoothingDesc": "DRS uses Exponential Weighted Moving Average (EWMA) over the last 30 minutes of collected metrics to smooth out transient CPU and memory spikes. This prevents unnecessary migrations triggered by short-lived load bursts.",
-    "metricsSmoothingFormula": "S(t) = α × X(t) + (1-α) × S(t-1), α = 0.3",
-    "metricsSmoothingFormulaDesc": "Each new data point contributes 30% to the smoothed value. Recent measurements have more weight, but older values still dampen sudden changes."
+    "excludedFromDRS": "Excluded from DRS"
   },
   "usersPage": {
     "rbacRoles": "RBAC Roles",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5007,7 +5007,11 @@
     "tagAffinity": "Garder ensemble sur le même nœud",
     "tagAntiAffinity": "Séparer sur des nœuds différents",
     "advancedOptions": "Options avancées",
+    "sectionMigrationLimits": "Limites de migration",
+    "sectionMigrationBehavior": "Comportement des migrations",
     "maxConcurrentMigrations": "Migrations simultanées max",
+    "maxConcurrentPerCluster": "Migrations simultanées max par cluster",
+    "maxTargetInflowPerCycle": "Migrations max vers un même node par cycle",
     "cooldownBetweenMigrations": "Cooldown entre migrations",
     "cooldownExample": "Ex: 5m, 10m, 1h",
     "migrateLargerFirst": "Migrer les gros guests en premier",
@@ -5091,6 +5095,8 @@
     "helpEnableAffinity": "Lorsqu'activé, DRS prend en compte les règles d'affinité (tags Proxmox ou règles manuelles) lors de la génération des recommandations. Les VMs avec des contraintes d'affinité seront placées en conséquence.",
     "helpEnforceAffinity": "Lorsqu'imposé, DRS ne recommandera jamais une migration qui viole une règle d'affinité, même si elle améliorerait l'équilibre. Sinon, les règles sont préférées mais pas obligatoires.",
     "helpMaxConcurrent": "Nombre maximum de migrations de VMs pouvant s'exécuter simultanément. Plus de migrations = équilibrage plus rapide mais plus de charge réseau.",
+    "helpMaxConcurrentPerCluster": "Limite le nombre de migrations actives en parallèle pour un même cluster. Mettre à 0 pour désactiver. Empêche qu'un cluster monopolise tous les slots disponibles quand plusieurs clusters ont besoin d'être rééquilibrés.",
+    "helpMaxTargetInflow": "Limite combien de migrations peuvent cibler le même node dans un seul cycle de rebalance. Mettre à 0 pour désactiver. Empêche que plusieurs migrations affluent simultanément vers le node le moins chargé.",
     "helpCooldown": "Temps d'attente minimum entre deux migrations de la même VM. Empêche une VM d'être migrée en boucle.",
     "maxPendingRecommendations": "Max recommandations en attente",
     "helpMaxPending": "Nombre maximum de recommandations en attente. Les plus anciennes sont automatiquement supprimées au-delà de cette limite.",
@@ -5100,11 +5106,7 @@
     "helpPreventOverprov": "Lorsqu'activé, DRS ne migrera pas une VM vers un nœud si cela causerait un dépassement de capacité (alloué > disponible). Empêche le surprovisionnement.",
     "helpResourceWeights": "L'influence de chaque type de ressource sur le score d'équilibrage.",
     "helpResourceWeightsDesc": "Mettre à 0 pour ignorer une ressource. Mettre à 2 pour priorité maximale. Exemple : Mémoire=1 CPU=0.3 Stockage=0 signifie que DRS se concentre principalement sur l'équilibre mémoire.",
-    "excludedFromDRS": "Exclu du DRS",
-    "metricsSmoothing": "Lissage des métriques",
-    "metricsSmoothingDesc": "DRS utilise une Moyenne Mobile Exponentielle Pondérée (EWMA) sur les 30 dernières minutes de métriques collectées pour lisser les pics transitoires de CPU et mémoire. Cela évite les migrations inutiles déclenchées par des pics de charge éphémères.",
-    "metricsSmoothingFormula": "S(t) = α × X(t) + (1-α) × S(t-1), α = 0.3",
-    "metricsSmoothingFormulaDesc": "Chaque nouveau point de données contribue à 30% de la valeur lissée. Les mesures récentes ont plus de poids, mais les anciennes valeurs atténuent les changements brusques."
+    "excludedFromDRS": "Exclu du DRS"
   },
   "usersPage": {
     "rbacRoles": "Rôles RBAC",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5049,11 +5049,7 @@
     "helpPreventOverprov": "启用后，DRS 不会将 VM 迁移到会导致节点超出容量（已分配 > 可用）的节点。防止资源过度分配。",
     "helpResourceWeights": "每种资源类型对平衡评分的影响程度。",
     "helpResourceWeightsDesc": "设为 0 以忽略某种资源。设为 2 获得最高优先级。例如，内存=1 CPU=0.3 存储=0 意味着 DRS 主要关注内存平衡。",
-    "excludedFromDRS": "已从 DRS 排除",
-    "metricsSmoothing": "指标平滑",
-    "metricsSmoothingDesc": "DRS 使用指数加权移动平均（EWMA）对最近 30 分钟的采集指标进行平滑处理，以过滤瞬时的 CPU 和内存峰值。这可以防止短暂负载突发触发不必要的迁移。",
-    "metricsSmoothingFormula": "S(t) = α × X(t) + (1-α) × S(t-1), α = 0.3",
-    "metricsSmoothingFormulaDesc": "每个新数据点贡献 30% 的平滑值。近期测量值权重更高，但历史值仍能抑制突变。"
+    "excludedFromDRS": "已从 DRS 排除"
   },
   "usersPage": {
     "rbacRoles": "RBAC 角色",


### PR DESCRIPTION
## Summary

UI counterpart to backend [PR #5](https://github.com/adminsyspro/proxcenter-backend/pull/5). Replaces the legacy global migration cap with the per-cluster cap as the primary control and introduces target-inflow throttling. Cleans up the DRS Settings Advanced section in the same pass.

## Changes

### Migration caps

- **Removed** "Max concurrent migrations" slider. The legacy global cap is no longer enforced by the engine; operators reason per-cluster, so exposing both was confusing.
- **Added** "Max concurrent migrations per cluster" slider (min 1, default 2). The new primary active-migration cap.
- **Added** "Max target inflow per cycle" slider (min 0 = off, default 0). Opt-in safety against target-node flooding. Recommended value: 1.

### Cleanup of misleading or dead knobs

- **Removed** "Prevent overprovisioning" toggle. Its scope is narrow (only rule-violation migrations) and its name implied a global guarantee it never provided. Backend default ON is preserved; advanced users can still set it via API.
- **Removed** "Migrate larger first" toggle. Engine has it marked DEAD KNOB (never read), exposing it was a no-op trap.
- **Removed** the EWMA "Metrics smoothing" descriptive block (formula + description). Documentation noise unrelated to anything tunable.

### Layout

The "Advanced" tab is reorganised into three labeled subsections with icons:

- **Migration limits** (speed-up icon) — per-cluster cap, target inflow
- **Migration behavior** (tools icon) — cooldown, max pending recommendations
- **Resource weights** (scales icon) — CPU / Memory / Storage

Slider helper text moved from below-the-slider captions to `HelpTip(?)` tooltips next to each slider title. Saves vertical space without losing information.

### Tooltip theming

`HelpTip` made theme-aware (`background.paper` / `text.primary` / `divider` via `slotProps`, plus border-matching arrow) per the project rule on MUI Tooltip theming. Benefits every `HelpTip` in the panel, not just the new ones.

## i18n

- New keys: `maxConcurrentPerCluster`, `helpMaxConcurrentPerCluster`, `maxTargetInflowPerCycle`, `helpMaxTargetInflow`, `sectionMigrationLimits`, `sectionMigrationBehavior` (en + fr)
- Orphan keys removed across en/fr/de/zh-CN: `metricsSmoothing`, `metricsSmoothingDesc`, `metricsSmoothingFormula`, `metricsSmoothingFormulaDesc`

## Test plan

- [x] Local: dialog opens, three subsections render with icons, tooltips show on `?` hover with theme-aware background
- [x] Local: per-cluster slider min=1 (no "off" position), target-inflow slider has "off" + values
- [ ] After backend PR #5 merges + restart: setting per-cluster=2 in UI and saving applies the change in DRS engine logs
- [ ] After backend PR #5 merges + restart: setting target-inflow=1 prevents two recs targeting the same node from both firing in the same tick

Ships together with backend PR #5 as DRS hardening vague 2 (items 2.1 + 2.2).