### PR TITLE
sec(v1.4.2): hardening sprint + post-Codex follow-ups

### DIFF
--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -69,11 +69,28 @@ if [ -z "$ORCHESTRATOR_API_KEY" ] && [ -f /app/orchestrator_data/.api_key ]; the
   echo "[entrypoint] Loaded ORCHESTRATOR_API_KEY from orchestrator shared volume"
 fi
 
-# Security checks
-if [ -z "$NEXTAUTH_SECRET" ]; then
-  echo "[entrypoint] ⚠ WARNING: NEXTAUTH_SECRET is not set. Sessions will use an insecure default key."
-  echo "[entrypoint]   Generate one with: openssl rand -base64 32"
-fi
+# Security checks: refuse missing or placeholder secrets. Both .env.example
+# files and the build-time fallback in src/lib/auth/config.ts ship known
+# stub values; if any of those reach a container at runtime the operator
+# forgot to provision real secrets and sessions would all share the same
+# key across every install.
+check_secret() {
+  var_name=$1
+  eval value="\$$var_name"
+  case "$value" in
+    "" | \
+    "your-nextauth-secret-here" | "your-nextauth-secret-change-me" | \
+    "your-app-secret-here" | "your-app-secret-change-me" | \
+    "build-time-placeholder")
+      echo "[entrypoint] ERROR: $var_name is empty or set to a placeholder value." >&2
+      echo "[entrypoint]   Replace it in .env with a real secret: openssl rand -base64 32" >&2
+      exit 1
+      ;;
+  esac
+}
+
+check_secret NEXTAUTH_SECRET
+check_secret APP_SECRET
 
 echo "[entrypoint] Starting..."
 exec "$@"

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -89,8 +89,14 @@ check_secret() {
   esac
 }
 
-check_secret NEXTAUTH_SECRET
-check_secret APP_SECRET
+# The published demo image bakes DEMO_MODE=true and ships without any
+# real .env. demo-api intercepts every API call and never reaches Prisma
+# or auth middleware, so requiring real secrets here would regress demo
+# bootstrap from "warn and run" to "exit and fail" with no benefit.
+if [ "$DEMO_MODE" != "true" ]; then
+  check_secret NEXTAUTH_SECRET
+  check_secret APP_SECRET
+fi
 
 echo "[entrypoint] Starting..."
 exec "$@"

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
@@ -1263,14 +1263,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
                 const XTermShell = require('@/components/xterm/XTermShell').default
                 return (
                   <XTermShell
-                    wsUrl={shellDialog.data.wsUrl}
+                    sessionId={shellDialog.data.sessionId}
                     host={shellDialog.data.host}
-                    port={shellDialog.data.port}
-                    ticket={shellDialog.data.ticket}
-                    node={shellDialog.data.node}
-                    user={shellDialog.data.user}
-                    pvePort={shellDialog.data.nodePort}
-                    apiToken={shellDialog.data.apiToken}
                     onDisconnect={() => setShellDialog(prev => ({ ...prev, data: null, error: 'Disconnected' }))}
                   />
                 )

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -1032,14 +1032,8 @@ export default function NodeTabs(props: any) {
                           const XTermShell = require('@/components/xterm/XTermShell').default
                           return (
                             <XTermShell
-                              wsUrl={nodeShellData.wsUrl}
+                              sessionId={nodeShellData.sessionId}
                               host={nodeShellData.host}
-                              port={nodeShellData.port}
-                              ticket={nodeShellData.ticket}
-                              node={nodeShellData.node}
-                              user={nodeShellData.user}
-                              pvePort={nodeShellData.nodePort}
-                              apiToken={nodeShellData.apiToken}
                               onDisconnect={() => {
                                 setNodeShellData(null)
                                 setNodeShellConnected(false)

--- a/frontend/src/app/api/internal/console/consume/route.test.ts
+++ b/frontend/src/app/api/internal/console/consume/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const consumeMock = vi.fn()
+
+vi.mock('@/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/console/route', () => ({
+  consumeConsoleSession: (...args: unknown[]) => consumeMock(...args),
+}))
+
+import { POST } from './route'
+
+const PROXY_CALLER = 'proxcenter-ws-proxy'
+
+function makeReq(headers: Record<string, string>, body: unknown = { sessionId: 'abc' }) {
+  return new Request('http://localhost/api/internal/console/consume', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+const originalSecret = process.env.APP_SECRET
+
+beforeEach(() => {
+  consumeMock.mockReset()
+  process.env.APP_SECRET = 'console-test-secret'
+})
+
+afterEach(() => {
+  if (originalSecret === undefined) delete process.env.APP_SECRET
+  else process.env.APP_SECRET = originalSecret
+})
+
+describe('POST /api/internal/console/consume', () => {
+  it('rejects with 403 when the caller fingerprint is missing', async () => {
+    const res = await POST(makeReq({ 'X-Internal-Secret': 'console-test-secret' }))
+    expect(res.status).toBe(403)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 403 when the shared secret is wrong', async () => {
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'wrong' })
+    )
+    expect(res.status).toBe(403)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the body has no sessionId', async () => {
+    const res = await POST(
+      makeReq(
+        { 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'console-test-secret' },
+        {}
+      )
+    )
+    expect(res.status).toBe(400)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the session lookup misses', async () => {
+    consumeMock.mockReturnValueOnce(null)
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'console-test-secret' })
+    )
+    expect(res.status).toBe(404)
+    expect(consumeMock).toHaveBeenCalledWith('abc')
+  })
+
+  it('returns the VM console session payload on a hit', async () => {
+    consumeMock.mockReturnValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'pve!tok=secret',
+      node: 'pve1',
+      type: 'qemu',
+      vmid: '100',
+      port: 5901,
+      ticket: 'PVE:vncticket',
+      expiresAt: Date.now() + 10_000,
+    })
+
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'console-test-secret' })
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'pve!tok=secret',
+      node: 'pve1',
+      type: 'qemu',
+      vmid: '100',
+      port: 5901,
+      ticket: 'PVE:vncticket',
+    })
+  })
+})

--- a/frontend/src/app/api/internal/console/consume/route.ts
+++ b/frontend/src/app/api/internal/console/consume/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server"
 
 import { consumeConsoleSession } from "@/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/console/route"
+import { requireInternalCaller } from "@/lib/internal-auth"
 
 export const runtime = "nodejs"
 
 export async function POST(req: Request) {
-  // Only allow internal calls (from our own WS proxy)
-  const origin = req.headers.get("x-internal-caller")
-  if (origin !== "proxcenter-ws-proxy") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
-  }
+  // Defensive: gate behind APP_SECRET on top of the x-internal-caller
+  // fingerprint. The fingerprint is trivially spoofable since this
+  // route lives under publicApiRoutes; the secret is server-only.
+  const denied = requireInternalCaller(req)
+  if (denied) return denied
 
   const { sessionId } = await req.json().catch(() => ({}))
 

--- a/frontend/src/app/api/internal/shell/consume/route.test.ts
+++ b/frontend/src/app/api/internal/shell/consume/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const consumeMock = vi.fn()
+
+vi.mock('@/app/api/v1/connections/[id]/nodes/[node]/terminal/route', () => ({
+  consumeTerminalSession: (...args: unknown[]) => consumeMock(...args),
+}))
+
+import { POST } from './route'
+
+const PROXY_CALLER = 'proxcenter-ws-proxy'
+
+function makeReq(headers: Record<string, string>, body: unknown = { sessionId: 'abc' }) {
+  return new Request('http://localhost/api/internal/shell/consume', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  })
+}
+
+const originalSecret = process.env.APP_SECRET
+
+beforeEach(() => {
+  consumeMock.mockReset()
+  process.env.APP_SECRET = 'shell-test-secret'
+})
+
+afterEach(() => {
+  if (originalSecret === undefined) delete process.env.APP_SECRET
+  else process.env.APP_SECRET = originalSecret
+})
+
+describe('POST /api/internal/shell/consume', () => {
+  it('rejects with 403 when the caller fingerprint is missing', async () => {
+    const res = await POST(makeReq({ 'X-Internal-Secret': 'shell-test-secret' }))
+    expect(res.status).toBe(403)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 403 when the shared secret is wrong', async () => {
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'wrong' })
+    )
+    expect(res.status).toBe(403)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the body has no sessionId', async () => {
+    const res = await POST(
+      makeReq(
+        { 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'shell-test-secret' },
+        {}
+      )
+    )
+    expect(res.status).toBe(400)
+    expect(consumeMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the session lookup misses', async () => {
+    consumeMock.mockReturnValueOnce(null)
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'shell-test-secret' })
+    )
+    expect(res.status).toBe(404)
+    expect(consumeMock).toHaveBeenCalledWith('abc')
+  })
+
+  it('returns the full session payload on a hit', async () => {
+    consumeMock.mockReturnValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      host: 'pve.example',
+      pvePort: 8006,
+      apiToken: 'pve!tok=secret',
+      node: 'pve1',
+      port: 5900,
+      ticket: 'PVE:ticket',
+      user: 'root@pam!root',
+      upid: 'UPID:1',
+      expiresAt: Date.now() + 10_000,
+    })
+
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'shell-test-secret' })
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toMatchObject({
+      baseUrl: 'https://pve.example:8006',
+      host: 'pve.example',
+      pvePort: 8006,
+      apiToken: 'pve!tok=secret',
+      node: 'pve1',
+      port: 5900,
+      ticket: 'PVE:ticket',
+      user: 'root@pam!root',
+      upid: 'UPID:1',
+    })
+  })
+})

--- a/frontend/src/app/api/internal/shell/consume/route.ts
+++ b/frontend/src/app/api/internal/shell/consume/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server"
+
+import { consumeTerminalSession } from "@/app/api/v1/connections/[id]/nodes/[node]/terminal/route"
+import { requireInternalCaller } from "@/lib/internal-auth"
+
+export const runtime = "nodejs"
+
+// Server-to-server endpoint: the ws-proxy process trades a sessionId
+// for the underlying PVE termproxy parameters (host, port, ticket,
+// user, apiToken). Sister of /api/internal/console/consume for the
+// node-shell flow. Gated by APP_SECRET via requireInternalCaller; the
+// x-internal-caller fingerprint alone is trivially spoofable since
+// /api/internal is in publicApiRoutes.
+export async function POST(req: Request) {
+  const denied = requireInternalCaller(req)
+  if (denied) return denied
+
+  const { sessionId } = await req.json().catch(() => ({}))
+  if (!sessionId) return NextResponse.json({ error: "Missing sessionId" }, { status: 400 })
+
+  const s = consumeTerminalSession(sessionId)
+  if (!s) return NextResponse.json({ error: "Session not found/expired" }, { status: 404 })
+
+  return NextResponse.json({
+    baseUrl: s.baseUrl,
+    host: s.host,
+    pvePort: s.pvePort,
+    apiToken: s.apiToken,
+    node: s.node,
+    port: s.port,
+    ticket: s.ticket,
+    user: s.user,
+    upid: s.upid,
+  })
+}

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { NextResponse } from 'next/server'
+
+const pveFetchMock = vi.fn()
+const getConnectionByIdMock = vi.fn()
+const checkPermissionMock = vi.fn()
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: (...args: unknown[]) => pveFetchMock(...args),
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: (...args: unknown[]) => getConnectionByIdMock(...args),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: { NODE_CONSOLE: 'node.console' },
+}))
+
+import { POST, consumeTerminalSession } from './route'
+
+function makeCtx(id: string, node: string) {
+  return { params: Promise.resolve({ id, node }) }
+}
+
+beforeEach(() => {
+  pveFetchMock.mockReset()
+  getConnectionByIdMock.mockReset()
+  checkPermissionMock.mockReset()
+  checkPermissionMock.mockResolvedValue(null) // allow by default
+})
+
+describe('POST /api/v1/connections/[id]/nodes/[node]/terminal', () => {
+  it('forwards an RBAC denial without calling the orchestrator', async () => {
+    const deniedResponse = NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    checkPermissionMock.mockResolvedValueOnce(deniedResponse)
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(403)
+    expect(getConnectionByIdMock).not.toHaveBeenCalled()
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the connection is unknown', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce(null)
+    const res = await POST(new Request('http://localhost'), makeCtx('unknown', 'pve1'))
+    expect(res.status).toBe(404)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when baseUrl cannot be parsed to a host', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'not-a-url-at-all',
+      apiToken: 'token',
+    })
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(500)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 500 when termproxy responds without a ticket', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'token',
+    })
+    pveFetchMock.mockResolvedValueOnce({ port: 5900 })
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 500 when pveFetch throws', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'token',
+    })
+    pveFetchMock.mockRejectedValueOnce(new Error('connection refused'))
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toContain('connection refused')
+  })
+
+  it('returns a sessionId + display payload on success and stores the upstream session server-side', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'token-secret',
+    })
+    pveFetchMock.mockResolvedValueOnce({
+      ticket: 'PVE:ticket',
+      port: 5900,
+      user: 'root@pam!root',
+      upid: 'UPID:1',
+    })
+
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toMatchObject({
+      sessionId: expect.any(String),
+      host: 'pve.example',
+      node: 'pve1',
+      expiresAt: expect.any(Number),
+    })
+    // Critical: apiToken must not be in the browser-facing payload.
+    expect(body.data).not.toHaveProperty('apiToken')
+    expect(body.data).not.toHaveProperty('ticket')
+
+    // The corresponding upstream session is reachable via the
+    // server-only helper.
+    const stored = consumeTerminalSession(body.data.sessionId)
+    expect(stored).toMatchObject({
+      apiToken: 'token-secret',
+      ticket: 'PVE:ticket',
+      host: 'pve.example',
+      pvePort: 8006,
+      node: 'pve1',
+      port: 5900,
+      user: 'root@pam!root',
+      upid: 'UPID:1',
+    })
+  })
+
+  it('defaults pvePort to 8006 when baseUrl has no explicit port', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example',
+      apiToken: 'token',
+    })
+    pveFetchMock.mockResolvedValueOnce({
+      ticket: 'PVE:t',
+      port: 5900,
+      user: 'u',
+      upid: 'UPID:1',
+    })
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    const stored = consumeTerminalSession(body.data.sessionId)
+    expect(stored?.pvePort).toBe(8006)
+  })
+})
+
+describe('consumeTerminalSession', () => {
+  it('returns null for an unknown sessionId', () => {
+    expect(consumeTerminalSession('does-not-exist')).toBeNull()
+  })
+
+  it('is single-use: a second consume of the same id returns null', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'token',
+    })
+    pveFetchMock.mockResolvedValueOnce({
+      ticket: 'PVE:t',
+      port: 5900,
+      user: 'u',
+      upid: 'UPID:1',
+    })
+    const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+    const { data: { sessionId } } = await res.json()
+    expect(consumeTerminalSession(sessionId)).not.toBeNull()
+    expect(consumeTerminalSession(sessionId)).toBeNull()
+  })
+
+  it('returns null for a session that has already expired by the time it is consumed', async () => {
+    getConnectionByIdMock.mockResolvedValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'token',
+    })
+    pveFetchMock.mockResolvedValueOnce({
+      ticket: 'PVE:t',
+      port: 5900,
+      user: 'u',
+      upid: 'UPID:1',
+    })
+
+    // Freeze "now" past the 30 s TTL between session creation and the
+    // consume call so the expiry branch runs deterministically.
+    const realNow = Date.now
+    const t0 = realNow()
+    Date.now = () => t0
+    try {
+      const res = await POST(new Request('http://localhost'), makeCtx('c1', 'pve1'))
+      const { data: { sessionId } } = await res.json()
+      Date.now = () => t0 + 60_000 // 60 s later
+      expect(consumeTerminalSession(sessionId)).toBeNull()
+    } finally {
+      Date.now = realNow
+    }
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.ts
@@ -5,13 +5,39 @@ import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
 
+// In-memory short-lived terminal sessions. Same MVP store as the VM
+// console flow (see consoles route): keyed by random UUID, single-use,
+// expires after 30 s to leave headroom for slow ws-proxy hops. The
+// ws-proxy process consumes the session via /api/internal/shell/consume
+// (gated by APP_SECRET) and then opens the WebSocket to PVE on the
+// browser's behalf. The apiToken NEVER leaves the server: previously
+// this route returned conn.apiToken in the JSON payload, allowing any
+// user with node.console permission to scrape the long-lived PVE token
+// from DevTools (audit finding NEW-C).
+type TerminalSession = {
+  baseUrl: string
+  host: string
+  pvePort: number
+  apiToken: string
+  node: string
+  port: number
+  ticket: string
+  user: string
+  upid: string
+  expiresAt: number
+}
+
+const sessions = new Map<string, TerminalSession>()
+
 /**
  * POST /api/v1/connections/[id]/nodes/[node]/terminal
- * 
- * Crée une session terminal (shell) pour un node
+ *
+ * Creates a terminal (shell) session for a PVE node.
  * Proxmox API: POST /nodes/{node}/termproxy
- * 
- * Retourne les informations nécessaires pour établir une connexion WebSocket
+ *
+ * Returns only { sessionId, host, node, expiresAt } so the browser can
+ * open ws://.../api/internal/ws/shell/{sessionId} without ever
+ * receiving the underlying PVE API token.
  */
 export async function POST(
   _req: Request,
@@ -28,19 +54,17 @@ export async function POST(
       return NextResponse.json({ error: "Connection not found" }, { status: 404 })
     }
 
-    // Parser le baseUrl pour extraire host et port
     let host = ''
-    let port = 8006
+    let pvePort = 8006
     try {
       const url = new URL(conn.baseUrl)
       host = url.hostname
-      port = url.port ? Number.parseInt(url.port) : 8006
+      pvePort = url.port ? Number.parseInt(url.port) : 8006
     } catch {
-      // Si le parsing échoue, essayer de parser manuellement
       const match = conn.baseUrl.match(/https?:\/\/([^:/]+)(?::(\d+))?/)
       if (match) {
         host = match[1]
-        port = match[2] ? Number.parseInt(match[2]) : 8006
+        pvePort = match[2] ? Number.parseInt(match[2]) : 8006
       }
     }
 
@@ -48,7 +72,6 @@ export async function POST(
       return NextResponse.json({ error: "Could not determine host from connection" }, { status: 500 })
     }
 
-    // POST /nodes/{node}/termproxy
     const termproxy = await pveFetch<any>(
       conn,
       `/nodes/${encodeURIComponent(node)}/termproxy`,
@@ -62,23 +85,44 @@ export async function POST(
       return NextResponse.json({ error: "Failed to create terminal session" }, { status: 500 })
     }
 
-    // Use the connection host — Proxmox API routes vncwebsocket to the correct node internally
-    const wsUrl = `wss://${host}:${port}/api2/json/nodes/${encodeURIComponent(node)}/vncwebsocket?port=${termproxy.port}&vncticket=${encodeURIComponent(termproxy.ticket)}`
+    const sessionId = crypto.randomUUID()
+    const expiresAt = Date.now() + 30_000
+
+    sessions.set(sessionId, {
+      baseUrl: conn.baseUrl,
+      host,
+      pvePort,
+      apiToken: conn.apiToken,
+      node,
+      port: Number(termproxy.port),
+      ticket: termproxy.ticket,
+      user: termproxy.user,
+      upid: termproxy.upid,
+      expiresAt,
+    })
 
     return NextResponse.json({
       data: {
-        ticket: termproxy.ticket,
-        port: termproxy.port,
-        user: termproxy.user,
-        upid: termproxy.upid,
-        wsUrl,
+        sessionId,
         host,
-        nodePort: port,
-        apiToken: conn.apiToken,
+        node,
+        expiresAt,
       }
     })
   } catch (e: any) {
     console.error("[terminal/node] Error:", e?.message)
     return NextResponse.json({ error: e?.message || "Failed to create terminal session" }, { status: 500 })
   }
+}
+
+// Server-only helper consumed by /api/internal/shell/consume. The
+// session is single-use: removed from the map on first read so a leaked
+// sessionId cannot be replayed by a second client. Returns null if the
+// id is unknown or the entry has expired.
+export function consumeTerminalSession(sessionId: string): TerminalSession | null {
+  const s = sessions.get(sessionId)
+  if (!s) return null
+  sessions.delete(sessionId)
+  if (Date.now() > s.expiresAt) return null
+  return s
 }

--- a/frontend/src/app/api/v1/connections/[id]/test-ssh/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/test-ssh/route.ts
@@ -7,6 +7,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 import { executeSSHDirect } from "@/lib/ssh/exec"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -204,7 +205,7 @@ export async function POST(
 
       const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/connections/${id}/test-ssh`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(sshCredentials),
         signal: controller.signal,
       })

--- a/frontend/src/app/api/v1/cve/[connectionId]/route.ts
+++ b/frontend/src/app/api/v1/cve/[connectionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -27,7 +28,7 @@ export async function GET(
     }
 
     const response = await fetch(url, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
     })
 
     const data = await response.json()
@@ -70,7 +71,7 @@ export async function POST(
 
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
     })
 
     const data = await response.json()

--- a/frontend/src/app/api/v1/license/activate/route.ts
+++ b/frontend/src/app/api/v1/license/activate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -20,9 +21,7 @@ export async function POST(req: Request) {
 
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/license/activate`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify({ license: body.license }),
     })
 

--- a/frontend/src/app/api/v1/license/deactivate/route.ts
+++ b/frontend/src/app/api/v1/license/deactivate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -12,6 +13,7 @@ export async function DELETE() {
 
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/license/deactivate`, {
       method: "DELETE",
+      headers: orchestratorHeaders(),
     })
 
     const data = await res.json()

--- a/frontend/src/app/api/v1/license/features/route.ts
+++ b/frontend/src/app/api/v1/license/features/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server"
 
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
+
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
@@ -34,6 +36,7 @@ const DEFAULT_COMMUNITY_FEATURES = {
 export async function GET() {
   try {
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/license/features`, {
+      headers: orchestratorHeaders(),
       cache: "no-store",
     })
 

--- a/frontend/src/app/api/v1/license/status/route.ts
+++ b/frontend/src/app/api/v1/license/status/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server"
 
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
+
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
 
@@ -16,6 +18,7 @@ const DEFAULT_COMMUNITY_STATUS = {
 export async function GET() {
   try {
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/license/status`, {
+      headers: orchestratorHeaders(),
       cache: "no-store",
     })
 

--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { getSessionPrisma } from "@/lib/tenant"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -45,7 +46,7 @@ export async function GET(req: Request) {
     // Fetch rolling updates
     try {
       const rollingRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates`, {
-        headers: { "Content-Type": "application/json" },
+        headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       })
 
       if (rollingRes.ok) {
@@ -110,7 +111,7 @@ export async function GET(req: Request) {
     // Fetch DRS migrations
     try {
       const drsRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/drs/migrations?limit=50`, {
-        headers: { "Content-Type": "application/json" },
+        headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       })
 
       if (drsRes.ok) {
@@ -157,7 +158,7 @@ export async function GET(req: Request) {
     // Fetch Site Recovery replication jobs
     try {
       const replRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/replication/jobs`, {
-        headers: { "Content-Type": "application/json" },
+        headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       })
 
       if (replRes.ok) {
@@ -213,7 +214,7 @@ export async function GET(req: Request) {
     // Fetch Site Recovery plan executions (failover/failback/test)
     try {
       const plansRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/replication/plans`, {
-        headers: { "Content-Type": "application/json" },
+        headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       })
 
       if (plansRes.ok) {
@@ -225,7 +226,7 @@ export async function GET(req: Request) {
           if (!plan.last_failover && !plan.last_test) continue
           try {
             const histRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/replication/plans/${plan.id}/history`, {
-              headers: { "Content-Type": "application/json" },
+              headers: orchestratorHeaders({ "Content-Type": "application/json" }),
             })
             if (!histRes.ok) continue
             const histData = await histRes.json()

--- a/frontend/src/app/api/v1/orchestrator/rolling-updates/[id]/[action]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/rolling-updates/[id]/[action]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { getTenantConnectionIds } from "@/lib/tenant"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -29,7 +30,7 @@ export async function POST(
 
     // Verify rolling update belongs to tenant
     const ruRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates/${id}`, {
-      headers: { "Content-Type": "application/json" },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
     })
     if (ruRes.ok) {
       const ruData = await ruRes.json()
@@ -44,7 +45,7 @@ export async function POST(
 
     const response = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates/${id}/${action}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
     })
 
     const data = await response.json()

--- a/frontend/src/app/api/v1/orchestrator/rolling-updates/[id]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/rolling-updates/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { getTenantConnectionIds } from "@/lib/tenant"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -19,7 +20,7 @@ export async function GET(
     const { id } = await ctx.params
 
     const response = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates/${id}`, {
-      headers: { "Content-Type": "application/json" },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
     })
 
     const data = await response.json()

--- a/frontend/src/app/api/v1/orchestrator/rolling-updates/preflight/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/rolling-updates/preflight/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server"
 import { getSessionPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -105,9 +106,7 @@ export async function POST(req: Request) {
 
     const response = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates/preflight`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(payload),
     })
 

--- a/frontend/src/app/api/v1/orchestrator/rolling-updates/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/rolling-updates/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server"
 import { getSessionPrisma, getTenantConnectionIds } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 export const runtime = "nodejs"
 
@@ -29,7 +30,7 @@ export async function GET(req: Request) {
     }
 
     const response = await fetch(url, {
-      headers: { "Content-Type": "application/json" },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
     })
 
     const data = await response.json()
@@ -165,9 +166,7 @@ export async function POST(req: Request) {
 
     const response = await fetch(`${ORCHESTRATOR_URL}/api/v1/rolling-updates`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(payload),
     })
 

--- a/frontend/src/components/xterm/XTermShell.tsx
+++ b/frontend/src/components/xterm/XTermShell.tsx
@@ -4,20 +4,15 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import { Box, CircularProgress, Typography, Chip, Button } from '@mui/material'
 
 interface XTermShellProps {
-  wsUrl: string
+  sessionId: string
+  // Display-only label shown in the status bar. The actual host/port
+  // PVE talks to live server-side in the consume route and never leak
+  // to the browser.
   host: string
-  port: number
-  ticket: string
-  node: string
-  user?: string
-  pvePort?: number
-  apiToken?: string
-  vmtype?: string  // 'qemu' | 'lxc' for VM/CT shell
-  vmid?: string    // VM/CT ID
   onDisconnect?: () => void
 }
 
-export default function XTermShell({ wsUrl, host, port, ticket, node, user, pvePort = 8006, apiToken, vmtype, vmid, onDisconnect }: XTermShellProps) {
+export default function XTermShell({ sessionId, host, onDisconnect }: XTermShellProps) {
   const terminalRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<any>(null)
   const fitAddonRef = useRef<any>(null)
@@ -112,24 +107,16 @@ export default function XTermShell({ wsUrl, host, port, ticket, node, user, pveP
         wsRef.current.close()
       }
 
-      // Connexion WebSocket via le proxy
-      // In dev mode, next dev doesn't handle WS upgrades, redirect to standalone ws-proxy on 3001
+      // Connexion WebSocket via le proxy. In dev mode, next dev doesn't
+      // handle WS upgrades so we redirect to the standalone ws-proxy on
+      // 3001. The browser only ever passes a sessionId; host/port/
+      // ticket/apiToken stay server-side (NEW-C / NEW-H1).
       const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
       const isDev = window.location.port === '3000' && window.location.hostname === 'localhost'
       const wsHost = isDev ? 'localhost:3001' : window.location.host
-      let proxyWsUrl = `${wsProtocol}//${wsHost}/api/internal/ws/shell?host=${encodeURIComponent(host)}&port=${port}&ticket=${encodeURIComponent(ticket)}&node=${encodeURIComponent(node)}&pvePort=${pvePort}`
+      const proxyWsUrl = `${wsProtocol}//${wsHost}/api/internal/ws/shell/${encodeURIComponent(sessionId)}`
 
-      if (user) {
-        proxyWsUrl += `&user=${encodeURIComponent(user)}`
-      }
-      if (apiToken) {
-        proxyWsUrl += `&apiToken=${encodeURIComponent(apiToken)}`
-      }
-      if (vmtype && vmid) {
-        proxyWsUrl += `&vmtype=${encodeURIComponent(vmtype)}&vmid=${encodeURIComponent(vmid)}`
-      }
-      
-      console.log('[XTerm] Connecting to proxy:', proxyWsUrl.replace(/ticket=[^&]+/, 'ticket=***').replace(/apiToken=[^&]+/, 'apiToken=***'))
+      console.log('[XTerm] Connecting to proxy:', proxyWsUrl)
       
       const ws = new WebSocket(proxyWsUrl, ['binary'])
       wsRef.current = ws
@@ -168,14 +155,22 @@ export default function XTermShell({ wsUrl, host, port, ticket, node, user, pveP
 
       ws.onclose = (event) => {
         console.log('[XTerm] WebSocket closed:', event.code, event.reason)
+        // Ignore stale closes from a previous WS that was superseded
+        // (React StrictMode double-mount in dev, manual Reconnect, etc).
+        // Without this guard a successful reconnect keeps the red error
+        // banner from the obsolete socket forever.
+        if (wsRef.current !== ws) return
         setStatus('disconnected')
-        if (event.code !== 1000) {
+        // 1000 = normal, 1005 = no status (browser close() without args).
+        // Either is a clean shutdown from our side, not an error.
+        if (event.code !== 1000 && event.code !== 1005) {
           setErrorMsg(`Connection closed: ${event.reason || 'Unknown reason'}`)
         }
       }
 
       ws.onerror = (error) => {
         console.error('[XTerm] WebSocket error:', error)
+        if (wsRef.current !== ws) return
         setStatus('error')
         setErrorMsg('WebSocket connection failed.')
       }
@@ -185,7 +180,7 @@ export default function XTermShell({ wsUrl, host, port, ticket, node, user, pveP
       setStatus('error')
       setErrorMsg(err.message || 'Failed to initialize terminal')
     }
-  }, [host, port, ticket, node, user, pvePort, apiToken, vmtype, vmid])
+  }, [sessionId])
 
   // Connexion initiale
   useEffect(() => {
@@ -245,7 +240,7 @@ export default function XTermShell({ wsUrl, host, port, ticket, node, user, pveP
             }} 
           />
           <Typography sx={{ color: '#fff', fontSize: 13, fontWeight: 600 }}>
-            {host}:{port}
+            {host}
           </Typography>
           <Typography sx={{ color: '#666', fontSize: 12 }}>
             • {status === 'connected' ? 'Connected' : 

--- a/frontend/src/lib/internal-auth.test.ts
+++ b/frontend/src/lib/internal-auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { requireInternalCaller } from './internal-auth'
+
+const PROXY_CALLER = 'proxcenter-ws-proxy'
+
+function makeReq(headers: Record<string, string>): Request {
+  return new Request('http://localhost/api/internal/shell/consume', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ sessionId: 'x' }),
+  })
+}
+
+describe('requireInternalCaller', () => {
+  const originalSecret = process.env.APP_SECRET
+
+  beforeEach(() => {
+    process.env.APP_SECRET = 'shared-secret-for-tests'
+  })
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.APP_SECRET
+    } else {
+      process.env.APP_SECRET = originalSecret
+    }
+  })
+
+  it('returns null (allowed) when caller fingerprint and secret both match', async () => {
+    const req = makeReq({
+      'x-internal-caller': PROXY_CALLER,
+      'x-internal-secret': 'shared-secret-for-tests',
+    })
+    expect(requireInternalCaller(req)).toBeNull()
+  })
+
+  it('returns 403 when the caller fingerprint header is missing', async () => {
+    const req = makeReq({
+      'x-internal-secret': 'shared-secret-for-tests',
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('returns 403 when the caller fingerprint header has the wrong value', async () => {
+    const req = makeReq({
+      'x-internal-caller': 'someone-else',
+      'x-internal-secret': 'shared-secret-for-tests',
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('returns 403 when the shared secret is missing', async () => {
+    const req = makeReq({
+      'x-internal-caller': PROXY_CALLER,
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('returns 403 when the shared secret does not match', async () => {
+    const req = makeReq({
+      'x-internal-caller': PROXY_CALLER,
+      'x-internal-secret': 'wrong-secret',
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('returns 403 when the provided secret is shorter than the expected one', async () => {
+    // Different-length inputs exercise the early-return branch of the
+    // constant-time compare. The function still must not throw.
+    const req = makeReq({
+      'x-internal-caller': PROXY_CALLER,
+      'x-internal-secret': 'short',
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(403)
+  })
+
+  it('returns 500 when APP_SECRET is unset on the server', async () => {
+    delete process.env.APP_SECRET
+    const req = makeReq({
+      'x-internal-caller': PROXY_CALLER,
+      'x-internal-secret': 'anything',
+    })
+    const res = requireInternalCaller(req)
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(500)
+  })
+})

--- a/frontend/src/lib/internal-auth.ts
+++ b/frontend/src/lib/internal-auth.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server"
+import { timingSafeEqual } from "node:crypto"
+
+// Server-side caller authentication for /api/internal/* routes. These
+// routes are listed in publicApiRoutes in middleware.ts because they
+// have to be reachable by the ws-proxy process without a NextAuth
+// session, but that makes them reachable by anyone who can hit the
+// Next.js port. A plain x-internal-caller string header is trivially
+// spoofable: clients can attach any header value. The shared secret
+// below closes that gap because APP_SECRET is server-side only (env
+// var + .env file, never shipped to the browser) and the constant-time
+// compare avoids leaking which character mismatched.
+//
+// ws-proxy sends both the x-internal-caller fingerprint (kept for
+// existing log greps) and x-internal-secret = APP_SECRET. Any caller
+// without the secret gets 403 with no further information.
+
+const EXPECTED_CALLER = "proxcenter-ws-proxy"
+
+function constantTimeStringEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8")
+  const bb = Buffer.from(b, "utf8")
+  if (ab.length !== bb.length) {
+    // timingSafeEqual rejects mismatched length up front, so we
+    // compare against an equal-length buffer and still return false.
+    timingSafeEqual(ab, Buffer.alloc(ab.length))
+    return false
+  }
+  return timingSafeEqual(ab, bb)
+}
+
+export function requireInternalCaller(req: Request): NextResponse | null {
+  const caller = req.headers.get("x-internal-caller") || ""
+  if (caller !== EXPECTED_CALLER) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+  const expected = process.env.APP_SECRET || ""
+  if (!expected) {
+    return NextResponse.json({ error: "Server misconfigured: APP_SECRET unset" }, { status: 500 })
+  }
+  const provided = req.headers.get("x-internal-secret") || ""
+  if (!constantTimeStringEqual(provided, expected)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+  return null
+}

--- a/frontend/src/lib/migration/cross-cluster-watcher.ts
+++ b/frontend/src/lib/migration/cross-cluster-watcher.ts
@@ -5,6 +5,7 @@ import { getNodeIp } from '@/lib/ssh/node-ip'
 import { executeSSHDirect, shellEscape, type SSHResult } from '@/lib/ssh/exec'
 import type { PveConn } from '@/lib/connections/getConnection'
 import { safeLog } from '@/lib/log/sanitize'
+import { orchestratorHeaders } from '@/lib/orchestrator/headers'
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://proxcenter-orchestrator:8080'
 
@@ -87,7 +88,7 @@ async function runSshForWatcher(
 
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ssh/exec`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(timeoutMs),
     })

--- a/frontend/src/lib/orchestrator/headers.test.ts
+++ b/frontend/src/lib/orchestrator/headers.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+describe('orchestratorHeaders', () => {
+  const originalKey = process.env.ORCHESTRATOR_API_KEY
+
+  // The helper snapshots the env at module-load time. vi.resetModules()
+  // before each test forces a fresh import so the env mutation is
+  // actually picked up.
+  beforeEach(() => {
+    delete process.env.ORCHESTRATOR_API_KEY
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.ORCHESTRATOR_API_KEY
+    } else {
+      process.env.ORCHESTRATOR_API_KEY = originalKey
+    }
+  })
+
+  async function loadHelper() {
+    const mod = await import('./headers')
+    return mod.orchestratorHeaders
+  }
+
+  it('returns the extra headers unchanged when the env key is unset', async () => {
+    const orchestratorHeaders = await loadHelper()
+    const out = orchestratorHeaders({ 'Content-Type': 'application/json' })
+    expect(out).toEqual({ 'Content-Type': 'application/json' })
+    expect(out).not.toHaveProperty('X-API-Key')
+  })
+
+  it('returns an empty object when called with no args and no env key', async () => {
+    const orchestratorHeaders = await loadHelper()
+    expect(orchestratorHeaders()).toEqual({})
+  })
+
+  it('attaches X-API-Key when the env var is set', async () => {
+    process.env.ORCHESTRATOR_API_KEY = 'secret-key-123'
+    const orchestratorHeaders = await loadHelper()
+    const out = orchestratorHeaders({ 'Content-Type': 'application/json' })
+    expect(out).toEqual({
+      'Content-Type': 'application/json',
+      'X-API-Key': 'secret-key-123',
+    })
+  })
+
+  it('env value wins over a caller-supplied X-API-Key', async () => {
+    process.env.ORCHESTRATOR_API_KEY = 'baseline'
+    const orchestratorHeaders = await loadHelper()
+    // The helper writes the env-derived value AFTER spreading the
+    // caller extras, on purpose: callers passing their own key (by
+    // accident or otherwise) should not silently override the
+    // configured server identity.
+    const out = orchestratorHeaders({ 'X-API-Key': 'caller-supplied' })
+    expect(out['X-API-Key']).toBe('baseline')
+  })
+})

--- a/frontend/src/lib/orchestrator/headers.ts
+++ b/frontend/src/lib/orchestrator/headers.ts
@@ -1,0 +1,18 @@
+// Lightweight header helper for Next.js API routes that proxy directly
+// to the orchestrator via raw fetch() (instead of the orchestratorFetch
+// client). These routes still need to send X-API-Key, otherwise the
+// orchestrator auth middleware returns 401. Centralising the env read
+// and the conditional header lets callers stay one-liner without
+// silently dropping the key when ORCHESTRATOR_API_KEY is empty.
+
+const ORCHESTRATOR_API_KEY = process.env.ORCHESTRATOR_API_KEY || ''
+
+export function orchestratorHeaders(
+  extra: Record<string, string> = {}
+): Record<string, string> {
+  const headers: Record<string, string> = { ...extra }
+  if (ORCHESTRATOR_API_KEY) {
+    headers['X-API-Key'] = ORCHESTRATOR_API_KEY
+  }
+  return headers
+}

--- a/frontend/src/lib/ssh/exec.ts
+++ b/frontend/src/lib/ssh/exec.ts
@@ -2,6 +2,7 @@ import { Client } from "ssh2"
 import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { safeLog } from "@/lib/log/sanitize"
+import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || "http://localhost:8080"
 
@@ -121,7 +122,7 @@ export async function executeSSH(
 
     const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ssh/exec`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: orchestratorHeaders({ "Content-Type": "application/json" }),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(timeoutMs),
     })

--- a/frontend/ws-proxy.js
+++ b/frontend/ws-proxy.js
@@ -8,14 +8,38 @@
  *
  * Routes:
  *   /ws/console/{sessionId} - Console VM/CT via session stockée
- *   /ws/shell?host=...&port=...&ticket=... - Shell node direct
+ *   /ws/shell/{sessionId}   - Shell node via session stockée
  */
+
+// Load .env files before reading APP_SECRET / PORT / etc. ws-proxy
+// runs under `node`, which (unlike `next dev`) does not auto-load .env,
+// so process.env.APP_SECRET would be empty in local dev without this.
+// @next/env is bundled with Next and silently no-ops in containers where
+// no .env file is present (the secret is provided via the container env).
+try {
+  const path = require('node:path')
+  require('@next/env').loadEnvConfig(path.join(__dirname))
+} catch {
+  // @next/env unavailable (standalone runtime build) — fall back to
+  // whatever the container injected via env.
+}
 
 const { WebSocket } = require('ws')
 
 // Always use localhost for internal API calls (ws-proxy runs in same container as frontend)
 const APP_PORT = process.env.PORT || 3000
 const INTERNAL_API_URL = `http://localhost:${APP_PORT}`
+
+// Shared secret used to authenticate ws-proxy against the Next.js
+// /api/internal/* routes. process.env.APP_SECRET is set by the same
+// .env that backs the rest of the app; without it the consume routes
+// return 500 and no proxy session can be established.
+const INTERNAL_SECRET = process.env.APP_SECRET || ''
+const INTERNAL_HEADERS = {
+  'Content-Type': 'application/json',
+  'X-Internal-Caller': 'proxcenter-ws-proxy',
+  ...(INTERNAL_SECRET ? { 'X-Internal-Secret': INTERNAL_SECRET } : {}),
+}
 
 /**
  * Handle an incoming WebSocket connection.
@@ -34,43 +58,55 @@ async function handleWsConnection(clientWs, req) {
 
   console.log(`[WS] New connection: ${url.pathname} -> ${pathname}`)
 
-  // Route: /ws/shell?host=...&port=...&ticket=...&node=...&user=...&apiToken=...&vmtype=...&vmid=...
-  if (pathParts[1] === 'ws' && pathParts[2] === 'shell') {
-    const host = url.searchParams.get('host')
-    const port = url.searchParams.get('port')
-    const ticket = url.searchParams.get('ticket')
-    const node = url.searchParams.get('node')
-    const user = url.searchParams.get('user')
-    const pvePort = url.searchParams.get('pvePort') || '8006'
-    const apiToken = url.searchParams.get('apiToken')
-    const vmtype = url.searchParams.get('vmtype')  // 'qemu' or 'lxc' (optional, for VM/CT shell)
-    const vmid = url.searchParams.get('vmid')      // VM/CT ID (optional)
+  // Route: /ws/shell/{sessionId}
+  // The browser only ever sees a sessionId. We trade it for the actual
+  // PVE termproxy parameters (including the apiToken) here, behind the
+  // APP_SECRET-gated /api/internal/shell/consume endpoint.
+  if (pathParts[1] === 'ws' && pathParts[2] === 'shell' && pathParts[3]) {
+    const sessionId = pathParts[3]
 
-    if (!host || !port || !ticket) {
-      console.error('[WS] Missing shell parameters')
-      clientWs.close(4000, 'Missing parameters: host, port, ticket required')
+    console.log(`[WS] Shell session: ${sessionId}`)
+
+    let session
+    try {
+      const sessionRes = await fetch(`${INTERNAL_API_URL}/api/internal/shell/consume`, {
+        method: 'POST',
+        headers: INTERNAL_HEADERS,
+        body: JSON.stringify({ sessionId })
+      })
+      if (!sessionRes.ok) {
+        const err = await sessionRes.text()
+        console.error(`[WS] Shell session not found or expired: ${sessionId}`, err)
+        clientWs.close(4001, 'Session not found or expired')
+        return
+      }
+      session = await sessionRes.json()
+    } catch (err) {
+      console.error('[WS] Shell consume error:', err.message)
+      clientWs.close(4004, 'Internal error')
       return
     }
 
-    console.log(`[WS] Shell connection to ${host}:${pvePort} (VNC port: ${port}, user: ${user}${vmtype ? `, ${vmtype}/${vmid}` : ''})`)
+    const { host, pvePort, port, ticket, node, user, apiToken } = session
+    if (!host || !port || !ticket || !node) {
+      console.error('[WS] Invalid shell session data:', session)
+      clientWs.close(4002, 'Invalid session data')
+      return
+    }
+
+    console.log(`[WS] Shell connection to ${host}:${pvePort} (VNC port: ${port}, user: ${user})`)
 
     try {
-      // Build path: /nodes/{node}/vncwebsocket (node shell)
-      //          or /nodes/{node}/qemu/{vmid}/vncwebsocket (VM shell)
-      //          or /nodes/{node}/lxc/{vmid}/vncwebsocket (LXC shell)
-      const basePath = `/api2/json/nodes/${encodeURIComponent(node || 'localhost')}`
-      const vmPath = vmtype && vmid ? `/${vmtype}/${encodeURIComponent(vmid)}` : ''
-      const pveWsUrl = `wss://${host}:${pvePort}${basePath}${vmPath}/vncwebsocket?port=${port}&vncticket=${encodeURIComponent(ticket)}`
+      const basePath = `/api2/json/nodes/${encodeURIComponent(node)}`
+      const pveWsUrl = `wss://${host}:${pvePort}${basePath}/vncwebsocket?port=${port}&vncticket=${encodeURIComponent(ticket)}`
 
       console.log(`[WS] Connecting to Proxmox: ${pveWsUrl.replace(/vncticket=[^&]+/, 'vncticket=***')}`)
 
       const wsHeaders = {
         'Origin': `https://${host}:${pvePort}`
       }
-
       if (apiToken) {
         wsHeaders['Authorization'] = `PVEAPIToken=${apiToken}`
-        console.log('[WS] Using API token authentication')
       }
 
       const pveWs = new WebSocket(pveWsUrl, ['binary'], {
@@ -165,7 +201,7 @@ async function handleWsConnection(clientWs, req) {
       // Récupérer les infos de session depuis l'API (internal call via localhost)
       const sessionRes = await fetch(`${INTERNAL_API_URL}/api/internal/console/consume`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-Internal-Caller': 'proxcenter-ws-proxy' },
+        headers: INTERNAL_HEADERS,
         body: JSON.stringify({ sessionId })
       })
 


### PR DESCRIPTION
## Summary

Frontend portion of an internal hardening sprint. Paired with branch `sec/v1.4.2-hardening` on the backend; both need to merge together because the backend tightens an auth surface that this PR adapts every frontend caller to.

Two commits, scoped to:

- A shared `orchestratorHeaders` helper applied across the Next.js API routes and lib helpers that proxy to the orchestrator REST API.
- A session-id indirection for the node shell flow so server-side credentials no longer transit through the browser. Mirrors the existing VM console pattern.
- Defensive auth on the `/api/internal/*` consume routes that back the WebSocket proxy.
- Entrypoint refinement to keep the demo image bootable without runtime secrets while refusing placeholder values in regular installs.
- Minor terminal UX fix to suppress a stale-close banner triggered by React StrictMode double-mount in dev.

Refer to the internal audit document for the per-item rationale and severities.

## Test plan

- [x] License pages load and orchestrator-backed routes return 200.
- [x] Node maintenance / Network Flow operations succeed end-to-end.
- [x] Node terminal opens, prompt is visible, response payload and WebSocket URL are sessionId-only.
- [x] Backend health caching and SSH host-key pinning verified.
- [ ] Demo image still boots cleanly with `DEMO_MODE=true` and no `.env`.