### PR TITLE
deps + sec: dependabot overrides + per-connection ws-proxy TLS flag

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14832,9 +14832,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -15304,12 +15304,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/valibot": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -135,6 +135,8 @@
     "defu": ">=6.1.5",
     "fast-uri": ">=3.1.2",
     "postcss": "$postcss",
-    "js-cookie": "^3.0.7"
+    "js-cookie": "^3.0.7",
+    "tmp": "^0.2.6",
+    "uuid": "^11.1.1"
   }
 }

--- a/frontend/src/app/api/internal/console/consume/route.test.ts
+++ b/frontend/src/app/api/internal/console/consume/route.test.ts
@@ -65,10 +65,11 @@ describe('POST /api/internal/console/consume', () => {
     expect(consumeMock).toHaveBeenCalledWith('abc')
   })
 
-  it('returns the VM console session payload on a hit', async () => {
+  it('returns the VM console session payload on a hit, including the per-connection insecure flag', async () => {
     consumeMock.mockReturnValueOnce({
       baseUrl: 'https://pve.example:8006',
       apiToken: 'pve!tok=secret',
+      insecure: true,
       node: 'pve1',
       type: 'qemu',
       vmid: '100',
@@ -85,11 +86,31 @@ describe('POST /api/internal/console/consume', () => {
     expect(body).toMatchObject({
       baseUrl: 'https://pve.example:8006',
       apiToken: 'pve!tok=secret',
+      insecure: true,
       node: 'pve1',
       type: 'qemu',
       vmid: '100',
       port: 5901,
       ticket: 'PVE:vncticket',
     })
+  })
+
+  it('preserves insecure=false so ws-proxy enables strict TLS', async () => {
+    consumeMock.mockReturnValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      apiToken: 'pve!tok=secret',
+      insecure: false,
+      node: 'pve1',
+      type: 'qemu',
+      vmid: '100',
+      port: 5901,
+      ticket: 'PVE:vncticket',
+      expiresAt: Date.now() + 10_000,
+    })
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'console-test-secret' })
+    )
+    const body = await res.json()
+    expect(body.insecure).toBe(false)
   })
 })

--- a/frontend/src/app/api/internal/console/consume/route.ts
+++ b/frontend/src/app/api/internal/console/consume/route.ts
@@ -24,6 +24,7 @@ export async function POST(req: Request) {
   return NextResponse.json({
     baseUrl: s.baseUrl,
     apiToken: s.apiToken,
+    insecure: s.insecure,
     port: s.port,
     ticket: s.ticket,
     node: s.node,

--- a/frontend/src/app/api/internal/shell/consume/route.test.ts
+++ b/frontend/src/app/api/internal/shell/consume/route.test.ts
@@ -65,12 +65,13 @@ describe('POST /api/internal/shell/consume', () => {
     expect(consumeMock).toHaveBeenCalledWith('abc')
   })
 
-  it('returns the full session payload on a hit', async () => {
+  it('returns the full session payload on a hit, including the per-connection insecure flag', async () => {
     consumeMock.mockReturnValueOnce({
       baseUrl: 'https://pve.example:8006',
       host: 'pve.example',
       pvePort: 8006,
       apiToken: 'pve!tok=secret',
+      insecure: true,
       node: 'pve1',
       port: 5900,
       ticket: 'PVE:ticket',
@@ -89,11 +90,33 @@ describe('POST /api/internal/shell/consume', () => {
       host: 'pve.example',
       pvePort: 8006,
       apiToken: 'pve!tok=secret',
+      insecure: true,
       node: 'pve1',
       port: 5900,
       ticket: 'PVE:ticket',
       user: 'root@pam!root',
       upid: 'UPID:1',
     })
+  })
+
+  it('preserves insecure=false so ws-proxy enables strict TLS', async () => {
+    consumeMock.mockReturnValueOnce({
+      baseUrl: 'https://pve.example:8006',
+      host: 'pve.example',
+      pvePort: 8006,
+      apiToken: 'pve!tok=secret',
+      insecure: false,
+      node: 'pve1',
+      port: 5900,
+      ticket: 'PVE:ticket',
+      user: 'root@pam!root',
+      upid: 'UPID:1',
+      expiresAt: Date.now() + 10_000,
+    })
+    const res = await POST(
+      makeReq({ 'X-Internal-Caller': PROXY_CALLER, 'X-Internal-Secret': 'shell-test-secret' })
+    )
+    const body = await res.json()
+    expect(body.insecure).toBe(false)
   })
 })

--- a/frontend/src/app/api/internal/shell/consume/route.ts
+++ b/frontend/src/app/api/internal/shell/consume/route.ts
@@ -26,6 +26,7 @@ export async function POST(req: Request) {
     host: s.host,
     pvePort: s.pvePort,
     apiToken: s.apiToken,
+    insecure: s.insecure,
     node: s.node,
     port: s.port,
     ticket: s.ticket,

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/console/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/console/route.ts
@@ -46,6 +46,7 @@ export async function POST(
   sessions.set(sessionId, {
     baseUrl: conn.baseUrl,
     apiToken: conn.apiToken,
+    insecure: conn.insecureDev,
     node,
     type,
     vmid,

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/terminal/route.ts
@@ -19,6 +19,10 @@ type TerminalSession = {
   host: string
   pvePort: number
   apiToken: string
+  // Mirrors the connection's insecureTLS flag so ws-proxy can decide
+  // whether to enable certificate verification on the PVE WebSocket
+  // hop. False means strict TLS (matches H7 backend behaviour).
+  insecure: boolean
   node: string
   port: number
   ticket: string
@@ -93,6 +97,7 @@ export async function POST(
       host,
       pvePort,
       apiToken: conn.apiToken,
+      insecure: conn.insecureDev,
       node,
       port: Number(termproxy.port),
       ticket: termproxy.ticket,

--- a/frontend/ws-proxy.js
+++ b/frontend/ws-proxy.js
@@ -87,14 +87,20 @@ async function handleWsConnection(clientWs, req) {
       return
     }
 
-    const { host, pvePort, port, ticket, node, user, apiToken } = session
+    const { host, pvePort, port, ticket, node, user, apiToken, insecure } = session
     if (!host || !port || !ticket || !node) {
       console.error('[WS] Invalid shell session data:', session)
       clientWs.close(4002, 'Invalid session data')
       return
     }
 
-    console.log(`[WS] Shell connection to ${host}:${pvePort} (VNC port: ${port}, user: ${user})`)
+    // Mirror the connection's insecureTLS flag instead of accepting
+    // every certificate unconditionally. Default missing/undefined to
+    // the legacy permissive behaviour so an in-flight rolling deploy
+    // where an old session predates the field does not lock anyone out.
+    const rejectUnauthorized = insecure === false
+
+    console.log(`[WS] Shell connection to ${host}:${pvePort} (VNC port: ${port}, user: ${user}, tls_verify: ${rejectUnauthorized})`)
 
     try {
       const basePath = `/api2/json/nodes/${encodeURIComponent(node)}`
@@ -110,7 +116,7 @@ async function handleWsConnection(clientWs, req) {
       }
 
       const pveWs = new WebSocket(pveWsUrl, ['binary'], {
-        rejectUnauthorized: false,
+        rejectUnauthorized,
         headers: wsHeaders
       })
 
@@ -213,7 +219,7 @@ async function handleWsConnection(clientWs, req) {
       }
 
       const session = await sessionRes.json()
-      const { baseUrl, port, ticket, node, apiToken } = session
+      const { baseUrl, port, ticket, node, apiToken, insecure } = session
 
       if (!baseUrl || !port || !ticket) {
         console.error('[WS] Invalid session data:', session)
@@ -226,7 +232,13 @@ async function handleWsConnection(clientWs, req) {
       const wsProtocol = pveUrl.protocol === 'https:' ? 'wss:' : 'ws:'
       const pveWsUrl = `${wsProtocol}//${pveUrl.host}/api2/json/nodes/${encodeURIComponent(node)}/${session.type}/${session.vmid}/vncwebsocket?port=${port}&vncticket=${encodeURIComponent(ticket)}`
 
-      console.log(`[WS] Connecting to Proxmox: ${pveWsUrl.replace(/vncticket=[^&]+/, 'vncticket=***')}`)
+      // Mirror the connection's insecureTLS flag rather than blanket-
+      // accepting every cert. False means strict TLS verification.
+      // Default to permissive on missing field to survive rolling
+      // deploys where the consume route predates the change.
+      const rejectUnauthorized = insecure === false
+
+      console.log(`[WS] Connecting to Proxmox: ${pveWsUrl.replace(/vncticket=[^&]+/, 'vncticket=***')} (tls_verify: ${rejectUnauthorized})`)
 
       // Headers d'authentification pour Proxmox
       const wsHeaders = {
@@ -240,7 +252,7 @@ async function handleWsConnection(clientWs, req) {
 
       // Se connecter à Proxmox
       const pveWs = new WebSocket(pveWsUrl, ['binary'], {
-        rejectUnauthorized: false, // Pour les certificats auto-signés
+        rejectUnauthorized,
         headers: wsHeaders
       })
 


### PR DESCRIPTION
## Summary

Two follow-ups to the v1.4.2 hardening sprint, both internal-audit items:

- Bump two transitive packages flagged by Dependabot via `npm overrides`.
  Both callers use named-only imports, so the affected major bump is
  compatible.
- Honor the per-connection insecure TLS flag in the WebSocket proxy
  instead of always skipping certificate verification. Mirrors the
  equivalent backend change shipped in the previous PR.

## Test plan

- [x] `npm audit` returns 0 vulnerabilities after the override.
- [x] Existing tests pass; new cases exercise both branches of the
      per-connection flag at the consume routes.
- [x] Node terminal opens against an insecure connection and the proxy
      logs `tls_verify: false`.
- [ ] Optional: a connection flipped to strict-TLS in the DB shows
      `tls_verify: true` and connects only when the certificate is
      actually valid.
