### PR TITLE
fix(alerts): respect silences in /api/v1/dashboard (home widget)

### DIFF
--- a/frontend/src/app/api/v1/dashboard/route.ts
+++ b/frontend/src/app/api/v1/dashboard/route.ts
@@ -9,7 +9,8 @@ import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { formatBytes } from "@/utils/format"
 import { generateFingerprint } from "@/lib/alerts/fingerprint"
-import { isDashboardAlertSilenced, isOrchestratorAlertSilenced, loadActiveSilenceFingerprints } from "@/lib/alerts/silenceFilter"
+import { loadActiveSilenceFingerprints } from "@/lib/alerts/silenceFilter"
+import { mergeAndFilterDashboardAlerts } from "@/lib/alerts/dashboardAlertMerge"
 import { authOptions } from "@/lib/auth/config"
 import { filterVmsByPermission, filterNodesByPermission } from "@/lib/rbac"
 import { alertsApi } from "@/lib/orchestrator/client"
@@ -762,67 +763,27 @@ return null
     const fTopCpu = fRunningVms.map((v: any) => ({ name: v.name || `VM ${v.vmid}`, vmid: v.vmid, node: v.node, connId: v.connectionId || v.connId, type: v.type || 'qemu', value: round1(Number(v.cpu || 0) * 100) })).sort((a: any, b: any) => b.value - a.value).slice(0, 10)
     const fTopRam = fRunningVms.map((v: any) => { const used = Number(v.mem || 0), max = Number(v.maxmem || 0); return { name: v.name || `VM ${v.vmid}`, vmid: v.vmid, node: v.node, connId: v.connectionId || v.connId, type: v.type || 'qemu', value: max > 0 ? round1((used / max) * 100) : 0 } }).sort((a: any, b: any) => b.value - a.value).slice(0, 10)
 
-    // Active silences for this tenant — used both to drop muted orchestrator
-    // alerts before merging and to drop muted dashboard-evaluated alerts at
-    // the end. Single query, set lookup is O(1).
-    const silencedFingerprints = await loadActiveSilenceFingerprints(await getSessionPrisma())
-
-    // Merge with orchestrator alerts (snapshots, event rules, etc.)
-    // Only attempt if orchestrator is explicitly configured (Enterprise edition)
+    // Merge orchestrator alerts in (Enterprise only) + drop muted entries.
+    // All logic lives in lib/alerts/dashboardAlertMerge.ts for testability.
+    let orchAlerts: any[] | undefined
     if (process.env.ORCHESTRATOR_URL) {
       try {
         const orchResponse = await alertsApi.getAlerts({ status: 'active', limit: 100 })
         const orchData = orchResponse.data as any
-        const orchAlerts: any[] = orchData?.data || (Array.isArray(orchData) ? orchData : [])
-
-        // Build a set of existing alert signatures to deduplicate
-        const existingKeys = new Set(alerts.map((a: any) => `${a.entityType}:${a.entityId}:${a.metric}:${a.severity}`))
-
-        const connNameMap = new Map(allConnections.map(c => [c.id, c.name]))
-
-        for (const oa of (Array.isArray(orchAlerts) ? orchAlerts : [])) {
-          // Drop muted orchestrator alerts using the SHA-256 fingerprint shared
-          // with /operations/alerts. Computed on the orchestrator-shape fields
-          // before they get transformed into the dashboard shape below.
-          if (isOrchestratorAlertSilenced(oa, silencedFingerprints)) continue
-
-          const key = `${oa.resource_type}:${oa.resource_id || oa.resource}:${oa.type}:${oa.severity}`
-          if (existingKeys.has(key)) continue
-          existingKeys.add(key)
-
-          alerts.push({
-            severity: oa.severity === 'critical' ? 'crit' : oa.severity === 'warning' ? 'warn' : oa.severity,
-            message: oa.message,
-            source: connNameMap.get(oa.connection_id) || oa.resource || 'Orchestrator',
-            sourceType: 'pve',
-            entityType: oa.resource_type,
-            entityId: oa.resource,
-            entityName: oa.resource,
-            connId: oa.connection_id,
-            metric: oa.type,
-            currentValue: oa.current_value,
-            threshold: oa.threshold,
-            time: oa.last_seen_at || oa.created_at,
-          })
-        }
-
-        // Re-sort after merge
-        alerts.sort((a: any, b: any) => (severityOrder[a.severity] || 2) - (severityOrder[b.severity] || 2))
+        orchAlerts = orchData?.data || (Array.isArray(orchData) ? orchData : [])
       } catch {
         // Silently ignore orchestrator errors — not critical for dashboard
       }
     }
-
-    // Filter alerts to only include visible resources
-    const visibleNodeNames = new Set(filteredNodes.map((n: any) => n.name))
-    let filteredAlerts = alerts.filter((a: any) => {
-      if (a.entityType === 'node') return visibleNodeNames.has(a.entityId)
-      return filteredNodes.length > 0
+    const visibleNodeNames = new Set<string>(filteredNodes.map((n: any) => n.name))
+    const filteredAlerts = mergeAndFilterDashboardAlerts({
+      baseAlerts: alerts,
+      orchAlerts,
+      connectionNameById: new Map(allConnections.map(c => [c.id, c.name])),
+      visibleNodeNames,
+      hasVisibleNodes: filteredNodes.length > 0,
+      silencedFingerprints: await loadActiveSilenceFingerprints(await getSessionPrisma()),
     })
-    // Drop dashboard-evaluated alerts whose MD5 fingerprint is silenced.
-    // Orchestrator alerts merged above were already filtered against their own
-    // SHA-256 fingerprint before being pushed.
-    filteredAlerts = filteredAlerts.filter((a: any) => !isDashboardAlertSilenced(a, silencedFingerprints))
 
     return NextResponse.json({
       data: {

--- a/frontend/src/app/api/v1/dashboard/route.ts
+++ b/frontend/src/app/api/v1/dashboard/route.ts
@@ -9,7 +9,7 @@ import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { formatBytes } from "@/utils/format"
 import { generateFingerprint } from "@/lib/alerts/fingerprint"
-import { isDashboardAlertSilenced, isOrchestratorAlertSilenced } from "@/lib/alerts/silenceFilter"
+import { isDashboardAlertSilenced, isOrchestratorAlertSilenced, loadActiveSilenceFingerprints } from "@/lib/alerts/silenceFilter"
 import { authOptions } from "@/lib/auth/config"
 import { filterVmsByPermission, filterNodesByPermission } from "@/lib/rbac"
 import { alertsApi } from "@/lib/orchestrator/client"
@@ -763,21 +763,9 @@ return null
     const fTopRam = fRunningVms.map((v: any) => { const used = Number(v.mem || 0), max = Number(v.maxmem || 0); return { name: v.name || `VM ${v.vmid}`, vmid: v.vmid, node: v.node, connId: v.connectionId || v.connId, type: v.type || 'qemu', value: max > 0 ? round1((used / max) * 100) : 0 } }).sort((a: any, b: any) => b.value - a.value).slice(0, 10)
 
     // Active silences for this tenant — used both to drop muted orchestrator
-    // alerts before merging and to drop muted dashboard-evaluated alerts at the
-    // end. Single query, set lookup is O(1). Same pattern as
-    // /api/v1/orchestrator/alerts/active.
-    let silencedFingerprints = new Set<string>()
-    try {
-      const sessionPrisma = await getSessionPrisma()
-      const now = new Date()
-      const silenceRows = await sessionPrisma.alertSilence.findMany({
-        where: { OR: [{ silencedUntil: null }, { silencedUntil: { gt: now } }] },
-        select: { fingerprint: true },
-      })
-      silencedFingerprints = new Set(silenceRows.map((s: { fingerprint: string }) => s.fingerprint))
-    } catch {
-      // AlertSilence table missing or unreadable — continue without filtering
-    }
+    // alerts before merging and to drop muted dashboard-evaluated alerts at
+    // the end. Single query, set lookup is O(1).
+    const silencedFingerprints = await loadActiveSilenceFingerprints(await getSessionPrisma())
 
     // Merge with orchestrator alerts (snapshots, event rules, etc.)
     // Only attempt if orchestrator is explicitly configured (Enterprise edition)
@@ -825,17 +813,16 @@ return null
       }
     }
 
-    // Filter alerts to only include visible resources AND drop dashboard-evaluated
-    // alerts whose MD5 fingerprint (from generateFingerprint) is silenced.
+    // Filter alerts to only include visible resources
+    const visibleNodeNames = new Set(filteredNodes.map((n: any) => n.name))
+    let filteredAlerts = alerts.filter((a: any) => {
+      if (a.entityType === 'node') return visibleNodeNames.has(a.entityId)
+      return filteredNodes.length > 0
+    })
+    // Drop dashboard-evaluated alerts whose MD5 fingerprint is silenced.
     // Orchestrator alerts merged above were already filtered against their own
     // SHA-256 fingerprint before being pushed.
-    const visibleNodeNames = new Set(filteredNodes.map((n: any) => n.name))
-    const filteredAlerts = alerts.filter((a: any) => {
-      if (a.entityType === 'node' && !visibleNodeNames.has(a.entityId)) return false
-      if (a.entityType !== 'node' && filteredNodes.length === 0) return false
-      if (isDashboardAlertSilenced(a, silencedFingerprints)) return false
-      return true
-    })
+    filteredAlerts = filteredAlerts.filter((a: any) => !isDashboardAlertSilenced(a, silencedFingerprints))
 
     return NextResponse.json({
       data: {

--- a/frontend/src/app/api/v1/dashboard/route.ts
+++ b/frontend/src/app/api/v1/dashboard/route.ts
@@ -9,6 +9,7 @@ import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { formatBytes } from "@/utils/format"
 import { generateFingerprint } from "@/lib/alerts/fingerprint"
+import { isDashboardAlertSilenced, isOrchestratorAlertSilenced } from "@/lib/alerts/silenceFilter"
 import { authOptions } from "@/lib/auth/config"
 import { filterVmsByPermission, filterNodesByPermission } from "@/lib/rbac"
 import { alertsApi } from "@/lib/orchestrator/client"
@@ -761,6 +762,23 @@ return null
     const fTopCpu = fRunningVms.map((v: any) => ({ name: v.name || `VM ${v.vmid}`, vmid: v.vmid, node: v.node, connId: v.connectionId || v.connId, type: v.type || 'qemu', value: round1(Number(v.cpu || 0) * 100) })).sort((a: any, b: any) => b.value - a.value).slice(0, 10)
     const fTopRam = fRunningVms.map((v: any) => { const used = Number(v.mem || 0), max = Number(v.maxmem || 0); return { name: v.name || `VM ${v.vmid}`, vmid: v.vmid, node: v.node, connId: v.connectionId || v.connId, type: v.type || 'qemu', value: max > 0 ? round1((used / max) * 100) : 0 } }).sort((a: any, b: any) => b.value - a.value).slice(0, 10)
 
+    // Active silences for this tenant — used both to drop muted orchestrator
+    // alerts before merging and to drop muted dashboard-evaluated alerts at the
+    // end. Single query, set lookup is O(1). Same pattern as
+    // /api/v1/orchestrator/alerts/active.
+    let silencedFingerprints = new Set<string>()
+    try {
+      const sessionPrisma = await getSessionPrisma()
+      const now = new Date()
+      const silenceRows = await sessionPrisma.alertSilence.findMany({
+        where: { OR: [{ silencedUntil: null }, { silencedUntil: { gt: now } }] },
+        select: { fingerprint: true },
+      })
+      silencedFingerprints = new Set(silenceRows.map((s: { fingerprint: string }) => s.fingerprint))
+    } catch {
+      // AlertSilence table missing or unreadable — continue without filtering
+    }
+
     // Merge with orchestrator alerts (snapshots, event rules, etc.)
     // Only attempt if orchestrator is explicitly configured (Enterprise edition)
     if (process.env.ORCHESTRATOR_URL) {
@@ -775,6 +793,11 @@ return null
         const connNameMap = new Map(allConnections.map(c => [c.id, c.name]))
 
         for (const oa of (Array.isArray(orchAlerts) ? orchAlerts : [])) {
+          // Drop muted orchestrator alerts using the SHA-256 fingerprint shared
+          // with /operations/alerts. Computed on the orchestrator-shape fields
+          // before they get transformed into the dashboard shape below.
+          if (isOrchestratorAlertSilenced(oa, silencedFingerprints)) continue
+
           const key = `${oa.resource_type}:${oa.resource_id || oa.resource}:${oa.type}:${oa.severity}`
           if (existingKeys.has(key)) continue
           existingKeys.add(key)
@@ -802,11 +825,16 @@ return null
       }
     }
 
-    // Filter alerts to only include visible resources
+    // Filter alerts to only include visible resources AND drop dashboard-evaluated
+    // alerts whose MD5 fingerprint (from generateFingerprint) is silenced.
+    // Orchestrator alerts merged above were already filtered against their own
+    // SHA-256 fingerprint before being pushed.
     const visibleNodeNames = new Set(filteredNodes.map((n: any) => n.name))
     const filteredAlerts = alerts.filter((a: any) => {
-      if (a.entityType === 'node') return visibleNodeNames.has(a.entityId)
-      return filteredNodes.length > 0
+      if (a.entityType === 'node' && !visibleNodeNames.has(a.entityId)) return false
+      if (a.entityType !== 'node' && filteredNodes.length === 0) return false
+      if (isDashboardAlertSilenced(a, silencedFingerprints)) return false
+      return true
     })
 
     return NextResponse.json({

--- a/frontend/src/lib/alerts/__tests__/dashboardAlertMerge.test.ts
+++ b/frontend/src/lib/alerts/__tests__/dashboardAlertMerge.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
+import { generateFingerprint } from '@/lib/alerts/fingerprint'
+import { mergeAndFilterDashboardAlerts } from '@/lib/alerts/dashboardAlertMerge'
+
+const baseLocalAlert = {
+  severity: 'warn',
+  message: 'Node pve-1 RAM high (85%)',
+  source: 'pve-prod',
+  sourceType: 'pve',
+  entityType: 'node',
+  entityId: 'pve-1',
+  metric: 'ram',
+}
+
+function visibleNodes(names: string[]) {
+  return new Set(names)
+}
+
+describe('mergeAndFilterDashboardAlerts', () => {
+  it('returns local alerts when no orchestrator alerts are provided', () => {
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-1']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].entityId).toBe('pve-1')
+  })
+
+  it('merges orchestrator alerts that do not duplicate a local alert', () => {
+    const orchAlert = {
+      connection_id: 'conn-1',
+      type: 'cpu',
+      severity: 'warning',
+      resource_type: 'node',
+      resource: 'pve-2',
+      message: 'CPU 88%',
+    }
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert],
+      orchAlerts: [orchAlert],
+      connectionNameById: new Map([['conn-1', 'My Cluster']]),
+      visibleNodeNames: visibleNodes(['pve-1', 'pve-2']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result.map(a => a.entityId).sort()).toEqual(['pve-1', 'pve-2'])
+    const orch = result.find(a => a.entityId === 'pve-2')!
+    expect(orch.severity).toBe('warn') // mapped from "warning"
+    expect(orch.source).toBe('My Cluster')
+    expect(orch.sourceType).toBe('pve')
+  })
+
+  it('dedups orchestrator alerts against an existing local alert by (entityType, entityId, metric, severity)', () => {
+    const dupOrch = {
+      connection_id: 'conn-1',
+      type: 'ram',
+      severity: 'warn',
+      resource_type: 'node',
+      resource: 'pve-1',
+      message: 'duplicate of baseLocalAlert',
+    }
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert],
+      orchAlerts: [dupOrch],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-1']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].message).toBe(baseLocalAlert.message)
+  })
+
+  it('drops orchestrator alerts whose SHA-256 fingerprint is silenced', () => {
+    const orchAlert = {
+      connection_id: 'conn-1',
+      type: 'cpu',
+      severity: 'warning',
+      resource_type: 'node',
+      resource: 'pve-2',
+    }
+    const silencedFp = buildOrchestratorFingerprint(orchAlert)
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [],
+      orchAlerts: [orchAlert],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-2']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set([silencedFp]),
+    })
+    expect(result).toEqual([])
+  })
+
+  it('drops dashboard-evaluated alerts whose MD5 fingerprint is silenced', () => {
+    const fp = generateFingerprint({
+      source: baseLocalAlert.source,
+      severity: baseLocalAlert.severity,
+      entityType: baseLocalAlert.entityType,
+      entityId: baseLocalAlert.entityId,
+      metric: baseLocalAlert.metric,
+    })
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-1']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set([fp]),
+    })
+    expect(result).toEqual([])
+  })
+
+  it('drops node alerts for nodes not in the visible set', () => {
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-99']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toEqual([])
+  })
+
+  it('drops non-node alerts when there are no visible nodes', () => {
+    const stormAlert = { ...baseLocalAlert, entityType: 'storage', entityId: 'local-lvm', metric: 'storage' }
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [stormAlert],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes([]),
+      hasVisibleNodes: false,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toEqual([])
+  })
+
+  it('sorts merged alerts by severity (crit → warn → info)', () => {
+    const orchCrit = {
+      connection_id: 'conn-1',
+      type: 'cpu',
+      severity: 'critical',
+      resource_type: 'node',
+      resource: 'pve-2',
+    }
+    const orchInfo = {
+      connection_id: 'conn-1',
+      type: 'storage',
+      severity: 'info',
+      resource_type: 'node',
+      resource: 'pve-3',
+    }
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [baseLocalAlert], // warn on pve-1
+      orchAlerts: [orchInfo, orchCrit],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-1', 'pve-2', 'pve-3']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result.map(a => a.severity)).toEqual(['crit', 'warn', 'info'])
+  })
+
+  it('falls back to "Orchestrator" as source when connection_id is missing', () => {
+    const orphan = { type: 'cpu', severity: 'warn', resource_type: 'node', resource: 'pve-x' }
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [],
+      orchAlerts: [orphan],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes(['pve-x']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result[0].source).toBe('pve-x')
+  })
+
+  it('handles empty inputs gracefully', () => {
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [],
+      orchAlerts: [],
+      connectionNameById: new Map(),
+      visibleNodeNames: visibleNodes([]),
+      hasVisibleNodes: false,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/frontend/src/lib/alerts/__tests__/silenceFilter.test.ts
+++ b/frontend/src/lib/alerts/__tests__/silenceFilter.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateFingerprint } from '@/lib/alerts/fingerprint'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
+import { isDashboardAlertSilenced, isOrchestratorAlertSilenced } from '@/lib/alerts/silenceFilter'
+
+describe('isOrchestratorAlertSilenced', () => {
+  const orchAlert = {
+    connection_id: 'conn-abc123',
+    type: 'memory',
+    severity: 'warning',
+    resource_type: 'node',
+    resource: 'pve-node-1',
+  }
+
+  it('returns false when the silence set is empty', () => {
+    expect(isOrchestratorAlertSilenced(orchAlert, new Set())).toBe(false)
+  })
+
+  it('returns false when the alert fingerprint is not in the silence set', () => {
+    expect(isOrchestratorAlertSilenced(orchAlert, new Set(['some-other-fp']))).toBe(false)
+  })
+
+  it('returns true when the alert fingerprint matches a silence', () => {
+    const fp = buildOrchestratorFingerprint(orchAlert)
+    expect(isOrchestratorAlertSilenced(orchAlert, new Set([fp]))).toBe(true)
+  })
+
+  it('uses rule_id in the match (rule-level disambiguation)', () => {
+    const ruleA = { ...orchAlert, type: 'event', rule_id: 'rule-A' }
+    const ruleB = { ...orchAlert, type: 'event', rule_id: 'rule-B' }
+    const silenceOnA = new Set([buildOrchestratorFingerprint(ruleA)])
+    expect(isOrchestratorAlertSilenced(ruleA, silenceOnA)).toBe(true)
+    // Same alert shape but different rule_id must not match a silence on rule A.
+    expect(isOrchestratorAlertSilenced(ruleB, silenceOnA)).toBe(false)
+  })
+})
+
+describe('isDashboardAlertSilenced', () => {
+  const dashAlert = {
+    source: 'pve-prod',
+    severity: 'warn',
+    entityType: 'node',
+    entityId: 'pve-node-1',
+    metric: 'ram',
+  }
+
+  it('returns false when the silence set is empty', () => {
+    expect(isDashboardAlertSilenced(dashAlert, new Set())).toBe(false)
+  })
+
+  it('returns false when the alert fingerprint is not in the silence set', () => {
+    expect(isDashboardAlertSilenced(dashAlert, new Set(['other']))).toBe(false)
+  })
+
+  it('returns true when the MD5 fingerprint matches a silence (same contract as /api/v1/alerts/sync)', () => {
+    const fp = generateFingerprint({
+      source: dashAlert.source,
+      severity: dashAlert.severity,
+      entityType: dashAlert.entityType,
+      entityId: dashAlert.entityId,
+      metric: dashAlert.metric,
+    })
+    expect(isDashboardAlertSilenced(dashAlert, new Set([fp]))).toBe(true)
+  })
+
+  it('treats missing source as empty string (matches generateFingerprint default behavior)', () => {
+    const alert = { severity: 'crit', entityType: 'storage', entityId: 'local-lvm', metric: 'storage' }
+    const fp = generateFingerprint({
+      source: '',
+      severity: 'crit',
+      entityType: 'storage',
+      entityId: 'local-lvm',
+      metric: 'storage',
+    })
+    expect(isDashboardAlertSilenced(alert, new Set([fp]))).toBe(true)
+  })
+})

--- a/frontend/src/lib/alerts/__tests__/silenceFilter.test.ts
+++ b/frontend/src/lib/alerts/__tests__/silenceFilter.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { generateFingerprint } from '@/lib/alerts/fingerprint'
 import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
-import { isDashboardAlertSilenced, isOrchestratorAlertSilenced } from '@/lib/alerts/silenceFilter'
+import { isDashboardAlertSilenced, isOrchestratorAlertSilenced, loadActiveSilenceFingerprints } from '@/lib/alerts/silenceFilter'
 
 describe('isOrchestratorAlertSilenced', () => {
   const orchAlert = {
@@ -74,5 +74,39 @@ describe('isDashboardAlertSilenced', () => {
       metric: 'storage',
     })
     expect(isDashboardAlertSilenced(alert, new Set([fp]))).toBe(true)
+  })
+})
+
+describe('loadActiveSilenceFingerprints', () => {
+  it('returns a Set of fingerprints from prisma rows', async () => {
+    const findMany = vi.fn().mockResolvedValue([{ fingerprint: 'fp-a' }, { fingerprint: 'fp-b' }])
+    const prisma = { alertSilence: { findMany } }
+
+    const result = await loadActiveSilenceFingerprints(prisma)
+    expect(result.has('fp-a')).toBe(true)
+    expect(result.has('fp-b')).toBe(true)
+    expect(result.size).toBe(2)
+  })
+
+  it('queries with the non-expired OR clause (silencedUntil null or > now)', async () => {
+    const findMany = vi.fn().mockResolvedValue([])
+    await loadActiveSilenceFingerprints({ alertSilence: { findMany } })
+
+    expect(findMany).toHaveBeenCalledTimes(1)
+    const where = findMany.mock.calls[0][0].where as { OR: Array<{ silencedUntil: unknown }> }
+    expect(where.OR.some(c => c.silencedUntil === null)).toBe(true)
+    expect(where.OR.some(c => (c.silencedUntil as { gt?: Date })?.gt instanceof Date)).toBe(true)
+  })
+
+  it('returns an empty Set when the table query throws (table missing on stale schema)', async () => {
+    const findMany = vi.fn().mockRejectedValue(new Error('relation "AlertSilence" does not exist'))
+    const result = await loadActiveSilenceFingerprints({ alertSilence: { findMany } })
+    expect(result.size).toBe(0)
+  })
+
+  it('returns an empty Set when no rows match', async () => {
+    const findMany = vi.fn().mockResolvedValue([])
+    const result = await loadActiveSilenceFingerprints({ alertSilence: { findMany } })
+    expect(result.size).toBe(0)
   })
 })

--- a/frontend/src/lib/alerts/dashboardAlertMerge.ts
+++ b/frontend/src/lib/alerts/dashboardAlertMerge.ts
@@ -1,0 +1,125 @@
+import {
+  isDashboardAlertSilenced,
+  isOrchestratorAlertSilenced,
+} from '@/lib/alerts/silenceFilter'
+
+/**
+ * Shape of the orchestrator alert as returned by `alertsApi.getAlerts`. Only
+ * the fields we read for dedup + fingerprint + transform are typed here.
+ */
+export interface RawOrchestratorAlert {
+  connection_id?: string
+  type?: string
+  severity?: string
+  resource?: string
+  resource_id?: number | string
+  resource_type?: string
+  rule_id?: string
+  message?: string
+  current_value?: number
+  threshold?: number
+  last_seen_at?: string
+  created_at?: string
+}
+
+/**
+ * Dashboard-shape alert: the format `/api/v1/dashboard` returns to the UI. The
+ * locally-evaluated alerts already use this shape; orchestrator alerts are
+ * transformed into it during merge.
+ */
+export interface DashboardAlert {
+  severity: string
+  message: string
+  source: string
+  sourceType: string
+  entityType: string
+  entityId: string
+  entityName?: string
+  connId?: string
+  metric?: string
+  currentValue?: number
+  threshold?: number
+  time?: string
+  [key: string]: unknown
+}
+
+const SEVERITY_ORDER: Record<string, number> = { crit: 0, warn: 1, info: 2 }
+
+/**
+ * Merge orchestrator alerts into the locally-evaluated dashboard alerts and
+ * filter out everything that is muted by an active silence. Single source of
+ * truth for the dashboard route's alert pipeline so it stays testable without
+ * the route's full upstream graph.
+ *
+ * - `baseAlerts` are the dashboard-evaluated alerts (already in dashboard shape).
+ * - `orchAlerts` are the raw orchestrator alerts; if omitted the merge step
+ *   is skipped (Community edition / orchestrator unreachable).
+ * - `silencedFingerprints` comes from `loadActiveSilenceFingerprints`.
+ *
+ * Two distinct silence checks because the mute UI in /operations/alerts stores
+ * the SHA-256 orchestrator-shape fingerprint, while /api/v1/alerts/sync stores
+ * the MD5 dashboard-shape fingerprint. A single mute should not have to
+ * compute both, so each call site uses the contract that matches the alert it
+ * is about to emit.
+ */
+export function mergeAndFilterDashboardAlerts(params: {
+  baseAlerts: DashboardAlert[]
+  orchAlerts?: RawOrchestratorAlert[]
+  connectionNameById: Map<string, string>
+  visibleNodeNames: Set<string>
+  hasVisibleNodes: boolean
+  silencedFingerprints: Set<string>
+}): DashboardAlert[] {
+  const {
+    baseAlerts,
+    orchAlerts,
+    connectionNameById,
+    visibleNodeNames,
+    hasVisibleNodes,
+    silencedFingerprints,
+  } = params
+
+  const merged: DashboardAlert[] = [...baseAlerts]
+
+  if (orchAlerts && orchAlerts.length > 0) {
+    const existingKeys = new Set(
+      merged.map(a => `${a.entityType}:${a.entityId}:${a.metric}:${a.severity}`),
+    )
+
+    for (const oa of orchAlerts) {
+      // Drop muted orchestrator alerts BEFORE the dashboard-shape transform —
+      // the SHA-256 fingerprint contract reads orchestrator-native fields.
+      if (isOrchestratorAlertSilenced(oa, silencedFingerprints)) continue
+
+      const key = `${oa.resource_type}:${oa.resource_id || oa.resource}:${oa.type}:${oa.severity}`
+      if (existingKeys.has(key)) continue
+      existingKeys.add(key)
+
+      merged.push({
+        severity: oa.severity === 'critical' ? 'crit' : oa.severity === 'warning' ? 'warn' : (oa.severity || 'info'),
+        message: oa.message || '',
+        source: (oa.connection_id && connectionNameById.get(oa.connection_id)) || oa.resource || 'Orchestrator',
+        sourceType: 'pve',
+        entityType: oa.resource_type || '',
+        entityId: String(oa.resource ?? ''),
+        entityName: oa.resource,
+        connId: oa.connection_id,
+        metric: oa.type,
+        currentValue: oa.current_value,
+        threshold: oa.threshold,
+        time: oa.last_seen_at || oa.created_at,
+      })
+    }
+
+    merged.sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 2) - (SEVERITY_ORDER[b.severity] ?? 2))
+  }
+
+  return merged.filter(a => {
+    // Visibility filter: nodes must be in the visible set; non-node alerts only
+    // pass when there is at least one visible node (matches the pre-PR logic).
+    if (a.entityType === 'node' && !visibleNodeNames.has(a.entityId)) return false
+    if (a.entityType !== 'node' && !hasVisibleNodes) return false
+    // Silence filter for dashboard-evaluated alerts (MD5 contract).
+    return !isDashboardAlertSilenced(a, silencedFingerprints)
+  })
+}

--- a/frontend/src/lib/alerts/silenceFilter.ts
+++ b/frontend/src/lib/alerts/silenceFilter.ts
@@ -2,6 +2,39 @@ import { generateFingerprint } from '@/lib/alerts/fingerprint'
 import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
 
 /**
+ * Minimal interface for the silence query — matches both the tenant-scoped
+ * `getSessionPrisma()` and a bare `prisma` client used by routes that run
+ * outside a user session.
+ */
+interface SilenceQueryClient {
+  alertSilence: {
+    findMany: (args: {
+      where: unknown
+      select: { fingerprint: true }
+    }) => Promise<Array<{ fingerprint: string }>>
+  }
+}
+
+/**
+ * Loads the set of fingerprints currently muted by an active silence
+ * (silencedUntil IS NULL OR silencedUntil > now()). Used by every alerts route
+ * that needs to skip muted entries before returning them. Failures (e.g.
+ * AlertSilence table missing on a stale schema) resolve to an empty set so
+ * the caller silently falls back to un-filtered results.
+ */
+export async function loadActiveSilenceFingerprints(prisma: SilenceQueryClient): Promise<Set<string>> {
+  try {
+    const rows = await prisma.alertSilence.findMany({
+      where: { OR: [{ silencedUntil: null }, { silencedUntil: { gt: new Date() } }] },
+      select: { fingerprint: true },
+    })
+    return new Set(rows.map(r => r.fingerprint))
+  } catch {
+    return new Set()
+  }
+}
+
+/**
  * Returns true if the orchestrator alert (raw shape, before transform into the
  * dashboard shape) is muted via the SHA-256 fingerprint stored by the
  * /operations/alerts mute UI. Single source of truth for the dashboard route's

--- a/frontend/src/lib/alerts/silenceFilter.ts
+++ b/frontend/src/lib/alerts/silenceFilter.ts
@@ -1,0 +1,51 @@
+import { generateFingerprint } from '@/lib/alerts/fingerprint'
+import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
+
+/**
+ * Returns true if the orchestrator alert (raw shape, before transform into the
+ * dashboard shape) is muted via the SHA-256 fingerprint stored by the
+ * /operations/alerts mute UI. Single source of truth for the dashboard route's
+ * pre-merge filter — same contract as /api/v1/orchestrator/alerts/active.
+ */
+export function isOrchestratorAlertSilenced(
+  orchAlert: {
+    connection_id?: string
+    type?: string
+    severity?: string
+    resource?: string
+    resource_type?: string
+    rule_id?: string
+  },
+  silencedFingerprints: Set<string>,
+): boolean {
+  if (silencedFingerprints.size === 0) return false
+  return silencedFingerprints.has(buildOrchestratorFingerprint(orchAlert))
+}
+
+/**
+ * Returns true if the dashboard-evaluated alert (already in dashboard shape:
+ * source / severity-short / entityType / entityId / metric) is muted via the
+ * MD5 fingerprint stored by /api/v1/alerts/sync. The dashboard route uses this
+ * AFTER its orchestrator merge so dashboard-evaluated and merged-orchestrator
+ * alerts both honor mutes from their respective UIs.
+ */
+export function isDashboardAlertSilenced(
+  alert: {
+    source?: string
+    severity?: string
+    entityType?: string
+    entityId?: string
+    metric?: string
+  },
+  silencedFingerprints: Set<string>,
+): boolean {
+  if (silencedFingerprints.size === 0) return false
+  const fp = generateFingerprint({
+    source: alert.source || '',
+    severity: alert.severity,
+    entityType: alert.entityType,
+    entityId: alert.entityId,
+    metric: alert.metric,
+  })
+  return silencedFingerprints.has(fp)
+}


### PR DESCRIPTION
## Summary

Follow-up to #365. The home AlertsListWidget kept showing alerts the user had muted via /operations/alerts because the dashboard route merged orchestrator alerts and emitted dashboard-evaluated alerts without consulting AlertSilence — same UX bug class as the badge counter that #365 fixed in /alerts/active.

- New `frontend/src/lib/alerts/silenceFilter.ts` exposes `isOrchestratorAlertSilenced` (SHA-256 contract, matches /operations/alerts mute) and `isDashboardAlertSilenced` (MD5 contract, matches /api/v1/alerts/sync).
- `/api/v1/dashboard` route loads active silences once per request and applies both filters: drop muted orchestrator alerts before the dashboard-shape transform, drop muted dashboard-evaluated alerts after the merge.
- Eight unit tests on the helper cover empty silence set, non-match, fingerprint match, rule_id disambiguation, and source-default-empty parity.

Confirmed live on dev: the alerts widget on /home decrements within the dashboard refresh interval after muting from /operations/alerts.

## Test plan
- [x] vitest passes for src/lib/alerts (34 cases across 4 files)
- [x] Manual: mute an alert in /operations/alerts, the home widget AlertsListWidget no longer shows it after refresh
- [ ] Sonar new-code coverage ≥ 80% (helper is fully covered by unit tests; the dashboard route change is a 3-line wrap around the helper, low new-code surface)