### PR TITLE
fix(pipelines): node 26 hardening for XCP-ng/Hyper-V/Nutanix (#340)

### DIFF
--- a/frontend/src/lib/http/insecure-fetch.test.ts
+++ b/frontend/src/lib/http/insecure-fetch.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { Agent } from "undici"
+
+import {
+  fetchWithInsecureTLS,
+  INSECURE_FETCH_HEADERS,
+  makeInsecureDispatcher,
+} from "./insecure-fetch"
+
+describe("insecure-fetch", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(new Response("ok"))
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe("INSECURE_FETCH_HEADERS", () => {
+    it("exports identity Accept-Encoding to defeat brotli/zstd regressions", () => {
+      expect(INSECURE_FETCH_HEADERS).toEqual({ "Accept-Encoding": "identity" })
+    })
+  })
+
+  describe("fetchWithInsecureTLS", () => {
+    it("injects Accept-Encoding: identity by default", async () => {
+      await fetchWithInsecureTLS("https://example.test/path")
+
+      expect(fetchMock).toHaveBeenCalledOnce()
+      const [url, opts] = fetchMock.mock.calls[0]
+      expect(url).toBe("https://example.test/path")
+      expect((opts as any).headers).toEqual({ "Accept-Encoding": "identity" })
+    })
+
+    it("merges caller headers on top of the identity default", async () => {
+      await fetchWithInsecureTLS("https://example.test", {
+        headers: {
+          Authorization: "Bearer xyz",
+          "Content-Type": "application/json",
+        },
+      })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).headers).toEqual({
+        "Accept-Encoding": "identity",
+        Authorization: "Bearer xyz",
+        "Content-Type": "application/json",
+      })
+    })
+
+    it("lets the caller override Accept-Encoding if explicitly set (escape hatch)", async () => {
+      await fetchWithInsecureTLS("https://example.test", {
+        headers: { "Accept-Encoding": "gzip" },
+      })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).headers["Accept-Encoding"]).toBe("gzip")
+    })
+
+    it("does not attach a dispatcher when insecureTLS is omitted", async () => {
+      await fetchWithInsecureTLS("https://example.test")
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).dispatcher).toBeUndefined()
+    })
+
+    it("does not attach a dispatcher when insecureTLS is false", async () => {
+      await fetchWithInsecureTLS("https://example.test", { insecureTLS: false })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).dispatcher).toBeUndefined()
+    })
+
+    it("attaches an undici Agent when insecureTLS is true", async () => {
+      await fetchWithInsecureTLS("https://example.test", { insecureTLS: true })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).dispatcher).toBeInstanceOf(Agent)
+    })
+
+    it("preserves an externally provided dispatcher instead of creating one", async () => {
+      const customAgent = new Agent()
+
+      await fetchWithInsecureTLS("https://example.test", {
+        insecureTLS: true,
+        dispatcher: customAgent,
+      })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).dispatcher).toBe(customAgent)
+    })
+
+    it("forwards method, body, and signal verbatim to fetch", async () => {
+      const signal = AbortSignal.timeout(10_000)
+
+      await fetchWithInsecureTLS("https://example.test", {
+        method: "POST",
+        body: '{"x":1}',
+        signal,
+      })
+
+      const [, opts] = fetchMock.mock.calls[0]
+      expect((opts as any).method).toBe("POST")
+      expect((opts as any).body).toBe('{"x":1}')
+      expect((opts as any).signal).toBe(signal)
+    })
+
+    it("returns the Response object from fetch untouched", async () => {
+      const response = new Response("payload", { status: 201 })
+      fetchMock.mockResolvedValueOnce(response)
+
+      const result = await fetchWithInsecureTLS("https://example.test")
+
+      expect(result).toBe(response)
+    })
+  })
+
+  describe("makeInsecureDispatcher", () => {
+    it("returns an undici Agent instance", async () => {
+      const dispatcher = await makeInsecureDispatcher()
+      expect(dispatcher).toBeInstanceOf(Agent)
+    })
+  })
+})

--- a/frontend/src/lib/http/insecure-fetch.ts
+++ b/frontend/src/lib/http/insecure-fetch.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared HTTP helper for migration-source pipelines that need:
+ *   1. Accept-Encoding: identity to defeat brotli/zstd handling regressions
+ *      seen on Node 26 + undici 8.x when a custom dispatcher is passed to
+ *      WHATWG fetch().
+ *   2. Optional self-signed TLS bypass via an undici Agent.
+ *
+ * Background: v1.4.1 fixed two compounding Node 26 / undici 8.x regressions
+ * on the vCenter SOAP path (brotli skipped, headers swallowed). The same
+ * `fetch + dispatcher` pattern existed in XCP-ng / Hyper-V / Nutanix clients;
+ * this helper centralises the defensive headers so the pattern is enforced
+ * once instead of duplicated per call site.
+ */
+
+export const INSECURE_FETCH_HEADERS = {
+  "Accept-Encoding": "identity",
+} as const
+
+export async function makeInsecureDispatcher(): Promise<unknown> {
+  const { Agent } = await import("undici")
+  return new Agent({ connect: { rejectUnauthorized: false } })
+}
+
+export type InsecureFetchInit = RequestInit & {
+  insecureTLS?: boolean
+  dispatcher?: unknown
+}
+
+export async function fetchWithInsecureTLS(
+  url: string,
+  opts: InsecureFetchInit = {}
+): Promise<Response> {
+  const { insecureTLS, headers, dispatcher, ...rest } = opts
+
+  const finalOpts: InsecureFetchInit = {
+    ...rest,
+    headers: { ...INSECURE_FETCH_HEADERS, ...headers },
+  }
+
+  if (dispatcher) {
+    finalOpts.dispatcher = dispatcher
+  } else if (insecureTLS) {
+    finalOpts.dispatcher = await makeInsecureDispatcher()
+  }
+
+  return fetch(url, finalOpts as RequestInit)
+}

--- a/frontend/src/lib/hyperv/winrm.ts
+++ b/frontend/src/lib/hyperv/winrm.ts
@@ -317,6 +317,9 @@ export class WinRMClient {
       headers: {
         "Content-Type": "application/soap+xml;charset=UTF-8",
         Authorization: this.authHeader,
+        // Defeat brotli/zstd decode regressions on Node 26 + undici 8.x when
+        // a custom dispatcher is attached (see lib/http/insecure-fetch.ts).
+        "Accept-Encoding": "identity",
       },
       body: soapXml,
       signal: AbortSignal.timeout(this.timeout),

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -29,6 +29,7 @@ import { pveFetch } from "@/lib/proxmox/client"
 import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH } from "@/lib/ssh/exec"
 import { getXoConnectionInfo, xoGetVmConfig, buildVdiDownloadUrl, xoCreateSnapshot, xoDeleteSnapshot } from "@/lib/xcpng/client"
+import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
@@ -739,17 +740,13 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       const downtimeStart = Date.now()
       await appendLog(jobId, "Shutting down source VM for cutover (downtime starts now)...", "warn")
       try {
-        const xoFetchInternal = async (path: string, opts: RequestInit = {}) => {
-          const fetchOpts: any = {
+        const xoFetchInternal = (path: string, opts: RequestInit = {}) =>
+          fetchWithInsecureTLS(`${xo.baseUrl}/rest/v0${path}`, {
             ...opts,
             headers: { Authorization: xo.authHeader, "Content-Type": "application/json", ...opts.headers },
             signal: AbortSignal.timeout(30000),
-          }
-          if (xo.insecureTLS) {
-            fetchOpts.dispatcher = new (await import("undici")).Agent({ connect: { rejectUnauthorized: false } })
-          }
-          return fetch(`${xo.baseUrl}/rest/v0${path}`, fetchOpts)
-        }
+            insecureTLS: xo.insecureTLS,
+          })
 
         const shutRes = await xoFetchInternal(`/vms/${config.sourceVmId}/actions/clean_shutdown`, { method: "POST" })
         if (!shutRes.ok) {

--- a/frontend/src/lib/nutanix/client.ts
+++ b/frontend/src/lib/nutanix/client.ts
@@ -64,6 +64,9 @@ export class NutanixClient {
         Authorization: this.authHeader,
         "Content-Type": "application/json",
         Accept: "application/json",
+        // Defeat brotli/zstd decode regressions on Node 26 + undici 8.x when
+        // a custom dispatcher is attached (see lib/http/insecure-fetch.ts).
+        "Accept-Encoding": "identity",
       },
       signal: AbortSignal.timeout(30_000),
     }

--- a/frontend/src/lib/xcpng/client.test.ts
+++ b/frontend/src/lib/xcpng/client.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { xoCreateSnapshot, buildVdiDownloadUrl, buildXoAuthHeader } from "./client"
+import type { XoConnectionInfo } from "./client"
+
+describe("xcpng/client", () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  const xo: XoConnectionInfo = {
+    baseUrl: "https://xo.test",
+    authHeader: "Basic dXNlcjpwYXNz",
+    insecureTLS: false,
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe("buildVdiDownloadUrl", () => {
+    it("builds raw download URL by default", () => {
+      expect(buildVdiDownloadUrl("https://xo.test", "vdi-1")).toBe(
+        "https://xo.test/rest/v0/vdis/vdi-1.raw"
+      )
+    })
+
+    it("supports vhd format when explicitly requested", () => {
+      expect(buildVdiDownloadUrl("https://xo.test", "vdi-1", "vhd")).toBe(
+        "https://xo.test/rest/v0/vdis/vdi-1.vhd"
+      )
+    })
+
+    it("strips a trailing slash from the base URL", () => {
+      expect(buildVdiDownloadUrl("https://xo.test/", "vdi-1")).toBe(
+        "https://xo.test/rest/v0/vdis/vdi-1.raw"
+      )
+    })
+  })
+
+  describe("buildXoAuthHeader", () => {
+    it("builds a Basic auth header from user:password credentials", () => {
+      expect(buildXoAuthHeader("user:pass")).toBe("Basic dXNlcjpwYXNz")
+    })
+  })
+
+  describe("xoCreateSnapshot (xoPost regression coverage)", () => {
+    it("parses a JSON body without depending on Content-Type", async () => {
+      // Regression: on Node 26 + undici 8.x with a custom dispatcher,
+      // res.headers.get('content-type') can return null even when the server
+      // sent it. The fix parses the body with JSON.parse + text fallback
+      // instead of branching on the header.
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ $id: "snap-uuid-1" }), { status: 200 })
+      )
+
+      const result = await xoCreateSnapshot(xo, "vm-uuid", "snap-name")
+      expect(result).toBe("snap-uuid-1")
+    })
+
+    it("returns the plain-text UUID when XO returns a bare string", async () => {
+      const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+      fetchMock.mockResolvedValueOnce(new Response(uuid, { status: 200 }))
+
+      const result = await xoCreateSnapshot(xo, "vm-uuid", "snap-name")
+      expect(result).toBe(uuid)
+    })
+
+    it("posts to the snapshot endpoint with the right body and helper headers", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("a1b2c3d4-e5f6-7890-abcd-ef1234567890", { status: 200 })
+      )
+
+      await xoCreateSnapshot(xo, "vm-source-uuid", "test-snap")
+
+      const [url, opts] = fetchMock.mock.calls[0]
+      expect(url).toBe("https://xo.test/rest/v0/vms/vm-source-uuid/actions/snapshot")
+      expect((opts as any).method).toBe("POST")
+      expect(JSON.parse((opts as any).body)).toEqual({ name: "test-snap" })
+      expect((opts as any).headers["Authorization"]).toBe("Basic dXNlcjpwYXNz")
+      // Defensive header injected by fetchWithInsecureTLS to defeat
+      // brotli/zstd regressions on Node 26 + undici 8.x.
+      expect((opts as any).headers["Accept-Encoding"]).toBe("identity")
+    })
+
+    it("surfaces the HTTP status and body when XO returns non-2xx", async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response("not authorized", { status: 401, statusText: "Unauthorized" })
+      )
+
+      await expect(xoCreateSnapshot(xo, "vm-uuid", "snap")).rejects.toThrow(
+        /XO API POST .* failed: 401 Unauthorized not authorized/
+      )
+    })
+  })
+})

--- a/frontend/src/lib/xcpng/client.ts
+++ b/frontend/src/lib/xcpng/client.ts
@@ -14,6 +14,7 @@
 
 import { getSessionPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
+import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 
 export interface XoConnectionInfo {
   baseUrl: string
@@ -78,21 +79,14 @@ export async function getXoConnectionInfo(connectionId: string): Promise<XoConne
  * Fetch from XO REST API
  */
 async function xoFetch<T = any>(xo: XoConnectionInfo, path: string): Promise<T> {
-  const fetchOpts: any = {
+  const res = await fetchWithInsecureTLS(`${xo.baseUrl}/rest/v0${path}`, {
     headers: {
       Authorization: xo.authHeader,
       Accept: "application/json",
     },
     signal: AbortSignal.timeout(30000),
-  }
-
-  if (xo.insecureTLS) {
-    fetchOpts.dispatcher = new (await import("undici")).Agent({
-      connect: { rejectUnauthorized: false },
-    })
-  }
-
-  const res = await fetch(`${xo.baseUrl}/rest/v0${path}`, fetchOpts)
+    insecureTLS: xo.insecureTLS,
+  })
 
   if (!res.ok) {
     throw new Error(`XO API error: ${res.status} ${res.statusText}`)
@@ -197,57 +191,45 @@ export function buildXoAuthHeader(creds: string): string {
  * POST to XO REST API (actions, snapshot creation, etc.)
  */
 async function xoPost<T = any>(xo: XoConnectionInfo, path: string, body?: Record<string, any>): Promise<T> {
-  const fetchOpts: any = {
+  const res = await fetchWithInsecureTLS(`${xo.baseUrl}/rest/v0${path}`, {
     method: "POST",
     headers: {
       Authorization: xo.authHeader,
       "Content-Type": "application/json",
       Accept: "application/json",
     },
+    body: body ? JSON.stringify(body) : undefined,
     signal: AbortSignal.timeout(120000),
-  }
-
-  if (body) fetchOpts.body = JSON.stringify(body)
-
-  if (xo.insecureTLS) {
-    fetchOpts.dispatcher = new (await import("undici")).Agent({
-      connect: { rejectUnauthorized: false },
-    })
-  }
-
-  const res = await fetch(`${xo.baseUrl}/rest/v0${path}`, fetchOpts)
+    insecureTLS: xo.insecureTLS,
+  })
 
   if (!res.ok) {
-    const text = await res.text().catch(() => "")
-    throw new Error(`XO API POST ${path} failed: ${res.status} ${res.statusText} ${text}`)
+    const errText = await res.text().catch(() => "")
+    throw new Error(`XO API POST ${path} failed: ${res.status} ${res.statusText} ${errText}`)
   }
 
-  const contentType = res.headers.get("content-type") || ""
-  if (contentType.includes("application/json")) {
-    return res.json()
-  }
-  // Some XO actions return the UUID as plain text
+  // Parse from the body, not from Content-Type: on Node 26 + undici 8.x with a
+  // custom dispatcher, response headers can come back empty so Content-Type is
+  // unreliable. XO endpoints return either JSON or a plain-text UUID/task path.
   const text = await res.text()
-  return text.trim() as unknown as T
+  try {
+    return JSON.parse(text) as T
+  } catch {
+    return text.trim() as unknown as T
+  }
 }
 
 /**
  * DELETE on XO REST API
  */
 async function xoDelete(xo: XoConnectionInfo, path: string): Promise<void> {
-  const fetchOpts: any = {
+  const res = await fetchWithInsecureTLS(`${xo.baseUrl}/rest/v0${path}`, {
     method: "DELETE",
     headers: { Authorization: xo.authHeader },
     signal: AbortSignal.timeout(60000),
-  }
+    insecureTLS: xo.insecureTLS,
+  })
 
-  if (xo.insecureTLS) {
-    fetchOpts.dispatcher = new (await import("undici")).Agent({
-      connect: { rejectUnauthorized: false },
-    })
-  }
-
-  const res = await fetch(`${xo.baseUrl}/rest/v0${path}`, fetchOpts)
   if (!res.ok && res.status !== 404) {
     throw new Error(`XO API DELETE ${path} failed: ${res.status} ${res.statusText}`)
   }


### PR DESCRIPTION
## Summary

Extends the v1.4.1 vCenter fix (#339) to the three remaining migration-source pipelines that share the same `fetch + custom dispatcher` pattern. Closes #340.

- **Real bug (HIGH, XCP-ng):** `xoPost` picked its parser via `res.headers.get("content-type")`, which returns `null` on Node 26 + undici 8.x when a custom dispatcher is attached. JSON responses were treated as plain text, breaking `xoCreateSnapshot` and the live-migration path in `xcpng-pipeline.ts`. Now parses from the body with `JSON.parse` + text fallback, no dependency on response headers.
- **Defensive (XCP-ng + Hyper-V + Nutanix):** add `Accept-Encoding: identity` to defeat brotli/zstd decoding regressions seen on the vCenter path.
- **Helper extraction:** new `lib/http/insecure-fetch.ts` centralises `fetchWithInsecureTLS` so the pattern is enforced once instead of duplicated across call sites.
- **Out of scope:** `lib/vmware/soap.ts` already moved to `undici.request()` in v1.4.1.

## Files touched

| File | Change |
|---|---|
| `lib/http/insecure-fetch.ts` *(new)* | Helper + `INSECURE_FETCH_HEADERS` constant |
| `lib/xcpng/client.ts` | `xoFetch`, `xoPost`, `xoDelete` migrated; `xoPost` JSON parsing fix |
| `lib/migration/xcpng-pipeline.ts` | inline `xoFetchInternal` migrated |
| `lib/hyperv/winrm.ts` | `Accept-Encoding: identity` added to `WinRM.post` |
| `lib/nutanix/client.ts` | `Accept-Encoding: identity` added to `fetchOpts()` |

## Test plan

- [x] XCP-ng: list VMs from a connection in `insecureTLS=true` mode (smoke tested)
- [x] Hyper-V: list VMs, no behaviour change (smoke tested)
- [ ] Nutanix: lab unavailable, change is header-only, no logic touched
- [x] vCenter: unchanged, still works