### PR TITLE
fix(vmware): switch soapRequest to undici.request to expose Set-Cookie on node 26

### DIFF
--- a/frontend/src/lib/vmware/soap.ts
+++ b/frontend/src/lib/vmware/soap.ts
@@ -53,7 +53,20 @@ export async function soapRetrieveServiceContent(
   return { sessionManager, propertyCollector, rootFolder, isVcenter, apiVersion }
 }
 
-/** Send a SOAP request to the ESXi /sdk endpoint */
+/** Send a SOAP request to the ESXi /sdk endpoint.
+ *
+ * Uses undici's lower-level `request()` API rather than the WHATWG fetch
+ * wrapper. Reason: in node 26-alpine (undici 8.x) the WHATWG Response
+ * returned by `fetch()` exposes an EMPTY Headers object whenever a custom
+ * `dispatcher` is passed (the path we take for `insecureTLS=true`). The
+ * body still parses fine, but Set-Cookie is gone, so the vCenter session
+ * cookie never makes it back to the caller and every subsequent SOAP
+ * call fails with "The session is not authenticated." (observed live
+ * 2026-05-21 on the prod v1.4.1 image). Undici `request()` returns
+ * headers as a plain object indexed by lowercased name, and Set-Cookie
+ * comes through as a string array, so we read the session cookie
+ * directly without going through the broken Headers proxy.
+ */
 export async function soapRequest(
   baseUrl: string,
   body: string,
@@ -61,36 +74,39 @@ export async function soapRequest(
   insecureTLS: boolean,
   timeoutMs = 30000
 ): Promise<{ text: string; cookie?: string }> {
-  const opts: any = {
+  const { request, Agent } = await import("undici")
+  const headers: Record<string, string> = {
+    "Content-Type": "text/xml; charset=utf-8",
+    SOAPAction: '"urn:vim25/8.0"',
+    // See header comment on the previous fetch-based version: forcing identity
+    // sidesteps brotli decompression edge cases on newer undici.
+    "Accept-Encoding": "identity",
+  }
+  if (cookie) headers.Cookie = cookie
+  const res = await request(`${baseUrl}/sdk`, {
     method: "POST",
-    headers: {
-      "Content-Type": "text/xml; charset=utf-8",
-      SOAPAction: '"urn:vim25/8.0"',
-      // Ask vCenter for uncompressed responses. The custom undici Agent
-      // instantiated below (for insecureTLS) doesn't always advertise
-      // Accept-Encoding the way the default fetch does, so vCenter
-      // sometimes sends a compressed/binary body while we read it via
-      // .text(), which produces replacement characters and breaks XML
-      // parsing (observed live on v1.4.1 after the node 22-alpine to
-      // 26-alpine bump shipped a newer undici). Identity sidesteps the
-      // whole content-encoding negotiation; SOAP payloads are small
-      // enough that the extra bytes on the wire are not a concern.
-      "Accept-Encoding": "identity",
-      ...(cookie ? { Cookie: cookie } : {}),
-    },
+    headers,
     body,
     signal: AbortSignal.timeout(timeoutMs),
-  }
-  if (insecureTLS) {
-    opts.dispatcher = new (await import("undici")).Agent({ connect: { rejectUnauthorized: false } })
-  }
-  const res = await fetch(`${baseUrl}/sdk`, opts)
-  const text = await res.text()
-  if (!res.ok && !text.includes("returnval")) {
+    dispatcher: insecureTLS
+      ? new Agent({ connect: { rejectUnauthorized: false } })
+      : undefined,
+  })
+  const text = await res.body.text()
+  if (res.statusCode >= 400 && !text.includes("returnval")) {
     const fault = text.match(/<faultstring>([\s\S]*?)<\/faultstring>/)?.[1]
-    throw new Error(`SOAP error ${res.status}: ${fault || text.substring(0, 500)}`)
+    throw new Error(`SOAP error ${res.statusCode}: ${fault || text.substring(0, 500)}`)
   }
-  const rawCookie = res.headers.get("set-cookie") || ""
+  // `request()` returns headers as `Record<string, string | string[]>`
+  // keyed by lowercased name. Set-Cookie is the canonical repeating
+  // header so it comes through as a string[] when there are multiple.
+  const setCookieRaw = res.headers["set-cookie"]
+  const setCookieArr = Array.isArray(setCookieRaw)
+    ? setCookieRaw
+    : typeof setCookieRaw === "string"
+      ? [setCookieRaw]
+      : []
+  const rawCookie = setCookieArr[0] || ""
   return { text, cookie: rawCookie.split(";")[0] || "" }
 }
 


### PR DESCRIPTION
## Summary

After the v1.4.1 force-tag added \`Accept-Encoding: identity\` (closing the brotli regression), every multi-call vCenter flow started failing with \`SOAP error 500: The session is not authenticated.\` Single-call paths like \`/status\` still worked; the broken paths are \`/vms\`, \`/vms/[vmid]\`, and the full migration pipeline.

## Root cause

When \`dispatcher\` is passed to the WHATWG \`fetch()\` wrapper on node 26-alpine (undici 8.x), the Response's \`Headers\` object comes back EMPTY. The body parses correctly, but \`headers.get(...)\`, \`headers.forEach\`, and even the iterator all return nothing. Set-Cookie included.

So \`soapRequest\` never saw the vCenter session cookie, the returned \`cookie\` string stayed empty, and every subsequent SOAP call hit an anonymous session.

Confirmed live by logging \`[...res.headers]\`, \`res.headers.forEach\`, \`res.headers.entries()\` — all three returned \`[]\` on the production image, while the body showed a valid SOAP RetrieveServiceContent response. Node 20 / older undici was forgiving (it violated the spec by exposing Set-Cookie through \`headers.get('set-cookie')\` and kept the rest of the Headers object populated).

## Fix

Use undici's lower-level \`request()\` API instead of \`fetch()\`. It returns headers as a \`Record<string, string | string[]>\` keyed by lowercased name, with Set-Cookie consistently exposed as a string array. The rest of \`soapRequest\` (timeout, error parsing, cookie split) stays unchanged.

## Scope

Only \`frontend/src/lib/vmware/soap.ts\`. The same pattern appears in:

- \`lib/hyperv/winrm.ts\` (Hyper-V WinRM auth)
- \`lib/xcpng/client.ts\` (Xen Orchestra API)
- \`lib/migration/xcpng-pipeline.ts\` (XCP-ng migration shutdown)
- \`lib/nutanix/client.ts\` (Nutanix v3 API)

Those are tracked separately and will land in v1.4.2 after manual validation per pipeline (they only matter for users with \`insecureTLS=true\` on those connection types, which need surfacing one by one).

## Test plan

- [x] Local Node 26 \`npm run dev\`: \`/api/v1/vmware/[id]/vms\` returns the VM list, no auth error
- [x] Logs show \`[soapResolveHostInventoryPaths]\` step 1-4 completing for vCenter inventory hierarchy (= multi-call flow working end-to-end)
- [ ] Prod image rebuilt + pulled: same behavior

## Release plan

Same force-tag pattern as the previous v1.4.1 hot-fix: merge this PR, force-move the v1.4.1 tag to the new HEAD, PATCH the GitHub release with \`draft=false\` + \`make_latest=true\` to undo the auto-draft from the tag delete. Docker workflow re-runs on tag push and overwrites \`:1.4.1\` + \`:latest\` on GHCR.

## Follow-up

After v1.4.1 settles, audit and patch the other 4 pipelines that share the broken fetch+dispatcher pattern. Likely refactor: extract a shared \`insecureFetch\` helper that wraps \`undici.request\` and returns a \`fetch\`-compatible object so the call sites stay stable.