### PR TITLE
fix(backups): translate legacy maxfiles to prune-backups (#341)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
@@ -224,8 +224,17 @@ export async function PUT(req: Request, ctx: RouteContext) {
       }
     }
 
-    if (body.maxfiles !== undefined) {
-      params.set('maxfiles', String(body.maxfiles))
+    // Legacy retention (maxfiles) translation. PVE 8.x removed `maxfiles` from
+    // the schema, so forwarding it triggers a 400. Convert to the equivalent
+    // `prune-backups=keep-last=N` when the modern UI didn't already provide a
+    // keep-* breakdown. Treat maxfiles<=0 as "no legacy retention" (old PVE
+    // accepted 0 to mean "keep all", and the right translation for that is to
+    // leave prune-backups unset, since PVE default keeps all).
+    if (body.maxfiles !== undefined && !params.has('prune-backups')) {
+      const legacy = Number.parseInt(String(body.maxfiles), 10)
+      if (Number.isFinite(legacy) && legacy > 0) {
+        params.set('prune-backups', `keep-last=${legacy}`)
+      }
     }
 
     // Note template

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-import { translateMaxfilesToPruneBackups } from "@/lib/backups/prune"
+import { applyMaxfilesTranslation } from "@/lib/backups/prune"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
@@ -225,15 +225,7 @@ export async function PUT(req: Request, ctx: RouteContext) {
       }
     }
 
-    // Legacy retention translation: convert maxfiles to prune-backups so
-    // PVE 8.x doesn't 400 on the removed parameter. Pass the existing job's
-    // prune-backups so a richer policy (keep-daily, keep-weekly, ns=, etc.)
-    // configured via the modern UI or PVE GUI is preserved when a legacy
-    // edit only carries maxfiles.
-    if (!params.has('prune-backups')) {
-      const translated = translateMaxfilesToPruneBackups(body.maxfiles, owned.job?.['prune-backups'])
-      if (translated) params.set('prune-backups', translated)
-    }
+    applyMaxfilesTranslation(params, body.maxfiles, owned.job?.['prune-backups'])
 
     // Note template
     if (body.notesTemplate) {

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
@@ -226,14 +226,42 @@ export async function PUT(req: Request, ctx: RouteContext) {
 
     // Legacy retention (maxfiles) translation. PVE 8.x removed `maxfiles` from
     // the schema, so forwarding it triggers a 400. Convert to the equivalent
-    // `prune-backups=keep-last=N` when the modern UI didn't already provide a
-    // keep-* breakdown. Treat maxfiles<=0 as "no legacy retention" (old PVE
-    // accepted 0 to mean "keep all", and the right translation for that is to
-    // leave prune-backups unset, since PVE default keeps all).
+    // keep-last when the modern UI didn't already provide a keep-* breakdown.
+    // Treat maxfiles<=0 as "no legacy retention" (old PVE accepted 0 to mean
+    // "keep all", and the right translation for that is to leave prune-backups
+    // unset, since PVE default keeps all). When the existing job already has
+    // a richer prune policy (keep-daily, keep-weekly, etc.) configured via
+    // the modern UI or PVE GUI, merge instead of overwriting so a legacy
+    // edit that only carries maxfiles doesn't silently drop those rules.
     if (body.maxfiles !== undefined && !params.has('prune-backups')) {
       const legacy = Number.parseInt(String(body.maxfiles), 10)
       if (Number.isFinite(legacy) && legacy > 0) {
-        params.set('prune-backups', `keep-last=${legacy}`)
+        const existing = owned.job?.['prune-backups']
+        const parts: string[] = []
+        let foundKeepLast = false
+        if (typeof existing === 'string') {
+          for (const seg of existing.split(',')) {
+            const trimmed = seg.trim()
+            if (!trimmed) continue
+            if (trimmed.startsWith('keep-last=')) {
+              parts.push(`keep-last=${legacy}`)
+              foundKeepLast = true
+            } else {
+              parts.push(trimmed)
+            }
+          }
+        } else if (existing && typeof existing === 'object') {
+          for (const [k, v] of Object.entries(existing as Record<string, unknown>)) {
+            if (k === 'keep-last') {
+              parts.push(`keep-last=${legacy}`)
+              foundKeepLast = true
+            } else {
+              parts.push(`${k}=${v}`)
+            }
+          }
+        }
+        if (!foundKeepLast) parts.push(`keep-last=${legacy}`)
+        params.set('prune-backups', parts.join(','))
       }
     }
 

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 
+import { translateMaxfilesToPruneBackups } from "@/lib/backups/prune"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
@@ -224,45 +225,14 @@ export async function PUT(req: Request, ctx: RouteContext) {
       }
     }
 
-    // Legacy retention (maxfiles) translation. PVE 8.x removed `maxfiles` from
-    // the schema, so forwarding it triggers a 400. Convert to the equivalent
-    // keep-last when the modern UI didn't already provide a keep-* breakdown.
-    // Treat maxfiles<=0 as "no legacy retention" (old PVE accepted 0 to mean
-    // "keep all", and the right translation for that is to leave prune-backups
-    // unset, since PVE default keeps all). When the existing job already has
-    // a richer prune policy (keep-daily, keep-weekly, etc.) configured via
-    // the modern UI or PVE GUI, merge instead of overwriting so a legacy
-    // edit that only carries maxfiles doesn't silently drop those rules.
-    if (body.maxfiles !== undefined && !params.has('prune-backups')) {
-      const legacy = Number.parseInt(String(body.maxfiles), 10)
-      if (Number.isFinite(legacy) && legacy > 0) {
-        const existing = owned.job?.['prune-backups']
-        const parts: string[] = []
-        let foundKeepLast = false
-        if (typeof existing === 'string') {
-          for (const seg of existing.split(',')) {
-            const trimmed = seg.trim()
-            if (!trimmed) continue
-            if (trimmed.startsWith('keep-last=')) {
-              parts.push(`keep-last=${legacy}`)
-              foundKeepLast = true
-            } else {
-              parts.push(trimmed)
-            }
-          }
-        } else if (existing && typeof existing === 'object') {
-          for (const [k, v] of Object.entries(existing as Record<string, unknown>)) {
-            if (k === 'keep-last') {
-              parts.push(`keep-last=${legacy}`)
-              foundKeepLast = true
-            } else {
-              parts.push(`${k}=${v}`)
-            }
-          }
-        }
-        if (!foundKeepLast) parts.push(`keep-last=${legacy}`)
-        params.set('prune-backups', parts.join(','))
-      }
+    // Legacy retention translation: convert maxfiles to prune-backups so
+    // PVE 8.x doesn't 400 on the removed parameter. Pass the existing job's
+    // prune-backups so a richer policy (keep-daily, keep-weekly, ns=, etc.)
+    // configured via the modern UI or PVE GUI is preserved when a legacy
+    // edit only carries maxfiles.
+    if (!params.has('prune-backups')) {
+      const translated = translateMaxfilesToPruneBackups(body.maxfiles, owned.job?.['prune-backups'])
+      if (translated) params.set('prune-backups', translated)
     }
 
     // Note template

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 
-import { extractKeepLastFromPruneBackups, translateMaxfilesToPruneBackups } from "@/lib/backups/prune"
+import { applyMaxfilesTranslation, extractKeepLastFromPruneBackups } from "@/lib/backups/prune"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
@@ -379,13 +379,7 @@ export async function POST(req: Request, ctx: RouteContext) {
       }
     }
 
-    // Legacy retention translation: convert maxfiles to prune-backups so
-    // PVE 8.x doesn't 400 on the removed parameter. Skipped when the modern
-    // UI already supplied a keep-* breakdown above.
-    if (!params.has('prune-backups')) {
-      const translated = translateMaxfilesToPruneBackups(body.maxfiles)
-      if (translated) params.set('prune-backups', translated)
-    }
+    applyMaxfilesTranslation(params, body.maxfiles)
 
     // Note template
     if (body.notesTemplate) {

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 
+import { extractKeepLastFromPruneBackups, translateMaxfilesToPruneBackups } from "@/lib/backups/prune"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
@@ -138,18 +139,7 @@ return job.namespace || ''
         // route translates) come back with maxfiles undefined. Surface the
         // keep-last value (if any) as maxfiles so the legacy edit form
         // shows the configured retention instead of falling back to 1.
-        maxfiles: (() => {
-          if (job.maxfiles !== undefined && job.maxfiles !== null) return job.maxfiles
-          const prune = job['prune-backups']
-          if (typeof prune === 'string') {
-            const m = prune.match(/keep-last=(\d+)/)
-            if (m) return Number.parseInt(m[1], 10)
-          } else if (prune && typeof prune === 'object' && 'keep-last' in prune) {
-            const v = Number((prune as any)['keep-last'])
-            if (Number.isFinite(v)) return v
-          }
-          return undefined
-        })(),
+        maxfiles: job.maxfiles ?? extractKeepLastFromPruneBackups(job['prune-backups']),
         pruneBackups: job['prune-backups'] || null,
 
         // Protection
@@ -389,17 +379,12 @@ export async function POST(req: Request, ctx: RouteContext) {
       }
     }
 
-    // Legacy retention (maxfiles) translation. PVE 8.x removed `maxfiles` from
-    // the schema, so forwarding it triggers a 400. Convert to the equivalent
-    // `prune-backups=keep-last=N` when the modern UI didn't already provide a
-    // keep-* breakdown. Treat maxfiles<=0 as "no legacy retention" (old PVE
-    // accepted 0 to mean "keep all", and the right translation for that is to
-    // leave prune-backups unset, since PVE default keeps all).
-    if (body.maxfiles !== undefined && !params.has('prune-backups')) {
-      const legacy = Number.parseInt(String(body.maxfiles), 10)
-      if (Number.isFinite(legacy) && legacy > 0) {
-        params.set('prune-backups', `keep-last=${legacy}`)
-      }
+    // Legacy retention translation: convert maxfiles to prune-backups so
+    // PVE 8.x doesn't 400 on the removed parameter. Skipped when the modern
+    // UI already supplied a keep-* breakdown above.
+    if (!params.has('prune-backups')) {
+      const translated = translateMaxfilesToPruneBackups(body.maxfiles)
+      if (translated) params.set('prune-backups', translated)
     }
 
     // Note template

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/route.ts
@@ -133,8 +133,23 @@ export async function GET(_req: Request, ctx: RouteContext) {
 return job.namespace || ''
         })(),
 
-        // Retention
-        maxfiles: job.maxfiles,
+        // Retention. PVE 8.x dropped `maxfiles` in favor of `prune-backups`,
+        // so jobs created on modern clusters (including those our create
+        // route translates) come back with maxfiles undefined. Surface the
+        // keep-last value (if any) as maxfiles so the legacy edit form
+        // shows the configured retention instead of falling back to 1.
+        maxfiles: (() => {
+          if (job.maxfiles !== undefined && job.maxfiles !== null) return job.maxfiles
+          const prune = job['prune-backups']
+          if (typeof prune === 'string') {
+            const m = prune.match(/keep-last=(\d+)/)
+            if (m) return Number.parseInt(m[1], 10)
+          } else if (prune && typeof prune === 'object' && 'keep-last' in prune) {
+            const v = Number((prune as any)['keep-last'])
+            if (Number.isFinite(v)) return v
+          }
+          return undefined
+        })(),
         pruneBackups: job['prune-backups'] || null,
 
         // Protection
@@ -374,8 +389,17 @@ export async function POST(req: Request, ctx: RouteContext) {
       }
     }
 
-    if (body.maxfiles !== undefined) {
-      params.set('maxfiles', String(body.maxfiles))
+    // Legacy retention (maxfiles) translation. PVE 8.x removed `maxfiles` from
+    // the schema, so forwarding it triggers a 400. Convert to the equivalent
+    // `prune-backups=keep-last=N` when the modern UI didn't already provide a
+    // keep-* breakdown. Treat maxfiles<=0 as "no legacy retention" (old PVE
+    // accepted 0 to mean "keep all", and the right translation for that is to
+    // leave prune-backups unset, since PVE default keeps all).
+    if (body.maxfiles !== undefined && !params.has('prune-backups')) {
+      const legacy = Number.parseInt(String(body.maxfiles), 10)
+      if (Number.isFinite(legacy) && legacy > 0) {
+        params.set('prune-backups', `keep-last=${legacy}`)
+      }
     }
 
     // Note template

--- a/frontend/src/lib/backups/prune.test.ts
+++ b/frontend/src/lib/backups/prune.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  applyMaxfilesTranslation,
+  extractKeepLastFromPruneBackups,
+  translateMaxfilesToPruneBackups,
+} from './prune'
+
+describe('extractKeepLastFromPruneBackups', () => {
+  it('returns undefined for missing / null / empty inputs', () => {
+    expect(extractKeepLastFromPruneBackups(undefined)).toBeUndefined()
+    expect(extractKeepLastFromPruneBackups(null)).toBeUndefined()
+    expect(extractKeepLastFromPruneBackups('')).toBeUndefined()
+  })
+
+  it('extracts keep-last from a single-rule string', () => {
+    expect(extractKeepLastFromPruneBackups('keep-last=30')).toBe(30)
+  })
+
+  it('extracts keep-last from a multi-rule string regardless of position', () => {
+    expect(extractKeepLastFromPruneBackups('keep-daily=7,keep-last=5')).toBe(5)
+    expect(extractKeepLastFromPruneBackups('keep-last=12,keep-weekly=4,keep-monthly=6')).toBe(12)
+  })
+
+  it('returns undefined when keep-last is absent from a string', () => {
+    expect(extractKeepLastFromPruneBackups('keep-daily=7,keep-weekly=4')).toBeUndefined()
+    expect(extractKeepLastFromPruneBackups('ns=prod')).toBeUndefined()
+  })
+
+  it('extracts keep-last from an object shape', () => {
+    expect(extractKeepLastFromPruneBackups({ 'keep-last': 10, 'keep-daily': 7 })).toBe(10)
+    expect(extractKeepLastFromPruneBackups({ 'keep-last': '15' })).toBe(15)
+  })
+
+  it('returns undefined when the object has no keep-last', () => {
+    expect(extractKeepLastFromPruneBackups({ 'keep-daily': 7 })).toBeUndefined()
+    expect(extractKeepLastFromPruneBackups({})).toBeUndefined()
+  })
+
+  it('returns undefined when keep-last cannot be parsed as a number', () => {
+    expect(extractKeepLastFromPruneBackups({ 'keep-last': 'not-a-number' })).toBeUndefined()
+  })
+})
+
+describe('translateMaxfilesToPruneBackups', () => {
+  it('returns null for missing or non-positive values (keep-all semantics)', () => {
+    expect(translateMaxfilesToPruneBackups(undefined)).toBeNull()
+    expect(translateMaxfilesToPruneBackups(null)).toBeNull()
+    expect(translateMaxfilesToPruneBackups(0)).toBeNull()
+    expect(translateMaxfilesToPruneBackups(-5)).toBeNull()
+    expect(translateMaxfilesToPruneBackups('not-a-number')).toBeNull()
+  })
+
+  it('translates a positive integer into keep-last when no existing policy', () => {
+    expect(translateMaxfilesToPruneBackups(30)).toBe('keep-last=30')
+  })
+
+  it('accepts numeric strings', () => {
+    expect(translateMaxfilesToPruneBackups('30')).toBe('keep-last=30')
+  })
+
+  it('replaces only keep-last in an existing string policy', () => {
+    expect(translateMaxfilesToPruneBackups(30, 'keep-last=3,keep-daily=7'))
+      .toBe('keep-last=30,keep-daily=7')
+  })
+
+  it('appends keep-last when the existing string policy has none', () => {
+    expect(translateMaxfilesToPruneBackups(30, 'keep-daily=7,keep-weekly=4'))
+      .toBe('keep-daily=7,keep-weekly=4,keep-last=30')
+  })
+
+  it('preserves the ns= namespace marker on the way through', () => {
+    expect(translateMaxfilesToPruneBackups(30, 'keep-last=3,ns=prod'))
+      .toBe('keep-last=30,ns=prod')
+  })
+
+  it('replaces only keep-last in an existing object policy', () => {
+    const out = translateMaxfilesToPruneBackups(30, { 'keep-last': 3, 'keep-daily': 7 })
+    // Object iteration preserves insertion order, so we can match a string.
+    expect(out).toBe('keep-last=30,keep-daily=7')
+  })
+
+  it('appends keep-last when the existing object policy has none', () => {
+    expect(translateMaxfilesToPruneBackups(30, { 'keep-daily': 7 }))
+      .toBe('keep-daily=7,keep-last=30')
+  })
+
+  it('skips empty segments in malformed strings', () => {
+    expect(translateMaxfilesToPruneBackups(30, ',keep-daily=7,,'))
+      .toBe('keep-daily=7,keep-last=30')
+  })
+})
+
+describe('applyMaxfilesTranslation', () => {
+  it('sets prune-backups when missing and maxfiles is valid', () => {
+    const p = new URLSearchParams()
+    applyMaxfilesTranslation(p, 30)
+    expect(p.get('prune-backups')).toBe('keep-last=30')
+  })
+
+  it('does nothing when prune-backups is already set', () => {
+    const p = new URLSearchParams()
+    p.set('prune-backups', 'keep-daily=14')
+    applyMaxfilesTranslation(p, 30)
+    expect(p.get('prune-backups')).toBe('keep-daily=14')
+  })
+
+  it('does nothing when maxfiles is missing or non-positive', () => {
+    const p = new URLSearchParams()
+    applyMaxfilesTranslation(p, undefined)
+    expect(p.has('prune-backups')).toBe(false)
+    applyMaxfilesTranslation(p, 0)
+    expect(p.has('prune-backups')).toBe(false)
+  })
+
+  it('merges with an existing policy from a previously-saved job', () => {
+    const p = new URLSearchParams()
+    applyMaxfilesTranslation(p, 30, 'keep-last=3,keep-daily=7')
+    expect(p.get('prune-backups')).toBe('keep-last=30,keep-daily=7')
+  })
+})

--- a/frontend/src/lib/backups/prune.ts
+++ b/frontend/src/lib/backups/prune.ts
@@ -74,3 +74,22 @@ export function translateMaxfilesToPruneBackups(
   if (!foundKeepLast) parts.push(`keep-last=${legacy}`)
   return parts.join(',')
 }
+
+/**
+ * Mutate `params` to translate legacy `maxfiles` into a `prune-backups`
+ * value. Skipped when `prune-backups` is already set (the modern UI keep-*
+ * breakdown took precedence) or when maxfiles has no useful value.
+ *
+ * Folding the `has/set` dance into the helper keeps each call site to a
+ * single line, so the create + update routes do not carry near-identical
+ * blocks that trip the new-code duplication metric.
+ */
+export function applyMaxfilesTranslation(
+  params: URLSearchParams,
+  maxfiles: unknown,
+  existingPruneBackups?: unknown,
+): void {
+  if (params.has('prune-backups')) return
+  const translated = translateMaxfilesToPruneBackups(maxfiles, existingPruneBackups)
+  if (translated) params.set('prune-backups', translated)
+}

--- a/frontend/src/lib/backups/prune.ts
+++ b/frontend/src/lib/backups/prune.ts
@@ -1,0 +1,76 @@
+// src/lib/backups/prune.ts
+// Helpers for the legacy `maxfiles` retention parameter on PVE backup jobs.
+//
+// PVE 8.x removed `maxfiles` from the /cluster/backup schema in favor of
+// `prune-backups=keep-last=N`. Both the create and update routes need to
+// translate between the two formats, and the list route needs the reverse
+// translation so the legacy edit form shows the configured retention.
+// Factored out so the create + update handlers share the same logic.
+
+/**
+ * Extract the keep-last value from a PVE `prune-backups` field.
+ *
+ * PVE returns prune-backups as either a comma-separated string
+ * ("keep-last=30,keep-daily=7") or as a parsed object depending on the
+ * version. Returns the number when keep-last is present, or undefined.
+ */
+export function extractKeepLastFromPruneBackups(pruneBackups: unknown): number | undefined {
+  if (typeof pruneBackups === 'string') {
+    const m = pruneBackups.match(/keep-last=(\d+)/)
+    if (m) return Number.parseInt(m[1], 10)
+    return undefined
+  }
+  if (pruneBackups && typeof pruneBackups === 'object' && 'keep-last' in pruneBackups) {
+    const v = Number((pruneBackups as Record<string, unknown>)['keep-last'])
+    if (Number.isFinite(v)) return v
+  }
+  return undefined
+}
+
+/**
+ * Translate a legacy `maxfiles` value to a `prune-backups` string suitable
+ * for PVE. Returns null when no translation should be sent (maxfiles missing
+ * or non-positive, matching old PVE's "keep all" semantics for maxfiles=0).
+ *
+ * When `existingPruneBackups` is provided (typical for the update path),
+ * the existing policy is parsed and only the keep-last segment is replaced.
+ * Other rules (keep-daily, keep-weekly, ns=, etc.) are preserved so a
+ * legacy edit that only carries `maxfiles` does not silently drop a richer
+ * policy configured via the modern UI or the PVE GUI.
+ */
+export function translateMaxfilesToPruneBackups(
+  maxfiles: unknown,
+  existingPruneBackups?: unknown,
+): string | null {
+  if (maxfiles === undefined || maxfiles === null) return null
+  const legacy = Number.parseInt(String(maxfiles), 10)
+  if (!Number.isFinite(legacy) || legacy <= 0) return null
+
+  const parts: string[] = []
+  let foundKeepLast = false
+
+  if (typeof existingPruneBackups === 'string') {
+    for (const seg of existingPruneBackups.split(',')) {
+      const trimmed = seg.trim()
+      if (!trimmed) continue
+      if (trimmed.startsWith('keep-last=')) {
+        parts.push(`keep-last=${legacy}`)
+        foundKeepLast = true
+      } else {
+        parts.push(trimmed)
+      }
+    }
+  } else if (existingPruneBackups && typeof existingPruneBackups === 'object') {
+    for (const [k, v] of Object.entries(existingPruneBackups as Record<string, unknown>)) {
+      if (k === 'keep-last') {
+        parts.push(`keep-last=${legacy}`)
+        foundKeepLast = true
+      } else {
+        parts.push(`${k}=${v}`)
+      }
+    }
+  }
+
+  if (!foundKeepLast) parts.push(`keep-last=${legacy}`)
+  return parts.join(',')
+}


### PR DESCRIPTION
## Summary

Closes #341.

PVE 8.x removed the legacy `maxfiles` parameter from the `/cluster/backup` schema in favor of `prune-backups`. Any save coming from the legacy backup UI (`/operations/backups`, inventory hardware handlers) was therefore returning a 400 error:

```
PVE 400 /cluster/backup: {"errors":{"maxfiles":"property is not defined in schema and the schema does not allow additional properties"}}
```

The fix translates between the two formats at the API layer so the existing form keeps working without an immediate UI rewrite. The modern inventory `BackupJobsPanel` (which already uses `keep-last / keep-daily / ...`) is unaffected.

## Changes

- **Write path (create + update)**: if `maxfiles` is provided and the modern keep-* fields aren't, send `prune-backups=keep-last=N` instead. Drop the legacy `maxfiles` parameter entirely. `maxfiles<=0` leaves `prune-backups` unset, matching old PVE's "keep all" semantics.
- **Read path (list endpoint)**: when PVE returns `prune-backups` but no `maxfiles`, extract `keep-last` and surface it as `maxfiles` so the legacy edit form shows the configured retention instead of falling back to 1. Handles both string and object shapes.
- **Merge on PUT (Codex review finding)**: when an existing job already has a richer policy (e.g. `keep-last=3,keep-daily=7,keep-weekly=4`), a legacy edit replaces only the `keep-last` segment and preserves the rest. The embedded `ns=` namespace marker is also preserved.

## Test plan

- [x] Create a backup job via `/operations/backups` with retention = 30, save without error
- [x] Edit the job, retention field shows 30 (not 1)
- [x] Verify on PVE: `prune-backups: keep-last=30` in `jobs.cfg`
- [ ] Create a job via PVE GUI with `keep-last=5,keep-daily=7`, edit a non-retention field via ProxCenter, verify `keep-daily=7` is preserved
- [ ] Modern UI `BackupJobsPanel` still works end-to-end (no regression on the keep-* surface)

Reported by @paxHadron.