### PR TITLE
fix(alerts): pull-based threshold + silence sync (#359)

### DIFF
--- a/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
@@ -84,6 +84,26 @@ describe('GET /api/v1/internal/alert-config', () => {
     expect(body.thresholds.snapshot_max_age_days).toBe(7)
   })
 
+  it('truncates fractional snapshot_max_age_days to int for the Go decoder', async () => {
+    // The Go AlertThresholds struct decodes snapshot_max_age_days as int.
+    // A fractional value (which the settings PUT path can persist) would make
+    // the configsync JSON decode fail and silently freeze the worker — exactly
+    // the silent-stale regression #359 is meant to eliminate.
+    getSettingMock.mockResolvedValueOnce({
+      memory_warning: 90,
+      snapshot_max_age_days: 7.9,
+    })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.thresholds.snapshot_max_age_days).toBe(7)
+    expect(Number.isInteger(body.thresholds.snapshot_max_age_days)).toBe(true)
+    // Non-int-typed fields stay as-is.
+    expect(body.thresholds.memory_warning).toBe(90)
+  })
+
   it('honors X-Tenant-ID by scoping the query', async () => {
     getSettingMock.mockResolvedValueOnce({})
     findManyMock.mockResolvedValueOnce([])

--- a/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const findManyMock = vi.fn()
+const getSettingMock = vi.fn()
+
+vi.mock('@/lib/db/settings', () => ({
+  getSetting: (...args: unknown[]) => getSettingMock(...args),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  DEFAULT_TENANT_ID: 'default',
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    alertSilence: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+    },
+  },
+}))
+
+import { GET } from '../route'
+
+function makeReq(headers: Record<string, string>) {
+  return new Request('http://localhost/api/v1/internal/alert-config', { headers })
+}
+
+beforeEach(() => {
+  findManyMock.mockReset()
+  getSettingMock.mockReset()
+  process.env.ORCHESTRATOR_API_KEY = 'secret-key'
+})
+
+describe('GET /api/v1/internal/alert-config', () => {
+  it('returns 401 when X-API-Key is missing', async () => {
+    const res = await GET(makeReq({}))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when X-API-Key is wrong', async () => {
+    const res = await GET(makeReq({ 'X-API-Key': 'nope' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when ORCHESTRATOR_API_KEY env var is empty', async () => {
+    process.env.ORCHESTRATOR_API_KEY = ''
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 200 + payload with valid key', async () => {
+    getSettingMock.mockResolvedValueOnce({
+      cpu_warning: 80, cpu_critical: 90,
+      memory_warning: 90, memory_critical: 95,
+      storage_warning: 80, storage_critical: 90,
+      snapshot_max_age_days: 7,
+    })
+    const future = new Date(Date.now() + 60_000)
+    findManyMock.mockResolvedValueOnce([
+      { fingerprint: 'fp-future', silencedUntil: future },
+      { fingerprint: 'fp-indef', silencedUntil: null },
+    ])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.thresholds.memory_warning).toBe(90)
+    expect(body.silences).toHaveLength(2)
+    expect(body.silences.map((s: { fingerprint: string }) => s.fingerprint)).toEqual(
+      expect.arrayContaining(['fp-future', 'fp-indef']),
+    )
+    expect(body.generated_at).toBeTruthy()
+    expect(res.headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('returns default thresholds when no setting stored', async () => {
+    getSettingMock.mockResolvedValueOnce(null)
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.thresholds.memory_warning).toBe(80)
+    expect(body.thresholds.snapshot_max_age_days).toBe(7)
+  })
+
+  it('honors X-Tenant-ID by scoping the query', async () => {
+    getSettingMock.mockResolvedValueOnce({})
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key', 'X-Tenant-ID': 'tenant-B' }))
+    expect(res.status).toBe(200)
+    expect(getSettingMock).toHaveBeenCalledWith('alert_thresholds', 'tenant-B')
+    // Also verify the silences query filtered by tenantId.
+    const call = findManyMock.mock.calls[0][0]
+    expect(call.where.tenantId).toBe('tenant-B')
+  })
+
+  it('filters expired silences server-side', async () => {
+    getSettingMock.mockResolvedValueOnce({})
+    findManyMock.mockResolvedValueOnce([
+      { fingerprint: 'fp-active', silencedUntil: null },
+    ])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    // The `findMany.where` clause should pass an OR filter excluding expired rows;
+    // the result here mocks the post-filter list, so we just confirm the contract
+    // by verifying the prisma call included the OR clause.
+    const call = findManyMock.mock.calls[0][0]
+    expect(call.where.OR).toBeDefined()
+    expect(call.where.OR.some((c: { silencedUntil: { gt?: Date } | null }) => c.silencedUntil === null)).toBe(true)
+    expect(body.silences).toEqual([{ fingerprint: 'fp-active', silenced_until: null }])
+  })
+})

--- a/frontend/src/app/api/internal/alert-config/route.ts
+++ b/frontend/src/app/api/internal/alert-config/route.ts
@@ -19,13 +19,19 @@ const DEFAULT_THRESHOLDS = {
 
 type Thresholds = typeof DEFAULT_THRESHOLDS
 
+// Fields the Go orchestrator decodes as int (see backend AlertThresholds).
+// A fractional value here makes the configsync JSON decode fail and the worker
+// rejects the entire payload, leaving thresholds and silences silently stale.
+const INT_THRESHOLD_KEYS: ReadonlySet<keyof Thresholds> = new Set(['snapshot_max_age_days'])
+
 function coerceThresholds(raw: unknown): Thresholds {
   const t = { ...DEFAULT_THRESHOLDS }
   if (!raw || typeof raw !== 'object') return t
   const obj = raw as Record<string, unknown>
   for (const key of Object.keys(DEFAULT_THRESHOLDS) as (keyof Thresholds)[]) {
     const v = obj[key]
-    if (typeof v === 'number' && Number.isFinite(v)) t[key] = v
+    if (typeof v !== 'number' || !Number.isFinite(v)) continue
+    t[key] = INT_THRESHOLD_KEYS.has(key) ? Math.trunc(v) : v
   }
   return t
 }

--- a/frontend/src/app/api/internal/alert-config/route.ts
+++ b/frontend/src/app/api/internal/alert-config/route.ts
@@ -1,0 +1,102 @@
+export const dynamic = 'force-dynamic'
+import { NextResponse } from 'next/server'
+
+import { prisma } from '@/lib/db/prisma'
+import { getSetting } from '@/lib/db/settings'
+import { DEFAULT_TENANT_ID } from '@/lib/tenant'
+
+export const runtime = 'nodejs'
+
+const DEFAULT_THRESHOLDS = {
+  cpu_warning: 80,
+  cpu_critical: 90,
+  memory_warning: 80,
+  memory_critical: 90,
+  storage_warning: 80,
+  storage_critical: 90,
+  snapshot_max_age_days: 7,
+}
+
+type Thresholds = typeof DEFAULT_THRESHOLDS
+
+function coerceThresholds(raw: unknown): Thresholds {
+  const t = { ...DEFAULT_THRESHOLDS }
+  if (!raw || typeof raw !== 'object') return t
+  const obj = raw as Record<string, unknown>
+  for (const key of Object.keys(DEFAULT_THRESHOLDS) as (keyof Thresholds)[]) {
+    const v = obj[key]
+    if (typeof v === 'number' && Number.isFinite(v)) t[key] = v
+  }
+  return t
+}
+
+/**
+ * GET /api/v1/internal/alert-config
+ *
+ * Consolidated config endpoint consumed by the Go orchestrator's configsync
+ * worker (issue #359). It pulls the current alert thresholds and the active
+ * silence set every 30s so the orchestrator no longer relies on the frontend
+ * pushing changes synchronously (the old PUT best-effort push was racy and
+ * silently dropped writes on a cold orchestrator).
+ *
+ * Auth: shared X-API-Key matching process.env.ORCHESTRATOR_API_KEY. A missing
+ * or empty env var always denies — we never want a misconfigured deployment
+ * to expose this endpoint without a key.
+ *
+ * Tenant scope: optional X-Tenant-ID header (default: provider tenant
+ * `default`). Phase B keeps the orchestrator single-tenant, but the header
+ * is wired through now to avoid a breaking change later.
+ *
+ * Body excludes expired silences (server-side OR filter) — the orchestrator
+ * does not need to re-evaluate `silenced_until` on the wire and a stale row
+ * was previously the only way to "unsilence by inaction".
+ *
+ * Cache-Control is `no-store` because thresholds and silences must propagate
+ * within the 30s poll cycle; an upstream proxy caching this response would
+ * pin alerting to a frozen state.
+ */
+export async function GET(req: Request) {
+  const expectedKey = process.env.ORCHESTRATOR_API_KEY
+  const providedKey = req.headers.get('X-API-Key')
+
+  if (!expectedKey || !providedKey || providedKey !== expectedKey) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const tenantId = req.headers.get('X-Tenant-ID') || DEFAULT_TENANT_ID
+
+  try {
+    const storedThresholds = await getSetting<unknown>('alert_thresholds', tenantId)
+    const thresholds = coerceThresholds(storedThresholds)
+
+    const now = new Date()
+    const silenceRows = await prisma.alertSilence.findMany({
+      where: {
+        tenantId,
+        OR: [
+          { silencedUntil: null },
+          { silencedUntil: { gt: now } },
+        ],
+      },
+      select: { fingerprint: true, silencedUntil: true },
+    })
+
+    const silences = silenceRows.map(s => ({
+      fingerprint: s.fingerprint,
+      silenced_until: s.silencedUntil ? s.silencedUntil.toISOString() : null,
+    }))
+
+    return NextResponse.json(
+      {
+        thresholds,
+        silences,
+        generated_at: now.toISOString(),
+      },
+      { headers: { 'Cache-Control': 'no-store' } },
+    )
+  } catch (error: unknown) {
+    const msg = error instanceof Error ? error.message : 'internal error'
+    console.error('[internal/alert-config] GET error:', msg)
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/v1/orchestrator/alerts/active/__tests__/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/active/__tests__/route.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const getActiveAlertsMock = vi.fn()
+const findManyMock = vi.fn()
+const isAlertVisibleToTenantMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  alertsApi: { getActiveAlerts: (...args: unknown[]) => getActiveAlertsMock(...args) },
+}))
+
+vi.mock('@/lib/demo/demo-api', () => ({
+  demoResponse: () => null,
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: vi.fn().mockResolvedValue('default'),
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>()),
+  getSessionPrisma: vi.fn().mockResolvedValue({
+    alertSilence: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+    },
+  }),
+}))
+
+vi.mock('@/lib/vdc/scope', () => ({
+  getVdcScope: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn().mockResolvedValue(null),
+  PERMISSIONS: { ALERTS_VIEW: 'alerts.view' },
+}))
+
+vi.mock('@/lib/alerts/visibility', () => ({
+  isAlertVisibleToTenant: (...args: unknown[]) => isAlertVisibleToTenantMock(...args),
+}))
+
+vi.mock('@/lib/alerts/vdcVmids', () => ({
+  getVdcVmidsByConnection: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { GET } from '../route'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
+
+function makeReq() {
+  return new Request('http://localhost/api/v1/orchestrator/alerts/active')
+}
+
+beforeEach(() => {
+  getActiveAlertsMock.mockReset()
+  findManyMock.mockReset()
+  isAlertVisibleToTenantMock.mockReset()
+  isAlertVisibleToTenantMock.mockResolvedValue(true)
+})
+
+describe('GET /api/v1/orchestrator/alerts/active', () => {
+  it('returns alerts unchanged when no silences exist', async () => {
+    const alert = {
+      connection_id: 'conn-1',
+      type: 'memory',
+      severity: 'warning',
+      resource_type: 'node',
+      resource: 'pve-node-1',
+    }
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [alert] })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].resource).toBe('pve-node-1')
+  })
+
+  it('drops alerts whose fingerprint is silenced', async () => {
+    const muted = {
+      connection_id: 'conn-1',
+      type: 'memory',
+      severity: 'warning',
+      resource_type: 'node',
+      resource: 'pve-node-1',
+    }
+    const visible = {
+      connection_id: 'conn-1',
+      type: 'cpu',
+      severity: 'warning',
+      resource_type: 'node',
+      resource: 'pve-node-2',
+    }
+    const mutedFp = buildOrchestratorFingerprint(muted)
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [muted, visible] })
+    findManyMock.mockResolvedValueOnce([{ fingerprint: mutedFp }])
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].resource).toBe('pve-node-2')
+  })
+
+  it('queries silences with the non-expired OR clause', async () => {
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [{ connection_id: 'c', type: 'cpu' }] })
+    findManyMock.mockResolvedValueOnce([])
+
+    await GET(makeReq())
+
+    expect(findManyMock).toHaveBeenCalledTimes(1)
+    const where = findManyMock.mock.calls[0][0].where
+    expect(where.OR).toBeDefined()
+    expect(where.OR.some((c: { silencedUntil: unknown }) => c.silencedUntil === null)).toBe(true)
+    expect(where.OR.some((c: { silencedUntil: { gt?: Date } }) => c.silencedUntil && (c.silencedUntil as { gt?: Date }).gt instanceof Date)).toBe(true)
+  })
+
+  it('skips the silence query when there are no alerts', async () => {
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [] })
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual([])
+    expect(findManyMock).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a Prisma error (AlertSilence table missing) by returning visible alerts un-filtered', async () => {
+    const alert = { connection_id: 'c', type: 'cpu', severity: 'warning', resource_type: 'node', resource: 'n' }
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [alert] })
+    findManyMock.mockRejectedValueOnce(new Error('relation "AlertSilence" does not exist'))
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+  })
+
+  it('filters out alerts not visible to the tenant before applying silence filter', async () => {
+    const a1 = { connection_id: 'c', type: 'cpu', severity: 'warning', resource_type: 'node', resource: 'n1' }
+    const a2 = { connection_id: 'c', type: 'cpu', severity: 'warning', resource_type: 'node', resource: 'n2' }
+    getActiveAlertsMock.mockResolvedValueOnce({ data: [a1, a2] })
+    // Only a2 is visible to this tenant
+    isAlertVisibleToTenantMock.mockImplementation((a: { resource: string }) => Promise.resolve(a.resource === 'n2'))
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].resource).toBe('n2')
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/alerts/active/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/active/route.ts
@@ -2,18 +2,21 @@ import { NextResponse } from 'next/server'
 
 import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
-import { getCurrentTenantId, getTenantConnectionIds } from '@/lib/tenant'
+import { getCurrentTenantId, getSessionPrisma, getTenantConnectionIds } from '@/lib/tenant'
 import { getVdcScope } from '@/lib/vdc/scope'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
 /**
  * GET /api/v1/orchestrator/alerts/active
- * Récupère uniquement les alertes actives, filtrées par tenant
+ * Récupère uniquement les alertes actives, filtrées par tenant ET par silences.
+ * Silenced alerts are excluded entirely — the sole consumer is the Infrastructure
+ * Health badge counter, which should reflect "alerts the user has not muted".
  */
 export async function GET(req: Request) {
   const demo = demoResponse(req)
@@ -46,6 +49,26 @@ export async function GET(req: Request) {
         alerts.map((a: any) => isAlertVisibleToTenant(a, visibilityCtx)),
       )
       filtered = alerts.filter((_: any, i: number) => visible[i])
+    }
+
+    // Drop silenced alerts. The sibling /alerts route annotates with
+    // status='silenced' so the list view can still show them; here we
+    // exclude them so the badge counter respects the mute.
+    if (Array.isArray(filtered) && filtered.length > 0) {
+      try {
+        const prisma = await getSessionPrisma()
+        const now = new Date()
+        const silences = await prisma.alertSilence.findMany({
+          where: { OR: [{ silencedUntil: null }, { silencedUntil: { gt: now } }] },
+          select: { fingerprint: true },
+        })
+        const silencedFingerprints = new Set(silences.map(s => s.fingerprint))
+        if (silencedFingerprints.size > 0) {
+          filtered = filtered.filter((a: any) => !silencedFingerprints.has(buildOrchestratorFingerprint(a)))
+        }
+      } catch {
+        // AlertSilence table may not exist yet — fall through with un-filtered results
+      }
     }
 
     return NextResponse.json(filtered)

--- a/frontend/src/app/api/v1/orchestrator/alerts/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/route.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import { NextResponse } from 'next/server'
 
 import { alertsApi } from '@/lib/orchestrator/client'
@@ -8,33 +7,10 @@ import { getVdcScope } from '@/lib/vdc/scope'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-/**
- * Build a fingerprint from an orchestrator alert to match against silences
- * and to dedupe within the list view.
- *
- * `rule_id` is part of the key: when two rules fire on the same event
- * (e.g. NEW-MSP "test" + CLOUD-MSP "start/stop" both subscribed to
- * vmstart on a shared cluster), the orchestrator stores them as two
- * rows with the same connection/severity/resource. Without rule_id in
- * the fingerprint they'd dedupe into one row and the wrong tenant
- * could end up owning the surviving alert.
- */
-function buildOrchestratorFingerprint(alert: {
-  connection_id?: string
-  type?: string
-  severity?: string
-  resource?: string
-  resource_type?: string
-  rule_id?: string
-}): string {
-  const source = alert.connection_id ? `${alert.connection_id}:${alert.type || ''}` : (alert.type || '')
-  const data = `${source}|${alert.severity || ''}|${alert.resource_type || ''}|${alert.resource || ''}|${alert.type || ''}|${alert.rule_id || ''}`
-  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 32)
-}
 
 /**
  * GET /api/v1/orchestrator/alerts

--- a/frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto'
 import { NextResponse } from 'next/server'
 
 import { alertsApi } from '@/lib/orchestrator/client'
@@ -8,23 +7,10 @@ import { getVdcScope } from '@/lib/vdc/scope'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-// rule_id MUST be in the fingerprint — see route.ts for the why.
-function buildOrchestratorFingerprint(alert: {
-  connection_id?: string
-  type?: string
-  severity?: string
-  resource?: string
-  resource_type?: string
-  rule_id?: string
-}): string {
-  const source = alert.connection_id ? `${alert.connection_id}:${alert.type || ''}` : (alert.type || '')
-  const data = `${source}|${alert.severity || ''}|${alert.resource_type || ''}|${alert.resource || ''}|${alert.type || ''}|${alert.rule_id || ''}`
-  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 32)
-}
 
 /**
  * GET /api/v1/orchestrator/alerts/summary

--- a/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
+++ b/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
@@ -1,0 +1,47 @@
+import crypto from 'crypto'
+import { describe, expect, it } from 'vitest'
+
+// This is the canonical contract that backend/internal/alerts/fingerprint.go must
+// also implement. Both implementations are tested against the same 6 vectors; any
+// drift breaks silence matching between the orchestrator and the UI mute flow.
+//
+// DO NOT REFACTOR THIS FUNCTION HERE WITHOUT UPDATING:
+//   - frontend/src/app/api/v1/orchestrator/alerts/route.ts (l.26-37)
+//   - frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts (l.16)
+//   - backend/internal/alerts/fingerprint.go (and its tests)
+function buildOrchestratorFingerprint(alert: {
+  connection_id?: string
+  type?: string
+  severity?: string
+  resource?: string
+  resource_type?: string
+  rule_id?: string
+}): string {
+  const source = alert.connection_id ? `${alert.connection_id}:${alert.type || ''}` : (alert.type || '')
+  const data = `${source}|${alert.severity || ''}|${alert.resource_type || ''}|${alert.resource || ''}|${alert.type || ''}|${alert.rule_id || ''}`
+  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 32)
+}
+
+describe('buildOrchestratorFingerprint (canonical contract)', () => {
+  const vectors = [
+    { name: 'vector1 node memory warning',       input: { connection_id: 'conn-abc123', type: 'memory',  severity: 'warning',  resource_type: 'node',  resource: 'pve-node-1' }, expected: '575acbec94557a1819409ecbb0cc251b' },
+    { name: 'vector2 node memory critical',      input: { connection_id: 'conn-abc123', type: 'memory',  severity: 'critical', resource_type: 'node',  resource: 'pve-node-1' }, expected: 'e078e43ce5591e33de724764b83673bb' },
+    { name: 'vector3 vm cpu warning',            input: { connection_id: 'conn-abc123', type: 'cpu',     severity: 'warning',  resource_type: 'vm',    resource: 'my-vm' },      expected: '4687c5f16158d0e0b1eda9e512497569' },
+    { name: 'vector4 storage on node',           input: { connection_id: 'conn-abc123', type: 'storage', severity: 'warning',  resource_type: 'node',  resource: 'pve-node-1' }, expected: 'a5a9f0d7ba8311b6dfbb879d0c3b50c3' },
+    { name: 'vector5 event with rule',           input: { connection_id: 'conn-abc123', type: 'event',   severity: 'warning',  resource_type: 'event', resource: '100', rule_id: 'rule-uuid-xyz' },   expected: '381423f2e2a93b55a890900ea01503c4' },
+    { name: 'vector6 event with different rule', input: { connection_id: 'conn-abc123', type: 'event',   severity: 'warning',  resource_type: 'event', resource: '100', rule_id: 'rule-uuid-OTHER' }, expected: '619999b15c20bc06ce993bf9042de5f3' },
+  ] as const
+
+  for (const v of vectors) {
+    it(v.name, () => {
+      expect(buildOrchestratorFingerprint(v.input)).toBe(v.expected)
+    })
+  }
+
+  it('rule_id changes the hash', () => {
+    const base = { connection_id: 'conn-abc123', type: 'event', severity: 'warning', resource_type: 'event', resource: '100' }
+    const a = buildOrchestratorFingerprint({ ...base, rule_id: 'rule-A' })
+    const b = buildOrchestratorFingerprint({ ...base, rule_id: 'rule-B' })
+    expect(a).not.toBe(b)
+  })
+})

--- a/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
+++ b/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
@@ -29,4 +29,27 @@ describe('buildOrchestratorFingerprint (canonical contract)', () => {
     const b = buildOrchestratorFingerprint({ ...base, rule_id: 'rule-B' })
     expect(a).not.toBe(b)
   })
+
+  it('falls back to type alone when connection_id is absent', () => {
+    // Exercises the ternary's falsy branch: source = type instead of `${cid}:${type}`.
+    const withCid = buildOrchestratorFingerprint({ connection_id: 'c', type: 'cpu', severity: 'warning', resource_type: 'node', resource: 'n' })
+    const withoutCid = buildOrchestratorFingerprint({ type: 'cpu', severity: 'warning', resource_type: 'node', resource: 'n' })
+    expect(withCid).not.toBe(withoutCid)
+    // Both should be 32-char hex.
+    expect(withoutCid).toMatch(/^[0-9a-f]{32}$/)
+  })
+
+  it('coerces undefined fields to empty strings without throwing', () => {
+    // Empty/undefined branch coverage for severity / resource_type / resource / type / rule_id.
+    const fp = buildOrchestratorFingerprint({})
+    expect(fp).toMatch(/^[0-9a-f]{32}$/)
+    // Stable under repeated invocation.
+    expect(buildOrchestratorFingerprint({})).toBe(fp)
+  })
+
+  it('treats explicit empty strings the same as undefined fields', () => {
+    const allEmpty = buildOrchestratorFingerprint({ connection_id: '', type: '', severity: '', resource_type: '', resource: '', rule_id: '' })
+    const allUndefined = buildOrchestratorFingerprint({})
+    expect(allEmpty).toBe(allUndefined)
+  })
 })

--- a/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
+++ b/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
@@ -1,26 +1,11 @@
-import crypto from 'crypto'
 import { describe, expect, it } from 'vitest'
 
-// This is the canonical contract that backend/internal/alerts/fingerprint.go must
-// also implement. Both implementations are tested against the same 6 vectors; any
-// drift breaks silence matching between the orchestrator and the UI mute flow.
-//
-// DO NOT REFACTOR THIS FUNCTION HERE WITHOUT UPDATING:
-//   - frontend/src/app/api/v1/orchestrator/alerts/route.ts (l.26-37)
-//   - frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts (l.16)
-//   - backend/internal/alerts/fingerprint.go (and its tests)
-function buildOrchestratorFingerprint(alert: {
-  connection_id?: string
-  type?: string
-  severity?: string
-  resource?: string
-  resource_type?: string
-  rule_id?: string
-}): string {
-  const source = alert.connection_id ? `${alert.connection_id}:${alert.type || ''}` : (alert.type || '')
-  const data = `${source}|${alert.severity || ''}|${alert.resource_type || ''}|${alert.resource || ''}|${alert.type || ''}|${alert.rule_id || ''}`
-  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 32)
-}
+import { buildOrchestratorFingerprint } from '../orchestratorFingerprint'
+
+// Canonical contract pinned across both repos. The Go side
+// (backend/internal/alerts/fingerprint.go) MUST produce identical hex outputs
+// for the same inputs — see its own canonical vector tests. Any drift here
+// silently breaks silence matching between the orchestrator and the UI mute flow.
 
 describe('buildOrchestratorFingerprint (canonical contract)', () => {
   const vectors = [

--- a/frontend/src/lib/alerts/orchestratorFingerprint.ts
+++ b/frontend/src/lib/alerts/orchestratorFingerprint.ts
@@ -1,0 +1,30 @@
+import crypto from 'crypto'
+
+/**
+ * Build a fingerprint from an orchestrator alert to match against silences
+ * and to dedupe within list views.
+ *
+ * `rule_id` is part of the key: when two rules fire on the same event
+ * (e.g. NEW-MSP "test" + CLOUD-MSP "start/stop" both subscribed to vmstart
+ * on a shared cluster), the orchestrator stores them as two rows with the
+ * same connection/severity/resource. Without rule_id in the fingerprint
+ * they'd dedupe into one row and the wrong tenant could end up owning the
+ * surviving alert.
+ *
+ * The Go orchestrator's `OrchestratorFingerprint` (backend/internal/alerts/fingerprint.go)
+ * MUST produce identical hex outputs for the same inputs. The canonical
+ * vectors in `__tests__/orchestratorFingerprint.test.ts` pin the contract on
+ * both sides — any drift here is a silent break of silence matching.
+ */
+export function buildOrchestratorFingerprint(alert: {
+  connection_id?: string
+  type?: string
+  severity?: string
+  resource?: string
+  resource_type?: string
+  rule_id?: string
+}): string {
+  const source = alert.connection_id ? `${alert.connection_id}:${alert.type || ''}` : (alert.type || '')
+  const data = `${source}|${alert.severity || ''}|${alert.resource_type || ''}|${alert.resource || ''}|${alert.type || ''}|${alert.rule_id || ''}`
+  return crypto.createHash('sha256').update(data).digest('hex').slice(0, 32)
+}


### PR DESCRIPTION
## Summary

Fixes [#359](https://github.com/adminsyspro/proxcenter-ui/issues/359). The orchestrator now respects UI-configured thresholds and UI-issued silences without operator action on standard install-script deployments.

### Bugs addressed

1. **Threshold set at 90% in UI but alerts fire at 80%.** The legacy frontend best-effort PUT to `/alerts/thresholds` failed silently (console.warn only) when the orchestrator was briefly unreachable. The orchestrator then stayed on its config.yaml defaults indefinitely while the UI showed the user-configured value.
2. **Muted alerts still send emails.** The mute UI wrote to the frontend's `AlertSilence` Prisma table but the orchestrator never read it. Emails kept firing on every alert re-creation cycle.
3. **Bonus: Infrastructure Health badge counted muted alerts.** `/api/v1/orchestrator/alerts/active` was the only sibling of the three orchestrator alert routes that did not apply the silence filter. Fixed in the same PR.

### Approach

Pull-based, not push-based. The Go orchestrator now runs a configsync worker that polls `GET /api/internal/alert-config` every 30s and applies thresholds + silences atomically. Failed pulls preserve current in-memory state. The previously silent best-effort PUT remains as a redundant fallback for setups where the worker cannot reach the frontend.

### Transparent upgrade

No new env vars required for standard installs:

- `FRONTEND_URL` defaults to `http://frontend:3000` (matches the install scripts' docker-compose service name).
- The shared API key is resolved from `cfg.API.APIKey` (the existing `PROXCENTER_API_API_KEY`), then `ORCHESTRATOR_API_KEY` env, then the persisted `/app/data/.api_key` file.
- Worker auto-starts when any of those keys is present, which is true for every install deployed via `install-enterprise.sh` / `install-community.sh`.
- Bug fixes apply automatically after upgrade.

Custom topologies (renamed frontend service, non-Docker deploys) keep working via the unchanged PUT fallback and can opt into the worker by setting `FRONTEND_URL` explicitly.

### Cross-repo

Pairs with [proxcenter-backend `fix/alert-thresholds-sync-and-silence`](https://github.com/adminsyspro/proxcenter-backend/tree/fix/alert-thresholds-sync-and-silence). Six canonical fingerprint vectors are asserted byte-identically on both sides (`frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts` + `backend/internal/alerts/fingerprint_test.go`) to prevent silent contract drift.

The backend branch must be deployed first (so the worker exists when the frontend endpoint comes online), but standard docker-compose redeploys both at the same time anyway.

## Trade-offs accepted

- **MSP installs**: the worker pulls the default tenant only and applies its silences cluster-wide. This is benign in practice: `visibility.ts` already filters cluster/node-level alerts to provider-only, and the orchestrator's email recipients are a single config.yaml list, so provider mutes only suppress provider's own emails. MSP tenant silences remain dashboard-only (same as before this PR). Multi-tenant configsync is a future follow-up tied to the broader visibility.ts tenant-awareness work.
- **Silence cache not persisted across orchestrator reboots.** Initially the worker also wrote `alert_silences_cache` to DB but a stale cache on installs where the frontend has gone away or was never reachable would have suppressed alerts indefinitely. Starting empty on each boot and letting the first pull repopulate within 30s is the safer default: an extra email beats a missed alert. Thresholds persistence stays (existing pre-PR behavior).
- **Up to 30s latency** between clicking mute and emails actually stopping. Acceptable per the design discussion; matches the worker tick interval.

## Test plan
- [x] vitest suite passes (31 tests across alert-config route, orchestratorFingerprint vectors, existing routes)
- [x] Go test suite passes on the paired backend branch (22 cases in internal/alerts/, including 6 canonical fingerprint vectors)
- [x] Live curl on /api/internal/alert-config returns 401 with no/wrong key, 200 with valid key
- [x] Codex review clean on all 4 frontend commits (one P2 found and fixed mid-stream: fractional snapshot_max_age_days coerced to int)
- [x] Mute then re-trigger an alert in the UI: badge counter on Infrastructure Health correctly decrements within 30s (validated by reporter)
- [ ] Post-merge: verify on a fresh enterprise install that no manual env-var change is required