### PR TITLE
fix(nodes): raise SSH budget for node management over WAN (#370)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { NODE_MGMT_SSH_TIMEOUT_MS } from '@/lib/ssh/exec'
+
+// vi.hoisted so the mocks exist before the (hoisted) async @/lib/ssh/exec
+// factory runs. See upgrade/route.test.ts for the same pattern.
+const { checkPermissionMock, getConnectionByIdMock, getNodeIpMock, executeSSHMock, pveFetchMock } =
+  vi.hoisted(() => ({
+    checkPermissionMock: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+    getConnectionByIdMock: vi.fn<(id: string) => Promise<any>>(),
+    getNodeIpMock: vi.fn<(...args: any[]) => Promise<string>>(),
+    executeSSHMock: vi.fn<(...args: any[]) => Promise<any>>(),
+    pveFetchMock: vi.fn<(...args: any[]) => Promise<any>>(),
+  }))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildNodeResourceId: (connId: string, node: string) => `${connId}:${node}`,
+  PERMISSIONS: { NODE_VIEW: 'node.view', NODE_MANAGE: 'node.manage' },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: getNodeIpMock,
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: pveFetchMock,
+}))
+
+vi.mock('@/lib/ssh/exec', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/ssh/exec')>()
+  return { ...actual, executeSSH: executeSSHMock }
+})
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'c1', baseUrl: 'https://10.0.0.1:8006' })
+  getNodeIpMock.mockReset().mockResolvedValue('203.0.113.9')
+  executeSSHMock.mockReset().mockResolvedValue({ success: true, output: 'ok' })
+  pveFetchMock.mockReset()
+})
+
+async function importHandlers() {
+  const mod = await import('./route')
+  return mod as {
+    GET: Parameters<typeof callRoute>[0]
+    POST: Parameters<typeof callRoute>[0]
+    DELETE: Parameters<typeof callRoute>[0]
+  }
+}
+
+describe('maintenance route SSH budget (#370)', () => {
+  it('POST enters maintenance with the WAN node-management budget', async () => {
+    const { POST } = await importHandlers()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, method: 'POST' })
+
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res)).success).toBe(true)
+
+    const [, , command, timeoutMs] = executeSSHMock.mock.calls[0]
+    expect(command).toContain('node-maintenance enable pve1')
+    expect(timeoutMs).toBe(NODE_MGMT_SSH_TIMEOUT_MS)
+    expect(timeoutMs).toBeGreaterThan(30_000)
+  })
+
+  it('DELETE exits maintenance with the same budget', async () => {
+    const { DELETE } = await importHandlers()
+    const res = await callRoute(DELETE, { params: { id: 'c1', node: 'pve1' }, method: 'DELETE' })
+
+    expect(res.status).toBe(200)
+    const [, , command, timeoutMs] = executeSSHMock.mock.calls[0]
+    expect(command).toContain('node-maintenance disable pve1')
+    expect(timeoutMs).toBe(NODE_MGMT_SSH_TIMEOUT_MS)
+  })
+
+  it('POST surfaces a 500 with a manual hint when SSH fails', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'SSH connection timeout (120s)' })
+    const { POST } = await importHandlers()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, method: 'POST' })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('timeout')
+    expect(body.hint).toContain('node-maintenance enable')
+  })
+
+  it('GET reports maintenance state from cluster resources', async () => {
+    pveFetchMock.mockResolvedValueOnce([{ node: 'pve1', hastate: 'maintenance' }])
+    const { GET } = await importHandlers()
+    const res = await callRoute(GET, { params: { id: 'c1', node: 'pve1' } })
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ data: { maintenance: 'maintenance' } })
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the denied Response when RBAC rejects the caller', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValueOnce(denied as any)
+
+    const { POST } = await importHandlers()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, method: 'POST' })
+
+    expect(res.status).toBe(403)
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, buildNodeResourceId, PERMISSIONS } from "@/lib/rbac"
-import { executeSSH } from "@/lib/ssh/exec"
+import { executeSSH, NODE_MGMT_SSH_TIMEOUT_MS } from "@/lib/ssh/exec"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
@@ -64,7 +64,7 @@ export async function POST(
     const command = `ha-manager crm-command node-maintenance enable ${node}`
 
     console.log(`[maintenance] POST ${node}: executing via SSH on ${nodeIp}: ${command}`)
-    const result = await executeSSH(id, nodeIp, command)
+    const result = await executeSSH(id, nodeIp, command, NODE_MGMT_SSH_TIMEOUT_MS)
 
     if (result.success) {
       return NextResponse.json({ success: true, method: 'ssh', output: result.output })
@@ -105,7 +105,7 @@ export async function DELETE(
     const command = `ha-manager crm-command node-maintenance disable ${node}`
 
     console.log(`[maintenance] DELETE ${node}: executing via SSH on ${nodeIp}: ${command}`)
-    const result = await executeSSH(id, nodeIp, command)
+    const result = await executeSSH(id, nodeIp, command, NODE_MGMT_SSH_TIMEOUT_MS)
 
     if (result.success) {
       return NextResponse.json({ success: true, method: 'ssh', output: result.output })

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { NODE_MGMT_SSH_TIMEOUT_MS } from '@/lib/ssh/exec'
+
+const { checkPermissionMock, getConnectionByIdMock, getNodeIpMock, executeSSHMock } = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  getConnectionByIdMock: vi.fn<(id: string) => Promise<any>>(),
+  getNodeIpMock: vi.fn<(...args: any[]) => Promise<string>>(),
+  executeSSHMock: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildNodeResourceId: (connId: string, node: string) => `${connId}:${node}`,
+  PERMISSIONS: { NODE_VIEW: 'node.view', NODE_MANAGE: 'node.manage' },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: getNodeIpMock,
+}))
+
+vi.mock('@/lib/ssh/exec', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/ssh/exec')>()
+  return { ...actual, executeSSH: executeSSHMock }
+})
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'c1', baseUrl: 'https://10.0.0.1:8006' })
+  getNodeIpMock.mockReset().mockResolvedValue('203.0.113.9')
+  executeSSHMock.mockReset().mockResolvedValue({ success: true, output: '' })
+})
+
+async function importPOST() {
+  const mod = await import('./route')
+  return mod.POST as Parameters<typeof callRoute>[0]
+}
+
+describe('POST .../upgrade/reboot SSH budget (#370)', () => {
+  it('reboots with the WAN node-management budget', async () => {
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, method: 'POST' })
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ rebooting: true })
+
+    const [, , command, timeoutMs] = executeSSHMock.mock.calls[0]
+    expect(command).toContain('reboot')
+    expect(timeoutMs).toBe(NODE_MGMT_SSH_TIMEOUT_MS)
+    expect(timeoutMs).toBeGreaterThan(30_000)
+  })
+
+  it('returns 500 when the reboot command fails', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'boom' })
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, method: 'POST' })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { getNodeIp } from "@/lib/ssh/node-ip"
-import { executeSSH } from "@/lib/ssh/exec"
+import { executeSSH, NODE_MGMT_SSH_TIMEOUT_MS } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
 
 export const runtime = "nodejs"
@@ -29,7 +29,7 @@ export async function POST(_req: Request, ctx: Ctx) {
   const nodeIp = await getNodeIp(conn, node)
 
   // Use nohup so the SSH session returns before the reboot kills it
-  const result = await executeSSH(id, nodeIp, "nohup bash -c 'sleep 1 && reboot' > /dev/null 2>&1 &")
+  const result = await executeSSH(id, nodeIp, "nohup bash -c 'sleep 1 && reboot' > /dev/null 2>&1 &", NODE_MGMT_SSH_TIMEOUT_MS)
 
   if (!result.success) {
     return NextResponse.json(

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { NODE_MGMT_SSH_TIMEOUT_MS } from '@/lib/ssh/exec'
+
+// Declared via vi.hoisted so they exist before the (hoisted) vi.mock factories
+// run — required because the @/lib/ssh/exec factory is async (importActual).
+const { checkPermissionMock, getConnectionByIdMock, getNodeIpMock, executeSSHMock } = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  getConnectionByIdMock: vi.fn<(id: string) => Promise<any>>(),
+  getNodeIpMock: vi.fn<(...args: any[]) => Promise<string>>(),
+  executeSSHMock: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildNodeResourceId: (connId: string, node: string) => `${connId}:${node}`,
+  PERMISSIONS: { NODE_VIEW: 'node.view', NODE_MANAGE: 'node.manage' },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: getNodeIpMock,
+}))
+
+// Mock executeSSH but keep the real NODE_MGMT_SSH_TIMEOUT_MS, so the test
+// guards the actual exported value rather than a hand-copied constant.
+vi.mock('@/lib/ssh/exec', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/ssh/exec')>()
+  return { ...actual, executeSSH: executeSSHMock }
+})
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'c1', baseUrl: 'https://10.0.0.1:8006' })
+  getNodeIpMock.mockReset().mockResolvedValue('203.0.113.9')
+  executeSSHMock.mockReset().mockResolvedValue({ success: true, output: '' })
+})
+
+async function importPOST() {
+  const mod = await import('./route')
+  return mod.POST as Parameters<typeof callRoute>[0]
+}
+
+async function importGET() {
+  const mod = await import('./route')
+  return mod.GET as Parameters<typeof callRoute>[0]
+}
+
+describe('POST /api/v1/connections/[id]/nodes/[node]/upgrade (#370 WAN timeout)', () => {
+  it('drives the upgrade SSH with the WAN node-management budget, not the 30s default', async () => {
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ started: true })
+
+    // The reported bug: a remote node over WAN timed out at the 30s default
+    // even though "Test SSH" (120s) connected. The start must use the larger
+    // budget. Asserting the exact arg guards the regression for good.
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+    const [connId, nodeIp, , timeoutMs] = executeSSHMock.mock.calls[0]
+    expect(connId).toBe('c1')
+    expect(nodeIp).toBe('203.0.113.9')
+    expect(timeoutMs).toBe(NODE_MGMT_SSH_TIMEOUT_MS)
+    expect(timeoutMs).toBeGreaterThan(30_000)
+  })
+
+  it('returns 500 when the SSH start fails', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'SSH connection timeout (120s)' })
+
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+
+    expect(res.status).toBe(500)
+    expect((await readJson<any>(res)).error).toContain('timeout')
+  })
+})
+
+describe('GET /api/v1/connections/[id]/nodes/[node]/upgrade (poll)', () => {
+  it('polls status with the same WAN budget', async () => {
+    executeSSHMock.mockResolvedValueOnce({
+      success: true,
+      output: 'RUNNING\n---SEPARATOR---\nupgrading...\n---SEPARATOR---\nNO',
+    })
+
+    const GET = await importGET()
+    const res = await callRoute(GET, { params: { id: 'c1', node: 'pve1' } })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.status).toBe('RUNNING')
+    expect(body.reboot_required).toBe(false)
+
+    const [, , , timeoutMs] = executeSSHMock.mock.calls[0]
+    expect(timeoutMs).toBe(NODE_MGMT_SSH_TIMEOUT_MS)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { getNodeIp } from "@/lib/ssh/node-ip"
-import { executeSSH } from "@/lib/ssh/exec"
+import { executeSSH, NODE_MGMT_SSH_TIMEOUT_MS } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
 
 export const runtime = "nodejs"
@@ -52,7 +52,7 @@ if [ $? -eq 0 ]; then echo COMPLETED > /tmp/.proxcenter-upgrade-status; else ech
 ${rebootCmd}
 ' > /dev/null 2>&1 &`
 
-  const result = await executeSSH(id, nodeIp, script)
+  const result = await executeSSH(id, nodeIp, script, NODE_MGMT_SSH_TIMEOUT_MS)
 
   if (!result.success) {
     return NextResponse.json(
@@ -86,7 +86,7 @@ export async function GET(_req: Request, ctx: Ctx) {
 
   const command = `cat /tmp/.proxcenter-upgrade-status 2>/dev/null || echo UNKNOWN; echo '---SEPARATOR---'; cat /tmp/.proxcenter-upgrade.log 2>/dev/null; echo '---SEPARATOR---'; test -f /var/run/reboot-required && echo YES || echo NO`
 
-  const result = await executeSSH(id, nodeIp, command)
+  const result = await executeSSH(id, nodeIp, command, NODE_MGMT_SSH_TIMEOUT_MS)
 
   if (!result.success) {
     return NextResponse.json(

--- a/frontend/src/lib/ssh/exec.test.ts
+++ b/frontend/src/lib/ssh/exec.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { executeSSHDirect, NODE_MGMT_SSH_TIMEOUT_MS } from '@/lib/ssh/exec'
+
+// Captures the connect config the ssh2 Client receives, and drives a
+// successful ready -> exec -> close cycle so executeSSHDirect resolves.
+const { sshState } = vi.hoisted(() => ({
+  sshState: { config: null as any, command: null as any },
+}))
+
+vi.mock('ssh2', () => {
+  class FakeClient {
+    private h: Record<string, (...a: any[]) => void> = {}
+    on(ev: string, cb: (...a: any[]) => void) {
+      this.h[ev] = cb
+      return this
+    }
+    connect(cfg: any) {
+      sshState.config = cfg
+      queueMicrotask(() => this.h.ready?.())
+    }
+    exec(cmd: string, cb: (err: any, stream: any) => void) {
+      sshState.command = cmd
+      const stream: any = {
+        on(ev: string, handler: (...a: any[]) => void) {
+          if (ev === 'close') queueMicrotask(() => handler(0))
+          return stream
+        },
+        stderr: { on() {} },
+      }
+      cb(null, stream)
+    }
+    end() {}
+  }
+  return { Client: FakeClient }
+})
+
+// Avoid touching the host-key store (DB) in a pure connect-config unit test.
+vi.mock('@/lib/ssh/host-key-store', () => ({
+  makeHostVerifier: () => () => true,
+}))
+
+const base = { host: 'h', port: 22, user: 'root', password: 'pw', command: 'hostname' }
+
+beforeEach(() => {
+  sshState.config = null
+  sshState.command = null
+})
+
+describe('executeSSHDirect readyTimeout (#370)', () => {
+  it('exports a 120s node-management budget', () => {
+    expect(NODE_MGMT_SSH_TIMEOUT_MS).toBe(120_000)
+  })
+
+  it('defaults the connect (readyTimeout) to 30s when no timeoutMs is given', async () => {
+    const r = await executeSSHDirect({ ...base })
+    expect(r.success).toBe(true)
+    expect(sshState.config.readyTimeout).toBe(30_000)
+  })
+
+  it('honors a larger timeoutMs on the connect step (the bug: it was hardcoded 30s)', async () => {
+    const r = await executeSSHDirect({ ...base, timeoutMs: NODE_MGMT_SSH_TIMEOUT_MS })
+    expect(r.success).toBe(true)
+    expect(sshState.config.readyTimeout).toBe(120_000)
+  })
+
+  it('caps the connect budget at 120s for very long operations', async () => {
+    await executeSSHDirect({ ...base, command: 'dd ...', timeoutMs: 3_600_000 })
+    expect(sshState.config.readyTimeout).toBe(120_000)
+  })
+})

--- a/frontend/src/lib/ssh/exec.ts
+++ b/frontend/src/lib/ssh/exec.ts
@@ -22,6 +22,15 @@ export interface SSHResult {
 }
 
 /**
+ * SSH budget for node-management actions (update, reboot, maintenance) that may
+ * target hosts reached over a high-latency WAN link (e.g. a remote node added
+ * by public IP). The commands themselves are quick or backgrounded; the slow
+ * part is the SSH connect/handshake, which can exceed the 30s executeSSH
+ * default. Matches the budget the "Test SSH" path already grants. See #370.
+ */
+export const NODE_MGMT_SSH_TIMEOUT_MS = 120_000
+
+/**
  * Execute an SSH command with orchestrator-first, ssh2-fallback strategy.
  *
  * 1. Try the Go orchestrator POST /api/v1/ssh/exec
@@ -229,7 +238,13 @@ export function executeSSHDirect(opts: {
       host: opts.host,
       port: opts.port,
       username: opts.user,
-      readyTimeout: 30_000,
+      // Connect/handshake budget. Honor the caller's timeoutMs (capped at
+      // 120s) instead of a hardcoded 30s, so high-latency WAN links and
+      // long-running ops get enough headroom to complete the SSH handshake.
+      // Plain 30s execs are unchanged (min(30s, 120s) === 30s). See #370:
+      // a node added over a public-IP WAN link timed out the upgrade at 30s
+      // even though "Test SSH" (which allows 120s) connected fine.
+      readyTimeout: Math.min(overallTimeoutMs, 120_000),
       // TOFU host-key verification. Pin on first contact, refuse any
       // later connection whose server key differs. Closes the MITM gap
       // that ssh2's default "trust everything" behaviour leaves open.


### PR DESCRIPTION
## Problem

Reported in #370: starting a node update over a WAN link (remote node added by public IP, ports 8006/22 open) fails with `SSH connection timeout (30s)`, even though **Test SSH Connection** succeeds and the package list loads.

## Root cause

The two paths use different timeout budgets:

| Step | Transport | Budget |
|---|---|---|
| Package list ("34 packages") | Proxmox API, port 8006 | PVE API timeout |
| **Test SSH Connection** | orchestrator `/test-ssh` | **120s** |
| **Start update** | `executeSSH(...)` | **30s** (default) |

The user proves connectivity with a 120s budget, then triggers an action capped at 30s. On a high-latency WAN link the SSH handshake lands between the two, so the test passes but the update times out. The package count comes over 8006, which masked that only the SSH (port 22) path was failing. The upgrade command is fully backgrounded (`nohup ... &`), so the only thing that can consume 30s is the connect/handshake, which is exactly what WAN latency inflates.

Same class as #332 (hardcoded-aggressive timeouts breaking slow links).

## Fix

- `lib/ssh/exec.ts`: `readyTimeout` now `Math.min(overallTimeoutMs, 120_000)` instead of a hardcoded `30_000`, so a caller asking for a larger budget actually gets it on connect (this was a latent bug: migration's large `timeoutMs` calls still capped connect at 30s). Default 30s callers are byte-for-byte unchanged. Export shared `NODE_MGMT_SSH_TIMEOUT_MS = 120_000`.
- Node-management routes pass the 120s budget, matching what Test SSH already grants: upgrade (start + poll), maintenance (enter + exit), reboot.
- Regression tests on the upgrade route guard the budget (and that it is not the 30s default).

## Testing

- New unit tests: 3 passed. Sibling suites (test-ssh, apt): 20 passed.
- Manual: SSH-driven node actions verified in dev; no regression on the fast (LAN) path where `min(30s, 120s)` stays 30s.

Closes #370