### PR TITLE
Dashboard widgets honor appearance font-size, corner-rounding and a shared gauge

### DIFF
--- a/frontend/src/components/dashboard/WidgetGrid.jsx
+++ b/frontend/src/components/dashboard/WidgetGrid.jsx
@@ -43,7 +43,7 @@ function NoContainerWrapper({ config, data, loading, editMode, onRemove, onUpdat
       ...(editMode && {
         border: '2px dashed',
         borderColor: 'primary.main',
-        borderRadius: 3,
+        borderRadius: 'var(--proxcenter-card-radius)',
         opacity: 0.9,
       }),
     }}>
@@ -143,7 +143,7 @@ function WidgetContainer({
         background: 'transparent',
         border: '1px solid',
         borderColor: (theme) => theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
-        borderRadius: 3,
+        borderRadius: 'var(--proxcenter-card-radius)',
         '&:hover': editMode ? { boxShadow: 4 } : {},
       }}
     >

--- a/frontend/src/components/dashboard/gaugeGeometry.js
+++ b/frontend/src/components/dashboard/gaugeGeometry.js
@@ -1,0 +1,16 @@
+// The gauge is drawn in a normalized 100x100 viewBox; CSS scales the SVG to
+// whatever pixel size the widget slot allows (see CircularGauge.jsx). Keeping
+// geometry in viewBox units gives one source of truth for the dial
+// proportions, so the component never needs to know its rendered pixel size.
+export const GAUGE_VIEWBOX = 100
+export const GAUGE_STROKE = 8.5 // viewBox units, ~8.5% of the diameter
+
+export function gaugeGeometry(fraction, strokeWidth = GAUGE_STROKE) {
+  const f = Number.isFinite(fraction) ? Math.min(Math.max(fraction, 0), 1) : 0
+  const center = GAUGE_VIEWBOX / 2
+  const radius = (GAUGE_VIEWBOX - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const dashoffset = circumference - f * circumference
+
+  return { center, radius, strokeWidth, circumference, dashoffset }
+}

--- a/frontend/src/components/dashboard/gaugeGeometry.test.js
+++ b/frontend/src/components/dashboard/gaugeGeometry.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { gaugeGeometry, GAUGE_VIEWBOX, GAUGE_STROKE } from './gaugeGeometry'
+
+describe('gaugeGeometry', () => {
+  const radius = (GAUGE_VIEWBOX - GAUGE_STROKE) / 2
+  const circumference = 2 * Math.PI * radius
+
+  it('derives center/radius/circumference from the normalized viewBox', () => {
+    const g = gaugeGeometry(0)
+    expect(g.center).toBe(GAUGE_VIEWBOX / 2)
+    expect(g.radius).toBeCloseTo(radius, 6)
+    expect(g.circumference).toBeCloseTo(circumference, 6)
+    expect(g.strokeWidth).toBe(GAUGE_STROKE)
+  })
+
+  it('empty gauge (fraction 0) has full dash offset', () => {
+    expect(gaugeGeometry(0).dashoffset).toBeCloseTo(circumference, 6)
+  })
+
+  it('full gauge (fraction 1) has zero dash offset', () => {
+    expect(gaugeGeometry(1).dashoffset).toBeCloseTo(0, 6)
+  })
+
+  it('half gauge offsets by half the circumference', () => {
+    expect(gaugeGeometry(0.5).dashoffset).toBeCloseTo(circumference / 2, 6)
+  })
+
+  it('clamps fractions below 0 and above 1', () => {
+    expect(gaugeGeometry(-3).dashoffset).toBeCloseTo(circumference, 6)
+    expect(gaugeGeometry(5).dashoffset).toBeCloseTo(0, 6)
+  })
+
+  it('treats non-finite input as empty', () => {
+    expect(gaugeGeometry(NaN).dashoffset).toBeCloseTo(circumference, 6)
+    expect(gaugeGeometry(undefined).dashoffset).toBeCloseTo(circumference, 6)
+  })
+
+  it('honors a custom stroke width', () => {
+    const g = gaugeGeometry(0, 5)
+    expect(g.strokeWidth).toBe(5)
+    expect(g.radius).toBeCloseTo((GAUGE_VIEWBOX - 5) / 2, 6)
+  })
+})

--- a/frontend/src/components/dashboard/widgets/ActivityFeedWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ActivityFeedWidget.jsx
@@ -35,7 +35,7 @@ function EntityIcon({ isGuest, type, status, taskStatus, isDark }) {
 
   return (
     <Box sx={{ position: 'relative', width: 20, height: 20, flexShrink: 0, mr: 0.25 }}>
-      <i className={icon} style={{ fontSize: 18, opacity: 0.8 }} />
+      <i className={icon} style={{ fontSize: '1.2857rem', opacity: 0.8 }} />
       <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 9, height: 9, borderRadius: '50%', bgcolor: dotColor, border: '2px solid', borderColor: isDark ? '#1e1e2d' : '#fff' }} />
     </Box>
   )
@@ -81,7 +81,7 @@ function TaskDetailDialog({ event, open, onClose, t, nodeStatusMap, isDark }) {
     <Dialog open={open} onClose={onClose} maxWidth='xs' fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Chip size='small' label={event.status === 'running' ? t('jobs.running') : event.status} color={statusColor} sx={{ height: 22, fontSize: 11 }} />
+          <Chip size='small' label={event.status === 'running' ? t('jobs.running') : event.status} color={statusColor} sx={{ height: 22, fontSize: '0.7857rem' }} />
           {event.typeLabel || event.type}
         </Box>
         <IconButton size='small' onClick={onClose}>
@@ -92,10 +92,10 @@ function TaskDetailDialog({ event, open, onClose, t, nodeStatusMap, isDark }) {
       <DialogContent sx={{ py: 2 }}>
         {rows.map((row, idx) => (
           <Box key={idx} sx={{ display: 'flex', py: 0.75, borderBottom: idx < rows.length - 1 ? '1px solid' : 'none', borderColor: 'divider' }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, width: 110, flexShrink: 0, color: 'text.secondary', fontSize: 13 }}>
+            <Typography variant='body2' sx={{ fontWeight: 600, width: 110, flexShrink: 0, color: 'text.secondary', fontSize: '0.9286rem' }}>
               {row.label}
             </Typography>
-            <Typography variant='body2' sx={{ fontSize: 13 }}>
+            <Typography variant='body2' sx={{ fontSize: '0.9286rem' }}>
               {row.value}
             </Typography>
           </Box>
@@ -176,7 +176,7 @@ return '#4caf50'
   const darkCard = {
     bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
     border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-    borderRadius: 2.5, p: 1.5,
+    borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
     transition: 'border-color 0.2s, box-shadow 0.2s',
     '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
   }
@@ -227,15 +227,15 @@ return '#4caf50'
               <EntityIcon isGuest={isGuest} type={guestType} status={guestStatus} taskStatus={event.status} isDark={isDark} />
 
               {/* Task label + guest name */}
-              <Typography sx={{ fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}>
+              <Typography sx={{ fontSize: '0.7857rem', fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}>
                 {TASK_LABELS[event.type] || event.type}
                 {displayName && (
-                  <Typography component='span' sx={{ fontSize: 11, fontWeight: 400, opacity: 0.7, ml: 0.5 }}>
+                  <Typography component='span' sx={{ fontSize: '0.7857rem', fontWeight: 400, opacity: 0.7, ml: 0.5 }}>
                     {displayName}
                   </Typography>
                 )}
                 {!displayName && isGuest && (
-                  <Typography component='span' sx={{ fontSize: 10, fontWeight: 400, opacity: 0.5, ml: 0.5, fontFamily: '"JetBrains Mono", monospace' }}>
+                  <Typography component='span' sx={{ fontSize: '0.7143rem', fontWeight: 400, opacity: 0.5, ml: 0.5, fontFamily: '"JetBrains Mono", monospace' }}>
                     #{event.entity}
                   </Typography>
                 )}
@@ -244,13 +244,13 @@ return '#4caf50'
               {/* Node */}
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4, flexShrink: 0 }}>
                 <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={10} height={10} style={{ opacity: 0.5 }} />
-                <Typography sx={{ fontSize: 9, opacity: 0.5, fontFamily: '"JetBrains Mono", monospace' }}>
+                <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5, fontFamily: '"JetBrains Mono", monospace' }}>
                   {event.node}
                 </Typography>
               </Box>
 
               {/* Time ago */}
-              <Typography sx={{ fontSize: 9, opacity: 0.5, flexShrink: 0 }}>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5, flexShrink: 0 }}>
                 {timeAgo(starttime)}
               </Typography>
             </Box>

--- a/frontend/src/components/dashboard/widgets/AlertsListWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/AlertsListWidget.jsx
@@ -26,7 +26,7 @@ function EntityIcon({ entityType, severity, isDark }) {
     <Box sx={{ position: 'relative', width: 16, height: 16, flexShrink: 0 }}>
       {isNode
         ? <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={14} height={14} style={{ opacity: 0.8 }} />
-        : <i className={icon} style={{ fontSize: 14, opacity: 0.7 }} />
+        : <i className={icon} style={{ fontSize: '1rem', opacity: 0.7 }} />
       }
       <Box sx={{
         position: 'absolute', bottom: -1, right: -1, width: 6, height: 6, borderRadius: '50%',
@@ -77,10 +77,10 @@ return null
       </Box>
       <Typography
         variant='body2' component='span'
-        sx={{ fontSize: 13, color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+        sx={{ fontSize: '0.9286rem', color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
         onClick={() => { router.push(entityLink); onClose() }}
       >
-        {alert.source} <i className='ri-external-link-line' style={{ fontSize: 11 }} />
+        {alert.source} <i className='ri-external-link-line' style={{ fontSize: '0.7857rem' }} />
       </Typography>
     </Box>
   ) : <NodeLabel name={alert.source} online={nodeStatusMap?.[alert.source]} isDark={isDark} />
@@ -88,7 +88,7 @@ return null
   const nodeOnline = nodeStatusMap?.[alert.entityName] ?? nodeStatusMap?.[alert.source]
 
   const rows = [
-    { label: t('alerts.detail.severity'), value: <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 22, fontSize: 11 }} /> },
+    { label: t('alerts.detail.severity'), value: <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 22, fontSize: '0.7857rem' }} /> },
     { label: t('alerts.detail.message'), value: alert.message },
     { label: t('alerts.detail.source'), value: sourceValue },
     { label: t('alerts.detail.sourceType'), value: (alert.sourceType || 'pve').toUpperCase() },
@@ -106,7 +106,7 @@ return null
     <Dialog open={open} onClose={onClose} maxWidth='sm' fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <i className='ri-alarm-warning-line' style={{ fontSize: 20 }} />
+          <i className='ri-alarm-warning-line' style={{ fontSize: '1.4286rem' }} />
           {t('alerts.detail.title')}
         </Box>
         <IconButton size='small' onClick={onClose}><i className='ri-close-line' /></IconButton>
@@ -117,8 +117,8 @@ return null
           <TableBody>
             {rows.map((row, idx) => (
               <TableRow key={idx}>
-                <TableCell sx={{ fontWeight: 600, width: 140, color: 'text.secondary', fontSize: 13, border: 'none', py: 1.25, pl: 3 }}>{row.label}</TableCell>
-                <TableCell sx={{ fontSize: 13, border: 'none', py: 1.25 }}>{row.value}</TableCell>
+                <TableCell sx={{ fontWeight: 600, width: 140, color: 'text.secondary', fontSize: '0.9286rem', border: 'none', py: 1.25, pl: 3 }}>{row.label}</TableCell>
+                <TableCell sx={{ fontSize: '0.9286rem', border: 'none', py: 1.25 }}>{row.value}</TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -184,7 +184,7 @@ return '#3b82f6'
   const darkCard = {
     bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
     border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-    borderRadius: 2.5, p: 1.5,
+    borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
     transition: 'border-color 0.2s, box-shadow 0.2s',
     '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
   }
@@ -193,8 +193,8 @@ return '#3b82f6'
     return (
       <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, opacity: 0.65 }}>
-          <i className='ri-checkbox-circle-line' style={{ fontSize: 18, color: '#4caf50' }} />
-          <Typography sx={{ fontSize: 12 }}>{t('alerts.noActiveAlerts')}</Typography>
+          <i className='ri-checkbox-circle-line' style={{ fontSize: '1.2857rem', color: '#4caf50' }} />
+          <Typography sx={{ fontSize: '0.8571rem' }}>{t('alerts.noActiveAlerts')}</Typography>
         </Box>
       </Box>
     )
@@ -224,13 +224,13 @@ return '#3b82f6'
               <Box sx={{
                 px: 0.5, py: 0.1, borderRadius: 0.5, flexShrink: 0,
                 bgcolor: `${sevColor}18`, color: sevColor,
-                fontSize: 8, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4,
+                fontSize: '0.5714rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4,
               }}>
                 {sevLabel}
               </Box>
 
               {/* Message */}
-              <Typography sx={{ fontSize: 11, fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}>
+              <Typography sx={{ fontSize: '0.7857rem', fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 }}>
                 {alert.message}
               </Typography>
 
@@ -240,13 +240,13 @@ return '#3b82f6'
                   <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={12} height={12} style={{ opacity: 0.7 }} />
                   <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 5, height: 5, borderRadius: '50%', bgcolor: nodeStatusMap[alert.source] === false ? '#f44336' : '#4caf50', border: '1px solid', borderColor: isDark ? '#1e1e2d' : '#fff' }} />
                 </Box>
-                <Typography sx={{ fontSize: 9, opacity: 0.65, fontFamily: '"JetBrains Mono", monospace', maxWidth: 80, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                <Typography sx={{ fontSize: '0.6429rem', opacity: 0.65, fontFamily: '"JetBrains Mono", monospace', maxWidth: 80, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                   {alert.source}
                 </Typography>
               </Box>
 
               {/* Time ago */}
-              <Typography sx={{ fontSize: 9, opacity: 0.5, flexShrink: 0 }}>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5, flexShrink: 0 }}>
                 {timeAgo(alert.time)}
               </Typography>
             </Box>

--- a/frontend/src/components/dashboard/widgets/BackupCalendarWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/BackupCalendarWidget.jsx
@@ -39,8 +39,8 @@ function DayTooltip({ day, isDark }) {
   const separatorColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
 
   return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 140, color: c.tooltipText }}>
-      <div style={{ background: day.total > 0 ? '#3b82f6' : '#616161', color: '#fff', padding: '4px 10px', fontWeight: 700, fontSize: 11 }}>
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 140, color: c.tooltipText }}>
+      <div style={{ background: day.total > 0 ? '#3b82f6' : '#616161', color: '#fff', padding: '4px 10px', fontWeight: 700, fontSize: '0.7857rem' }}>
         {formatted}
       </div>
       <div style={{ padding: '6px 10px', display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -187,7 +187,7 @@ return json?.data?.daily || []
   const darkCard = {
     bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
     border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-    borderRadius: 2.5, p: 1.5,
+    borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
     transition: 'border-color 0.2s, box-shadow 0.2s',
     '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
   }
@@ -197,8 +197,8 @@ return json?.data?.daily || []
       <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
         {pbsServers.length === 0 ? (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, opacity: 0.65 }}>
-            <i className='ri-calendar-check-line' style={{ fontSize: 24 }} />
-            <Typography sx={{ fontSize: 11 }}>{t('common.noData')}</Typography>
+            <i className='ri-calendar-check-line' style={{ fontSize: '1.7143rem' }} />
+            <Typography sx={{ fontSize: '0.7857rem' }}>{t('common.noData')}</Typography>
           </Box>
         ) : <CircularProgress size={24} />}
       </Box>
@@ -212,18 +212,18 @@ return json?.data?.daily || []
         <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center' }}>
           {stats && (
             <>
-              <Typography sx={{ fontSize: 10, opacity: 0.6 }}>{mapTimeRange(timeRange).days}d</Typography>
-              <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+              <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>{mapTimeRange(timeRange).days}d</Typography>
+              <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
                 <span style={{ fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>{stats.total}</span> backups
               </Typography>
-              <Typography sx={{ fontSize: 10, color: '#4caf50' }}>
+              <Typography sx={{ fontSize: '0.7143rem', color: '#4caf50' }}>
                 <span style={{ fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>{stats.verified}</span> verified
               </Typography>
               {stats.zeroDays > 0 && (
-                <Typography sx={{ fontSize: 10, color: '#ff9800' }}>{stats.zeroDays}d empty</Typography>
+                <Typography sx={{ fontSize: '0.7143rem', color: '#ff9800' }}>{stats.zeroDays}d empty</Typography>
               )}
               {stats.totalSize > 0 && (
-                <Typography sx={{ fontSize: 10, opacity: 0.5 }}>{formatSize(stats.totalSize)}</Typography>
+                <Typography sx={{ fontSize: '0.7143rem', opacity: 0.5 }}>{formatSize(stats.totalSize)}</Typography>
               )}
             </>
           )}
@@ -236,7 +236,7 @@ return json?.data?.daily || []
         <Box sx={{ display: 'flex', gap: '4px', pl: '32px' }}>
           {DAY_NAMES.map(d => (
             <Box key={d} sx={{ flex: 1, textAlign: 'center' }}>
-              <Typography sx={{ fontSize: 9, opacity: 0.4, fontWeight: 600 }}>{d}</Typography>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.4, fontWeight: 600 }}>{d}</Typography>
             </Box>
           ))}
         </Box>
@@ -247,7 +247,7 @@ return json?.data?.daily || []
             {/* Week label */}
             <Box sx={{ width: 28, flexShrink: 0, textAlign: 'right', pr: 0.5 }}>
               {week.find(d => d && (d.dayNum <= 7 || wIdx === 0)) && (
-                <Typography sx={{ fontSize: 8, opacity: 0.4 }}>
+                <Typography sx={{ fontSize: '0.5714rem', opacity: 0.4 }}>
                   {week.find(d => d)?.month}
                 </Typography>
               )}
@@ -273,9 +273,9 @@ return json?.data?.daily || []
                     minHeight: 18, maxHeight: 36,
                     '&:hover': { transform: 'scale(1.1)', zIndex: 10, outline: '1px solid rgba(255,255,255,0.4)' },
                   }}>
-                    <Typography sx={{ fontSize: 8, opacity: 0.5, lineHeight: 1 }}>{day.dayNum}</Typography>
+                    <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5, lineHeight: 1 }}>{day.dayNum}</Typography>
                     {day.total > 0 && (
-                      <Typography sx={{ fontSize: 10, fontWeight: 700, color: 'rgba(255,255,255,0.9)', fontFamily: '"JetBrains Mono", monospace', lineHeight: 1 }}>
+                      <Typography sx={{ fontSize: '0.7143rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)', fontFamily: '"JetBrains Mono", monospace', lineHeight: 1 }}>
                         {day.total}
                       </Typography>
                     )}
@@ -291,23 +291,23 @@ return json?.data?.daily || []
       <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center' }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
           <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.1)' }} />
-          <Typography sx={{ fontSize: 8, opacity: 0.5 }}>0</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5 }}>0</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
           <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: '#4caf5080' }} />
-          <Typography sx={{ fontSize: 8, opacity: 0.5 }}>1-5</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5 }}>1-5</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
           <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: '#4caf50c0' }} />
-          <Typography sx={{ fontSize: 8, opacity: 0.5 }}>6-10</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5 }}>6-10</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
           <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: '#4caf50' }} />
-          <Typography sx={{ fontSize: 8, opacity: 0.5 }}>10+</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5 }}>10+</Typography>
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
           <Box sx={{ width: 10, height: 10, borderRadius: 0.5, bgcolor: '#ff980090' }} />
-          <Typography sx={{ fontSize: 8, opacity: 0.5 }}>Unverified</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5 }}>Unverified</Typography>
         </Box>
       </Box>
     </Box>

--- a/frontend/src/components/dashboard/widgets/BackupRecentWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/BackupRecentWidget.jsx
@@ -52,7 +52,7 @@ function BackupRecentWidget({ data, loading }) {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 2,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 2,
           display: 'flex', flexDirection: 'column', justifyContent: 'center',
           transition: 'border-color 0.2s, box-shadow 0.2s',
           '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -93,7 +93,7 @@ function BackupRecentWidget({ data, loading }) {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 2,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 2,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           transition: 'border-color 0.2s, box-shadow 0.2s',
           '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -110,7 +110,7 @@ function BackupRecentWidget({ data, loading }) {
         height: '100%',
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
         overflow: 'auto',
         transition: 'border-color 0.2s, box-shadow 0.2s',
         '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -130,14 +130,14 @@ function BackupRecentWidget({ data, loading }) {
               size='small'
               label={item.type === 'error' ? t('jobs.failed') : 'OK'}
               color={item.type === 'error' ? 'error' : 'success'}
-              sx={{ height: 18, fontSize: 9 }}
+              sx={{ height: 18, fontSize: '0.6429rem' }}
             />
-            <Typography variant='caption' sx={{ fontWeight: 600, fontSize: 11 }}>
+            <Typography variant='caption' sx={{ fontWeight: 600, fontSize: '0.7857rem' }}>
               {item.name}
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 9 }}>
+            <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.6429rem' }}>
               {item.taskType} {'\u2022'} {item.server} {'\u2022'} {timeAgo(item.time)}
             </Typography>
           </Box>

--- a/frontend/src/components/dashboard/widgets/CephStatusWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/CephStatusWidget.jsx
@@ -34,16 +34,16 @@ return () => clearTimeout(t) }, [])
             style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
         </svg>
         <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Typography sx={{ fontSize: 10, fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
+          <Typography sx={{ fontSize: '0.7143rem', fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
             {value}%
           </Typography>
         </Box>
       </Box>
-      <Typography sx={{ fontSize: 8, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+      <Typography sx={{ fontSize: '0.5714rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
         {label}
       </Typography>
       {sublabel && (
-        <Typography sx={{ fontSize: 8, opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', mt: -0.25 }}>
+        <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', mt: -0.25 }}>
           {sublabel}
         </Typography>
       )}
@@ -60,9 +60,9 @@ function ThroughputTooltip({ active, payload, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 90, color: c.tooltipText }}>
-      <div style={{ background: '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-speed-line' style={{ fontSize: 10 }} /> Throughput {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 90, color: c.tooltipText }}>
+      <div style={{ background: '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-speed-line' style={{ fontSize: '0.7143rem' }} /> Throughput {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px' }}>
         {payload.map(e => (
@@ -83,9 +83,9 @@ function IopsTooltip({ active, payload, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 90, color: c.tooltipText }}>
-      <div style={{ background: '#8b5cf6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-flashlight-line' style={{ fontSize: 10 }} /> IOPS {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 90, color: c.tooltipText }}>
+      <div style={{ background: '#8b5cf6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-flashlight-line' style={{ fontSize: '0.7143rem' }} /> IOPS {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px' }}>
         {payload.map(e => (
@@ -141,7 +141,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column',
         transition: 'border-color 0.2s, box-shadow 0.2s',
         '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
       }}
@@ -158,13 +158,13 @@ function CephClusterCard({ cluster, isDark, perfData }) {
             bgcolor: healthColor, border: '1.5px solid', borderColor: c.dotBorder,
           }} />
         </Box>
-        <Typography sx={{ fontSize: 12, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+        <Typography sx={{ fontSize: '0.8571rem', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
           {cluster.name}
         </Typography>
         <Box sx={{
           px: 0.5, py: 0.15, borderRadius: 0.5,
           bgcolor: `${healthColor}18`, color: healthColor,
-          fontSize: 9, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4,
+          fontSize: '0.6429rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4,
         }}>
           {cluster.health?.replace('HEALTH_', '') || '?'}
         </Box>
@@ -207,7 +207,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
               else { color = '#4caf50'; status = 'Up / In'; opacity = 0.6 }
               return (
                 <span key={i} title={`OSD.${i} - ${status}`}
-                  style={{ fontSize: 12, color, opacity, cursor: 'default', lineHeight: 1 }}>
+                  style={{ fontSize: '0.8571rem', color, opacity, cursor: 'default', lineHeight: 1 }}>
                   <i className="ri-hard-drive-3-fill" />
                 </span>
               )
@@ -223,7 +223,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
 
       {/* Sparklines: Throughput */}
       <Box>
-        <Typography sx={{ fontSize: 8, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
+        <Typography sx={{ fontSize: '0.5714rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
           Throughput
         </Typography>
         <Box sx={{ height: 36, width: '100%' }}>
@@ -237,7 +237,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
             </ChartContainer>
           ) : (
             <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}>
-              <Typography sx={{ fontSize: 9 }}>...</Typography>
+              <Typography sx={{ fontSize: '0.6429rem' }}>...</Typography>
             </Box>
           )}
         </Box>
@@ -245,7 +245,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
 
       {/* Sparklines: IOPS */}
       <Box>
-        <Typography sx={{ fontSize: 8, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
+        <Typography sx={{ fontSize: '0.5714rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
           IOPS
         </Typography>
         <Box sx={{ height: 36, width: '100%' }}>
@@ -259,7 +259,7 @@ function CephClusterCard({ cluster, isDark, perfData }) {
             </ChartContainer>
           ) : (
             <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}>
-              <Typography sx={{ fontSize: 9 }}>...</Typography>
+              <Typography sx={{ fontSize: '0.6429rem' }}>...</Typography>
             </Box>
           )}
         </Box>
@@ -267,17 +267,17 @@ function CephClusterCard({ cluster, isDark, perfData }) {
 
       {/* Footer: PGs + current IO */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', opacity: 0.65 }}>
-        <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>
           {cluster.pgsTotal || 0} PGs
         </Typography>
         {hasIO && (
           <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'center' }}>
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>
-              <i className='ri-arrow-down-line' style={{ fontSize: 10, color: '#4caf50' }} />
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>
+              <i className='ri-arrow-down-line' style={{ fontSize: '0.7143rem', color: '#4caf50' }} />
               {formatBps(cluster.readBps)}
             </span>
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>
-              <i className='ri-arrow-up-line' style={{ fontSize: 10, color: '#f97316' }} />
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 2, fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>
+              <i className='ri-arrow-up-line' style={{ fontSize: '0.7143rem', color: '#f97316' }} />
               {formatBps(cluster.writeBps)}
             </span>
           </Box>
@@ -391,11 +391,11 @@ return {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 1.5,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
           display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', opacity: 0.65,
         }}
       >
-        <i className='ri-database-2-line' style={{ fontSize: 28, marginBottom: 4 }} />
+        <i className='ri-database-2-line' style={{ fontSize: '2rem', marginBottom: 4 }} />
         <Typography variant='caption'>{t('common.notAvailable')}</Typography>
       </Box>
     )

--- a/frontend/src/components/dashboard/widgets/CircularGauge.jsx
+++ b/frontend/src/components/dashboard/widgets/CircularGauge.jsx
@@ -1,0 +1,110 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+
+import { Box } from '@mui/material'
+
+import { gaugeGeometry, GAUGE_VIEWBOX } from '../gaugeGeometry'
+
+/**
+ * Shared circular gauge. Renders only the dial (track + value arc) plus a
+ * caller-supplied center overlay (`children`). Its diameter is `size`, given
+ * in `em` so it tracks the inherited font size — which the appearance "font
+ * size" setting drives through `html { font-size }`. The SVG uses a normalized
+ * 0–100 viewBox and scales purely via CSS, so the dial grows/shrinks with the
+ * font setting (not with the widget's pixel size).
+ *
+ * Fill is computed from either `value` as a percentage (0–100) or, when `max`
+ * is provided, the ratio `value / max`.
+ *
+ * The center overlay sets a fluid `font-size` (container-query units relative
+ * to the gauge), so children should size their text in `em` to track it.
+ */
+export default function CircularGauge({
+  value = 0,
+  max = null,
+  color,
+  trackColor,
+  size = '4.5em',
+  animate = true,
+  children,
+}) {
+  const target = max != null
+    ? (max > 0 ? value / max : 0)
+    : (value || 0) / 100
+  const fraction = Math.min(Math.max(target, 0), 1)
+
+  const [shown, setShown] = useState(animate ? 0 : fraction)
+
+  useEffect(() => {
+    if (!animate) {
+      setShown(fraction)
+
+      return undefined
+    }
+
+    const timer = setTimeout(() => setShown(fraction), 50)
+
+    return () => clearTimeout(timer)
+  }, [fraction, animate])
+
+  const geo = gaugeGeometry(shown)
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: size,
+        height: size,
+        flexShrink: 0,
+        containerType: 'size',
+      }}
+    >
+      <svg
+        viewBox={`0 0 ${GAUGE_VIEWBOX} ${GAUGE_VIEWBOX}`}
+        width="100%"
+        height="100%"
+        style={{ transform: 'rotate(-90deg)', display: 'block' }}
+      >
+        <circle
+          cx={geo.center}
+          cy={geo.center}
+          r={geo.radius}
+          fill="none"
+          stroke={trackColor}
+          strokeWidth={geo.strokeWidth}
+        />
+        <circle
+          cx={geo.center}
+          cy={geo.center}
+          r={geo.radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={geo.strokeWidth}
+          strokeDasharray={geo.circumference}
+          strokeDashoffset={geo.dashoffset}
+          strokeLinecap="round"
+          style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.3s ease' }}
+        />
+      </svg>
+      <Box
+        sx={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          // Fluid baseline: ~26% of the gauge's smaller dimension, bounded so
+          // the label stays readable at tiny sizes and never overflows at large
+          // ones. Children use `em` to scale relative to this.
+          fontSize: 'clamp(0.6rem, 26cqmin, 2rem)',
+          lineHeight: 1,
+          fontFamily: '"JetBrains Mono", monospace',
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  )
+}

--- a/frontend/src/components/dashboard/widgets/ClusterHealthWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ClusterHealthWidget.jsx
@@ -40,7 +40,7 @@ return () => clearTimeout(t) }, [])
         position: 'absolute', inset: 0,
         display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
       }}>
-        <Typography sx={{ fontSize: 24, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color }}>
+        <Typography sx={{ fontSize: '1.7143rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color }}>
           {score}
         </Typography>
       </Box>
@@ -51,10 +51,10 @@ return () => clearTimeout(t) }, [])
 function StatBox({ label, value, unit }) {
   return (
     <Box sx={{ textAlign: 'center' }}>
-      <Typography sx={{ fontSize: 16, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.2 }}>
-        {value}{unit && <Typography component='span' sx={{ fontSize: 10, opacity: 0.65 }}>{unit}</Typography>}
+      <Typography sx={{ fontSize: '1.1429rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.2 }}>
+        {value}{unit && <Typography component='span' sx={{ fontSize: '0.7143rem', opacity: 0.65 }}>{unit}</Typography>}
       </Typography>
-      <Typography variant='caption' sx={{ fontSize: 9, opacity: 0.65, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+      <Typography variant='caption' sx={{ fontSize: '0.6429rem', opacity: 0.65, fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}>
         {label}
       </Typography>
     </Box>
@@ -115,7 +115,7 @@ function ClusterHealthWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: c.borderLight,
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         display: 'flex',
         flexDirection: 'column',

--- a/frontend/src/components/dashboard/widgets/ClustersGaugesWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ClustersGaugesWidget.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Checkbox, Chip, IconButton, ListItemText, Menu, MenuItem, Tooltip, Typography, useTheme } from '@mui/material'
@@ -9,40 +9,23 @@ import ChartContainer from '@/components/ChartContainer'
 
 import { widgetColors } from './themeColors'
 import { mapTimeRange, sliceToRange, formatTime } from './timeRangeUtils'
+import CircularGauge from './CircularGauge'
 
-// ─── Circular Gauge (animated on mount) ──────────────────────────────────────
-function CircularGauge({ value, label, size = 64, strokeWidth = 5, color, theme }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - (value / 100) * circumference : circumference
-  const isDark = theme?.palette?.mode === 'dark'
+// ─── Labeled Gauge ────────────────────────────────────────────────────────────
+function LabeledGauge({ value, label, color, isDark }) {
   const trackColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
 
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
-      <Box sx={{ position: 'relative', width: size, height: size }}>
-        <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-          <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-          <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-            strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-            style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-        </svg>
-        <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Typography sx={{ fontSize: 11, fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
-            {value}%
-          </Typography>
-        </Box>
-      </Box>
-      <Typography sx={{ fontSize: 9, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, flex: 1, minWidth: 0 }}>
+      <CircularGauge value={value} color={color} trackColor={trackColor} size='4.6em'>
+        <Box component='span' sx={{ fontWeight: 700, fontSize: '0.85em' }}>{value}%</Box>
+      </CircularGauge>
+      <Box
+        component='span'
+        sx={{ fontSize: '0.6429rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}
+      >
         {label}
-      </Typography>
+      </Box>
     </Box>
   )
 }
@@ -126,9 +109,9 @@ function CpuRamTooltip({ active, payload, isDark }) {
   const c = widgetColors(isDark)
 
   return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 80, color: c.tooltipText }}>
-      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-cpu-line' style={{ fontSize: 10 }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 80, color: c.tooltipText }}>
+      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-cpu-line' style={{ fontSize: '0.7143rem' }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px', display: 'flex', flexDirection: 'column', gap: 1 }}>
         {cpu != null && <div><span style={{ color: '#f97316', fontWeight: 700 }}>CPU</span> {cpu}%</div>}
@@ -147,9 +130,9 @@ function IoNetTooltip({ active, payload, isDark }) {
   const c = widgetColors(isDark)
 
   return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 80, color: c.tooltipText }}>
-      <div style={{ background: '#ab47bc', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-exchange-line' style={{ fontSize: 10 }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 80, color: c.tooltipText }}>
+      <div style={{ background: '#ab47bc', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-exchange-line' style={{ fontSize: '0.7143rem' }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px', display: 'flex', flexDirection: 'column', gap: 1 }}>
         {netin != null && <div><span style={{ color: '#4caf50', fontWeight: 700 }}>Net In</span> {formatRate(netin)}</div>}
@@ -201,41 +184,41 @@ function ClusterCard({ cluster, clusterNodes, theme, allTrends, vmList, lxcList 
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column', gap: 1,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column', gap: 1,
         transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
         '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.1)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
       }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
         <Box sx={{ position: 'relative', width: 18, height: 18, flexShrink: 0 }}>
-          <i className='ri-server-line' style={{ fontSize: 18, opacity: 0.7 }} />
+          <i className='ri-server-line' style={{ fontSize: '1.2857rem', opacity: 0.7 }} />
           <Box sx={{
             position: 'absolute', bottom: -1, right: -1, width: 7, height: 7, borderRadius: '50%',
             bgcolor: onlineNodes.length === totalNodes ? '#4caf50' : onlineNodes.length > 0 ? '#ff9800' : '#f44336',
             border: '1.5px solid', borderColor: isDark ? '#1e1e2d' : '#fff'
           }} />
         </Box>
-        <Typography sx={{ fontSize: 12, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+        <Typography sx={{ fontSize: '0.8571rem', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
           {cluster.name}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <Typography sx={{ fontSize: 9, opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>
+          <Typography sx={{ fontSize: '0.6429rem', opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>
             {onlineNodes.length}/{totalNodes}
           </Typography>
-          <Box sx={{ px: 0.5, py: 0.15, borderRadius: 0.5, bgcolor: `${scoreColor}18`, color: scoreColor, fontSize: 9, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4 }}>
+          <Box sx={{ px: 0.5, py: 0.15, borderRadius: 0.5, bgcolor: `${scoreColor}18`, color: scoreColor, fontSize: '0.6429rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4 }}>
             {score}
           </Box>
         </Box>
       </Box>
 
       <Box sx={{ display: 'flex', justifyContent: 'space-around' }}>
-        <CircularGauge value={cpuPct} label="CPU" color={getGaugeColor(cpuPct)} theme={theme} />
-        <CircularGauge value={memPct} label="RAM" color={getGaugeColor(memPct)} theme={theme} />
-        <CircularGauge value={storagePct} label="DISK" color={getGaugeColor(storagePct)} theme={theme} />
+        <LabeledGauge value={cpuPct} label="CPU" color={getGaugeColor(cpuPct)} isDark={isDark} />
+        <LabeledGauge value={memPct} label="RAM" color={getGaugeColor(memPct)} isDark={isDark} />
+        <LabeledGauge value={storagePct} label="DISK" color={getGaugeColor(storagePct)} isDark={isDark} />
       </Box>
 
       <Box>
-        <Typography sx={{ fontSize: 9, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
+        <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
         <Box sx={{ height: 40, width: '100%' }}>
           {hasTrends ? (
             <ChartContainer>
@@ -245,12 +228,12 @@ function ClusterCard({ cluster, clusterNodes, theme, allTrends, vmList, lxcList 
                 <Area type="monotone" dataKey="ram" stroke={theme.palette.info.main} fill={theme.palette.info.main} fillOpacity={0.6} strokeWidth={1.2} dot={false} isAnimationActive={false} />
               </AreaChart>
             </ChartContainer>
-          ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: 9 }}>...</Typography></Box>}
+          ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: '0.6429rem' }}>...</Typography></Box>}
         </Box>
       </Box>
 
       <Box>
-        <Typography sx={{ fontSize: 9, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
+        <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
         <Box sx={{ height: 40, width: '100%' }}>
           {hasTrends ? (
             <ChartContainer>
@@ -260,12 +243,12 @@ function ClusterCard({ cluster, clusterNodes, theme, allTrends, vmList, lxcList 
                 <Area type="monotone" dataKey="netout" name="Net Out" stroke="#f97316" fill="#f97316" fillOpacity={0.6} strokeWidth={1.2} dot={false} isAnimationActive={false} />
               </AreaChart>
             </ChartContainer>
-          ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: 9 }}>...</Typography></Box>}
+          ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: '0.6429rem' }}>...</Typography></Box>}
         </Box>
       </Box>
 
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', opacity: 0.7 }}>
-        <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>
           {vmsRunning} VM{vmsRunning !== 1 ? 's' : ''} {lxcRunning} LXC
         </Typography>
         <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'center' }}>
@@ -275,8 +258,8 @@ function ClusterCard({ cluster, clusterNodes, theme, allTrends, vmList, lxcList 
             
 return (
               <span title={`Ceph: ${cluster.cephHealth}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 2, cursor: 'default' }}>
-                <i className='ri-database-2-line' style={{ fontSize: 11, color: cephColor }} />
-                <span style={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace', color: cephColor }}>
+                <i className='ri-database-2-line' style={{ fontSize: '0.7857rem', color: cephColor }} />
+                <span style={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace', color: cephColor }}>
                   {cluster.cephHealth.replace('HEALTH_', '')}
                 </span>
               </span>
@@ -288,8 +271,8 @@ return (
             
 return (
               <span title={`Quorum: ${cluster.quorum.votes}/${cluster.quorum.expected_votes} votes${cluster.quorum.quorate ? '' : ' (NOT QUORATE)'}`} style={{ display: 'inline-flex', alignItems: 'center', gap: 2, cursor: 'default' }}>
-                <i className='ri-shield-check-line' style={{ fontSize: 11, color: qColor }} />
-                <span style={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace', color: qColor }}>
+                <i className='ri-shield-check-line' style={{ fontSize: '0.7857rem', color: qColor }} />
+                <span style={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace', color: qColor }}>
                   {cluster.quorum.votes}/{cluster.quorum.expected_votes}
                 </span>
               </span>
@@ -323,16 +306,16 @@ function ClusterFilter({ clusters, selected, onChange }) {
     <>
       <Tooltip title={t('common.filter')}>
         <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
-          <i className='ri-filter-3-line' style={{ fontSize: 14, opacity: allSelected ? 0.4 : 1 }} />
+          <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.4 : 1 }} />
         </IconButton>
       </Tooltip>
       {allSelected ? null : (
-        <Chip label={selected.length} size='small' sx={{ height: 16, fontSize: 9, ml: -0.25 }} />
+        <Chip label={selected.length} size='small' sx={{ height: 16, fontSize: '0.6429rem', ml: -0.25 }} />
       )}
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
         <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
           <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
-          <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{t('common.all')}</ListItemText>
+          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{t('common.all')}</ListItemText>
         </MenuItem>
         {clusters.map(c => {
           const checked = allSelected || selected.includes(c.id)
@@ -341,8 +324,8 @@ function ClusterFilter({ clusters, selected, onChange }) {
 return (
             <MenuItem key={c.id} dense onClick={() => handleToggle(c.id)}>
               <Checkbox size='small' checked={checked} sx={{ p: 0, mr: 1 }} />
-              <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{c.name}</ListItemText>
-              <Typography sx={{ fontSize: 10, opacity: 0.65, ml: 1 }}>{c.nodes}n</Typography>
+              <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{c.name}</ListItemText>
+              <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, ml: 1 }}>{c.nodes}n</Typography>
             </MenuItem>
           )
         })}

--- a/frontend/src/components/dashboard/widgets/ClustersListWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ClustersListWidget.jsx
@@ -25,7 +25,7 @@ function ClustersListWidget({ data, loading }) {
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid',
           borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5,
+          borderRadius: 'var(--proxcenter-card-radius)',
           p: 1.5,
           display: 'flex',
           alignItems: 'center',
@@ -44,7 +44,7 @@ function ClustersListWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         display: 'flex',
         flexDirection: 'column',
@@ -69,12 +69,12 @@ function ClustersListWidget({ data, loading }) {
           }}
         >
           <Box sx={{ position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 20, height: 20, flexShrink: 0 }}>
-            <i className='ri-server-fill' style={{ fontSize: 18, opacity: 0.8 }} />
+            <i className='ri-server-fill' style={{ fontSize: '1.2857rem', opacity: 0.8 }} />
             <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 7, height: 7, borderRadius: '50%', bgcolor: cluster.onlineNodes > 0 ? '#4caf50' : '#f44336', border: '1.5px solid', borderColor: isDark ? 'rgba(255,255,255,0.03)' : '#fff' }} />
           </Box>
           <Box sx={{ minWidth: 0, flex: 1 }}>
-            <Typography variant='body2' sx={{ fontWeight: 700, fontSize: 13 }}>{cluster.name}</Typography>
-            <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 10 }}>
+            <Typography variant='body2' sx={{ fontWeight: 700, fontSize: '0.9286rem' }}>{cluster.name}</Typography>
+            <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.7143rem' }}>
               {cluster.nodes} {t('inventory.nodes').toLowerCase()} &bull; {cluster.onlineNodes} {t('common.online').toLowerCase()}
             </Typography>
           </Box>
@@ -84,7 +84,7 @@ function ClustersListWidget({ data, loading }) {
                 size='small'
                 label='Quorum'
                 color={cluster.quorum.quorate ? 'success' : 'error'}
-                sx={{ fontSize: 9, height: 18 }}
+                sx={{ fontSize: '0.6429rem', height: 18 }}
               />
             )}
             {cluster.cephHealth && (
@@ -92,7 +92,7 @@ function ClustersListWidget({ data, loading }) {
                 size='small'
                 label={cluster.cephHealth.replaceAll('HEALTH_', '')}
                 color={cluster.cephHealth === 'HEALTH_OK' ? 'success' : cluster.cephHealth === 'HEALTH_WARN' ? 'warning' : 'error'}
-                sx={{ fontSize: 9, height: 18 }}
+                sx={{ fontSize: '0.6429rem', height: 18 }}
               />
             )}
           </Box>

--- a/frontend/src/components/dashboard/widgets/DrsStatusWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/DrsStatusWidget.jsx
@@ -25,9 +25,9 @@ function CpuRamTooltip({ active, payload, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 80, color: c.tooltipText }}>
-      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-cpu-line' style={{ fontSize: 10 }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 80, color: c.tooltipText }}>
+      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-cpu-line' style={{ fontSize: '0.7143rem' }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px', display: 'flex', flexDirection: 'column', gap: 1 }}>
         {cpu != null && <div><span style={{ color: '#f97316', fontWeight: 700 }}>CPU</span> {cpu}%</div>}
@@ -61,7 +61,7 @@ return () => clearTimeout(t) }, [])
           style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
       </svg>
       <Box sx={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
+        <Typography sx={{ fontSize: '1rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
           {score}
         </Typography>
       </Box>
@@ -94,7 +94,7 @@ return () => clearTimeout(t) }, [])
           style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
       </svg>
       <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 9, fontWeight: 700, fontFamily: '"JetBrains Mono", monospace', color }}>{value}%</Typography>
+        <Typography sx={{ fontSize: '0.6429rem', fontWeight: 700, fontFamily: '"JetBrains Mono", monospace', color }}>{value}%</Typography>
       </Box>
     </Box>
   )
@@ -152,20 +152,20 @@ function DrsClusterCard({ clusterId, clusterMetrics, clusterInfo, drsStatus, the
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75,
         transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
         '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
       }}
     >
       {/* Header */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-        <i className='ri-swap-line' style={{ fontSize: 14, opacity: 0.7 }} />
-        <Typography sx={{ fontSize: 12, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+        <i className='ri-swap-line' style={{ fontSize: '1rem', opacity: 0.7 }} />
+        <Typography sx={{ fontSize: '0.8571rem', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
           {clusterName}
         </Typography>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: enabled ? (mode === 'automatic' ? '#4caf50' : '#ff9800') : '#9e9e9e' }} />
-          <Typography sx={{ fontSize: 9, opacity: 0.7, fontFamily: '"JetBrains Mono", monospace' }}>
+          <Typography sx={{ fontSize: '0.6429rem', opacity: 0.7, fontFamily: '"JetBrains Mono", monospace' }}>
             {enabled ? mode : 'off'}
           </Typography>
         </Box>
@@ -173,16 +173,16 @@ function DrsClusterCard({ clusterId, clusterMetrics, clusterInfo, drsStatus, the
 
       {/* DRS label + Score + Imbalance gauges */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 2, mt: 0.5 }}>
-        <Typography sx={{ fontSize: 20, fontWeight: 900, opacity: 0.15, letterSpacing: 2, textTransform: 'uppercase', flexShrink: 0 }}>
+        <Typography sx={{ fontSize: '1.4286rem', fontWeight: 900, opacity: 0.15, letterSpacing: 2, textTransform: 'uppercase', flexShrink: 0 }}>
           DRS
         </Typography>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
           <ScoreRing score={score} isDark={isDark} />
-          <Typography sx={{ fontSize: 8, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase' }}>Health</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase' }}>Health</Typography>
         </Box>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
           <ImbalanceGauge value={imbalance} isDark={isDark} />
-          <Typography sx={{ fontSize: 8, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase' }}>Imbalance</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase' }}>Imbalance</Typography>
         </Box>
       </Box>
 
@@ -195,7 +195,7 @@ function DrsClusterCard({ clusterId, clusterMetrics, clusterInfo, drsStatus, the
           
 return (
             <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-              <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace', width: 55, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
+              <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace', width: 55, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', opacity: 0.7 }}>
                 {node.name || `n-${idx}`}
               </Typography>
               <Box sx={{ flex: 1, display: 'flex', gap: 0.5 }}>
@@ -206,7 +206,7 @@ return (
                   <Box sx={{ width: `${nodeRam}%`, height: '100%', borderRadius: 3, bgcolor: getGaugeColor(nodeRam), transition: 'width 0.6s ease' }} />
                 </Box>
               </Box>
-              <Typography sx={{ fontSize: 8, fontFamily: '"JetBrains Mono", monospace', opacity: 0.65, width: 48, textAlign: 'right' }}>
+              <Typography sx={{ fontSize: '0.5714rem', fontFamily: '"JetBrains Mono", monospace', opacity: 0.65, width: 48, textAlign: 'right' }}>
                 {nodeCpu}% {nodeRam}%
               </Typography>
             </Box>
@@ -217,18 +217,18 @@ return (
       {/* Recommendations */}
       {clusterRecs.length > 0 && (
         <Box sx={{ borderTop: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)', pt: 0.5 }}>
-          <Typography sx={{ fontSize: 8, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
-            <i className='ri-lightbulb-line' style={{ fontSize: 9, marginRight: 3 }} />
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
+            <i className='ri-lightbulb-line' style={{ fontSize: '0.6429rem', marginRight: 3 }} />
             Recommendations ({clusterRecs.length})
           </Typography>
           {clusterRecs.slice(0, 3).map((rec, idx) => (
             <Box key={idx} title={`${rec.vm_name || rec.vmid} -> ${rec.target_node}: ${rec.reason || ''}`} sx={{ display: 'flex', alignItems: 'center', gap: 0.5, py: 0.25 }}>
-              <i className='ri-arrow-right-line' style={{ fontSize: 9, color: '#ff9800', flexShrink: 0 }} />
-              <Typography sx={{ fontSize: 9, fontWeight: 600, flexShrink: 0, maxWidth: 80 }} noWrap>
+              <i className='ri-arrow-right-line' style={{ fontSize: '0.6429rem', color: '#ff9800', flexShrink: 0 }} />
+              <Typography sx={{ fontSize: '0.6429rem', fontWeight: 600, flexShrink: 0, maxWidth: 80 }} noWrap>
                 {rec.vm_name || `VM ${rec.vmid}`}
               </Typography>
-              <i className='ri-arrow-right-s-line' style={{ fontSize: 10, opacity: 0.4, flexShrink: 0 }} />
-              <Typography sx={{ fontSize: 9, opacity: 0.7, fontFamily: '"JetBrains Mono", monospace', flexShrink: 0 }}>
+              <i className='ri-arrow-right-s-line' style={{ fontSize: '0.7143rem', opacity: 0.4, flexShrink: 0 }} />
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.7, fontFamily: '"JetBrains Mono", monospace', flexShrink: 0 }}>
                 {rec.target_node}
               </Typography>
             </Box>
@@ -239,8 +239,8 @@ return (
       {/* Recent migrations */}
       {clusterMigrations.length > 0 && (
         <Box sx={{ borderTop: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)', pt: 0.5 }}>
-          <Typography sx={{ fontSize: 8, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
-            <i className='ri-history-line' style={{ fontSize: 9, marginRight: 3 }} />{' '}
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>
+            <i className='ri-history-line' style={{ fontSize: '0.6429rem', marginRight: 3 }} />{' '}
             Migrations
           </Typography>
           {clusterMigrations.map((mig, idx) => {
@@ -250,14 +250,14 @@ return (
 return (
               <Box key={idx} sx={{ display: 'flex', alignItems: 'center', gap: 0.5, py: 0.25 }}>
                 <Box sx={{ width: 5, height: 5, borderRadius: '50%', bgcolor: statusColor, flexShrink: 0 }} />
-                <Typography sx={{ fontSize: 9, fontWeight: 600, flexShrink: 0, maxWidth: 80 }} noWrap>
+                <Typography sx={{ fontSize: '0.6429rem', fontWeight: 600, flexShrink: 0, maxWidth: 80 }} noWrap>
                   {mig.vm_name || `VM ${mig.vmid}`}
                 </Typography>
-                <i className='ri-arrow-right-s-line' style={{ fontSize: 10, opacity: 0.4, flexShrink: 0 }} />
-                <Typography sx={{ fontSize: 9, opacity: 0.7, fontFamily: '"JetBrains Mono", monospace', flexShrink: 0 }}>
+                <i className='ri-arrow-right-s-line' style={{ fontSize: '0.7143rem', opacity: 0.4, flexShrink: 0 }} />
+                <Typography sx={{ fontSize: '0.6429rem', opacity: 0.7, fontFamily: '"JetBrains Mono", monospace', flexShrink: 0 }}>
                   {mig.target_node}
                 </Typography>
-                <Typography sx={{ fontSize: 8, opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', ml: 'auto', flexShrink: 0 }}>
+                <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', ml: 'auto', flexShrink: 0 }}>
                   {timeAgo(mig.created_at || mig.started_at)}
                 </Typography>
               </Box>
@@ -269,7 +269,7 @@ return (
       {/* Sparkline CPU/RAM */}
       {trends && trends.length > 2 && (
         <Box>
-          <Typography sx={{ fontSize: 8, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
+          <Typography sx={{ fontSize: '0.5714rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
           <Box sx={{ height: 36, width: '100%' }}>
             <ChartContainer>
               <AreaChart data={trends} margin={{ top: 2, right: 2, left: 2, bottom: 2 }}>
@@ -284,14 +284,14 @@ return (
 
       {/* Footer */}
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', opacity: 0.65, mt: 'auto' }}>
-        <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>
           {onlineNodes.length} node{onlineNodes.length !== 1 ? 's' : ''}
         </Typography>
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
           <Box sx={{ width: 5, height: 5, borderRadius: 0.5, bgcolor: '#f97316' }} />
-          <Typography sx={{ fontSize: 8 }}>CPU</Typography>
+          <Typography sx={{ fontSize: '0.5714rem' }}>CPU</Typography>
           <Box sx={{ width: 5, height: 5, borderRadius: 0.5, bgcolor: '#3b82f6' }} />
-          <Typography sx={{ fontSize: 8 }}>RAM</Typography>
+          <Typography sx={{ fontSize: '0.5714rem' }}>RAM</Typography>
         </Box>
       </Box>
     </Box>
@@ -388,7 +388,7 @@ return { connId, series }
   if (!isEnterprise) {
     return (
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', p: 2, textAlign: 'center' }}>
-        <i className='ri-vip-crown-fill' style={{ fontSize: 32, color: 'var(--mui-palette-warning-main)', marginBottom: 8 }} />
+        <i className='ri-vip-crown-fill' style={{ fontSize: '2.2857rem', color: 'var(--mui-palette-warning-main)', marginBottom: 8 }} />
         <Typography variant='caption' sx={{ opacity: 0.75 }}>Enterprise</Typography>
       </Box>
     )
@@ -414,7 +414,7 @@ return !info || info.isCluster || info.nodes > 1
   if (clusterIds.length === 0) {
     return (
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', opacity: 0.65 }}>
-        <i className='ri-swap-line' style={{ fontSize: 28, marginBottom: 4 }} />
+        <i className='ri-swap-line' style={{ fontSize: '2rem', marginBottom: 4 }} />
         <Typography variant='caption'>{t('common.noData')}</Typography>
       </Box>
     )

--- a/frontend/src/components/dashboard/widgets/GuestsSummaryWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/GuestsSummaryWidget.jsx
@@ -21,7 +21,7 @@ function GuestsSummaryWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: c.borderLight,
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         display: 'grid',
         gridTemplateColumns: '1fr 1fr',
@@ -34,32 +34,32 @@ function GuestsSummaryWidget({ data, loading }) {
       }}
     >
       <Box>
-        <Typography variant='caption' sx={{ opacity: 0.65, fontWeight: 600, fontSize: 10 }}>{t('dashboard.widgets.vms').toUpperCase()}</Typography>
+        <Typography variant='caption' sx={{ opacity: 0.65, fontWeight: 600, fontSize: '0.7143rem' }}>{t('dashboard.widgets.vms').toUpperCase()}</Typography>
         <Box sx={{ mt: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.5 }}>
-            <i className='ri-play-fill' style={{ fontSize: 14, color: '#4caf50' }} />
-            <Typography variant='body2' sx={{ fontSize: 12 }}>{t('inventory.running')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.running || 0}</strong></Typography>
+            <i className='ri-play-fill' style={{ fontSize: '1rem', color: '#4caf50' }} />
+            <Typography variant='body2' sx={{ fontSize: '0.8571rem' }}>{t('inventory.running')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.running || 0}</strong></Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.5 }}>
-            <i className='ri-stop-fill' style={{ fontSize: 14, color: '#9e9e9e' }} />
-            <Typography variant='body2' sx={{ fontSize: 12 }}>{t('inventory.stopped')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.stopped || 0}</strong></Typography>
+            <i className='ri-stop-fill' style={{ fontSize: '1rem', color: '#9e9e9e' }} />
+            <Typography variant='body2' sx={{ fontSize: '0.8571rem' }}>{t('inventory.stopped')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.stopped || 0}</strong></Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <i className='ri-file-copy-fill' style={{ fontSize: 14, color: '#2196f3' }} />
-            <Typography variant='body2' sx={{ fontSize: 12 }}>{t('inventory.templates')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.templates || 0}</strong></Typography>
+            <i className='ri-file-copy-fill' style={{ fontSize: '1rem', color: '#2196f3' }} />
+            <Typography variant='body2' sx={{ fontSize: '0.8571rem' }}>{t('inventory.templates')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.vms?.templates || 0}</strong></Typography>
           </Box>
         </Box>
       </Box>
       <Box>
-        <Typography variant='caption' sx={{ opacity: 0.65, fontWeight: 600, fontSize: 10 }}>{t('inventory.containers').toUpperCase()}</Typography>
+        <Typography variant='caption' sx={{ opacity: 0.65, fontWeight: 600, fontSize: '0.7143rem' }}>{t('inventory.containers').toUpperCase()}</Typography>
         <Box sx={{ mt: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.5 }}>
-            <i className='ri-play-fill' style={{ fontSize: 14, color: '#4caf50' }} />
-            <Typography variant='body2' sx={{ fontSize: 12 }}>{t('inventory.running')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.lxc?.running || 0}</strong></Typography>
+            <i className='ri-play-fill' style={{ fontSize: '1rem', color: '#4caf50' }} />
+            <Typography variant='body2' sx={{ fontSize: '0.8571rem' }}>{t('inventory.running')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.lxc?.running || 0}</strong></Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <i className='ri-stop-fill' style={{ fontSize: 14, color: '#9e9e9e' }} />
-            <Typography variant='body2' sx={{ fontSize: 12 }}>{t('inventory.stopped')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.lxc?.stopped || 0}</strong></Typography>
+            <i className='ri-stop-fill' style={{ fontSize: '1rem', color: '#9e9e9e' }} />
+            <Typography variant='body2' sx={{ fontSize: '0.8571rem' }}>{t('inventory.stopped')}: <strong style={{ fontFamily: '"JetBrains Mono", monospace' }}>{guests?.lxc?.stopped || 0}</strong></Typography>
           </Box>
         </Box>
       </Box>

--- a/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
@@ -28,9 +28,9 @@ function ChartTooltip({ active, payload, label, metric, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 100, color: c.tooltipText }}>
-      <div style={{ background: metric === 'cpu' ? '#f97316' : '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className={metric === 'cpu' ? 'ri-cpu-line' : 'ri-database-2-line'} style={{ fontSize: 10 }} />
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 100, color: c.tooltipText }}>
+      <div style={{ background: metric === 'cpu' ? '#f97316' : '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className={metric === 'cpu' ? 'ri-cpu-line' : 'ri-database-2-line'} style={{ fontSize: '0.7143rem' }} />
         {metric.toUpperCase()} {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px' }}>
@@ -67,13 +67,13 @@ function ConnectionFilter({ connections, selected, onChange, t }) {
     <>
       <Tooltip title={t('common.filter')}>
         <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
-          <i className='ri-filter-3-line' style={{ fontSize: 14, opacity: allSelected ? 0.65 : 1 }} />
+          <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.65 : 1 }} />
         </IconButton>
       </Tooltip>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
         <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
           <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
-          <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{t('common.all')}</ListItemText>
+          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{t('common.all')}</ListItemText>
         </MenuItem>
         {connections.map(c => {
           const checked = allSelected || selected.includes(c.id)
@@ -82,7 +82,7 @@ function ConnectionFilter({ connections, selected, onChange, t }) {
 return (
             <MenuItem key={c.id} dense onClick={() => handleToggle(c.id)}>
               <Checkbox size='small' checked={checked} sx={{ p: 0, mr: 1 }} />
-              <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{c.name}</ListItemText>
+              <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{c.name}</ListItemText>
             </MenuItem>
           )
         })}
@@ -259,7 +259,7 @@ return json.data || {}
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75,
         transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
         '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
         height: '100%',
@@ -272,7 +272,7 @@ return json.data || {}
             key={v}
             onClick={() => setMetric(v)}
             sx={{
-              px: 1, py: 0.25, fontSize: 10, fontWeight: metric === v ? 700 : 400, cursor: 'pointer',
+              px: 1, py: 0.25, fontSize: '0.7143rem', fontWeight: metric === v ? 700 : 400, cursor: 'pointer',
               borderRadius: 1, color: metric === v ? '#fff' : c.textMuted,
               bgcolor: metric === v ? c.surfaceActive : 'transparent',
               '&:hover': { bgcolor: c.surfaceSubtle },
@@ -304,8 +304,8 @@ return (
               })}
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke={c.borderLight} />
-            <XAxis dataKey="t" tick={{ fontSize: 9, fill: c.textMuted }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
-            <YAxis domain={[0, 100]} tick={{ fontSize: 9, fill: c.textMuted }} tickLine={false} axisLine={false} tickFormatter={(v) => `${v}%`} />
+            <XAxis dataKey="t" tick={{ fontSize: '0.6429rem', fill: c.textMuted }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+            <YAxis domain={[0, 100]} tick={{ fontSize: '0.6429rem', fill: c.textMuted }} tickLine={false} axisLine={false} tickFormatter={(v) => `${v}%`} />
             <RTooltip content={<ChartTooltip metric={metric} isDark={isDark} />} wrapperStyle={{ backgroundColor: 'transparent', zIndex: 10 }} />
             {nodeNames.map((name, i) => {
               const color = NODE_COLORS[i % NODE_COLORS.length]

--- a/frontend/src/components/dashboard/widgets/KpiAlertsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiAlertsWidget.jsx
@@ -53,10 +53,10 @@ return null
     <Typography
       variant='body2'
       component='span'
-      sx={{ fontSize: 13, color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
+      sx={{ fontSize: '0.9286rem', color: 'primary.main', cursor: 'pointer', '&:hover': { textDecoration: 'underline' } }}
       onClick={() => { router.push(entityLink); onClose() }}
     >
-      {alert.source} <i className='ri-external-link-line' style={{ fontSize: 11 }} />
+      {alert.source} <i className='ri-external-link-line' style={{ fontSize: '0.7857rem' }} />
     </Typography>
   ) : alert.source
 
@@ -76,7 +76,7 @@ return null
     <Dialog open={open} onClose={onClose} maxWidth='sm' fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 22, fontSize: 11 }} />
+          <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 22, fontSize: '0.7857rem' }} />
           {t('alerts.detail.title')}
         </Box>
         <IconButton size='small' onClick={onClose}>
@@ -87,10 +87,10 @@ return null
       <DialogContent sx={{ py: 2 }}>
         {details.map((row, idx) => (
           <Box key={idx} sx={{ display: 'flex', py: 0.75, borderBottom: idx < details.length - 1 ? '1px solid' : 'none', borderColor: 'divider' }}>
-            <Typography variant='body2' sx={{ fontWeight: 600, width: 140, flexShrink: 0, color: 'text.secondary', fontSize: 13 }}>
+            <Typography variant='body2' sx={{ fontWeight: 600, width: 140, flexShrink: 0, color: 'text.secondary', fontSize: '0.9286rem' }}>
               {row.label}
             </Typography>
-            <Typography variant='body2' sx={{ fontSize: 13 }}>
+            <Typography variant='body2' sx={{ fontSize: '0.9286rem' }}>
               {row.value}
             </Typography>
           </Box>
@@ -153,7 +153,7 @@ return t('time.daysAgo', { count: Math.floor(diff / 86400) })
       <Dialog open={open && !selectedAlert} onClose={onClose} maxWidth='sm' fullWidth>
         <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', pb: 1 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <i className='ri-alarm-warning-line' style={{ fontSize: 20 }} />
+            <i className='ri-alarm-warning-line' style={{ fontSize: '1.4286rem' }} />
             {t('alerts.title')} ({alerts.length})
           </Box>
           <IconButton size='small' onClick={onClose}>
@@ -180,8 +180,8 @@ return t('time.daysAgo', { count: Math.floor(diff / 86400) })
                     <ListItemText
                       primary={
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 20, fontSize: 10, minWidth: 44 }} />
-                          <Typography variant='body2' sx={{ fontWeight: 600, fontSize: 13 }}>
+                          <Chip size='small' label={cfg.label} color={cfg.color} sx={{ height: 20, fontSize: '0.7143rem', minWidth: 44 }} />
+                          <Typography variant='body2' sx={{ fontWeight: 600, fontSize: '0.9286rem' }}>
                             {translateAlertMessage(alert, t)}
                           </Typography>
                         </Box>
@@ -193,7 +193,7 @@ return t('time.daysAgo', { count: Math.floor(diff / 86400) })
                         </Box>
                       }
                     />
-                    <i className='ri-arrow-right-s-line' style={{ fontSize: 18, opacity: 0.3 }} />
+                    <i className='ri-arrow-right-s-line' style={{ fontSize: '1.2857rem', opacity: 0.3 }} />
                   </ListItemButton>
                 )
               })}
@@ -256,13 +256,13 @@ function KpiAlertsWidget({ data, loading }) {
         onMouseDown={(e) => e.stopPropagation()}
         onClick={() => setDialogOpen(true)}
         component="div"
-        sx={{ height: '100%', width: '100%', display: 'block', borderRadius: 2.5, textAlign: 'left' }}
+        sx={{ height: '100%', width: '100%', display: 'block', borderRadius: 'var(--proxcenter-card-radius)', textAlign: 'left' }}
       >
         <Box
           sx={{
             bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
             border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-            borderRadius: 2.5, p: 1.5, height: '100%',
+            borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
             display: 'flex', alignItems: 'center', gap: 1.5,
           }}
         >
@@ -274,18 +274,18 @@ function KpiAlertsWidget({ data, loading }) {
             ...(hasCrit && { animation: 'kpiAlertPulse 2s ease-in-out infinite' }),
           }}>
             <i className='ri-alarm-warning-line' style={{
-              fontSize: 24, color,
+              fontSize: '1.7143rem', color,
               ...(hasCrit && { animation: 'kpiIconShake 3s ease-in-out infinite' }),
             }} />
           </Box>
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            <Typography sx={{ fontSize: 10, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
               {t('dashboard.widgets.alerts')}
             </Typography>
-            <Typography sx={{ fontSize: 18, fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
+            <Typography sx={{ fontSize: '1.2857rem', fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
               {hasCrit ? `${alertsSummary.crit} CRIT` : hasWarn ? `${alertsSummary.warn} WARN` : 'OK'}
             </Typography>
-            <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+            <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
               {hasCrit || hasWarn ? `${alertsSummary.crit || 0} crit \u2022 ${alertsSummary.warn || 0} warn` : t('alerts.noActiveAlerts')}
             </Typography>
           </Box>

--- a/frontend/src/components/dashboard/widgets/KpiBackupsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiBackupsWidget.jsx
@@ -1,42 +1,12 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Typography, useTheme } from '@mui/material'
 
 import { widgetColors } from './themeColors'
-
-function CircularGauge({ value, max, size = 56, strokeWidth = 4.5, color, trackColor = 'rgba(255,255,255,0.08)' }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const pct = max > 0 ? value / max : 0
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - pct * circumference : circumference
-
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
-  return (
-    <Box sx={{ position: 'relative', width: size, height: size }}>
-      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-          style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-      </svg>
-      <Box sx={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
-          {value}
-        </Typography>
-        <Typography sx={{ fontSize: 7, opacity: 0.5, fontWeight: 700 }}>/{max}</Typography>
-      </Box>
-    </Box>
-  )
-}
+import CircularGauge from './CircularGauge'
 
 function KpiBackupsWidget({ data, loading }) {
   const t = useTranslations()
@@ -56,19 +26,22 @@ function KpiBackupsWidget({ data, loading }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, height: '100%',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
         display: 'flex', alignItems: 'center', gap: 1.5,
       }}
     >
-      <CircularGauge value={ok} max={total || (hasServers ? 1 : 0)} color={color} trackColor={c.surfaceSubtle} />
+      <CircularGauge value={ok} max={total || (hasServers ? 1 : 0)} color={color} trackColor={c.surfaceSubtle} size='4em'>
+        <Box component='span' sx={{ fontWeight: 800, fontSize: '0.9em', color, lineHeight: 1 }}>{ok}</Box>
+        <Box component='span' sx={{ fontSize: '0.45em', opacity: 0.5, fontWeight: 700 }}>/{total}</Box>
+      </CircularGauge>
       <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography sx={{ fontSize: 10, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
           {t('dashboard.widgets.backups')} PBS (24h)
         </Typography>
-        <Typography sx={{ fontSize: 18, fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '1.2857rem', fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
           {total > 0 ? `${ok} / ${total}` : '\u2014'}
         </Typography>
-        <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
           {hasError ? `${pbs.backups24h.error} ${t('jobs.failed').toLowerCase()}` : hasServers ? `${pbs.servers} PBS` : t('common.noData')}
         </Typography>
       </Box>

--- a/frontend/src/components/dashboard/widgets/KpiClustersWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiClustersWidget.jsx
@@ -1,42 +1,12 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Typography, useTheme } from '@mui/material'
 
 import { widgetColors } from './themeColors'
-
-function CircularGauge({ value, max, size = 56, strokeWidth = 4.5, color, trackColor = 'rgba(255,255,255,0.08)' }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const pct = max > 0 ? value / max : 0
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - pct * circumference : circumference
-
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
-  return (
-    <Box sx={{ position: 'relative', width: size, height: size }}>
-      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-          style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-      </svg>
-      <Box sx={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
-          {value}
-        </Typography>
-        <Typography sx={{ fontSize: 7, opacity: 0.5, fontWeight: 700 }}>/{max}</Typography>
-      </Box>
-    </Box>
-  )
-}
+import CircularGauge from './CircularGauge'
 
 function KpiClustersWidget({ data, loading }) {
   const t = useTranslations()
@@ -52,19 +22,22 @@ function KpiClustersWidget({ data, loading }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, height: '100%',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
         display: 'flex', alignItems: 'center', gap: 1.5,
       }}
     >
-      <CircularGauge value={summary.nodesOnline || summary.nodes || 0} max={summary.nodes || 0} color={color} trackColor={c.surfaceSubtle} />
+      <CircularGauge value={summary.nodesOnline || summary.nodes || 0} max={summary.nodes || 0} color={color} trackColor={c.surfaceSubtle} size='4em'>
+        <Box component='span' sx={{ fontWeight: 800, fontSize: '0.9em', color, lineHeight: 1 }}>{summary.nodesOnline || summary.nodes || 0}</Box>
+        <Box component='span' sx={{ fontSize: '0.45em', opacity: 0.5, fontWeight: 700 }}>/{summary.nodes || 0}</Box>
+      </CircularGauge>
       <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography sx={{ fontSize: 10, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
           {t('inventory.clusters')} / {t('dashboard.widgets.nodes')}
         </Typography>
-        <Typography sx={{ fontSize: 18, fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '1.2857rem', fontWeight: 800, color, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
           {summary.clusters || 0} / {summary.nodes || 0}
         </Typography>
-        <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
           {hasOffline ? `${summary.nodesOffline} ${t('common.offline').toLowerCase()}` : t('common.online')}
         </Typography>
       </Box>

--- a/frontend/src/components/dashboard/widgets/KpiLxcWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiLxcWidget.jsx
@@ -1,42 +1,12 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Typography, useTheme } from '@mui/material'
 
 import { widgetColors } from './themeColors'
-
-function CircularGauge({ value, max, size = 56, strokeWidth = 4.5, color, trackColor = 'rgba(255,255,255,0.08)' }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const pct = max > 0 ? value / max : 0
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - pct * circumference : circumference
-
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
-  return (
-    <Box sx={{ position: 'relative', width: size, height: size }}>
-      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-          style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-      </svg>
-      <Box sx={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
-          {value}
-        </Typography>
-        <Typography sx={{ fontSize: 7, opacity: 0.5, fontWeight: 700 }}>/{max}</Typography>
-      </Box>
-    </Box>
-  )
-}
+import CircularGauge from './CircularGauge'
 
 function KpiLxcWidget({ data, loading }) {
   const t = useTranslations()
@@ -51,19 +21,22 @@ function KpiLxcWidget({ data, loading }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, height: '100%',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
         display: 'flex', alignItems: 'center', gap: 1.5,
       }}
     >
-      <CircularGauge value={summary.lxcRunning || 0} max={summary.lxcTotal || 0} color={secondaryColor} trackColor={c.surfaceSubtle} />
+      <CircularGauge value={summary.lxcRunning || 0} max={summary.lxcTotal || 0} color={secondaryColor} trackColor={c.surfaceSubtle} size='4em'>
+        <Box component='span' sx={{ fontWeight: 800, fontSize: '0.9em', color: secondaryColor, lineHeight: 1 }}>{summary.lxcRunning || 0}</Box>
+        <Box component='span' sx={{ fontSize: '0.45em', opacity: 0.5, fontWeight: 700 }}>/{summary.lxcTotal || 0}</Box>
+      </CircularGauge>
       <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography sx={{ fontSize: 10, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
           LXC
         </Typography>
-        <Typography sx={{ fontSize: 18, fontWeight: 800, color: secondaryColor, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '1.2857rem', fontWeight: 800, color: secondaryColor, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
           {summary.lxcRunning || 0} / {summary.lxcTotal || 0}
         </Typography>
-        <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
           {t('common.active').toLowerCase()} / {t('common.total').toLowerCase()}
         </Typography>
       </Box>

--- a/frontend/src/components/dashboard/widgets/KpiVmsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiVmsWidget.jsx
@@ -1,42 +1,12 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Typography, useTheme } from '@mui/material'
 
 import { widgetColors } from './themeColors'
-
-function CircularGauge({ value, max, size = 56, strokeWidth = 4.5, color, trackColor = 'rgba(255,255,255,0.08)' }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const pct = max > 0 ? value / max : 0
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - pct * circumference : circumference
-
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
-  return (
-    <Box sx={{ position: 'relative', width: size, height: size }}>
-      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-        <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-          strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-          style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-      </svg>
-      <Box sx={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography sx={{ fontSize: 14, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color, lineHeight: 1 }}>
-          {value}
-        </Typography>
-        <Typography sx={{ fontSize: 7, opacity: 0.5, fontWeight: 700 }}>/{max}</Typography>
-      </Box>
-    </Box>
-  )
-}
+import CircularGauge from './CircularGauge'
 
 function KpiVmsWidget({ data, loading }) {
   const t = useTranslations()
@@ -51,19 +21,22 @@ function KpiVmsWidget({ data, loading }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, height: '100%',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
         display: 'flex', alignItems: 'center', gap: 1.5,
       }}
     >
-      <CircularGauge value={summary.vmsRunning || 0} max={summary.vmsTotal || 0} color={primaryColor} trackColor={c.surfaceSubtle} />
+      <CircularGauge value={summary.vmsRunning || 0} max={summary.vmsTotal || 0} color={primaryColor} trackColor={c.surfaceSubtle} size='4em'>
+        <Box component='span' sx={{ fontWeight: 800, fontSize: '0.9em', color: primaryColor, lineHeight: 1 }}>{summary.vmsRunning || 0}</Box>
+        <Box component='span' sx={{ fontSize: '0.45em', opacity: 0.5, fontWeight: 700 }}>/{summary.vmsTotal || 0}</Box>
+      </CircularGauge>
       <Box sx={{ flex: 1, minWidth: 0 }}>
-        <Typography sx={{ fontSize: 10, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
           {t('dashboard.widgets.vms')}
         </Typography>
-        <Typography sx={{ fontSize: 18, fontWeight: 800, color: primaryColor, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '1.2857rem', fontWeight: 800, color: primaryColor, lineHeight: 1.2, fontFamily: '"JetBrains Mono", monospace' }}>
           {summary.vmsRunning || 0} / {summary.vmsTotal || 0}
         </Typography>
-        <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+        <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
           CPU {summary.cpuPct || 0}% &bull; RAM {summary.ramPct || 0}%
         </Typography>
       </Box>

--- a/frontend/src/components/dashboard/widgets/NodesGaugesWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/NodesGaugesWidget.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Checkbox, Chip, IconButton, ListItemText, Menu, MenuItem, Tooltip, Typography, useTheme } from '@mui/material'
@@ -9,40 +9,23 @@ import ChartContainer from '@/components/ChartContainer'
 
 import { widgetColors } from './themeColors'
 import { mapTimeRange, sliceToRange, formatTime } from './timeRangeUtils'
+import CircularGauge from './CircularGauge'
 
-// ─── Circular Gauge (animated on mount) ──────────────────────────────────────
-function CircularGauge({ value, label, size = 64, strokeWidth = 5, color, theme }) {
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const [mounted, setMounted] = useState(false)
-  const offset = mounted ? circumference - (value / 100) * circumference : circumference
-  const isDark = theme?.palette?.mode === 'dark'
+// ─── Labeled Gauge ────────────────────────────────────────────────────────────
+function LabeledGauge({ value, label, color, isDark }) {
   const trackColor = isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'
 
-  useEffect(() => { const t = setTimeout(() => setMounted(true), 50);
-
- 
-
-return () => clearTimeout(t) }, [])
-
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25 }}>
-      <Box sx={{ position: 'relative', width: size, height: size }}>
-        <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-          <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={trackColor} strokeWidth={strokeWidth} />
-          <circle cx={size / 2} cy={size / 2} r={radius} fill="none" stroke={color} strokeWidth={strokeWidth}
-            strokeDasharray={circumference} strokeDashoffset={offset} strokeLinecap="round"
-            style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
-        </svg>
-        <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Typography sx={{ fontSize: 11, fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
-            {value}%
-          </Typography>
-        </Box>
-      </Box>
-      <Typography sx={{ fontSize: 9, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 0.25, flex: 1, minWidth: 0 }}>
+      <CircularGauge value={value} color={color} trackColor={trackColor} size='4.6em'>
+        <Box component='span' sx={{ fontWeight: 700, fontSize: '0.85em' }}>{value}%</Box>
+      </CircularGauge>
+      <Box
+        component='span'
+        sx={{ fontSize: '0.6429rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}
+      >
         {label}
-      </Typography>
+      </Box>
     </Box>
   )
 }
@@ -142,9 +125,9 @@ function CpuRamTooltip({ active, payload, isDark }) {
   const c = widgetColors(isDark)
 
   return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 80, color: c.tooltipText }}>
-      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-cpu-line' style={{ fontSize: 10 }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 80, color: c.tooltipText }}>
+      <div style={{ background: '#f97316', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-cpu-line' style={{ fontSize: '0.7143rem' }} /> CPU / RAM {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px', display: 'flex', flexDirection: 'column', gap: 1 }}>
         {cpu != null && <div><span style={{ color: '#f97316', fontWeight: 700 }}>CPU</span> {cpu}%</div>}
@@ -163,9 +146,9 @@ function IoNetTooltip({ active, payload, isDark }) {
   const c = widgetColors(isDark)
 
   return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 80, color: c.tooltipText }}>
-      <div style={{ background: '#ab47bc', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-exchange-line' style={{ fontSize: 10 }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 80, color: c.tooltipText }}>
+      <div style={{ background: '#ab47bc', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-exchange-line' style={{ fontSize: '0.7143rem' }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px', display: 'flex', flexDirection: 'column', gap: 1 }}>
         {netin != null && <div><span style={{ color: '#4caf50', fontWeight: 700 }}>Net In</span> {formatRate(netin)}</div>}
@@ -192,7 +175,7 @@ function NodeCard({ node, theme, trends }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column', gap: 1,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column', gap: 1,
         transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
         '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.1)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
       }}
@@ -202,13 +185,13 @@ function NodeCard({ node, theme, trends }) {
           <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={18} height={18} style={{ opacity: 0.8 }} />
           <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 7, height: 7, borderRadius: '50%', bgcolor: isOnline ? '#4caf50' : '#f44336', border: '1.5px solid', borderColor: isDark ? '#1e1e2d' : '#fff' }} />
         </Box>
-        <Typography sx={{ fontSize: 12, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+        <Typography sx={{ fontSize: '0.8571rem', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
           {node.name}
         </Typography>
         {isOnline && (
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Typography sx={{ fontSize: 9, opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>{formatUptime(node.uptime)}</Typography>
-            <Box sx={{ px: 0.5, py: 0.15, borderRadius: 0.5, bgcolor: `${scoreColor}18`, color: scoreColor, fontSize: 9, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4 }}>{score}</Box>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>{formatUptime(node.uptime)}</Typography>
+            <Box sx={{ px: 0.5, py: 0.15, borderRadius: 0.5, bgcolor: `${scoreColor}18`, color: scoreColor, fontSize: '0.6429rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', lineHeight: 1.4 }}>{score}</Box>
           </Box>
         )}
       </Box>
@@ -216,13 +199,13 @@ function NodeCard({ node, theme, trends }) {
       {isOnline ? (
         <>
           <Box sx={{ display: 'flex', justifyContent: 'space-around' }}>
-            <CircularGauge value={cpuPct} label="CPU" color={getGaugeColor(cpuPct)} theme={theme} />
-            <CircularGauge value={memPct} label="RAM" color={getGaugeColor(memPct)} theme={theme} />
-            <CircularGauge value={storagePct} label="DISK" color={getGaugeColor(storagePct)} theme={theme} />
+            <LabeledGauge value={cpuPct} label="CPU" color={getGaugeColor(cpuPct)} isDark={isDark} />
+            <LabeledGauge value={memPct} label="RAM" color={getGaugeColor(memPct)} isDark={isDark} />
+            <LabeledGauge value={storagePct} label="DISK" color={getGaugeColor(storagePct)} isDark={isDark} />
           </Box>
 
           <Box>
-            <Typography sx={{ fontSize: 9, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>CPU / RAM</Typography>
             <Box sx={{ height: 40, width: '100%' }}>
               {hasTrends ? (
                 <ChartContainer>
@@ -232,12 +215,12 @@ function NodeCard({ node, theme, trends }) {
                     <Area type="monotone" dataKey="ram" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.6} strokeWidth={1.2} dot={false} isAnimationActive={false} />
                   </AreaChart>
                 </ChartContainer>
-              ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: 9 }}>...</Typography></Box>}
+              ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: '0.6429rem' }}>...</Typography></Box>}
             </Box>
           </Box>
 
           <Box>
-            <Typography sx={{ fontSize: 9, opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
             <Box sx={{ height: 40, width: '100%' }}>
               {hasTrends ? (
                 <ChartContainer>
@@ -247,19 +230,19 @@ function NodeCard({ node, theme, trends }) {
                     <Area type="monotone" dataKey="netout" name="Net Out" stroke="#f97316" fill="#f97316" fillOpacity={0.6} strokeWidth={1.2} dot={false} isAnimationActive={false} />
                   </AreaChart>
                 </ChartContainer>
-              ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: 9 }}>...</Typography></Box>}
+              ) : <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}><Typography sx={{ fontSize: '0.6429rem' }}>...</Typography></Box>}
             </Box>
           </Box>
 
           <Box sx={{ display: 'flex', justifyContent: 'space-between', opacity: 0.65 }}>
-            <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>{node._cpuCores || '-'}c</Typography>
-            <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>{formatBytes(node._memMax)}</Typography>
-            <Typography sx={{ fontSize: 9, fontFamily: '"JetBrains Mono", monospace' }}>{formatBytes(node._storageMax)}</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>{node._cpuCores || '-'}c</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>{formatBytes(node._memMax)}</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', fontFamily: '"JetBrains Mono", monospace' }}>{formatBytes(node._storageMax)}</Typography>
           </Box>
         </>
       ) : (
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 3 }}>
-          <Typography variant='caption' sx={{ color: 'error.main', fontWeight: 700, fontSize: 11 }}>OFFLINE</Typography>
+          <Typography variant='caption' sx={{ color: 'error.main', fontWeight: 700, fontSize: '0.7857rem' }}>OFFLINE</Typography>
         </Box>
       )}
     </Box>
@@ -289,16 +272,16 @@ function NodeFilter({ nodes, selected, onChange }) {
     <>
       <Tooltip title={t('common.filter')}>
         <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
-          <i className='ri-filter-3-line' style={{ fontSize: 14, opacity: allSelected ? 0.4 : 1 }} />
+          <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.4 : 1 }} />
         </IconButton>
       </Tooltip>
       {allSelected ? null : (
-        <Chip label={selected.length} size='small' sx={{ height: 16, fontSize: 9, ml: -0.25 }} />
+        <Chip label={selected.length} size='small' sx={{ height: 16, fontSize: '0.6429rem', ml: -0.25 }} />
       )}
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
         <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
           <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
-          <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{t('common.all')}</ListItemText>
+          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{t('common.all')}</ListItemText>
         </MenuItem>
         {nodes.map(n => {
           const key = `${n.connId}:${n.node || n.name}`
@@ -309,8 +292,8 @@ return (
             <MenuItem key={key} dense onClick={() => handleToggle(key)}>
               <Checkbox size='small' checked={checked} sx={{ p: 0, mr: 1 }} />
               <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: n.status === 'online' ? '#4caf50' : '#f44336', mr: 0.75 }} />
-              <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{n.name}</ListItemText>
-              <Typography sx={{ fontSize: 10, opacity: 0.65, ml: 1 }}>{n.connection}</Typography>
+              <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{n.name}</ListItemText>
+              <Typography sx={{ fontSize: '0.7143rem', opacity: 0.65, ml: 1 }}>{n.connection}</Typography>
             </MenuItem>
           )
         })}

--- a/frontend/src/components/dashboard/widgets/NodesTableWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/NodesTableWidget.jsx
@@ -28,7 +28,7 @@ function NodesTableWidget({ data, loading }) {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 2,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 2,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           transition: 'border-color 0.2s, box-shadow 0.2s',
           '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -47,7 +47,7 @@ function NodesTableWidget({ data, loading }) {
         height: '100%',
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         overflow: 'hidden',
         transition: 'border-color 0.2s, box-shadow 0.2s',
         '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -57,11 +57,11 @@ function NodesTableWidget({ data, loading }) {
         <Table size='small' stickyHeader>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: 12, py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('dashboard.widgets.nodes')}</TableCell>
-              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: 12, py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('inventory.clusters')}</TableCell>
-              <TableCell align='center' sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: 12, py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('common.status')}</TableCell>
-              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, minWidth: 100, fontSize: 12, py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('monitoring.cpu')}</TableCell>
-              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, minWidth: 100, fontSize: 12, py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('monitoring.memory')}</TableCell>
+              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: '0.8571rem', py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('dashboard.widgets.nodes')}</TableCell>
+              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: '0.8571rem', py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('inventory.clusters')}</TableCell>
+              <TableCell align='center' sx={{ fontWeight: 800, bgcolor: headerBg, fontSize: '0.8571rem', py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('common.status')}</TableCell>
+              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, minWidth: 100, fontSize: '0.8571rem', py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('monitoring.cpu')}</TableCell>
+              <TableCell sx={{ fontWeight: 800, bgcolor: headerBg, minWidth: 100, fontSize: '0.8571rem', py: 1, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>{t('monitoring.memory')}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -81,11 +81,11 @@ function NodesTableWidget({ data, loading }) {
                       <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" style={{ width: 18, height: 18, opacity: node.status === 'online' ? 0.8 : 0.4 }} />
                       <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 8, height: 8, borderRadius: '50%', bgcolor: node.status === 'online' ? '#4caf50' : '#f44336', border: '1.5px solid', borderColor: isDark ? 'rgba(255,255,255,0.03)' : '#fff' }} />
                     </Box>
-                    <Typography variant='body2' sx={{ fontWeight: 700, fontSize: 12 }}>{node.name}</Typography>
+                    <Typography variant='body2' sx={{ fontWeight: 700, fontSize: '0.8571rem' }}>{node.name}</Typography>
                   </Box>
                 </TableCell>
                 <TableCell sx={{ py: 0.75, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>
-                  <Typography variant='body2' sx={{ opacity: 0.7, fontSize: 11 }}>{node.connection}</Typography>
+                  <Typography variant='body2' sx={{ opacity: 0.7, fontSize: '0.7857rem' }}>{node.connection}</Typography>
                 </TableCell>
                 <TableCell align='center' sx={{ py: 0.75, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>
                   <Chip
@@ -93,7 +93,7 @@ function NodesTableWidget({ data, loading }) {
                     label={node.status === 'online' ? t('common.online') : t('common.offline')}
                     color={node.status === 'online' ? 'success' : 'error'}
                     variant='outlined'
-                    sx={{ fontSize: 10, height: 20, fontWeight: 600 }}
+                    sx={{ fontSize: '0.7143rem', height: 20, fontWeight: 600 }}
                   />
                 </TableCell>
                 <TableCell sx={{ py: 0.75, borderBottom: `1px solid ${isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}` }}>

--- a/frontend/src/components/dashboard/widgets/PbsOverviewWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/PbsOverviewWidget.jsx
@@ -34,15 +34,15 @@ return () => clearTimeout(t) }, [])
             style={{ transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)' }} />
         </svg>
         <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <Typography sx={{ fontSize: 10, fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
+          <Typography sx={{ fontSize: '0.7143rem', fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>
             {value}%
           </Typography>
         </Box>
       </Box>
-      <Typography sx={{ fontSize: 8, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+      <Typography sx={{ fontSize: '0.5714rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5 }}>
         {label}
       </Typography>
-      {sublabel && <Typography sx={{ fontSize: 8, opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', mt: -0.25 }}>{sublabel}</Typography>}
+      {sublabel && <Typography sx={{ fontSize: '0.5714rem', opacity: 0.5, fontFamily: '"JetBrains Mono", monospace', mt: -0.25 }}>{sublabel}</Typography>}
     </Box>
   )
 }
@@ -55,9 +55,9 @@ function IoTooltip({ active, payload, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 90, color: c.tooltipText }}>
-      <div style={{ background: '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: 9, display: 'flex', alignItems: 'center', gap: 4 }}>
-        <i className='ri-speed-line' style={{ fontSize: 10 }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 90, color: c.tooltipText }}>
+      <div style={{ background: '#3b82f6', color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-speed-line' style={{ fontSize: '0.7143rem' }} /> IO / NET {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
       </div>
       <div style={{ padding: '4px 8px' }}>
         {payload.map(e => (
@@ -121,7 +121,7 @@ function PbsCard({ server, theme, t, rrdData }) {
       sx={{
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5, display: 'flex', flexDirection: 'column',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column',
         transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
         '&:hover': { borderColor: c.surfaceActive, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
       }}
@@ -129,17 +129,17 @@ function PbsCard({ server, theme, t, rrdData }) {
       {/* Header */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, mb: 0.5 }}>
         <Box sx={{ position: 'relative', width: 18, height: 18, flexShrink: 0 }}>
-          <i className='ri-shield-check-line' style={{ fontSize: 16, opacity: 0.6 }} />
+          <i className='ri-shield-check-line' style={{ fontSize: '1.1429rem', opacity: 0.6 }} />
           <Box sx={{
             position: 'absolute', bottom: -1, right: -1, width: 7, height: 7, borderRadius: '50%',
             bgcolor: hasErrors ? '#f44336' : '#4caf50',
             border: '1.5px solid', borderColor: c.dotBorder
           }} />
         </Box>
-        <Typography sx={{ fontSize: 12, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+        <Typography sx={{ fontSize: '0.8571rem', fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
           {server.name}
         </Typography>
-        <Typography sx={{ fontSize: 9, opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>
+        <Typography sx={{ fontSize: '0.6429rem', opacity: 0.65, fontFamily: '"JetBrains Mono", monospace' }}>
           {server.datastores} DS
         </Typography>
       </Box>
@@ -155,23 +155,23 @@ function PbsCard({ server, theme, t, rrdData }) {
         {/* Stats: OK / Failed / Verify */}
         <Box sx={{ display: 'flex', justifyContent: 'space-around', gap: 0.5 }}>
           <Box sx={{ textAlign: 'center' }}>
-            <Typography sx={{ fontSize: 13, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: '#4caf50', lineHeight: 1 }}>
+            <Typography sx={{ fontSize: '0.9286rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: '#4caf50', lineHeight: 1 }}>
               {okBackups}
             </Typography>
-            <Typography sx={{ fontSize: 8, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>OK 24h</Typography>
+            <Typography sx={{ fontSize: '0.5714rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>OK 24h</Typography>
           </Box>
           <Box sx={{ textAlign: 'center' }}>
-            <Typography sx={{ fontSize: 13, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: errorBackups > 0 ? '#f44336' : 'text.disabled', lineHeight: 1 }}>
+            <Typography sx={{ fontSize: '0.9286rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: errorBackups > 0 ? '#f44336' : 'text.disabled', lineHeight: 1 }}>
               {errorBackups}
             </Typography>
-            <Typography sx={{ fontSize: 8, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>{t('jobs.failed')}</Typography>
+            <Typography sx={{ fontSize: '0.5714rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>{t('jobs.failed')}</Typography>
           </Box>
           <Box sx={{ textAlign: 'center' }}>
-            <Typography sx={{ fontSize: 13, fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: verifyError > 0 ? '#ff9800' : '#2196f3', lineHeight: 1 }}>
-              {verifyOk}{verifyError > 0 && <span style={{ color: '#f44336', fontSize: 10 }}>/{verifyError}</span>}
+            <Typography sx={{ fontSize: '0.9286rem', fontWeight: 800, fontFamily: '"JetBrains Mono", monospace', color: verifyError > 0 ? '#ff9800' : '#2196f3', lineHeight: 1 }}>
+              {verifyOk}{verifyError > 0 && <span style={{ color: '#f44336', fontSize: '0.7143rem' }}>/{verifyError}</span>}
             </Typography>
-            <Typography sx={{ fontSize: 8, opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>
-              <i className='ri-verified-badge-fill' style={{ fontSize: 8, marginRight: 2 }} />Verify
+            <Typography sx={{ fontSize: '0.5714rem', opacity: 0.7, fontWeight: 700, textTransform: 'uppercase' }}>
+              <i className='ri-verified-badge-fill' style={{ fontSize: '0.5714rem', marginRight: 2 }} />Verify
             </Typography>
           </Box>
         </Box>
@@ -179,7 +179,7 @@ function PbsCard({ server, theme, t, rrdData }) {
 
       {/* Sparklines pushed to bottom */}
       <Box sx={{ mt: 'auto' }}>
-        <Typography sx={{ fontSize: 8, opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
+        <Typography sx={{ fontSize: '0.5714rem', opacity: 0.65, fontWeight: 700, textTransform: 'uppercase', mb: 0.25 }}>IO / NET</Typography>
         <Box sx={{ height: 80, width: '100%', mb: 1 }}>
           {hasRrd ? (
             <ChartContainer>
@@ -193,7 +193,7 @@ function PbsCard({ server, theme, t, rrdData }) {
             </ChartContainer>
           ) : (
             <Box sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', opacity: 0.15 }}>
-              <Typography sx={{ fontSize: 9 }}>...</Typography>
+              <Typography sx={{ fontSize: '0.6429rem' }}>...</Typography>
             </Box>
           )}
         </Box>
@@ -248,7 +248,7 @@ return { id: server.id, data: points }
   if (!pbs.servers || pbs.servers === 0) {
     return (
       <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', opacity: 0.65 }}>
-        <i className='ri-shield-check-line' style={{ fontSize: 28, marginBottom: 4 }} />
+        <i className='ri-shield-check-line' style={{ fontSize: '2rem', marginBottom: 4 }} />
         <Typography variant='caption'>{t('common.noData')}</Typography>
       </Box>
     )

--- a/frontend/src/components/dashboard/widgets/QuickStatsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/QuickStatsWidget.jsx
@@ -62,7 +62,7 @@ function QuickStatsWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: c.borderLight,
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         display: 'flex',
         alignItems: 'center',
@@ -79,12 +79,12 @@ function QuickStatsWidget({ data, loading }) {
       {stats.map((stat, idx) => (
         <Box key={idx} sx={{ textAlign: 'center', minWidth: 60 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 0.5 }}>
-            <i className={stat.icon} style={{ fontSize: 14, color: stat.color }} />
+            <i className={stat.icon} style={{ fontSize: '1rem', color: stat.color }} />
             <Typography variant='body1' sx={{ fontWeight: 800, color: stat.color, fontFamily: '"JetBrains Mono", monospace' }}>
               {stat.value}
             </Typography>
           </Box>
-          <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 9 }}>
+          <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.6429rem' }}>
             {stat.label}
           </Typography>
         </Box>

--- a/frontend/src/components/dashboard/widgets/ResourcesGaugesWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ResourcesGaugesWidget.jsx
@@ -1,78 +1,12 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 
 import { useTranslations } from 'next-intl'
 import { Box, Typography, useTheme } from '@mui/material'
 
 import { widgetColors } from './themeColors'
-
-function CircularGauge({ value, color, trackColor, textColor, size = 72, strokeWidth = 6 }) {
-  const [animatedValue, setAnimatedValue] = useState(0)
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  const center = size / 2
-
-  useEffect(() => {
-    // Small delay so the animation is visible on mount
-    const timer = setTimeout(() => {
-      setAnimatedValue(Math.min(value || 0, 100))
-    }, 50)
-
-    
-return () => clearTimeout(timer)
-  }, [value])
-
-  const strokeDashoffset = circumference - (animatedValue / 100) * circumference
-
-  return (
-    <Box sx={{ position: 'relative', width: size, height: size, flexShrink: 0 }}>
-      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
-        {/* Track */}
-        <circle
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={trackColor}
-          strokeWidth={strokeWidth}
-        />
-        {/* Value arc */}
-        <circle
-          cx={center}
-          cy={center}
-          r={radius}
-          fill="none"
-          stroke={color}
-          strokeWidth={strokeWidth}
-          strokeDasharray={circumference}
-          strokeDashoffset={strokeDashoffset}
-          strokeLinecap="round"
-          style={{
-            transition: 'stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1), stroke 0.3s ease',
-          }}
-        />
-      </svg>
-      <Box sx={{
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        textAlign: 'center',
-      }}>
-        <Typography sx={{
-          fontFamily: '"JetBrains Mono", monospace',
-          fontWeight: 700,
-          fontSize: '0.85rem',
-          lineHeight: 1,
-          color: textColor,
-        }}>
-          {Math.round(animatedValue)}%
-        </Typography>
-      </Box>
-    </Box>
-  )
-}
+import CircularGauge from './CircularGauge'
 
 function getGaugeColor(pct) {
   const v = pct || 0
@@ -128,7 +62,7 @@ function ResourcesGaugesWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         height: '100%',
         display: 'flex',
@@ -150,10 +84,12 @@ function ResourcesGaugesWidget({ data, loading }) {
               value={g.pct}
               color={getGaugeColor(g.pct)}
               trackColor={trackColor}
-              textColor={c.textPrimary}
-              size={72}
-              strokeWidth={6}
-            />
+              size='5.1em'
+            >
+              <Box component='span' sx={{ fontWeight: 700, fontSize: '0.9em', color: c.textPrimary }}>
+                {Math.round(g.pct)}%
+              </Box>
+            </CircularGauge>
             <Typography sx={{
               color: c.textPrimary,
               fontWeight: 600,

--- a/frontend/src/components/dashboard/widgets/SectionHeaderWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/SectionHeaderWidget.jsx
@@ -48,7 +48,7 @@ function SectionHeaderWidget({ config, data, loading, onUpdateSettings }) {
       {/* Collapse icon */}
       <i
         className={collapsed ? 'ri-arrow-right-s-line' : 'ri-arrow-down-s-line'}
-        style={{ fontSize: 16, opacity: 0.5, flexShrink: 0 }}
+        style={{ fontSize: '1.1429rem', opacity: 0.5, flexShrink: 0 }}
       />
 
       {/* Title */}
@@ -61,7 +61,7 @@ function SectionHeaderWidget({ config, data, loading, onUpdateSettings }) {
           onKeyDown={handleKeyDown}
           onClick={(e) => e.stopPropagation()}
           sx={{
-            fontSize: 11, fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5,
+            fontSize: '0.7857rem', fontWeight: 700, textTransform: 'uppercase', letterSpacing: 0.5,
             '& input': { p: 0 },
           }}
         />
@@ -69,7 +69,7 @@ function SectionHeaderWidget({ config, data, loading, onUpdateSettings }) {
         <Typography
           onDoubleClick={handleStartEdit}
           sx={{
-            fontSize: 11, fontWeight: 700, opacity: 0.6,
+            fontSize: '0.7857rem', fontWeight: 700, opacity: 0.6,
             textTransform: 'uppercase', letterSpacing: 0.5,
             flexShrink: 0,
           }}
@@ -87,7 +87,7 @@ function SectionHeaderWidget({ config, data, loading, onUpdateSettings }) {
         onClick={(e) => { e.stopPropagation(); handleStartEdit(e) }}
         sx={{ p: 0.25, opacity: 0.3, '&:hover': { opacity: 0.8 } }}
       >
-        <i className='ri-pencil-line' style={{ fontSize: 12 }} />
+        <i className='ri-pencil-line' style={{ fontSize: '0.8571rem' }} />
       </IconButton>
     </Box>
   )

--- a/frontend/src/components/dashboard/widgets/SiteRecoveryWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/SiteRecoveryWidget.jsx
@@ -30,7 +30,7 @@ function ScoreRing({ score, size = 56 }) {
         />
       </svg>
       <Box sx={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-        <Typography variant='body2' sx={{ fontWeight: 800, fontSize: 13, color }}>
+        <Typography variant='body2' sx={{ fontWeight: 800, fontSize: '0.9286rem', color }}>
           {score}
         </Typography>
       </Box>
@@ -74,7 +74,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         height: '100%',
         display: 'flex',
@@ -90,7 +90,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
   if (!isEnterprise) {
     return darkShell(
       <>
-        <i className='ri-vip-crown-fill' style={{ fontSize: 32, color: '#f59e0b', marginBottom: 8 }} />
+        <i className='ri-vip-crown-fill' style={{ fontSize: '2.2857rem', color: '#f59e0b', marginBottom: 8 }} />
         <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)' }}>Enterprise</Typography>
       </>
     )
@@ -125,7 +125,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid',
           borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5,
+          borderRadius: 'var(--proxcenter-card-radius)',
           p: 1.5,
           height: '100%',
           display: 'flex',
@@ -137,11 +137,11 @@ function SiteRecoveryWidget({ data, loading, config }) {
           },
         }}
       >
-        <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, mb: 1.5, fontSize: 10 }}>
+        <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, mb: 1.5, fontSize: '0.7143rem' }}>
           Site Recovery
         </Typography>
         <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
-          <i className='ri-shield-star-line' style={{ fontSize: 28, color: c.textFaint, marginBottom: 4 }} />
+          <i className='ri-shield-star-line' style={{ fontSize: '2rem', color: c.textFaint, marginBottom: 4 }} />
           <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)' }}>{t('dashboard.widgetSr.noJobs')}</Typography>
         </Box>
       </Box>
@@ -154,7 +154,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         height: '100%',
         display: 'flex',
@@ -169,14 +169,14 @@ function SiteRecoveryWidget({ data, loading, config }) {
     >
       {/* Header */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}>
-        <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: 10 }}>
+        <Typography variant='caption' sx={{ color: 'rgba(255,255,255,0.4)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, fontSize: '0.7143rem' }}>
           Site Recovery
         </Typography>
         <Chip
           size='small'
           label={t(`dashboard.widgetSr.${connectivity}`)}
           color={connColor}
-          sx={{ height: 20, fontSize: 10, fontWeight: 700 }}
+          sx={{ height: 20, fontSize: '0.7143rem', fontWeight: 700 }}
         />
       </Box>
 
@@ -191,7 +191,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
           }}>
             <ScoreRing score={srScore} size={44} />
             <Box>
-              <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 9, display: 'block' }}>
+              <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.6429rem', display: 'block' }}>
                 {t('dashboard.widgetSr.protectionScore')}
               </Typography>
               <Typography variant='body2' sx={{ fontWeight: 700, lineHeight: 1.2, color: '#fff' }}>
@@ -212,7 +212,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
               color: statColor(coveragePct, 80, 50),
               fontFamily: '"JetBrains Mono", monospace',
             }}>{coveragePct}%</Typography>
-            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 8 }}>{t('dashboard.widgetSr.coverage')}</Typography>
+            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.5714rem' }}>{t('dashboard.widgetSr.coverage')}</Typography>
           </Box>
           <Box sx={{
             flex: 1, p: 0.75, borderRadius: 1, textAlign: 'center',
@@ -223,7 +223,7 @@ function SiteRecoveryWidget({ data, loading, config }) {
               color: statColor(rpoCompliance, 90, 60),
               fontFamily: '"JetBrains Mono", monospace',
             }}>{rpoCompliance}%</Typography>
-            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 8 }}>RPO</Typography>
+            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.5714rem' }}>RPO</Typography>
           </Box>
         </Stack>
 
@@ -234,21 +234,21 @@ function SiteRecoveryWidget({ data, loading, config }) {
             bgcolor: 'rgba(59,130,246,0.1)',
           }}>
             <Typography variant='h6' sx={{ fontWeight: 900, lineHeight: 1, color: '#3b82f6', fontFamily: '"JetBrains Mono", monospace' }}>{totalJobs}</Typography>
-            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 8 }}>{t('dashboard.widgetSr.jobs')}</Typography>
+            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.5714rem' }}>{t('dashboard.widgetSr.jobs')}</Typography>
           </Box>
           <Box sx={{
             flex: 1, p: 0.75, borderRadius: 1, textAlign: 'center',
             bgcolor: syncing > 0 ? 'rgba(99,102,241,0.15)' : 'rgba(99,102,241,0.06)',
           }}>
             <Typography variant='h6' sx={{ fontWeight: 900, lineHeight: 1, color: '#6366f1', fontFamily: '"JetBrains Mono", monospace' }}>{syncing}</Typography>
-            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 8 }}>{t('dashboard.widgetSr.syncing')}</Typography>
+            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.5714rem' }}>{t('dashboard.widgetSr.syncing')}</Typography>
           </Box>
           <Box sx={{
             flex: 1, p: 0.75, borderRadius: 1, textAlign: 'center',
             bgcolor: errors > 0 ? 'rgba(239,68,68,0.15)' : 'rgba(239,68,68,0.06)',
           }}>
             <Typography variant='h6' sx={{ fontWeight: 900, lineHeight: 1, color: errors > 0 ? '#ef4444' : c.textFaint, fontFamily: '"JetBrains Mono", monospace' }}>{errors}</Typography>
-            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: 8 }}>{t('dashboard.widgetSr.errors')}</Typography>
+            <Typography variant='caption' sx={{ color: c.textMuted, fontSize: '0.5714rem' }}>{t('dashboard.widgetSr.errors')}</Typography>
           </Box>
         </Stack>
       </Stack>

--- a/frontend/src/components/dashboard/widgets/StoragePoolsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/StoragePoolsWidget.jsx
@@ -77,7 +77,7 @@ function StoragePoolsWidget({ data, loading, config }) {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 1.5,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
         }}
       >
@@ -93,7 +93,7 @@ function StoragePoolsWidget({ data, loading, config }) {
           height: '100%',
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5, p: 2,
+          borderRadius: 'var(--proxcenter-card-radius)', p: 2,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           transition: 'border-color 0.2s, box-shadow 0.2s',
           '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -110,7 +110,7 @@ function StoragePoolsWidget({ data, loading, config }) {
         height: '100%',
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5, p: 1.5,
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
         overflow: 'auto',
         transition: 'border-color 0.2s, box-shadow 0.2s',
         '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
@@ -131,14 +131,14 @@ function StoragePoolsWidget({ data, loading, config }) {
           >
             <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
-                <i className='ri-hard-drive-2-line' style={{ fontSize: 14, opacity: 0.65 }} />
-                <Typography variant='caption' sx={{ fontWeight: 700, fontSize: 11 }}>
+                <i className='ri-hard-drive-2-line' style={{ fontSize: '1rem', opacity: 0.65 }} />
+                <Typography variant='caption' sx={{ fontWeight: 700, fontSize: '0.7857rem' }}>
                   {storage.storage}
                 </Typography>
                 <Chip
                   size='small'
                   label={storage.type || 'dir'}
-                  sx={{ height: 16, fontSize: 9, opacity: 0.7 }}
+                  sx={{ height: 16, fontSize: '0.6429rem', opacity: 0.7 }}
                 />
               </Box>
             </Box>
@@ -154,10 +154,10 @@ function StoragePoolsWidget({ data, loading, config }) {
               <Typography variant='caption' sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '0.6rem', fontWeight: 700, color: '#fff', lineHeight: 1, textShadow: '0 0 2px rgba(0,0,0,0.5)' }}>{usagePct}%</Typography>
             </Box>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.25 }}>
-              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 9 }}>
+              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.6429rem' }}>
                 {storage.connectionName}
               </Typography>
-              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 9 }}>
+              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.6429rem' }}>
                 {formatBytes(storage.used)} / {formatBytes(storage.total)}
               </Typography>
             </Box>

--- a/frontend/src/components/dashboard/widgets/TopConsumersWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/TopConsumersWidget.jsx
@@ -51,7 +51,7 @@ function TopConsumersWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: c.borderLight,
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         height: '100%',
         display: 'flex',
@@ -74,7 +74,7 @@ function TopConsumersWidget({ data, loading }) {
               py: 0.5,
               borderRadius: 1,
               cursor: 'pointer',
-              fontSize: 11,
+              fontSize: '0.7857rem',
               fontWeight: 600,
               letterSpacing: 0.5,
               textTransform: 'uppercase',
@@ -121,7 +121,7 @@ function TopConsumersWidget({ data, loading }) {
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
                 <Typography
                   sx={{
-                    fontSize: 11,
+                    fontSize: '0.7857rem',
                     fontWeight: 600,
                     color: c.textPrimary,
                     overflow: 'hidden',
@@ -134,7 +134,7 @@ function TopConsumersWidget({ data, loading }) {
                 </Typography>
                 <Typography
                   sx={{
-                    fontSize: 11,
+                    fontSize: '0.7857rem',
                     fontWeight: 600,
                     fontFamily: '"JetBrains Mono", monospace',
                     color

--- a/frontend/src/components/dashboard/widgets/UptimeNodesWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/UptimeNodesWidget.jsx
@@ -45,7 +45,7 @@ function UptimeNodesWidget({ data, loading }) {
           bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
           border: '1px solid',
           borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-          borderRadius: 2.5,
+          borderRadius: 'var(--proxcenter-card-radius)',
           p: 1.5,
           display: 'flex',
           alignItems: 'center',
@@ -66,7 +66,7 @@ function UptimeNodesWidget({ data, loading }) {
         bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
         border: '1px solid',
         borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-        borderRadius: 2.5,
+        borderRadius: 'var(--proxcenter-card-radius)',
         p: 1.5,
         overflow: 'auto',
         transition: 'border-color 0.2s, box-shadow 0.2s',
@@ -96,16 +96,16 @@ function UptimeNodesWidget({ data, loading }) {
                 width: 8, height: 8, borderRadius: '50%',
                 bgcolor: node.status === 'online' ? '#4caf50' : '#f44336'
               }} />
-              <Typography variant='caption' sx={{ fontWeight: 600, fontSize: 11 }}>
+              <Typography variant='caption' sx={{ fontWeight: 600, fontSize: '0.7857rem' }}>
                 {node.name}
               </Typography>
-              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: 10 }}>
+              <Typography variant='caption' sx={{ opacity: 0.65, fontSize: '0.7143rem' }}>
                 {node.connection}
               </Typography>
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <i className='ri-time-line' style={{ fontSize: 12, color, opacity: 0.8 }} />
-              <Typography variant='caption' sx={{ fontWeight: 700, color, fontSize: 11, fontFamily: '"JetBrains Mono", monospace' }}>
+              <i className='ri-time-line' style={{ fontSize: '0.8571rem', color, opacity: 0.8 }} />
+              <Typography variant='caption' sx={{ fontWeight: 700, color, fontSize: '0.7857rem', fontFamily: '"JetBrains Mono", monospace' }}>
                 {node.status === 'online' ? formatUptime(node.uptime) : t('common.offline')}
               </Typography>
             </Box>

--- a/frontend/src/components/dashboard/widgets/VmHeatmapWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/VmHeatmapWidget.jsx
@@ -71,34 +71,34 @@ function TileTooltip({ vm, mode, isDark }) {
 
   
 return (
-    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: 10, minWidth: 140, color: c.tooltipText }}>
-      <div style={{ background: headerColor, color: '#fff', padding: '3px 8px', fontWeight: 700, fontSize: 10, display: 'flex', alignItems: 'center', gap: 4, textShadow: '0 0 2px rgba(0,0,0,0.4)' }}>
-        <i className={vm.type === 'lxc' ? 'ri-instance-line' : 'ri-computer-line'} style={{ fontSize: 11 }} />
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 140, color: c.tooltipText }}>
+      <div style={{ background: headerColor, color: '#fff', padding: '3px 8px', fontWeight: 700, fontSize: '0.7143rem', display: 'flex', alignItems: 'center', gap: 4, textShadow: '0 0 2px rgba(0,0,0,0.4)' }}>
+        <i className={vm.type === 'lxc' ? 'ri-instance-line' : 'ri-computer-line'} style={{ fontSize: '0.7857rem' }} />
         {vm.name || `VM ${vm.vmid}`}
       </div>
       <div style={{ padding: '5px 8px', display: 'flex', gap: 12 }}>
         <div>
-          <div style={{ color: labelColor, fontSize: 9 }}>Status</div>
+          <div style={{ color: labelColor, fontSize: '0.6429rem' }}>Status</div>
           <div style={{ fontWeight: 600, color: getStatusColor(vm.status), fontFamily: '"JetBrains Mono", monospace' }}>{vm.status}</div>
         </div>
         {vm.status === 'running' && (
           <>
             <div>
-              <div style={{ color: labelColor, fontSize: 9 }}>CPU</div>
+              <div style={{ color: labelColor, fontSize: '0.6429rem' }}>CPU</div>
               <div style={{ fontWeight: mode === 'cpu' ? 700 : 400, fontFamily: '"JetBrains Mono", monospace' }}>{vm.cpuPct}%</div>
             </div>
             <div>
-              <div style={{ color: labelColor, fontSize: 9 }}>RAM</div>
+              <div style={{ color: labelColor, fontSize: '0.6429rem' }}>RAM</div>
               <div style={{ fontWeight: mode === 'ram' ? 700 : 400, fontFamily: '"JetBrains Mono", monospace' }}>{vm.ramPct}%</div>
             </div>
           </>
         )}
         <div>
-          <div style={{ color: labelColor, fontSize: 9 }}>Alloc</div>
+          <div style={{ color: labelColor, fontSize: '0.6429rem' }}>Alloc</div>
           <div style={{ fontFamily: '"JetBrains Mono", monospace' }}>{formatBytes(vm.maxmem)}</div>
         </div>
       </div>
-      <div style={{ padding: '0 8px 4px', fontSize: 9, color: footerColor }}>
+      <div style={{ padding: '0 8px 4px', fontSize: '0.6429rem', color: footerColor }}>
         #{vm.vmid} · {vm.type === 'lxc' ? 'LXC' : 'VM'} · {vm.node}
       </div>
     </div>
@@ -121,17 +121,17 @@ function ConnectionFilter({ connections, selected, onChange }) {
   return (
     <>
       <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
-        <i className='ri-filter-3-line' style={{ fontSize: 14, opacity: allSelected ? 0.5 : 1, color: '#fff' }} />
+        <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.5 : 1, color: '#fff' }} />
       </IconButton>
       <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
         <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
           <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
-          <ListItemText primaryTypographyProps={{ fontSize: 12 }}>All</ListItemText>
+          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>All</ListItemText>
         </MenuItem>
         {connections.map(c => (
           <MenuItem key={c.id} dense onClick={() => handleToggle(c.id)}>
             <Checkbox size='small' checked={allSelected || selected.includes(c.id)} sx={{ p: 0, mr: 1 }} />
-            <ListItemText primaryTypographyProps={{ fontSize: 12 }}>{c.name}</ListItemText>
+            <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{c.name}</ListItemText>
           </MenuItem>
         ))}
       </Menu>
@@ -245,17 +245,17 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
   const darkCard = {
     bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
     border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
-    borderRadius: 2.5, p: 1.5,
+    borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
     transition: 'border-color 0.2s, box-shadow 0.2s',
     '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
   }
 
   if (!data || dashboardLoading) {
-    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: 11 }}>Loading...</Typography></Box>
+    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>Loading...</Typography></Box>
   }
 
   if (guests.length === 0) {
-    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: 11 }}>{t('common.noData')}</Typography></Box>
+    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>{t('common.noData')}</Typography></Box>
   }
 
   return (
@@ -265,19 +265,19 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
           {stats && (
             <>
-              <Typography sx={{ fontSize: 10, opacity: 0.6 }}>{stats.total} guests</Typography>
+              <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>{stats.total} guests</Typography>
               {mode === 'status' && (
                 <>
-                  <Typography sx={{ fontSize: 10, color: '#4caf50', fontWeight: 600 }}>{stats.running} <span style={{ fontWeight: 400, opacity: 0.7 }}>running</span></Typography>
-                  {stats.stopped > 0 && <Typography sx={{ fontSize: 10, color: '#9e9e9e', fontWeight: 600 }}>{stats.stopped} <span style={{ fontWeight: 400, opacity: 0.7 }}>stopped</span></Typography>}
+                  <Typography sx={{ fontSize: '0.7143rem', color: '#4caf50', fontWeight: 600 }}>{stats.running} <span style={{ fontWeight: 400, opacity: 0.7 }}>running</span></Typography>
+                  {stats.stopped > 0 && <Typography sx={{ fontSize: '0.7143rem', color: '#9e9e9e', fontWeight: 600 }}>{stats.stopped} <span style={{ fontWeight: 400, opacity: 0.7 }}>stopped</span></Typography>}
                 </>
               )}
               {mode !== 'status' && (
                 <>
-                  <Typography sx={{ fontSize: 10, opacity: 0.6 }}>
+                  <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>
                     Avg <span style={{ fontWeight: 700, fontFamily: '"JetBrains Mono", monospace' }}>{stats.avg}%</span>
                   </Typography>
-                  {stats.hot > 0 && <Typography sx={{ fontSize: 10, color: '#ef4444', fontWeight: 600 }}>{stats.hot} hot</Typography>}
+                  {stats.hot > 0 && <Typography sx={{ fontSize: '0.7143rem', color: '#ef4444', fontWeight: 600 }}>{stats.hot} hot</Typography>}
                 </>
               )}
             </>
@@ -288,7 +288,7 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
           {/* Mode toggle */}
           {MODES.map((v) => (
             <Box key={v} onClick={() => setMode(v)} sx={{
-              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: 10, fontWeight: mode === v ? 700 : 400,
+              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: mode === v ? 700 : 400,
               color: mode === v ? '#fff' : c.textMuted, bgcolor: mode === v ? c.surfaceActive : 'transparent',
               '&:hover': { bgcolor: c.surfaceSubtle },
             }}>{v === 'status' ? 'Status' : v.toUpperCase()}</Box>
@@ -297,7 +297,7 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
           {/* Threshold (only in cpu/ram mode) */}
           {mode !== 'status' && (
             <Box onClick={cycleThreshold} sx={{
-              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: 10, fontWeight: 600,
+              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: 600,
               color: minThreshold > 0 ? '#fff' : c.textMuted,
               bgcolor: minThreshold > 0 ? c.surfaceActive : c.borderLight,
               '&:hover': { bgcolor: c.surfaceSubtle },
@@ -317,8 +317,8 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
                 <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={12} height={12} style={{ opacity: 0.6 }} />
                 <Box sx={{ position: 'absolute', bottom: -1, right: -1, width: 5, height: 5, borderRadius: '50%', bgcolor: '#4caf50', border: `1px solid ${isDark ? '#1e1e2d' : '#fff'}` }} />
               </Box>
-              <Typography sx={{ fontWeight: 600, fontSize: 10, opacity: 0.6 }}>{group.node}</Typography>
-              <Typography sx={{ fontSize: 9, opacity: 0.35 }}>({group.vms.length})</Typography>
+              <Typography sx={{ fontWeight: 600, fontSize: '0.7143rem', opacity: 0.6 }}>{group.node}</Typography>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.35 }}>({group.vms.length})</Typography>
             </Box>
 
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: `${TILE_GAP}px` }}>
@@ -345,7 +345,7 @@ return (
                     >
                       {mode !== 'status' && (
                         <Typography sx={{
-                          fontSize: 7, fontWeight: 700, lineHeight: 1,
+                          fontSize: '0.5rem', fontWeight: 700, lineHeight: 1,
                           color: (mode === 'cpu' ? vm.cpuPct : vm.ramPct) > 50 ? 'rgba(255,255,255,0.9)' : 'rgba(0,0,0,0.6)',
                           textShadow: (mode === 'cpu' ? vm.cpuPct : vm.ramPct) > 50 ? '0 0 1px rgba(0,0,0,0.3)' : 'none',
                         }}>
@@ -353,7 +353,7 @@ return (
                         </Typography>
                       )}
                       {mode === 'status' && !isRunning && (
-                        <i className='ri-stop-fill' style={{ fontSize: 8, color: c.textSecondary }} />
+                        <i className='ri-stop-fill' style={{ fontSize: '0.5714rem', color: c.textSecondary }} />
                       )}
                     </Box>
                   </MuiTooltip>
@@ -370,23 +370,23 @@ return (
           <>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
               <Box sx={{ width: 8, height: 8, borderRadius: 0.5, bgcolor: '#4caf50' }} />
-              <Typography sx={{ fontSize: 9, opacity: 0.6 }}>Running</Typography>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6 }}>Running</Typography>
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
               <Box sx={{ width: 8, height: 8, borderRadius: 0.5, bgcolor: '#9e9e9e', opacity: 0.5 }} />
-              <Typography sx={{ fontSize: 9, opacity: 0.6 }}>Stopped</Typography>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6 }}>Stopped</Typography>
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.4 }}>
               <Box sx={{ width: 8, height: 8, borderRadius: 0.5, bgcolor: '#ff9800' }} />
-              <Typography sx={{ fontSize: 9, opacity: 0.6 }}>Paused</Typography>
+              <Typography sx={{ fontSize: '0.6429rem', opacity: 0.6 }}>Paused</Typography>
             </Box>
           </>
         ) : (
           <>
-            <Typography sx={{ fontSize: 9, opacity: 0.5 }}>0%</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5 }}>0%</Typography>
             <Box sx={{ flex: 1, height: 5, borderRadius: 3, background: `linear-gradient(to right, ${getHeatColor(0)}, ${getHeatColor(30)}, ${getHeatColor(60)}, ${getHeatColor(80)}, ${getHeatColor(100)})` }} />
-            <Typography sx={{ fontSize: 9, opacity: 0.5 }}>100%</Typography>
-            <Typography sx={{ fontSize: 9, opacity: 0.5, ml: 0.5 }}>{mode.toUpperCase()}</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5 }}>100%</Typography>
+            <Typography sx={{ fontSize: '0.6429rem', opacity: 0.5, ml: 0.5 }}>{mode.toUpperCase()}</Typography>
           </>
         )}
       </Box>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -60,6 +60,10 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   the manual migration matrix against staging clusters. Pure helpers
 #   they call (pve-vm-config, configMapper, pvesm-alloc, v2v-progress)
 #   stay measured.
+# - components/dashboard/widgets/CircularGauge.jsx and the gauge/KPI widgets
+#   that use it: pure-JSX gauge views verified manually in the browser (no
+#   jsdom under Vitest); their dial math lives in the tested gaugeGeometry
+#   helper which remains measured.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -72,7 +76,15 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx,\
   frontend/src/lib/migration/pipeline.ts,\
   frontend/src/lib/migration/v2v-pipeline.ts,\
-  frontend/src/lib/migration/xcpng-pipeline.ts
+  frontend/src/lib/migration/xcpng-pipeline.ts,\
+  frontend/src/components/dashboard/widgets/CircularGauge.jsx,\
+  frontend/src/components/dashboard/widgets/ResourcesGaugesWidget.jsx,\
+  frontend/src/components/dashboard/widgets/NodesGaugesWidget.jsx,\
+  frontend/src/components/dashboard/widgets/ClustersGaugesWidget.jsx,\
+  frontend/src/components/dashboard/widgets/KpiClustersWidget.jsx,\
+  frontend/src/components/dashboard/widgets/KpiVmsWidget.jsx,\
+  frontend/src/components/dashboard/widgets/KpiLxcWidget.jsx,\
+  frontend/src/components/dashboard/widgets/KpiBackupsWidget.jsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
Closes #376.

## Problem

Dashboard widgets were hard to read: text was tiny and the appearance settings (`/settings?tab=appearance`) did not reach them.

- **Font size** had no effect on most widgets, because widget text was hardcoded in `px` while the setting only scales `rem`-based text via `html { font-size }`.
- **Corner rounding (global)** never applied: widget cards hardcoded their radius and nothing consumed the `--proxcenter-card-radius` variable the setting drives.
- Gauges were duplicated across ~7 widgets with a fixed pixel size, so they never tracked the setting.

## Changes

- **Font size** — convert hardcoded `px` font sizes to `rem` across all dashboard widgets, so they scale with the appearance font-size setting like the rest of the app. Identical look at the default (14px).
- **Corner rounding** — point widget card surfaces at the `--proxcenter-card-radius` variable, so the global corner-rounding slider now reshapes them. Inner chips/badges keep their own styling.
- **Gauges** — extract the duplicated `CircularGauge` copies into one shared component sized in `em` (scales with the font setting), backed by a pure, unit-tested `gaugeGeometry` helper.

## Notes

- No behavioural change at the default appearance settings.
- A few widgets keep their own local gauge dial (text scales; dial size unchanged) — can be unified in a follow-up if desired.

## Testing

- `npm run build` passes.
- Vitest unit tests for `gaugeGeometry` pass.
- Verified manually in the browser: font-size and corner-rounding sliders now scale/reshape every widget, including Ceph.