### PR TITLE
fix(oidc): pass issuer to NextAuth on manual endpoint-override path

### DIFF
--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -656,6 +656,11 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
     id: 'oidc',
     name: oidcConfig.providerName || 'SSO',
     type: 'oauth',
+    // When manual endpoint overrides are used we skip .well-known discovery,
+    // so openid-client has no canonical issuer to validate the id_token `iss`
+    // claim against and rejects every callback with `expected undefined`.
+    // Passing `issuer` here gives it the value to compare against.
+    issuer: oidcConfig.authorizationUrl ? oidcConfig.issuerUrl : undefined,
     wellKnown: oidcConfig.authorizationUrl ? undefined : `${oidcConfig.issuerUrl.replace(/\/+$/, '')}/.well-known/openid-configuration`,
     authorization: oidcConfig.authorizationUrl ? {
       url: oidcConfig.authorizationUrl,


### PR DESCRIPTION
## Summary

OIDC sign-in fails with `unexpected iss value, expected undefined` whenever the **Advanced Endpoints** override fields (Authorization URL, Token URL, Userinfo URL) are populated.

When those overrides are set, ProxCenter skips `.well-known/openid-configuration` discovery and openid-client builds the `Issuer` from the raw endpoints, with no canonical `issuer` metadata. The id_token's `iss` claim then has nothing to validate against, so every callback is rejected.

This passes the configured **Issuer URL** through to NextAuth on the manual-override path only. The discovery path (no overrides) is untouched.

## Changes

- `frontend/src/lib/auth/config.ts`: add `issuer: oidcConfig.authorizationUrl ? oidcConfig.issuerUrl : undefined` to the dynamically-built OIDC provider.

## Context

Reported in discussion #349 (Duo SSO behind nginx). The workaround (clear the override fields, keep only Issuer URL) was confirmed working by the reporter; this removes the foot-gun so all four fields can be populated safely.

Docs updated in proxcenter-docs (ldap-oidc + sso-duo troubleshooting).

## Test plan

- [ ] OIDC provider with override fields set: sign-in completes, no `expected undefined` in the `frontend` container log.
- [ ] OIDC provider using discovery only (no overrides): sign-in still works, no regression.
- [ ] Local credentials / LDAP sign-in unaffected.