### PR TITLE
fix: node update/reboot over WAN for standalone hosts behind NAT (#370)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const getNodeIpMock = vi.fn<(...args: any[]) => Promise<string>>()
+const executeSSHMock = vi.fn<(...args: any[]) => Promise<any>>()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildNodeResourceId: (c: string, n: string) => `${c}:${n}`,
+  PERMISSIONS: { NODE_VIEW: 'node.view', NODE_MANAGE: 'node.manage' },
+}))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock('@/lib/ssh/node-ip', () => ({ getNodeIp: getNodeIpMock }))
+vi.mock('@/lib/ssh/exec', () => ({ executeSSH: executeSSHMock }))
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ baseUrl: 'https://203.0.113.10:8006' })
+  getNodeIpMock.mockReset()
+  executeSSHMock.mockReset()
+})
+
+const importPOST = async () => (await import('./route')).POST as Parameters<typeof callRoute>[0]
+
+describe('POST reboot — identity guard', () => {
+  it('reboots when the target is the connection host and hostname matches', async () => {
+    getNodeIpMock.mockResolvedValue('203.0.113.10')
+    executeSSHMock
+      .mockResolvedValueOnce({ success: true, output: 'pve1' }) // probe
+      .mockResolvedValueOnce({ success: true })                 // reboot
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ rebooting: true })
+    expect(executeSSHMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refuses (409) and does NOT reboot when hostname mismatches', async () => {
+    getNodeIpMock.mockResolvedValue('203.0.113.10')
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'bastion' }) // probe only
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(409)
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the actionable C error when the reboot SSH fails to a private IP', async () => {
+    getNodeIpMock.mockResolvedValue('10.0.0.5')
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'timeout' })
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(500)
+    expect((await readJson<any>(res)).error).toMatch(/private address/)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/reboot/route.ts
@@ -3,6 +3,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 import { executeSSH } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
+import { verifyNodeTarget, sshTargetError } from "@/lib/ssh/verify-node-target"
 
 export const runtime = "nodejs"
 
@@ -28,12 +29,17 @@ export async function POST(_req: Request, ctx: Ctx) {
 
   const nodeIp = await getNodeIp(conn, node)
 
+  const check = await verifyNodeTarget(id, conn, node, nodeIp)
+  if (!check.ok) {
+    return NextResponse.json({ error: check.error }, { status: check.status })
+  }
+
   // Use nohup so the SSH session returns before the reboot kills it
   const result = await executeSSH(id, nodeIp, "nohup bash -c 'sleep 1 && reboot' > /dev/null 2>&1 &")
 
   if (!result.success) {
     return NextResponse.json(
-      { error: result.error || "Failed to reboot node" },
+      { error: sshTargetError(node, nodeIp, result.error || "Failed to reboot node") },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const getNodeIpMock = vi.fn<(...args: any[]) => Promise<string>>()
+const executeSSHMock = vi.fn<(...args: any[]) => Promise<any>>()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildNodeResourceId: (c: string, n: string) => `${c}:${n}`,
+  PERMISSIONS: { NODE_VIEW: 'node.view', NODE_MANAGE: 'node.manage' },
+}))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock('@/lib/ssh/node-ip', () => ({ getNodeIp: getNodeIpMock }))
+vi.mock('@/lib/ssh/exec', () => ({ executeSSH: executeSSHMock }))
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ baseUrl: 'https://203.0.113.10:8006' })
+  getNodeIpMock.mockReset()
+  executeSSHMock.mockReset()
+})
+
+const importPOST = async () => (await import('./route')).POST as Parameters<typeof callRoute>[0]
+const importGET = async () => (await import('./route')).GET as Parameters<typeof callRoute>[0]
+
+describe('POST upgrade — identity guard', () => {
+  it('launches the upgrade when the target is the connection host and hostname matches', async () => {
+    getNodeIpMock.mockResolvedValue('203.0.113.10')
+    executeSSHMock
+      .mockResolvedValueOnce({ success: true, output: 'pve1' }) // probe
+      .mockResolvedValueOnce({ success: true })                 // script
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ started: true })
+    expect(executeSSHMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refuses (409) and does NOT launch when hostname mismatches', async () => {
+    getNodeIpMock.mockResolvedValue('203.0.113.10')
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'bastion' }) // probe only
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(409)
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the probe for a direct-IP resolution and launches', async () => {
+    getNodeIpMock.mockResolvedValue('10.0.0.5') // != connHost
+    executeSSHMock.mockResolvedValueOnce({ success: true }) // script only
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(200)
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the actionable C error when the script SSH fails to a private IP', async () => {
+    getNodeIpMock.mockResolvedValue('10.0.0.5')
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'timeout' })
+    const POST = await importPOST()
+    const res = await callRoute(POST, { params: { id: 'c1', node: 'pve1' }, body: {} })
+    expect(res.status).toBe(500)
+    expect((await readJson<any>(res)).error).toMatch(/private address/)
+  })
+})
+
+describe('GET upgrade poll — shared error', () => {
+  it('returns the actionable C error when polling a private IP fails', async () => {
+    getNodeIpMock.mockResolvedValue('10.0.0.5')
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'timeout' })
+    const GET = await importGET()
+    const res = await callRoute(GET, { params: { id: 'c1', node: 'pve1' } })
+    expect(res.status).toBe(500)
+    expect((await readJson<any>(res)).error).toMatch(/private address/)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/upgrade/route.ts
@@ -3,6 +3,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 import { executeSSH } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
+import { verifyNodeTarget, sshTargetError } from "@/lib/ssh/verify-node-target"
 
 export const runtime = "nodejs"
 
@@ -37,6 +38,11 @@ export async function POST(req: Request, ctx: Ctx) {
 
   const nodeIp = await getNodeIp(conn, node)
 
+  const check = await verifyNodeTarget(id, conn, node, nodeIp)
+  if (!check.ok) {
+    return NextResponse.json({ error: check.error }, { status: check.status })
+  }
+
   // Build the upgrade script
   // Status file: /tmp/.proxcenter-upgrade-status
   // Log file:    /tmp/.proxcenter-upgrade.log
@@ -56,7 +62,7 @@ ${rebootCmd}
 
   if (!result.success) {
     return NextResponse.json(
-      { error: result.error || "Failed to start upgrade" },
+      { error: sshTargetError(node, nodeIp, result.error || "Failed to start upgrade") },
       { status: 500 }
     )
   }
@@ -90,7 +96,7 @@ export async function GET(_req: Request, ctx: Ctx) {
 
   if (!result.success) {
     return NextResponse.json(
-      { error: result.error || "Failed to poll upgrade status" },
+      { error: sshTargetError(node, nodeIp, result.error || "Failed to poll upgrade status") },
       { status: 500 }
     )
   }

--- a/frontend/src/lib/net/ip.test.ts
+++ b/frontend/src/lib/net/ip.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { isPrivateIp, extractHostname } from './ip'
+
+describe('isPrivateIp', () => {
+  it('flags IPv4 private / non-routable ranges', () => {
+    for (const ip of ['10.0.0.5', '172.16.4.1', '172.31.255.1', '192.168.1.10',
+                       '100.64.0.1', '127.0.0.1', '169.254.1.1', '0.0.0.0']) {
+      expect(isPrivateIp(ip), ip).toBe(true)
+    }
+  })
+  it('treats public IPv4 as not private', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '203.0.113.10', '172.32.0.1', '172.15.0.1']) {
+      expect(isPrivateIp(ip), ip).toBe(false)
+    }
+  })
+  it('flags IPv6 loopback / link-local / ULA', () => {
+    for (const ip of ['::1', 'fe80::1', 'fd00::1', 'fc00::1', '[fe80::1]']) {
+      expect(isPrivateIp(ip), ip).toBe(true)
+    }
+  })
+  it('treats public IPv6 as not private', () => {
+    expect(isPrivateIp('2606:4700:4700::1111')).toBe(false)
+  })
+  it('maps IPv4-mapped IPv6 to its IPv4', () => {
+    expect(isPrivateIp('::ffff:10.0.0.5')).toBe(true)
+    expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false)
+  })
+  it('returns false for hostnames and garbage', () => {
+    for (const h of ['pve.example.com', 'pve.lan', '', 'not-an-ip', '999.1.1.1']) {
+      expect(isPrivateIp(h), h).toBe(false)
+    }
+  })
+  it('maps hex-form IPv4-mapped IPv6 to its IPv4', () => {
+    expect(isPrivateIp('::ffff:7f00:1')).toBe(true)     // 127.0.0.1
+    expect(isPrivateIp('::ffff:0a00:0005')).toBe(true)  // 10.0.0.5
+    expect(isPrivateIp('::ffff:c0a8:0101')).toBe(true)  // 192.168.1.1
+    expect(isPrivateIp('::ffff:0808:0808')).toBe(false) // 8.8.8.8
+  })
+  it('flags IPv6 unspecified and multicast as non-routable', () => {
+    expect(isPrivateIp('::')).toBe(true)
+    expect(isPrivateIp('ff02::1')).toBe(true)
+  })
+  it('normalizes uppercase IPv6', () => {
+    expect(isPrivateIp('FE80::1')).toBe(true)
+  })
+})
+
+describe('extractHostname', () => {
+  it('extracts host from URLs, stripping userinfo and port', () => {
+    expect(extractHostname('https://10.0.0.1:8006')).toBe('10.0.0.1')
+    expect(extractHostname('https://pve.example.com:8006')).toBe('pve.example.com')
+    expect(extractHostname('https://user:pass@host.example:8006')).toBe('host.example')
+  })
+  it('unbrackets IPv6 URL literals', () => {
+    expect(extractHostname('https://[fd00::1]:8006')).toBe('fd00::1')
+  })
+  it('handles bare hosts and host:port', () => {
+    expect(extractHostname('10.0.0.5')).toBe('10.0.0.5')
+    expect(extractHostname('10.0.0.5:22')).toBe('10.0.0.5')
+    expect(extractHostname('[fd00::1]:22')).toBe('fd00::1')
+    expect(extractHostname('pve.lan')).toBe('pve.lan')
+  })
+  it('returns empty string for empty input', () => {
+    expect(extractHostname('')).toBe('')
+  })
+})

--- a/frontend/src/lib/net/ip.ts
+++ b/frontend/src/lib/net/ip.ts
@@ -1,0 +1,79 @@
+import net from "node:net"
+import { extractHostFromUrl } from "@/lib/proxmox/urlUtils"
+
+/** Strip IPv6 brackets + zone id, map IPv4-mapped IPv6 (dotted or hex form) to IPv4, lowercase. */
+function normalizeIp(host: string): string {
+  let h = host.trim().replace(/^\[|\]$/g, "")
+  const pct = h.indexOf("%")
+  if (pct !== -1) h = h.slice(0, pct)
+  // IPv4-mapped IPv6 -> IPv4: handles both ::ffff:10.0.0.5 and ::ffff:0a00:0005.
+  // (6to4 / NAT64 embeddings are intentionally out of scope.)
+  const mapped = /^::ffff:(.+)$/i.exec(h)
+  if (mapped) {
+    const tail = mapped[1]
+    if (net.isIP(tail) === 4) {
+      h = tail
+    } else {
+      const hex = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i.exec(tail)
+      if (hex) {
+        const hi = parseInt(hex[1], 16)
+        const lo = parseInt(hex[2], 16)
+        h = `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`
+      }
+    }
+  }
+  return h.toLowerCase()
+}
+
+function isPrivateV4(ip: string): boolean {
+  const p = ip.split(".").map(Number)
+  if (p.length !== 4 || p.some(n => Number.isNaN(n) || n < 0 || n > 255)) return false
+  const [a, b] = p
+  if (a === 10) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 168) return true
+  if (a === 100 && b >= 64 && b <= 127) return true // CGNAT 100.64/10
+  if (a === 127) return true                          // loopback
+  if (a === 169 && b === 254) return true             // link-local
+  if (a === 0) return true                            // this-network 0.0.0.0/8
+  return false
+}
+
+function isPrivateV6(ip: string): boolean {
+  if (ip === "::1") return true                       // loopback
+  if (ip === "::") return true                         // unspecified / wildcard
+  if (/^ff/.test(ip)) return true                      // multicast ff00::/8 (never a unicast SSH target)
+  if (/^fe[89ab]/.test(ip)) return true               // fe80::/10 link-local
+  if (/^f[cd]/.test(ip)) return true                  // fc00::/7 unique-local
+  return false
+}
+
+/**
+ * True when `host` is an IP literal that is NOT a routable public unicast
+ * address, i.e. unreachable from the WAN. Hostnames and non-IP strings
+ * return false (they may resolve to anything; identity is verified separately
+ * on the destructive path).
+ */
+export function isPrivateIp(host: string): boolean {
+  if (!host) return false
+  const h = normalizeIp(host)
+  const v = net.isIP(h)
+  if (v === 4) return isPrivateV4(h)
+  if (v === 6) return isPrivateV6(h)
+  return false
+}
+
+/** Extract a bare hostname/IP from a URL or a raw host[:port] string. */
+export function extractHostname(hostOrUrl: string): string {
+  if (!hostOrUrl) return ""
+  const fromUrl = extractHostFromUrl(hostOrUrl) // new URL(u).hostname (strips userinfo + port)
+  if (fromUrl) return fromUrl.replace(/^\[|\]$/g, "")
+  const h = hostOrUrl.trim()
+  if (h.startsWith("[")) {
+    const end = h.indexOf("]")
+    if (end !== -1) return h.slice(1, end)
+  }
+  const m = /^(.*):(\d+)$/.exec(h)
+  if (m && !m[1].includes(":")) return m[1] // host:port, but not a bare IPv6 literal
+  return h
+}

--- a/frontend/src/lib/ssh/node-ip.test.ts
+++ b/frontend/src/lib/ssh/node-ip.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const findUniqueMock = vi.fn<(args: any) => Promise<any>>()
+const countMock = vi.fn<(args: any) => Promise<number>>()
 const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
 const resolve4Mock = vi.fn<(name: string) => Promise<string[]>>()
 
@@ -8,6 +9,7 @@ vi.mock('@/lib/db/prisma', () => ({
   prisma: {
     managedHost: {
       findUnique: findUniqueMock,
+      count: countMock,
     },
   },
 }))
@@ -24,6 +26,7 @@ vi.mock('dns', () => ({
 
 beforeEach(() => {
   findUniqueMock.mockReset()
+  countMock.mockReset()
   pveFetchMock.mockReset()
   resolve4Mock.mockReset()
 })
@@ -196,5 +199,137 @@ describe('getNodeIp - resilience', () => {
 
     expect(ip).toBe('10.0.0.5')
     expect(findUniqueMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('getNodeIp - standalone WAN substitution', () => {
+  it('replaces a private mgmt IP with the public connection host for a standalone node', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    countMock.mockResolvedValueOnce(1)
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '10.0.0.5', gateway: '10.0.0.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('203.0.113.10')
+  })
+
+  it('keeps a PUBLIC mgmt IP even on a standalone public connection (no substitution)', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    countMock.mockResolvedValueOnce(1)
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '198.51.100.7', gateway: '198.51.100.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('198.51.100.7')
+  })
+
+  it('replaces a stored private ManagedHost.ip with the public connection host (standalone)', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: '10.0.0.5' })
+    countMock.mockResolvedValueOnce(1)
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('203.0.113.10')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT substitute for a multi-node cluster (count > 1)', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    countMock.mockResolvedValueOnce(3)
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '10.0.0.5', gateway: '10.0.0.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve2',
+    )
+    expect(ip).toBe('10.0.0.5')
+  })
+
+  it('fails closed when no ManagedHost row exists for the requested node', async () => {
+    findUniqueMock.mockResolvedValueOnce(null)
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '10.0.0.5', gateway: '10.0.0.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('10.0.0.5')
+    expect(countMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT substitute when behindProxy even with a public baseUrl', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '10.0.0.5', gateway: '10.0.0.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: true },
+      'pve1',
+    )
+    expect(ip).toBe('10.0.0.5')
+    expect(countMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the sshAddress override before any standalone/connHost logic', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: '198.51.100.9', ip: '10.0.0.5' })
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('198.51.100.9')
+    expect(countMock).not.toHaveBeenCalled()
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('replaces a private DNS-resolved IP with the connection host (standalone)', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    countMock.mockResolvedValueOnce(1)
+    pveFetchMock.mockResolvedValueOnce([])
+    resolve4Mock.mockResolvedValueOnce(['10.0.0.42'])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('203.0.113.10')
+  })
+
+  it('fails closed (no substitution) when the standalone count query throws', async () => {
+    findUniqueMock.mockResolvedValueOnce({ sshAddress: null, ip: null })
+    countMock.mockRejectedValueOnce(new Error('DB down'))
+    pveFetchMock.mockResolvedValueOnce([
+      { iface: 'vmbr0', address: '10.0.0.5', gateway: '10.0.0.1' },
+    ])
+
+    const { getNodeIp } = await import('./node-ip')
+    const ip = await getNodeIp(
+      { id: 'c1', baseUrl: 'https://203.0.113.10:8006', behindProxy: false },
+      'pve1',
+    )
+    expect(ip).toBe('10.0.0.5')
   })
 })

--- a/frontend/src/lib/ssh/node-ip.ts
+++ b/frontend/src/lib/ssh/node-ip.ts
@@ -1,64 +1,84 @@
 import { pveFetch } from "@/lib/proxmox/client"
 import { resolveManagementIp } from "@/lib/proxmox/resolveManagementIp"
 import { prisma } from "@/lib/db/prisma"
+import { isPrivateIp, extractHostname } from "@/lib/net/ip"
 
 /**
- * Resolve the management IP of a Proxmox node.
+ * Resolve the SSH-reachable address of a Proxmox node.
  *
  * Priority:
- *  0. ManagedHost.sshAddress override (user-configured)
- *  1. ManagedHost.ip (management IP already resolved and stored in DB)
- *  2. Node network interfaces via Proxmox API (gateway = management)
- *  3. DNS resolution of the node name
- *  4. Connection host (skipped when behindProxy to avoid returning LB IP)
- *  5. Node name as-is (last resort)
+ *  0. ManagedHost.sshAddress override (user-configured) — always wins.
+ *  1. ManagedHost.ip (stored mgmt IP).
+ *  2. Node network interfaces via Proxmox API (gateway = management).
+ *  3. DNS resolution of the node name.
+ *  4. Connection host (skipped when behindProxy).
+ *  5. Node name as-is (last resort).
+ *
+ * Resolve-then-replace: a candidate from steps 1-3 that is a PROVEN-PRIVATE IP
+ * is replaced by the connection host, but ONLY for a standalone connection
+ * reached over a routable (public) address — a private node IP is then
+ * unreachable from here. Gated to a single-node connection so a cluster node is
+ * never routed to the connection host. Identity is re-verified before any
+ * destructive op (see verify-node-target.ts). Fail-closed on any ambiguity.
  */
 export async function getNodeIp(conn: any, nodeName: string): Promise<string> {
   const connId = conn.id || conn.connectionId
 
-  // 0. Check for user-configured SSH address override
-  // 1. Check for stored management IP from DB
-  // We use the global (unscoped) prisma because ManagedHost rows belong
-  // to the connection's owner tenant; a vDC tenant calling getNodeIp on
-  // a provider-owned connection would otherwise get null and fall
-  // through to the slower probing paths even when a managed-IP record
-  // already exists. Authorisation on the connection is the caller's job.
+  // 0. Explicit override wins; also tells us a row exists for THIS node.
+  let host: { sshAddress: string | null; ip: string | null } | null = null
   try {
     if (connId) {
-      const host = await prisma.managedHost.findUnique({
+      host = await prisma.managedHost.findUnique({
         where: { connectionId_node: { connectionId: connId, node: nodeName } },
         select: { sshAddress: true, ip: true },
       })
       if (host?.sshAddress) return host.sshAddress
-      if (host?.ip) return host.ip
     }
   } catch {}
 
-  // 2. Try node network interfaces (gateway = management)
+  const connHost = extractHostname(conn.host || conn.baseUrl || "")
+  const connHostRoutable = !!connHost && !conn.behindProxy && !isPrivateIp(connHost)
+
+  // Standalone proof: a row exists for this node (host != null) AND it is the
+  // only node (count === 1). Queried only when it could matter. Fail-closed.
+  let mayUseConnHost = false
+  if (connHostRoutable && host && connId) {
+    try {
+      mayUseConnHost = (await prisma.managedHost.count({ where: { connectionId: connId } })) === 1
+    } catch {
+      mayUseConnHost = false
+    }
+  }
+
+  // 1. Stored management IP.
+  if (host?.ip) {
+    if (mayUseConnHost && isPrivateIp(host.ip)) return connHost
+    return host.ip
+  }
+
+  // 2. Node network interfaces (gateway = management).
   try {
     const networks = await pveFetch<any[]>(conn, `/nodes/${encodeURIComponent(nodeName)}/network`)
     const ip = resolveManagementIp(networks)
-    if (ip) return ip
+    if (ip) {
+      if (mayUseConnHost && isPrivateIp(ip)) return connHost
+      return ip
+    }
   } catch {}
 
-  // 3. Try DNS resolution of the node name
+  // 3. DNS resolution of the node name.
   try {
     const dns = await import("dns")
     const resolved = await dns.promises.resolve4(nodeName)
-    if (resolved?.[0]) return resolved[0]
+    if (resolved?.[0]) {
+      if (mayUseConnHost && isPrivateIp(resolved[0])) return connHost
+      return resolved[0]
+    }
   } catch {}
 
-  // 4. Fallback to connection host (skip if behind proxy/LB — the LB IP is useless for SSH)
-  if (!conn.behindProxy) {
-    try {
-      const host = conn.host || conn.baseUrl || ""
-      const cleanHost = host
-        .replace(/^https?:\/\//, "")
-        .replace(/:\d+$/, "")
-        .replace(/\/.*$/, "")
-      if (cleanHost && !cleanHost.includes("/")) return cleanHost
-    } catch {}
-  }
+  // 4. Fallback to connection host (skip if behind proxy/LB).
+  if (!conn.behindProxy && connHost) return connHost
 
+  // 5. Node name as-is.
   return nodeName
 }

--- a/frontend/src/lib/ssh/verify-node-target.test.ts
+++ b/frontend/src/lib/ssh/verify-node-target.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const executeSSHMock = vi.fn<(...args: any[]) => Promise<any>>()
+vi.mock('@/lib/ssh/exec', () => ({ executeSSH: executeSSHMock }))
+
+beforeEach(() => executeSSHMock.mockReset())
+
+const conn = { baseUrl: 'https://203.0.113.10:8006' }
+
+describe('verifyNodeTarget', () => {
+  it('passes without probing when the target is NOT the connection host (direct IP)', async () => {
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '10.0.0.5')
+    expect(r).toEqual({ ok: true })
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+
+  it('passes when target is the connection host and remote hostname matches', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'pve1\n' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r).toEqual({ ok: true })
+    expect(executeSSHMock).toHaveBeenCalledWith('c1', '203.0.113.10', 'hostname -s')
+  })
+
+  it('matches on the short label when node is an FQDN', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'pve1' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1.example.com', '203.0.113.10')
+    expect(r).toEqual({ ok: true })
+  })
+
+  it('refuses (409) when target is the connection host but hostname mismatches', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'bastion' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.status).toBe(409)
+      expect(r.error).toMatch(/bastion/)
+    }
+  })
+
+  it('returns 502 with an actionable error when the probe fails', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'timeout' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.status).toBe(502)
+  })
+
+  it('refuses (409) when the remote hostname is empty (identity unverifiable)', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: '   ' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.status).toBe(409)
+      expect(r.error).toMatch(/identity cannot be confirmed/)
+    }
+  })
+
+  it('matches case-insensitively', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'PVE1' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r).toEqual({ ok: true })
+  })
+
+  it('matches when the remote reports an FQDN but the node is short', async () => {
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'pve1.example.com' })
+    const { verifyNodeTarget } = await import('./verify-node-target')
+    const r = await verifyNodeTarget('c1', conn, 'pve1', '203.0.113.10')
+    expect(r).toEqual({ ok: true })
+  })
+})
+
+describe('sshTargetError', () => {
+  it('gives an actionable hint for a private target', async () => {
+    const { sshTargetError } = await import('./verify-node-target')
+    expect(sshTargetError('pve1', '10.0.0.5')).toMatch(/private address/)
+  })
+  it('uses the fallback for a public target', async () => {
+    const { sshTargetError } = await import('./verify-node-target')
+    expect(sshTargetError('pve1', '203.0.113.10', 'Failed to start upgrade')).toBe('Failed to start upgrade')
+  })
+  it('has a generic default when no fallback is given for a public target', async () => {
+    const { sshTargetError } = await import('./verify-node-target')
+    expect(sshTargetError('pve1', '203.0.113.10')).toMatch(/pve1/)
+  })
+})

--- a/frontend/src/lib/ssh/verify-node-target.ts
+++ b/frontend/src/lib/ssh/verify-node-target.ts
@@ -1,0 +1,69 @@
+import { executeSSH } from "@/lib/ssh/exec"
+import { extractHostname, isPrivateIp } from "@/lib/net/ip"
+
+// Flat result shape rather than a discriminated union: this project compiles
+// with strictNullChecks off, where narrowing a boolean-discriminant union via
+// `if (!check.ok)` does not apply. `status`/`error` are set only when ok=false.
+export type TargetCheck = { ok: boolean; status?: number; error?: string }
+
+/**
+ * Build a user-facing error for an unreachable SSH target. When the target is a
+ * private IP, point the operator at the per-node SSH address override; otherwise
+ * fall back to the caller's generic message.
+ */
+export function sshTargetError(node: string, nodeIp: string, fallback?: string): string {
+  if (isPrivateIp(nodeIp)) {
+    return `Could not reach node '${node}' at ${nodeIp} over SSH. That looks like a private address, not reachable from ProxCenter (e.g. the node is behind NAT). Set an SSH address override for this node to the address you reach it on.`
+  }
+  return fallback || `Failed to reach node '${node}' at ${nodeIp} over SSH.`
+}
+
+/**
+ * Reachability + identity check before a destructive SSH op on a node.
+ *
+ * The hostname-identity check only runs when resolution substituted the
+ * connection host (i.e. `nodeIp` equals the connection address). For direct
+ * node-IP resolutions the function returns ok without probing, so existing
+ * cluster/LAN behavior is unchanged.
+ */
+export async function verifyNodeTarget(
+  connId: string,
+  conn: { host?: string; baseUrl?: string },
+  node: string,
+  nodeIp: string,
+): Promise<TargetCheck> {
+  const connHost = extractHostname(conn.host || conn.baseUrl || "")
+  const resolvedViaConnHost = !!connHost && nodeIp === connHost
+  if (!resolvedViaConnHost) return { ok: true }
+
+  const probe = await executeSSH(connId, nodeIp, "hostname -s")
+  if (!probe.success) {
+    return { ok: false, status: 502, error: sshTargetError(node, nodeIp, probe.error || "SSH unreachable") }
+  }
+
+  // Compare short hostname labels on both sides: `hostname -s` is short, but a
+  // misconfigured host can still emit an FQDN, and the Proxmox node name may be
+  // an FQDN too. Shortening both can only prevent a false mismatch, never cause
+  // a false match.
+  const remote = (probe.output || "").trim().toLowerCase().split(".")[0]
+  const want = node.split(".")[0].toLowerCase()
+
+  // Fail-closed: an empty/unreadable remote hostname means we cannot confirm the
+  // target is the requested node. On this substituted-connection-host path that
+  // is exactly the ambiguity we must not run a destructive op through.
+  if (!remote) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Refusing the operation: could not read a hostname from the address resolved for node '${node}' (${nodeIp}), so its identity cannot be confirmed. Set a per-node SSH address override to the correct host.`,
+    }
+  }
+  if (remote !== want) {
+    return {
+      ok: false,
+      status: 409,
+      error: `Refusing the operation: the address resolved for node '${node}' (${nodeIp}) reports hostname '${remote}'. This does not look like that node. Set a per-node SSH address override to the correct host.`,
+    }
+  }
+  return { ok: true }
+}


### PR DESCRIPTION
## Problem

A single Proxmox host added by its **public IP** (8006/22 port-forwarded through NAT) cannot be updated from the dashboard: the node Update button hangs ~30s and fails with an SSH timeout. Inventory, package list, and SSH test all work on the same host.

Root cause: the node update resolves its SSH target with `getNodeIp`, which returned the node's own management-interface IP (a private RFC1918 address behind NAT, unreachable from ProxCenter). The package list (Proxmox API over 8006) and the SSH test (orchestrator) work because they reach the box on the connection address the user configured; only the update derived the private interface IP.

## Fix

- **`getNodeIp` resolve-then-replace:** a resolved candidate (stored IP, gateway interface, or DNS result) that is a *proven-private* address is replaced by the connection host, but only for a **standalone** connection (exactly one `ManagedHost` row, and a row for this node) reached over a **routable public** address. A public node IP still wins, and cluster / LAN / behind-proxy resolution is byte-for-byte unchanged. Resolution fails closed on any ambiguity (no row, multiple nodes, DB error).
- **`isPrivateIp` / `extractHostname`** (`src/lib/net/ip.ts`): RFC1918, CGNAT, loopback, link-local, `0.0.0.0/8`, IPv6 ULA/link-local/multicast/unspecified, IPv4-mapped IPv6; robust host extraction (userinfo, ports, IPv6 brackets).
- **`verifyNodeTarget`** (`src/lib/ssh/verify-node-target.ts`): before the destructive `apt dist-upgrade` / reboot on the substituted path, a pre-flight `hostname -s` probe confirms the SSH target really is the requested node, refusing (409) on mismatch or unreadable hostname and 502 if unreachable. For direct-IP resolutions it is a no-op, so existing behavior is unchanged.
- SSH failures on the update / reboot / poll paths now return an actionable error pointing to the per-node SSH address override.

## Safety / non-regression

The substitution only fires for standalone + public-API-host + private-candidate, a case that was already broken (every SSH-to-node feature dialed the unreachable private IP). LAN / cluster / behind-proxy paths and the other `getNodeIp` callers are unchanged. The identity guard is a last line of defense so a misconfigured connection address can never run a destructive command on the wrong host.

## Tests

92 tests across the new helpers, `getNodeIp`, `verifyNodeTarget`, and the upgrade/reboot route handlers (unit + `callRoute`): substitution, public-IP-wins, fail-closed branches, the 409/502 identity outcomes, and the direct-IP no-probe path.

## Out of scope (follow-ups)

- `pveFetch` failover behind NAT (same root assumption: it dials each node's own private IP; only affects multi-node clusters behind a single public IP).
- Migration uses its own node-IP resolver, not covered here.

Refs #370
