### PR TITLE
fix(deps): override js-cookie to 3.0.7 to clear Dependabot HIGH (#344)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4739,6 +4739,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4748,7 +4749,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -10353,10 +10354,13 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
-      "license": "MIT"
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14757,7 +14761,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,6 +131,7 @@
     "@hono/node-server": ">=1.19.13",
     "defu": ">=6.1.5",
     "fast-uri": ">=3.1.2",
-    "postcss": "$postcss"
+    "postcss": "$postcss",
+    "js-cookie": "^3.0.7"
   }
 }


### PR DESCRIPTION
## Summary

Closes #344. Forces \`js-cookie@^3.0.7\` across the dependency tree via \`overrides\` to clear [Dependabot #165/#166](https://github.com/adminsyspro/proxcenter-ui/security/dependabot/166) ([GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j), prototype hijack in \`Cookies.set\` \`assign()\`).

\`react-use@17.6.0\` still pins \`js-cookie ^2.2.1\` transitively, so a plain bump is impossible — an override is the cleanest path. Our two callers (\`useObjectCookie.js\`, \`useLayoutInit.js\`) pass constant attributes only, so the GHSA is **not exploitable in our usage**, but we want the alert closed and the patched version on disk regardless.

## Verification

- \`npm ls js-cookie\` → \`js-cookie@3.0.7 overridden\`
- \`react-use\`'s internal \`useCookie\` only uses \`get\`/\`set\`/\`remove\` — fully compatible with js-cookie 3.x (no \`getJSON\` or \`withConverter\` calls that broke in 3.x)
- 583/583 tests pass
- Color preference + settings cookies survive a page reload in dev (Community mode)

## Files

- \`frontend/package.json\` — added \`"js-cookie": "^3.0.7"\` to \`overrides\`
- \`frontend/package-lock.json\` — regenerated

## Test plan

- [x] \`npm ls js-cookie\` shows >= 3.0.7
- [x] Full test suite passes (583/583)
- [x] Color preference cookie survives reload
- [x] Settings/customizer cookie survives reload
- [ ] Dependabot #165/#166 auto-closes once merged