### PR TITLE
sec: TOFU host-key verification for the ssh2 frontend path

### DIFF
--- a/frontend/prisma/migrations/20260529125455_ssh_host_keys/migration.sql
+++ b/frontend/prisma/migrations/20260529125455_ssh_host_keys/migration.sql
@@ -1,0 +1,16 @@
+
+-- CreateTable
+CREATE TABLE "ssh_host_keys" (
+    "id" TEXT NOT NULL,
+    "host" TEXT NOT NULL,
+    "key_type" TEXT NOT NULL,
+    "key_data" BYTEA NOT NULL,
+    "first_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ssh_host_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ssh_host_keys_host_key" ON "ssh_host_keys"("host");
+

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -1004,3 +1004,19 @@ model NodeGreenConfig {
   @@id([connectionId, nodeName])
   @@map("node_green_config")
 }
+
+// TOFU host-key store for the frontend ssh2 path. Mirrors the backend
+// orchestrator's /app/data/known_hosts store. Keyed by host (lowercased,
+// without port — same host is assumed to present the same key on every
+// SSH port we use). The first successful connection pins the key; every
+// subsequent connection verifies it matches.
+model SshHostKey {
+  id          String   @id @default(cuid())
+  host        String   @unique
+  keyType     String   @map("key_type")
+  keyData     Bytes    @map("key_data")
+  firstSeenAt DateTime @default(now()) @map("first_seen_at")
+  lastUsedAt  DateTime @default(now()) @updatedAt @map("last_used_at")
+
+  @@map("ssh_host_keys")
+}

--- a/frontend/src/lib/ssh/exec.ts
+++ b/frontend/src/lib/ssh/exec.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { safeLog } from "@/lib/log/sanitize"
 import { orchestratorHeaders } from "@/lib/orchestrator/headers"
+import { verifyOrPin } from "@/lib/ssh/host-key-store"
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || "http://localhost:8080"
 
@@ -229,6 +230,30 @@ export function executeSSHDirect(opts: {
       port: opts.port,
       username: opts.user,
       readyTimeout: 30_000,
+      // TOFU host-key verification. Pin on first contact, refuse any
+      // later connection whose server key differs. Closes the MITM gap
+      // that ssh2's default "trust everything" behaviour leaves open
+      // (audit finding NEW-H2).
+      hostVerifier: (key: Buffer, verify: (ok: boolean) => void) => {
+        verifyOrPin(opts.host, opts.port, key)
+          .then((result) => {
+            if (result.status === "mismatch") {
+              console.warn(
+                `[ssh] host-key mismatch for ${safeLog(opts.host)}: pinned ${result.expectedKeyType}, presented ${result.presentedKeyType}. Refusing to connect. Remove the row in ssh_host_keys to re-pin.`,
+              )
+              verify(false)
+              return
+            }
+            if (result.status === "pinned-new") {
+              console.log(`[ssh] pinned ${result.keyType} host key for ${safeLog(opts.host)} (first contact)`)
+            }
+            verify(true)
+          })
+          .catch((err) => {
+            console.error(`[ssh] host-key verification failed for ${safeLog(opts.host)}: ${err?.message || err}`)
+            verify(false)
+          })
+      },
     }
 
     if (opts.key) {

--- a/frontend/src/lib/ssh/exec.ts
+++ b/frontend/src/lib/ssh/exec.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { safeLog } from "@/lib/log/sanitize"
 import { orchestratorHeaders } from "@/lib/orchestrator/headers"
-import { verifyOrPin } from "@/lib/ssh/host-key-store"
+import { makeHostVerifier } from "@/lib/ssh/host-key-store"
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || "http://localhost:8080"
 
@@ -232,28 +232,8 @@ export function executeSSHDirect(opts: {
       readyTimeout: 30_000,
       // TOFU host-key verification. Pin on first contact, refuse any
       // later connection whose server key differs. Closes the MITM gap
-      // that ssh2's default "trust everything" behaviour leaves open
-      // (audit finding NEW-H2).
-      hostVerifier: (key: Buffer, verify: (ok: boolean) => void) => {
-        verifyOrPin(opts.host, opts.port, key)
-          .then((result) => {
-            if (result.status === "mismatch") {
-              console.warn(
-                `[ssh] host-key mismatch for ${safeLog(opts.host)}: pinned ${result.expectedKeyType}, presented ${result.presentedKeyType}. Refusing to connect. Remove the row in ssh_host_keys to re-pin.`,
-              )
-              verify(false)
-              return
-            }
-            if (result.status === "pinned-new") {
-              console.log(`[ssh] pinned ${result.keyType} host key for ${safeLog(opts.host)} (first contact)`)
-            }
-            verify(true)
-          })
-          .catch((err) => {
-            console.error(`[ssh] host-key verification failed for ${safeLog(opts.host)}: ${err?.message || err}`)
-            verify(false)
-          })
-      },
+      // that ssh2's default "trust everything" behaviour leaves open.
+      hostVerifier: makeHostVerifier(opts.host, opts.port),
     }
 
     if (opts.key) {

--- a/frontend/src/lib/ssh/host-key-store.test.ts
+++ b/frontend/src/lib/ssh/host-key-store.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/db/prisma', () => ({
   },
 }))
 
-import { verifyOrPin } from './host-key-store'
+import { verifyOrPin, makeHostVerifier } from './host-key-store'
 
 // Build a fake ssh2 public-key buffer: <4-byte BE length><algo name><payload>.
 // We never inspect the payload bytes for verification (those are compared
@@ -158,5 +158,64 @@ describe('verifyOrPin', () => {
     updateMock.mockRejectedValueOnce(new Error('row vanished'))
     const out = await verifyOrPin('lossy.example', 22, key)
     expect(out).toEqual({ status: 'pinned-existing', keyType: 'ssh-ed25519' })
+  })
+})
+
+describe('makeHostVerifier', () => {
+  // Helper: drive the ssh2-style (key, callback) shape and resolve when
+  // the callback fires. Lets a single await give us the boolean decision.
+  function drive(verifier: (key: Buffer, cb: (ok: boolean) => void) => void, key: Buffer): Promise<boolean> {
+    return new Promise((resolve) => verifier(key, resolve))
+  }
+
+  it('returns true on a first-contact pin and logs the algo and host', async () => {
+    findUniqueMock.mockResolvedValueOnce(null)
+    createMock.mockResolvedValueOnce({})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const key = fakeKey('ssh-ed25519', 'tofu')
+    const ok = await drive(makeHostVerifier('pve.example', 22), key)
+    expect(ok).toBe(true)
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log.mock.calls[0]?.[0]).toContain('ssh-ed25519')
+    expect(log.mock.calls[0]?.[0]).toContain('pve.example')
+    log.mockRestore()
+  })
+
+  it('returns true silently on a ratified pin', async () => {
+    const key = fakeKey('ssh-ed25519', 'pinned')
+    findUniqueMock.mockResolvedValueOnce({ keyType: 'ssh-ed25519', keyData: Uint8Array.from(key) })
+    updateMock.mockResolvedValueOnce({})
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    const ok = await drive(makeHostVerifier('pve.example', 22), key)
+    expect(ok).toBe(true)
+    // pinned-existing path does not log; the noise floor stays low.
+    expect(log).not.toHaveBeenCalled()
+    log.mockRestore()
+  })
+
+  it('returns false and warns on a mismatch', async () => {
+    const pinned = fakeKey('ssh-rsa', 'original')
+    const presented = fakeKey('ssh-rsa', 'rotated')
+    findUniqueMock.mockResolvedValueOnce({ keyType: 'ssh-rsa', keyData: Uint8Array.from(pinned) })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const ok = await drive(makeHostVerifier('pve.example', 22), presented)
+    expect(ok).toBe(false)
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]?.[0]).toContain('host-key mismatch')
+    warn.mockRestore()
+  })
+
+  it('returns false and logs the error path when verifyOrPin throws', async () => {
+    findUniqueMock.mockRejectedValueOnce(new Error('db down'))
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const ok = await drive(makeHostVerifier('pve.example', 22), fakeKey('ssh-ed25519'))
+    expect(ok).toBe(false)
+    expect(err).toHaveBeenCalledTimes(1)
+    expect(err.mock.calls[0]?.[0]).toContain('db down')
+    err.mockRestore()
   })
 })

--- a/frontend/src/lib/ssh/host-key-store.test.ts
+++ b/frontend/src/lib/ssh/host-key-store.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const findUniqueMock = vi.fn()
+const createMock = vi.fn()
+const updateMock = vi.fn()
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    sshHostKey: {
+      findUnique: (...args: unknown[]) => findUniqueMock(...args),
+      create: (...args: unknown[]) => createMock(...args),
+      update: (...args: unknown[]) => updateMock(...args),
+    },
+  },
+}))
+
+import { verifyOrPin } from './host-key-store'
+
+// Build a fake ssh2 public-key buffer: <4-byte BE length><algo name><payload>.
+// We never inspect the payload bytes for verification (those are compared
+// constant-time), so any random suffix works. The algo header is what
+// readKeyType extracts for logging.
+function fakeKey(algo: string, suffix = 'payload-bytes'): Buffer {
+  const algoBuf = Buffer.from(algo, 'utf8')
+  const lenBuf = Buffer.alloc(4)
+  lenBuf.writeUInt32BE(algoBuf.length, 0)
+  const payload = Buffer.from(suffix, 'utf8')
+  return Buffer.concat([lenBuf, algoBuf, payload])
+}
+
+beforeEach(() => {
+  findUniqueMock.mockReset()
+  createMock.mockReset()
+  updateMock.mockReset()
+})
+
+describe('verifyOrPin', () => {
+  it('pins a new key on first contact and reports the algorithm', async () => {
+    findUniqueMock.mockResolvedValueOnce(null)
+    createMock.mockResolvedValueOnce({})
+    const key = fakeKey('ssh-ed25519', 'first-fingerprint')
+
+    const out = await verifyOrPin('PVE1.example', 22, key)
+
+    expect(out).toEqual({ status: 'pinned-new', keyType: 'ssh-ed25519' })
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { host: 'pve1.example:22' },
+      select: { keyType: true, keyData: true },
+    })
+    expect(createMock).toHaveBeenCalledTimes(1)
+    const createArg = createMock.mock.calls[0]?.[0]?.data
+    expect(createArg.host).toBe('pve1.example:22')
+    expect(createArg.keyType).toBe('ssh-ed25519')
+    expect(Buffer.from(createArg.keyData).equals(key)).toBe(true)
+  })
+
+  it('returns pinned-existing and refreshes lastUsedAt when the presented key matches', async () => {
+    const key = fakeKey('ecdsa-sha2-nistp256', 'pinned-fingerprint')
+    findUniqueMock.mockResolvedValueOnce({ keyType: 'ecdsa-sha2-nistp256', keyData: Uint8Array.from(key) })
+    updateMock.mockResolvedValueOnce({})
+
+    const out = await verifyOrPin('pve2.example', 22, key)
+
+    expect(out).toEqual({ status: 'pinned-existing', keyType: 'ecdsa-sha2-nistp256' })
+    expect(createMock).not.toHaveBeenCalled()
+    expect(updateMock).toHaveBeenCalledTimes(1)
+    expect(updateMock.mock.calls[0]?.[0]?.where).toEqual({ host: 'pve2.example:22' })
+  })
+
+  it('pins the same hostname on different ports as distinct entries', async () => {
+    const key22 = fakeKey('ssh-ed25519', 'bastion-22')
+    const key2222 = fakeKey('ssh-ed25519', 'bastion-2222')
+    findUniqueMock
+      .mockResolvedValueOnce({ keyType: 'ssh-ed25519', keyData: Uint8Array.from(key22) })
+      .mockResolvedValueOnce(null)
+    updateMock.mockResolvedValueOnce({})
+    createMock.mockResolvedValueOnce({})
+
+    const a = await verifyOrPin('bastion.example', 22, key22)
+    expect(a.status).toBe('pinned-existing')
+    expect(updateMock.mock.calls[0]?.[0]?.where).toEqual({ host: 'bastion.example:22' })
+
+    const b = await verifyOrPin('bastion.example', 2222, key2222)
+    expect(b.status).toBe('pinned-new')
+    expect(findUniqueMock.mock.calls[1]?.[0]?.where).toEqual({ host: 'bastion.example:2222' })
+    expect(createMock.mock.calls[0]?.[0]?.data?.host).toBe('bastion.example:2222')
+  })
+
+  it('returns mismatch when the presented key differs from the pinned one', async () => {
+    const pinned = fakeKey('ssh-rsa', 'original')
+    const presented = fakeKey('ssh-rsa', 'rotated')
+    findUniqueMock.mockResolvedValueOnce({ keyType: 'ssh-rsa', keyData: Uint8Array.from(pinned) })
+
+    const out = await verifyOrPin('pve3.example', 22, presented)
+
+    expect(out).toEqual({
+      status: 'mismatch',
+      expectedKeyType: 'ssh-rsa',
+      presentedKeyType: 'ssh-rsa',
+    })
+    expect(createMock).not.toHaveBeenCalled()
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty host instead of attempting any DB call', async () => {
+    const out = await verifyOrPin('   ', 22, fakeKey('ssh-ed25519'))
+    expect(out.status).toBe('mismatch')
+    expect(findUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('reports keyType=unknown for malformed key buffers', async () => {
+    findUniqueMock.mockResolvedValueOnce(null)
+    createMock.mockResolvedValueOnce({})
+    const out = await verifyOrPin('pve.example', 22, Buffer.from([1, 2, 3]))
+    expect(out).toEqual({ status: 'pinned-new', keyType: 'unknown' })
+  })
+
+  it('handles a concurrent race (P2002) by re-reading the row that won', async () => {
+    const winningKey = fakeKey('ssh-ed25519', 'won')
+    findUniqueMock
+      .mockResolvedValueOnce(null) // first read: nothing pinned yet
+      .mockResolvedValueOnce({ keyType: 'ssh-ed25519', keyData: Uint8Array.from(winningKey) })
+    const conflict = Object.assign(new Error('unique'), { code: 'P2002' })
+    createMock.mockRejectedValueOnce(conflict)
+    updateMock.mockResolvedValueOnce({})
+
+    const out = await verifyOrPin('race.example', 22, winningKey)
+    expect(out).toEqual({ status: 'pinned-existing', keyType: 'ssh-ed25519' })
+  })
+
+  it('reports mismatch when the race winner has a different key', async () => {
+    const ours = fakeKey('ssh-ed25519', 'mine')
+    const theirs = fakeKey('ssh-rsa', 'theirs')
+    findUniqueMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ keyType: 'ssh-rsa', keyData: Uint8Array.from(theirs) })
+    createMock.mockRejectedValueOnce(Object.assign(new Error('unique'), { code: 'P2002' }))
+
+    const out = await verifyOrPin('race-mismatch.example', 22, ours)
+    expect(out).toEqual({
+      status: 'mismatch',
+      expectedKeyType: 'ssh-rsa',
+      presentedKeyType: 'ssh-ed25519',
+    })
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  it('rethrows non-P2002 errors from create', async () => {
+    findUniqueMock.mockResolvedValueOnce(null)
+    const fatal = Object.assign(new Error('disk full'), { code: 'P3000' })
+    createMock.mockRejectedValueOnce(fatal)
+    await expect(verifyOrPin('boom.example', 22, fakeKey('ssh-ed25519'))).rejects.toThrow('disk full')
+  })
+
+  it('swallows update failures so an SSH op is not aborted by a missing row', async () => {
+    const key = fakeKey('ssh-ed25519', 'pinned')
+    findUniqueMock.mockResolvedValueOnce({ keyType: 'ssh-ed25519', keyData: Uint8Array.from(key) })
+    updateMock.mockRejectedValueOnce(new Error('row vanished'))
+    const out = await verifyOrPin('lossy.example', 22, key)
+    expect(out).toEqual({ status: 'pinned-existing', keyType: 'ssh-ed25519' })
+  })
+})

--- a/frontend/src/lib/ssh/host-key-store.ts
+++ b/frontend/src/lib/ssh/host-key-store.ts
@@ -1,0 +1,133 @@
+import { prisma } from "@/lib/db/prisma"
+import { timingSafeEqual } from "node:crypto"
+
+// TOFU host-key store for the frontend ssh2 path. Mirrors the backend
+// orchestrator's /app/data/known_hosts. Keyed by "host:port" so that
+// two distinct SSH endpoints reachable through the same hostname (NAT,
+// bastion port-forwards, alternate daemons on the same host) can pin
+// different keys without colliding. First successful connection pins
+// the key; every subsequent connection must match it bit-for-bit or
+// the SSH handshake is aborted.
+//
+// The verifier is intentionally async (uses Prisma) and pairs with the
+// ssh2 `hostVerifier` async signature. Using the DB rather than a flat
+// file avoids coordinating filesystem paths between the Next.js process
+// and ws-proxy and survives container rebuilds naturally.
+
+export type VerifyResult =
+  | { status: "pinned-new"; keyType: string }
+  | { status: "pinned-existing"; keyType: string }
+  | { status: "mismatch"; expectedKeyType: string; presentedKeyType: string }
+
+function normalizeHost(host: string, port: number): string {
+  const h = host.trim().toLowerCase()
+  if (!h) return ""
+  // Default port 22 still gets the suffix so we never have a row that
+  // could be confused with a port-less entry from an older deployment.
+  const p = Number.isFinite(port) && port > 0 ? Math.trunc(port) : 22
+  return `${h}:${p}`
+}
+
+// Hint extracted from the ssh2 public key buffer. The first 4 bytes are
+// a big-endian length, followed by the algorithm name (e.g. "ssh-rsa",
+// "ecdsa-sha2-nistp256", "ssh-ed25519"). Used for log/error messages
+// only — the security decision is always taken on the raw bytes.
+function readKeyType(key: Buffer): string {
+  if (!Buffer.isBuffer(key) || key.length < 5) return "unknown"
+  const nameLen = key.readUInt32BE(0)
+  if (nameLen <= 0 || nameLen > 64 || key.length < 4 + nameLen) return "unknown"
+  return key.subarray(4, 4 + nameLen).toString("utf8")
+}
+
+function bytesEqualConstantTime(a: Buffer, b: Buffer): boolean {
+  if (a.length !== b.length) {
+    // Pad to a fixed length to keep the timing profile uniform.
+    timingSafeEqual(a, Buffer.alloc(a.length))
+    return false
+  }
+  return timingSafeEqual(a, b)
+}
+
+/**
+ * Verify the presented host key against the pinned entry for `host`, or
+ * pin it on first contact. Returns a structured result so callers can
+ * log the outcome distinctly (new pin, ratified, or rejected).
+ *
+ * The function returns a result rather than throwing because ssh2's
+ * verify-callback signature is `(verify: (ok: boolean) => void) => void`
+ * and the caller needs to decide what to log/surface separately.
+ */
+export async function verifyOrPin(host: string, port: number, key: Buffer): Promise<VerifyResult> {
+  const normalized = normalizeHost(host, port)
+  if (!normalized) {
+    return { status: "mismatch", expectedKeyType: "n/a", presentedKeyType: "n/a" }
+  }
+  const presentedKeyType = readKeyType(key)
+
+  const existing = await prisma.sshHostKey.findUnique({
+    where: { host: normalized },
+    select: { keyType: true, keyData: true },
+  })
+
+  if (!existing) {
+    try {
+      await prisma.sshHostKey.create({
+        data: {
+          host: normalized,
+          keyType: presentedKeyType,
+          // Prisma's `Bytes` column types as Uint8Array<ArrayBuffer> in
+          // 7.x; the Buffer view ssh2 hands us is technically backed by
+          // ArrayBufferLike, so copy into a fresh ArrayBuffer to satisfy
+          // the narrower contract at compile time.
+          keyData: Uint8Array.from(key),
+        },
+      })
+      return { status: "pinned-new", keyType: presentedKeyType }
+    } catch (err: any) {
+      // P2002 means two concurrent first-connect attempts raced. The
+      // second writer reads back the now-pinned key and treats it as a
+      // normal verification.
+      if (err?.code !== "P2002") throw err
+      const winner = await prisma.sshHostKey.findUnique({
+        where: { host: normalized },
+        select: { keyType: true, keyData: true },
+      })
+      if (!winner) {
+        return { status: "mismatch", expectedKeyType: "n/a", presentedKeyType }
+      }
+      if (bytesEqualConstantTime(Buffer.from(winner.keyData), key)) {
+        await touchLastUsed(normalized)
+        return { status: "pinned-existing", keyType: winner.keyType }
+      }
+      return {
+        status: "mismatch",
+        expectedKeyType: winner.keyType,
+        presentedKeyType,
+      }
+    }
+  }
+
+  if (!bytesEqualConstantTime(Buffer.from(existing.keyData), key)) {
+    return {
+      status: "mismatch",
+      expectedKeyType: existing.keyType,
+      presentedKeyType,
+    }
+  }
+
+  await touchLastUsed(normalized)
+  return { status: "pinned-existing", keyType: existing.keyType }
+}
+
+async function touchLastUsed(host: string): Promise<void> {
+  // Best-effort; if the row disappeared between read and update we just
+  // skip the timestamp bump rather than fail the whole SSH op.
+  try {
+    await prisma.sshHostKey.update({
+      where: { host },
+      data: { lastUsedAt: new Date() },
+    })
+  } catch {
+    // ignore
+  }
+}

--- a/frontend/src/lib/ssh/host-key-store.ts
+++ b/frontend/src/lib/ssh/host-key-store.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db/prisma"
 import { timingSafeEqual } from "node:crypto"
+import { safeLog } from "@/lib/log/sanitize"
 
 // TOFU host-key store for the frontend ssh2 path. Mirrors the backend
 // orchestrator's /app/data/known_hosts. Keyed by "host:port" so that
@@ -129,5 +130,39 @@ async function touchLastUsed(host: string): Promise<void> {
     })
   } catch {
     // ignore
+  }
+}
+
+type VerifyCallback = (ok: boolean) => void
+
+/**
+ * Builds the ssh2 `hostVerifier` callback. Kept here rather than inline
+ * in executeSSHDirect so the logging branches stay unit-testable. Every
+ * interpolated value passes through safeLog because keyType strings
+ * come from the buffer the remote server hands us, and CodeQL's
+ * js/log-injection rule treats anything reachable from network input
+ * as tainted until a known sanitiser is applied.
+ */
+export function makeHostVerifier(host: string, port: number) {
+  return (key: Buffer, verify: VerifyCallback): void => {
+    const safeHost = safeLog(host)
+    verifyOrPin(host, port, key)
+      .then((result) => {
+        if (result.status === "mismatch") {
+          console.warn(
+            `[ssh] host-key mismatch for ${safeHost}: pinned ${safeLog(result.expectedKeyType)}, presented ${safeLog(result.presentedKeyType)}. Refusing to connect. Remove the row in ssh_host_keys to re-pin.`,
+          )
+          verify(false)
+          return
+        }
+        if (result.status === "pinned-new") {
+          console.log(`[ssh] pinned ${safeLog(result.keyType)} host key for ${safeHost} (first contact)`)
+        }
+        verify(true)
+      })
+      .catch((err) => {
+        console.error(`[ssh] host-key verification failed for ${safeHost}: ${safeLog(err?.message || String(err))}`)
+        verify(false)
+      })
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to the v1.4.2 hardening sprint, addressing one remaining internal-audit item: the frontend ssh2 path now performs TOFU host-key verification instead of accepting any key the server presents.

Scope:

- New Prisma model + migration for the host-key store.
- New `lib/ssh/host-key-store.ts` helper with `verifyOrPin(host, port, key)`. Constant-time comparison, race-safe upsert.
- `executeSSHDirect` wires the helper through ssh2's `hostVerifier` callback. On first contact the key is pinned; subsequent connections must match bit-for-bit or the handshake aborts.
- 10 unit tests, including the case where two SSH endpoints share a hostname but use different ports.

Mirrors the equivalent backend change that shipped in the previous sprint.

## Operations

To re-pin a host (legitimate key rotation, hardware swap, etc.), delete the corresponding row:

```sql
DELETE FROM ssh_host_keys WHERE host = '<host>:<port>';
```

The next SSH connection will pin the new key.

## Test plan

- [x] Existing tests pass.
- [x] 10 new tests in `host-key-store.test.ts`.
- [x] Manual: `Maintenance` on a PVE node populates `ssh_host_keys` with the expected entry, second connection matches.
- [ ] Optional: alter a pinned key in the DB and confirm the next SSH op refuses to connect with a `host-key mismatch` log line.
