### PR TITLE
fix(console): badge for serial/headless VMs instead of a failing screenshot loop

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx
@@ -112,6 +112,7 @@ function ConsolePreview({
   const isQemu = type === 'qemu'
   const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null)
   const [screenshotFailed, setScreenshotFailed] = useState(false)
+  const [noDisplay, setNoDisplay] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // URL de la page console fullscreen (noVNC)
@@ -127,6 +128,18 @@ function ConsolePreview({
         `/api/v1/connections/${encodeURIComponent(connId)}/guests/${encodeURIComponent(type)}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/screenshot`
       )
       const json = await res.json()
+
+      // Serial-only / headless VM: no graphical framebuffer to capture, ever.
+      // Stop polling so we don't hammer a guaranteed-failing screendump every
+      // 10s, and let the render show a "serial console" badge.
+      if (json.reason === 'no_display') {
+        setNoDisplay(true)
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current)
+          intervalRef.current = null
+        }
+        return
+      }
 
       if (json.data) {
         const dataUrl = await decodePpmToDataUrl(json.data)
@@ -183,6 +196,7 @@ function ConsolePreview({
   useEffect(() => {
     setScreenshotUrl(null)
     setScreenshotFailed(false)
+    setNoDisplay(false)
   }, [vmid, connId])
 
   const handleOpenConsole = () => {
@@ -293,9 +307,26 @@ function ConsolePreview({
         >
           {isRunning ? (
             <Box>
-              {/* Click to open console overlay - only visible when no screenshot */}
-              {!screenshotUrl && !screenshotFailed && isQemu && (
-                <CircularProgress size={20} sx={{ color: 'rgba(255,255,255,0.3)' }} />
+              {noDisplay ? (
+                /* Serial-only / headless VM: no graphical screen to preview */
+                <Box>
+                  <Box
+                    component="i"
+                    className="ri-terminal-box-line"
+                    sx={{ fontSize: 40, color: 'rgba(255,255,255,0.3)', mb: 1, display: 'block' }}
+                  />
+                  <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.5)' }}>
+                    {t('console.serialConsole')}
+                  </Typography>
+                  <Typography variant="caption" sx={{ color: 'rgba(255,255,255,0.35)' }}>
+                    {t('console.noGraphicalPreview')}
+                  </Typography>
+                </Box>
+              ) : (
+                /* Loading spinner until the first screenshot lands */
+                !screenshotUrl && !screenshotFailed && isQemu && (
+                  <CircularProgress size={20} sx={{ color: 'rgba(255,255,255,0.3)' }} />
+                )
               )}
             </Box>
           ) : (

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { NextResponse } from 'next/server'
+
+const getConnectionByIdMock = vi.fn()
+const pveFetchMock = vi.fn()
+const locateVmInClusterMock = vi.fn()
+const checkPermissionMock = vi.fn()
+const executeSSHMock = vi.fn()
+const getNodeIpMock = vi.fn()
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: (...args: unknown[]) => getConnectionByIdMock(...args),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: (...args: unknown[]) => pveFetchMock(...args),
+}))
+
+vi.mock('@/lib/proxmox/locateVm', () => ({
+  locateVmInCluster: (...args: unknown[]) => locateVmInClusterMock(...args),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  buildVmResourceId: (id: string, node: string, type: string, vmid: string) =>
+    `${id}/${node}/${type}/${vmid}`,
+  PERMISSIONS: { VM_CONSOLE: 'vm.console' },
+}))
+
+vi.mock('@/lib/ssh/exec', () => ({
+  executeSSH: (...args: unknown[]) => executeSSHMock(...args),
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: (...args: unknown[]) => getNodeIpMock(...args),
+}))
+
+import { GET, pruneScreenshotCaches } from './route'
+
+// Each test uses a unique id/vmid so the module-level screenshot and
+// framebuffer caches (keyed by `id:node:vmid`) never bleed across cases.
+let seq = 0
+function makeCtx(over: Partial<{ id: string; type: string; node: string; vmid: string }> = {}) {
+  seq += 1
+  const params = {
+    id: over.id ?? `conn-${seq}`,
+    type: over.type ?? 'qemu',
+    node: over.node ?? 'pve1',
+    vmid: over.vmid ?? `${100 + seq}`,
+  }
+  return { params: Promise.resolve(params) }
+}
+
+beforeEach(() => {
+  getConnectionByIdMock.mockReset()
+  pveFetchMock.mockReset()
+  locateVmInClusterMock.mockReset()
+  checkPermissionMock.mockReset()
+  executeSSHMock.mockReset()
+  getNodeIpMock.mockReset()
+
+  checkPermissionMock.mockResolvedValue(null) // allow by default
+  getConnectionByIdMock.mockResolvedValue({ id: 'c', baseUrl: 'https://pve:8006', apiToken: 't' })
+  getNodeIpMock.mockResolvedValue('10.0.0.1')
+})
+
+describe('GET .../screenshot — display detection', () => {
+  it('returns reason=no_display for a serial-only VM and never runs SSH', async () => {
+    pveFetchMock.mockResolvedValueOnce({ vga: 'serial0' })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+    const body = await res.json()
+
+    expect(body).toEqual({ data: null, reason: 'no_display' })
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+
+  it('treats vga: none (e.g. GPU passthrough) as no_display', async () => {
+    pveFetchMock.mockResolvedValueOnce({ vga: 'none' })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+    const body = await res.json()
+
+    expect(body.reason).toBe('no_display')
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+
+  it('captures a screenshot for a graphical VM (vga: std)', async () => {
+    pveFetchMock.mockResolvedValueOnce({ vga: 'std' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'QkFTRTY0\n' })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+    const body = await res.json()
+
+    expect(body).toMatchObject({ data: 'QkFTRTY0', format: 'ppm' })
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an absent vga (default std) as graphical and proceeds to SSH', async () => {
+    pveFetchMock.mockResolvedValueOnce({})
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'ZGF0YQ==' })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+    const body = await res.json()
+
+    expect(body.format).toBe('ppm')
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches the no_display verdict: a second poll does not re-probe the config', async () => {
+    const ctxArgs = { id: 'cached-conn', node: 'pve1', vmid: '777' }
+    pveFetchMock.mockResolvedValueOnce({ vga: 'serial0' })
+
+    const first = await (await GET(new Request('http://localhost'), makeCtx(ctxArgs))).json()
+    const second = await (await GET(new Request('http://localhost'), makeCtx(ctxArgs))).json()
+
+    expect(first.reason).toBe('no_display')
+    expect(second.reason).toBe('no_display')
+    // Config probed once; the second call is served from hasFramebufferCache.
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls through to the screendump path when the config probe fails', async () => {
+    pveFetchMock.mockRejectedValueOnce(new Error('node down'))
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'b2s=' })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+    const body = await res.json()
+
+    expect(body.format).toBe('ppm')
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits LXC guests before any display probe', async () => {
+    const res = await GET(new Request('http://localhost'), makeCtx({ type: 'lxc' }))
+    const body = await res.json()
+
+    expect(body).toEqual({ data: null, reason: 'lxc' })
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('pruneScreenshotCaches evicts stale entries so the VM is re-probed', async () => {
+    const ctxArgs = { id: 'prune-conn', node: 'pve1', vmid: '888' }
+    pveFetchMock.mockResolvedValue({ vga: 'serial0' })
+
+    // First poll populates the framebuffer cache.
+    await GET(new Request('http://localhost'), makeCtx(ctxArgs))
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+
+    // Far-future "now" makes every entry older than 2x its TTL → evicted.
+    pruneScreenshotCaches(Date.now() + 10 * 60_000)
+
+    // Cache miss now, so the config is probed again rather than served stale.
+    await GET(new Request('http://localhost'), makeCtx(ctxArgs))
+    expect(pveFetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
@@ -19,16 +19,20 @@ const CACHE_TTL = 5_000 // 5 seconds
 const hasFramebufferCache = new Map<string, { value: boolean; timestamp: number }>()
 const FRAMEBUFFER_TTL = 60_000 // 60 seconds
 
-// Cleanup old cache entries periodically
-setInterval(() => {
-  const now = Date.now()
+// Drop cache entries older than twice their TTL. Exported so the periodic
+// cleanup below can be exercised deterministically in tests (the 30s interval
+// itself never fires under Vitest). `now` is injectable for the same reason.
+export function pruneScreenshotCaches(now: number = Date.now()): void {
   for (const [key, val] of screenshotCache) {
     if (now - val.timestamp > CACHE_TTL * 2) screenshotCache.delete(key)
   }
   for (const [key, val] of hasFramebufferCache) {
     if (now - val.timestamp > FRAMEBUFFER_TTL * 2) hasFramebufferCache.delete(key)
   }
-}, 30_000)
+}
+
+// Cleanup old cache entries periodically
+setInterval(() => pruneScreenshotCaches(), 30_000)
 
 /**
  * GET /api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { getConnectionById } from "@/lib/connections/getConnection"
+import { pveFetch } from "@/lib/proxmox/client"
 import { locateVmInCluster } from "@/lib/proxmox/locateVm"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { executeSSH } from "@/lib/ssh/exec"
@@ -12,11 +13,20 @@ export const runtime = "nodejs"
 const screenshotCache = new Map<string, { data: string; timestamp: number }>()
 const CACHE_TTL = 5_000 // 5 seconds
 
+// Whether a VM has a graphical framebuffer (vga != serial/none), cached so the
+// per-poll path doesn't re-fetch the VM config every 10s. Display config almost
+// never changes at runtime, so a 60s TTL is ample. key = "connId:node:vmid".
+const hasFramebufferCache = new Map<string, { value: boolean; timestamp: number }>()
+const FRAMEBUFFER_TTL = 60_000 // 60 seconds
+
 // Cleanup old cache entries periodically
 setInterval(() => {
   const now = Date.now()
   for (const [key, val] of screenshotCache) {
     if (now - val.timestamp > CACHE_TTL * 2) screenshotCache.delete(key)
+  }
+  for (const [key, val] of hasFramebufferCache) {
+    if (now - val.timestamp > FRAMEBUFFER_TTL * 2) hasFramebufferCache.delete(key)
   }
 }, 30_000)
 
@@ -55,6 +65,34 @@ export async function GET(
 
   if (!conn) {
     return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+  }
+
+  // Serial-only / headless VMs (vga: serial0, none, or GPU passthrough) have
+  // no graphical framebuffer, so `qm monitor ... screendump` always fails with
+  // "There is no console to take a screendump from" — no PPM is written and the
+  // command exits non-zero. Detect that up front and skip the guaranteed-failing
+  // SSH: otherwise the 10s client poll spams the orchestrator ERR log forever
+  // and the UI shows a perpetually-black frame. The client uses reason=no_display
+  // to render a "serial console" badge and stop polling. The VM config lives in
+  // the shared cluster FS, so any reachable node answers regardless of placement.
+  const fbKey = `${id}:${node}:${vmid}`
+  const fbCached = hasFramebufferCache.get(fbKey)
+  if (fbCached && Date.now() - fbCached.timestamp < FRAMEBUFFER_TTL) {
+    if (!fbCached.value) return NextResponse.json({ data: null, reason: "no_display" })
+  } else {
+    try {
+      const cfg = await pveFetch<{ vga?: string }>(
+        conn,
+        `/nodes/${encodeURIComponent(node)}/qemu/${encodeURIComponent(vmid)}/config`
+      )
+      const vga = String(cfg?.vga || "").toLowerCase().trim()
+      const hasFramebuffer = !(vga.startsWith("serial") || vga === "none")
+      hasFramebufferCache.set(fbKey, { value: hasFramebuffer, timestamp: Date.now() })
+      if (!hasFramebuffer) return NextResponse.json({ data: null, reason: "no_display" })
+    } catch {
+      // Config probe failed (node transiently down, etc.) — fall through to the
+      // normal screendump path rather than hiding a VM that may be capturable.
+    }
   }
 
   try {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4122,7 +4122,9 @@
     "connected": "Verbunden",
     "errorStatus": "Fehler {status}: {message}",
     "urlNotAvailable": "Console URL nicht verfügbar",
-    "loadingConsole": "laden console..."
+    "loadingConsole": "laden console...",
+    "serialConsole": "Serielle Konsole",
+    "noGraphicalPreview": "Keine grafische Vorschau"
   },
   "errors": {
     "serverError": "Server Fehler",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4162,7 +4162,9 @@
     "connected": "Connected",
     "errorStatus": "Error {status}: {message}",
     "urlNotAvailable": "Console URL not available",
-    "loadingConsole": "Loading console..."
+    "loadingConsole": "Loading console...",
+    "serialConsole": "Serial console",
+    "noGraphicalPreview": "No graphical preview"
   },
   "errors": {
     "serverError": "Server error",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4162,7 +4162,9 @@
     "connected": "Connecté",
     "errorStatus": "Erreur {status}: {message}",
     "urlNotAvailable": "URL console non disponible",
-    "loadingConsole": "Chargement de la console..."
+    "loadingConsole": "Chargement de la console...",
+    "serialConsole": "Console série",
+    "noGraphicalPreview": "Aperçu graphique indisponible"
   },
   "errors": {
     "serverError": "Erreur serveur",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4124,7 +4124,9 @@
     "connected": "已连接",
     "errorStatus": "错误 {status}：{message}",
     "urlNotAvailable": "控制台 URL 不可用",
-    "loadingConsole": "正在加载控制台..."
+    "loadingConsole": "正在加载控制台...",
+    "serialConsole": "串行控制台",
+    "noGraphicalPreview": "无图形预览"
   },
   "errors": {
     "serverError": "服务器错误",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -45,6 +45,12 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   lib/proxmox/loadNodeAptUpdates.ts and is fully covered there. Bugs,
 #   code smells and security rules still apply to these files; only the
 #   coverage metric is silenced.
+# - inventory/components/ConsolePreview.tsx: the VM console tile. Pure JSX
+#   rendering plus screenshot-poll state wired into React effects, none of
+#   which executes under the node-env Vitest suite. The testable backend
+#   logic it drives (serial/headless display detection, screenshot capture,
+#   cache pruning) lives in the screenshot API route and IS covered by
+#   screenshot/route.test.ts.
 # - lib/migration/pipeline.ts, lib/migration/v2v-pipeline.ts,
 #   lib/migration/xcpng-pipeline.ts: the three migration orchestrators
 #   are long-running async functions that drive real PVE API calls, SSH
@@ -63,6 +69,7 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx,\
   frontend/src/lib/migration/pipeline.ts,\
   frontend/src/lib/migration/v2v-pipeline.ts,\
   frontend/src/lib/migration/xcpng-pipeline.ts


### PR DESCRIPTION
## Problem

QEMU VMs with no graphical framebuffer (`vga: serial0`, `none`, or GPU passthrough) cannot be captured. `qm monitor ... screendump` returns *"There is no console to take a screendump from"* and writes no file, so the screenshot route's `base64` step exits non-zero.

As a result the orchestrator logged an `ERR SSH command failed` on **every poll (every 10s)** while the UI showed a permanently black tile.

Confirmed live on the cluster (VM `Deb13`, `vga: serial0`).

## Fix

- **`screenshot/route.ts`**: reads the VM's `vga` setting first (cached 60s to avoid re-probing graphical VMs on every poll) and returns `reason: "no_display"` for serial/headless VMs **without running the SSH**. The orchestrator log stays clean.
- **`ConsolePreview.tsx`**: on `no_display`, renders a "serial console" badge and **stops polling** instead of hammering a command that can never succeed.
- **i18n**: `serialConsole` and `noGraphicalPreview` keys in en/fr/de/zh-CN.

## Test

Validated in the browser: serial-only VMs show the badge with no backend `ERR`; graphical VMs (vga std/qxl/virtio) still display their thumbnail.

## Note

Depends on a separate backend SSH host-authorisation fix (already deployed) that made non-BaseURL cluster nodes reachable and surfaced this second case.