### PR TITLE
feat(rbac): role-level default scope inherited by assignments

### DIFF
--- a/frontend/prisma/migrations/20260603052448_rbac_role_default_scopes/migration.sql
+++ b/frontend/prisma/migrations/20260603052448_rbac_role_default_scopes/migration.sql
@@ -1,0 +1,14 @@
+-- Role-level default scope (issue #383).
+-- Custom roles can carry a default resource scope inherited by every
+-- assignment whose scope_type is 'inherit'. Shape: [{ scopeType, scopeTarget }].
+ALTER TABLE "rbac_roles" ADD COLUMN "default_scopes" JSONB;
+
+-- Convert existing SSO-managed assignments from explicit global to inherit so
+-- they follow the role's default scope automatically. Behavior-neutral today
+-- (no role has a default scope yet, so inherit resolves to global) and removes
+-- a duplicate-row hazard once the SSO login sync keys on the inherit row.
+-- The underscore is escaped because it is a single-character wildcard in LIKE.
+UPDATE "rbac_user_roles"
+   SET "scope_type" = 'inherit', "scope_target" = NULL
+ WHERE "scope_type" = 'global'
+   AND ("id" LIKE 'ldap\_%' ESCAPE '\' OR "id" LIKE 'oidc\_%' ESCAPE '\');

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -492,6 +492,12 @@ model RbacRole {
   // Shape: { hidden: string[] }. Composed across roles as a union (any role
   // denying a widget hides it for the user).
   widgetOverrides Json?    @map("widget_overrides")
+  // Default resource scope inherited by every assignment of this role whose
+  // scopeType is "inherit". Shape: [{ scopeType, scopeTarget }] reusing the
+  // assignment scope vocabulary (connection|node|vm|tag|pool). Null/empty =
+  // global. Allowed on custom roles only — never on system roles, whose
+  // super-admin/protected shortcuts bypass scope resolution entirely.
+  defaultScopes   Json?    @map("default_scopes")
   // Tenant scoping. Null = global (system roles, visible to every tenant).
   // Non-null = custom role only visible to that tenant's admins.
   tenantId        String?  @map("tenant_id")

--- a/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx
+++ b/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx
@@ -1,0 +1,145 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+
+import { Box, FormControl, InputLabel, Select, MenuItem, Button, Chip, Typography, Paper } from '@mui/material'
+
+import { buildScopeOptions, resolveScopeTargetLabel } from './scope-options'
+
+export type RoleScopeEntry = { scopeType: string; scopeTarget: string }
+
+// Scope types a role default scope may carry — mirrors ROLE_DEFAULT_SCOPE_TYPES
+// on the backend (no global, no inherit).
+const TYPES = ['tag', 'pool', 'node', 'connection', 'vm'] as const
+
+const typeIcon: Record<string, string> = {
+  tag: 'ri-price-tag-3-line',
+  pool: 'ri-folder-shared-line',
+  node: 'ri-computer-line',
+  connection: 'ri-server-line',
+  vm: 'ri-instance-line',
+}
+
+/**
+ * Editor for a custom role's default scope (issue #383). Builds a list of
+ * { scopeType, scopeTarget } entries from the live inventory; any assignment
+ * with scope_type "inherit" then follows this scope automatically.
+ */
+export default function RoleDefaultScopeEditor({
+  value,
+  onChange,
+  t,
+}: {
+  value: RoleScopeEntry[]
+  onChange: (scopes: RoleScopeEntry[]) => void
+  t: any
+}) {
+  const [inventory, setInventory] = useState<any>(null)
+  const [type, setType] = useState<string>('tag')
+  const [target, setTarget] = useState<string>('')
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/v1/inventory')
+      .then(r => r.json())
+      .then(d => { if (active) setInventory(d?.data ?? d) })
+      .catch(() => {})
+    return () => { active = false }
+  }, [])
+
+  const options = useMemo(() => buildScopeOptions(inventory, type, t), [inventory, type, t])
+
+  const has = (st: string, tgt: string) => value.some(s => s.scopeType === st && s.scopeTarget === tgt)
+
+  const add = () => {
+    if (!target || has(type, target)) return
+    onChange([...value, { scopeType: type, scopeTarget: target }])
+    setTarget('')
+  }
+
+  const remove = (st: string, tgt: string) =>
+    onChange(value.filter(s => !(s.scopeType === st && s.scopeTarget === tgt)))
+
+  const labelFor = (st: string) => t(`rbac.scopes.${st === 'vm' ? 'vmct' : st}`)
+
+  return (
+    <Box>
+      <Typography variant='caption' sx={{ display: 'block', mb: 1, opacity: 0.7 }}>
+        {t('rbacPage.defaultScope.desc')}
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mb: 1 }}>
+        <FormControl size='small' sx={{ minWidth: 150 }}>
+          <InputLabel>{t('rbacPage.scope')}</InputLabel>
+          <Select
+            value={type}
+            label={t('rbacPage.scope')}
+            onChange={e => { setType(e.target.value); setTarget('') }}
+          >
+            {TYPES.map(ty => (
+              <MenuItem key={ty} value={ty}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className={typeIcon[ty]} style={{ opacity: 0.7 }} />
+                  {labelFor(ty)}
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size='small' sx={{ flex: 1 }}>
+          <InputLabel>{t('navigation.resources')}</InputLabel>
+          <Select
+            value={target}
+            label={t('navigation.resources')}
+            onChange={e => setTarget(e.target.value)}
+            disabled={!inventory}
+            // Single-line closed value (icon + label, drop the sublabel) so this
+            // select keeps the exact same height as the Scope one beside it.
+            renderValue={val => {
+              const o = options.find(opt => opt.id === val)
+
+              return (
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className={o?.icon || typeIcon[type]} style={{ opacity: 0.6 }} />
+                  {o?.label ?? String(val)}
+                </Box>
+              )
+            }}
+          >
+            {options.map(o => (
+              <MenuItem key={o.id} value={o.id} disabled={has(type, o.id)}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className={o.icon || typeIcon[type]} style={{ opacity: 0.6 }} />
+                  {o.label}
+                  {o.sublabel && <Typography component='span' variant='caption' sx={{ opacity: 0.6 }}>{o.sublabel}</Typography>}
+                </Box>
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Button variant='outlined' onClick={add} disabled={!target} sx={{ alignSelf: 'stretch' }}>
+          {t('common.add')}
+        </Button>
+      </Box>
+
+      {value.length > 0 ? (
+        <Paper variant='outlined' sx={{ p: 1, display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+          {value.map(s => (
+            <Chip
+              key={`${s.scopeType}:${s.scopeTarget}`}
+              size='small'
+              icon={<i className={typeIcon[s.scopeType] || 'ri-price-tag-3-line'} style={{ fontSize: 14 }} />}
+              label={`${labelFor(s.scopeType)}: ${resolveScopeTargetLabel(inventory, s.scopeType, s.scopeTarget, t)}`}
+              onDelete={() => remove(s.scopeType, s.scopeTarget)}
+              variant='outlined'
+            />
+          ))}
+        </Paper>
+      ) : (
+        <Typography variant='caption' sx={{ opacity: 0.6 }}>{t('rbacPage.defaultScope.none')}</Typography>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/app/(dashboard)/security/rbac/page.tsx
+++ b/frontend/src/app/(dashboard)/security/rbac/page.tsx
@@ -21,16 +21,18 @@ import { Features, useLicense } from '@/contexts/LicenseContext'
 import { useRBAC } from '@/contexts/RBACContext'
 import { CardsSkeleton, TableSkeleton } from '@/components/skeletons'
 import { WIDGET_REGISTRY, WIDGET_CATEGORIES } from '@/components/dashboard/widgetRegistry'
+import RoleDefaultScopeEditor from './RoleDefaultScopeEditor'
+import { formatScopeTarget } from './scope-options'
 
 // Types
 interface Permission { id: string; name: string; category: string; description: string; is_dangerous: boolean }
 interface PermissionCategory { id: string; label: string; permissions: Permission[] }
-interface Role { id: string; name: string; description: string | null; is_system: boolean; color: string; permissions: Permission[]; user_count: number }
+interface Role { id: string; name: string; description: string | null; is_system: boolean; color: string; permissions: Permission[]; user_count: number; default_scopes?: { scopeType: string; scopeTarget: string }[] | null }
 interface User { id: string; email: string; name: string | null }
 interface Assignment { id: string; user: User; role: { id: string; name: string; color: string }; scope_type: string; scope_target: string | null; granted_at: string; granted_by_email: string | null }
 
 // Constants
-const scopeIcons = { global: 'ri-global-line', connection: 'ri-server-line', node: 'ri-computer-line', vm: 'ri-instance-line', tag: 'ri-price-tag-3-line', pool: 'ri-folder-shared-line' }
+const scopeIcons = { global: 'ri-global-line', connection: 'ri-server-line', node: 'ri-computer-line', vm: 'ri-instance-line', tag: 'ri-price-tag-3-line', pool: 'ri-folder-shared-line', inherit: 'ri-links-line' }
 const catIcons = { vm: 'ri-instance-line', storage: 'ri-hard-drive-3-line', node: 'ri-computer-line', connection: 'ri-server-line', backup: 'ri-archive-line', admin: 'ri-shield-user-line' }
 
 // Roles that must NEVER be assigned in a non-default tenant. Two reasons
@@ -64,7 +66,8 @@ const getScopeLabels = (t: any) => ({
   node: t('rbac.scopes.node'),
   vm: t('rbac.scopes.vmct'),
   tag: t('rbac.scopes.tag'),
-  pool: t('rbac.scopes.pool')
+  pool: t('rbac.scopes.pool'),
+  inherit: t('rbac.scopes.inherit')
 })
 
 const timeAgo = (d, t?: any, locale?: string) => {
@@ -85,6 +88,7 @@ function RoleDialog({ open, onClose, role, categories, onSave, t }) {
   const [color, setColor] = useState('#6366f1')
   const [selectedPerms, setSelectedPerms] = useState(new Set())
   const [hiddenWidgets, setHiddenWidgets] = useState(new Set())
+  const [defaultScopes, setDefaultScopes] = useState<{ scopeType: string; scopeTarget: string }[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [expanded, setExpanded] = useState(new Set())
@@ -98,8 +102,9 @@ function RoleDialog({ open, onClose, role, categories, onSave, t }) {
       setColor(role.color || '#6366f1')
       setSelectedPerms(new Set(role.permissions.map(p => p.id)))
       setHiddenWidgets(new Set(role.widget_overrides?.hidden || []))
+      setDefaultScopes(Array.isArray(role.default_scopes) ? role.default_scopes : [])
     } else {
-      setName(''); setDescription(''); setColor('#6366f1'); setSelectedPerms(new Set()); setHiddenWidgets(new Set())
+      setName(''); setDescription(''); setColor('#6366f1'); setSelectedPerms(new Set()); setHiddenWidgets(new Set()); setDefaultScopes([])
     }
 
     setExpanded(new Set(categories.map(c => c.id)))
@@ -159,7 +164,7 @@ return }
     const widgetOverrides = hiddenWidgets.size > 0 ? { hidden: Array.from(hiddenWidgets) } : null
     const payload = role?.is_system
       ? { widget_overrides: widgetOverrides }
-      : { name: name.trim(), description: description.trim() || null, color, permissions: Array.from(selectedPerms), widget_overrides: widgetOverrides }
+      : { name: name.trim(), description: description.trim() || null, color, permissions: Array.from(selectedPerms), widget_overrides: widgetOverrides, default_scopes: defaultScopes }
 
     try {
       const res = await fetch(isEdit ? `/api/v1/rbac/roles/${role.id}` : '/api/v1/rbac/roles', {
@@ -225,6 +230,21 @@ return n })}>
             )
           })}
         </Paper>
+
+        {/* Role default scope (issue #383). Custom roles only — system roles
+            bypass scope resolution via their super-admin/protected shortcuts. */}
+        {!role?.is_system && (
+          <Box sx={{ mt: 3 }}>
+            <Typography variant='subtitle2' sx={{ mb: 0.5, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
+              <i className='ri-links-line' style={{ fontSize: '1.1rem' }} />
+              {t('rbacPage.defaultScope.title')}
+              {defaultScopes.length > 0 && (
+                <Chip size='small' label={defaultScopes.length} color='primary' variant='outlined' />
+              )}
+            </Typography>
+            <RoleDefaultScopeEditor value={defaultScopes} onChange={setDefaultScopes} t={t} />
+          </Box>
+        )}
 
         {/* Widget visibility (denylist) — admins tick widgets to hide for users
             carrying this role. Always editable, including on system roles. */}
@@ -300,7 +320,9 @@ function AssignmentDialog({ open, onClose, roles, users, assignments = [], tenan
   // operator can pick any enabled tenant — the POST body's tenant_id field is
   // honored only when the session is in the provider tenant (server check).
   const [tenantId, setTenantId] = useState<string>(currentTenantId)
-  const [scopeType, setScopeType] = useState('global')
+  // Default to "inherit" so a new assignment follows the role's default scope
+  // (issue #383). The admin can still pick an explicit override.
+  const [scopeType, setScopeType] = useState('inherit')
   const [selectedTargets, setSelectedTargets] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -329,7 +351,7 @@ function AssignmentDialog({ open, onClose, roles, users, assignments = [], tenan
       setUser(null)
       setRoleId('')
       setTenantId(currentTenantId)
-      setScopeType('global')
+      setScopeType('inherit')
       setSelectedTargets([])
       setSearchFilter('')
       setError('')
@@ -527,9 +549,12 @@ return scopeOptions.filter((o: any) =>
 return
     }
 
-    if (scopeType !== 'global' && selectedTargets.length === 0) {
+    // global and inherit carry no target — a single assignment is created.
+    const scopeHasNoTarget = scopeType === 'global' || scopeType === 'inherit'
+
+    if (!scopeHasNoTarget && selectedTargets.length === 0) {
       setError(t('common.error'))
-      
+
 return
     }
 
@@ -537,7 +562,7 @@ return
     setError('')
 
     try {
-      const targets = scopeType === 'global' ? [null] : selectedTargets
+      const targets = scopeHasNoTarget ? [null] : selectedTargets
       let successCount = 0
       let errors: string[] = []
 
@@ -665,6 +690,15 @@ return
             label={t('rbacPage.scope')}
             onChange={e => { setScopeType(e.target.value); setSelectedTargets([]) }}
           >
+            <MenuItem value='inherit'>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className='ri-links-line' style={{ color: '#10b981' }} />
+                <Box>
+                  <Typography variant='body2'>{t('rbac.scopes.inherit')}</Typography>
+                  <Typography variant='caption' sx={{ opacity: 0.6 }}>{t('rbacPage.defaultScope.desc')}</Typography>
+                </Box>
+              </Box>
+            </MenuItem>
             <MenuItem value='global'>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <i className='ri-global-line' style={{ color: '#6366f1' }} />
@@ -742,7 +776,7 @@ return
         )}
 
         {/* Sélection des ressources */}
-        {scopeType !== 'global' && (
+        {scopeType !== 'global' && scopeType !== 'inherit' && (
           <Box sx={{ mt: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
               <Typography variant='subtitle2'>
@@ -835,6 +869,12 @@ return
           </Box>
         )}
 
+        {scopeType === 'inherit' && (
+          <Alert severity='info' sx={{ mt: 2 }} icon={<i className='ri-links-line' />}>
+            {t('rbacPage.defaultScope.desc')}
+          </Alert>
+        )}
+
         {scopeType === 'global' && (
           <Alert severity='info' sx={{ mt: 2 }}>
             {/* Translation contains <strong>…</strong> as inline rich text.
@@ -860,7 +900,7 @@ return
             !roleId ||
             !!conflict.existingDifferentRole ||
             (scopeType === 'global' && conflict.globalAlreadyExists) ||
-            (scopeType !== 'global' && selectedTargets.length === 0)
+            (scopeType !== 'global' && scopeType !== 'inherit' && selectedTargets.length === 0)
           }
         >
           {saving ? t('common.saving') : selectedTargets.length > 1 ? `${t('common.save')} (${selectedTargets.length})` : t('common.save')}
@@ -896,6 +936,47 @@ function RolesTab({ roles, categories, onRefresh, t }) {
   const [toDelete, setToDelete] = useState(null)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState('')
+  const [connNames, setConnNames] = useState({})
+
+  // Connection id -> name so the default-scope chips show the connection name
+  // instead of its opaque id (issue #383). Lighter than the full inventory the
+  // dialogs load: the card only needs to resolve connection scopes.
+  useEffect(() => {
+    let active = true
+    fetch('/api/v1/connections?type=pve')
+      .then(r => r.json())
+      .then(d => {
+        if (!active) return
+        const map = {}
+        for (const c of d?.data ?? []) if (c?.id) map[c.id] = c.name || c.id
+        setConnNames(map)
+      })
+      .catch(() => {})
+
+    return () => { active = false }
+  }, [])
+
+  // Map permission id -> its category, so a role's permissions can be
+  // summarised by area (e.g. "VM 13") instead of listing individual names.
+  const permCat = useMemo(() => {
+    const m = {}
+    for (const cat of categories || []) for (const p of cat.permissions || []) m[p.id] = cat
+
+    return m
+  }, [categories])
+
+  const catCounts = useCallback(role => {
+    const counts = new Map()
+    for (const p of role.permissions) {
+      const cat = permCat[p.id]
+      const id = cat?.id ?? p.name.split('.')[0]
+      const entry = counts.get(id) || { id, label: cat ? t(`rbac.categories.${cat.id}`, { defaultValue: cat.label }) : id, count: 0 }
+      entry.count++
+      counts.set(id, entry)
+    }
+
+    return Array.from(counts.values()).sort((a, b) => b.count - a.count)
+  }, [permCat, t])
 
   const handleDelete = async () => {
     if (!toDelete) return
@@ -924,14 +1005,23 @@ return }
       </Box>
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 2 }}>
         {roles.map(role => (
-          <Paper key={role.id} variant='outlined' sx={{ p: 2, borderLeft: 4, borderLeftColor: role.color, '&:hover': { bgcolor: 'action.hover' } }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>{role.is_system ? t(`rbac.roles.${role.id}`, { defaultValue: role.name }) : role.name}</Typography>
-                  {role.is_system && <Chip label={t('rbacPage.systemRole')} size='small' variant='outlined' sx={{ height: 20, fontSize: '0.7rem' }} />}
+          <Paper key={role.id} variant='outlined' sx={{ p: 2, overflow: 'hidden', borderLeft: 4, borderLeftColor: role.color, '&:hover': { bgcolor: 'action.hover' } }}>
+            {/* Tinted header band carries the role colour from the left accent
+                across the whole header (issue #383 polish). */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1, mt: -2, mx: -2, mb: 0, px: 2, py: 1.5, bgcolor: alpha(role.color, 0.08), borderBottom: '1px solid', borderColor: 'divider' }}>
+              <Box sx={{ minWidth: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                  <Typography variant='subtitle1' noWrap sx={{ fontWeight: 600 }}>{role.is_system ? t(`rbac.roles.${role.id}`, { defaultValue: role.name }) : role.name}</Typography>
+                  {role.is_system && <Chip label={t('rbacPage.systemRole')} size='small' variant='outlined' sx={{ height: 20, fontSize: '0.7rem', flexShrink: 0 }} />}
                 </Box>
-                {role.description && <Typography variant='body2' sx={{ opacity: 0.6 }}>{role.is_system ? t(`rbac.roleDesc.${role.id}`, { defaultValue: role.description }) : role.description}</Typography>}
+                {/* Always reserve a 2-line (clamped) description block so every
+                    card header has the same height, with or without a description. */}
+                <Typography
+                  variant='body2'
+                  sx={{ opacity: 0.6, mt: 0.25, minHeight: 40, display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden' }}
+                >
+                  {role.is_system ? t(`rbac.roleDesc.${role.id}`, { defaultValue: role.description || '' }) : (role.description || '')}
+                </Typography>
               </Box>
               {isSuperAdmin && (
                 <Box>
@@ -940,15 +1030,57 @@ return }
                 </Box>
               )}
             </Box>
-            <Divider sx={{ my: 1 }} />
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Typography variant='body2'><i className='ri-key-line' style={{ opacity: 0.5, marginRight: 4 }} />{role.permissions.length} {t('rbacPage.permissions')}</Typography>
-              <Typography variant='body2'><i className='ri-user-line' style={{ opacity: 0.5, marginRight: 4 }} />{t('rbacPage.userCount', { count: role.user_count })}</Typography>
-            </Box>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
-              {role.permissions.slice(0, 4).map(p => <Chip key={p.id} label={p.name.split('.')[1]} size='small' variant='outlined' sx={{ height: 20, fontSize: '0.7rem' }} />)}
-              {role.permissions.length > 4 && <Chip label={`+${role.permissions.length - 4}`} size='small' sx={{ height: 20, fontSize: '0.7rem' }} />}
-            </Box>
+            {/* Meta line: counts only, no individual permission names. */}
+            <Typography variant='caption' sx={{ display: 'block', opacity: 0.6, mt: 1.5 }}>
+              {role.permissions.length} {t('rbacPage.permissions')} &nbsp;·&nbsp; {t('rbacPage.userCount', { count: role.user_count })}
+            </Typography>
+
+            {/* Permissions summarised by area (issue #383): "VM 13", "Connection 1". */}
+            {role.permissions.length > 0 && (
+              <Box sx={{ mt: 1.5 }}>
+                <Typography variant='overline' sx={{ display: 'block', opacity: 0.5, fontSize: '0.65rem', letterSpacing: '0.08em', lineHeight: 1.6 }}>
+                  {t('rbacPage.permissions')}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.25 }}>
+                  {catCounts(role).map(c => (
+                    <Chip
+                      key={c.id}
+                      size='small'
+                      variant='outlined'
+                      icon={<i className={catIcons[c.id] || 'ri-folder-line'} style={{ fontSize: 14 }} />}
+                      label={<span>{c.label}&nbsp;<Box component='span' sx={{ fontWeight: 700 }}>{c.count}</Box></span>}
+                      sx={{ height: 22, fontSize: '0.72rem' }}
+                    />
+                  ))}
+                </Box>
+              </Box>
+            )}
+
+            {/* Default scope summary (issue #383): inheriting assignments follow this. */}
+            {Array.isArray(role.default_scopes) && role.default_scopes.length > 0 && (
+              <Box sx={{ mt: 1.5 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                  <i className='ri-links-line' style={{ fontSize: 14, color: '#10b981' }} />
+                  <Typography variant='overline' sx={{ opacity: 0.5, fontSize: '0.65rem', letterSpacing: '0.08em', lineHeight: 1.6 }}>
+                    {t('rbacPage.defaultScope.title')}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.25 }}>
+                  {role.default_scopes.slice(0, 4).map(s => (
+                    <Chip
+                      key={`${s.scopeType}:${s.scopeTarget}`}
+                      size='small'
+                      color='primary'
+                      variant='outlined'
+                      icon={<i className={scopeIcons[s.scopeType] || 'ri-price-tag-3-line'} style={{ fontSize: 14 }} />}
+                      label={formatScopeTarget(connNames, s.scopeType, s.scopeTarget)}
+                      sx={{ height: 22, fontSize: '0.72rem' }}
+                    />
+                  ))}
+                  {role.default_scopes.length > 4 && <Chip label={`+${role.default_scopes.length - 4}`} size='small' sx={{ height: 22, fontSize: '0.72rem' }} />}
+                </Box>
+              </Box>
+            )}
           </Paper>
         ))}
       </Box>
@@ -1429,7 +1561,12 @@ return scopeOptions.filter((o: any) =>
 return
     }
 
-    if (scopeType !== 'global' && selectedTargets.length === 0) {
+    // global and inherit carry no target (issue #383); only truly scoped types
+    // require a selection.
+    const noTarget = scopeType === 'global' || scopeType === 'inherit'
+    const wasNoTarget = assignmentGroup.scope_type === 'global' || assignmentGroup.scope_type === 'inherit'
+
+    if (!noTarget && selectedTargets.length === 0) {
       setError(t('common.error'))
 
 return
@@ -1440,7 +1577,7 @@ return
 
     try {
       const originalTargets = new Set<string>(assignmentGroup.scope_targets || [])
-      const newTargets = scopeType === 'global' ? new Set<string>() : new Set(selectedTargets)
+      const newTargets = noTarget ? new Set<string>() : new Set(selectedTargets)
       
       // Calculer les différences
       const toAdd = [...newTargets].filter(t => !originalTargets.has(t))
@@ -1464,8 +1601,9 @@ return
 
       // Mettre à jour le rôle des assignations conservées si changé
       if (roleId !== assignmentGroup.role.id) {
-        // Global scope: update the single assignment directly (no targets to iterate)
-        if (scopeType === 'global' && assignmentGroup.scope_type === 'global') {
+        // No-target scope (global/inherit), unchanged type: update the single
+        // assignment directly (no targets to iterate).
+        if (noTarget && assignmentGroup.scope_type === scopeType) {
           for (const assignment of assignmentGroup.assignments) {
             const res = await fetch(`/api/v1/rbac/assignments/${assignment.id}`, {
               method: 'PATCH',
@@ -1526,9 +1664,9 @@ return
         }
       }
 
-      // Cas spécial: passage à global
-      if (scopeType === 'global' && assignmentGroup.scope_type !== 'global') {
-        // Supprimer toutes les anciennes assignations et créer une globale
+      // Cas spécial: passage vers un scope sans cible (global ou inherit) depuis
+      // un scope différent. Supprime tout et crée une seule assignation.
+      if (noTarget && assignmentGroup.scope_type !== scopeType) {
         for (const assignment of assignmentGroup.assignments) {
           await fetch(`/api/v1/rbac/assignments/${assignment.id}`, { method: 'DELETE' })
         }
@@ -1539,7 +1677,7 @@ return
           body: JSON.stringify({
             user_id: assignmentGroup.user.id,
             role_id: roleId,
-            scope_type: 'global',
+            scope_type: scopeType,
             scope_target: null,
             ...tenantPayload,
           })
@@ -1552,9 +1690,9 @@ return
         }
       }
 
-      // Cas spécial: passage de global à spécifique
-      if (scopeType !== 'global' && assignmentGroup.scope_type === 'global') {
-        // Supprimer l'assignation globale
+      // Cas spécial: passage d'un scope sans cible vers un scope spécifique
+      if (!noTarget && wasNoTarget) {
+        // Supprimer l'assignation sans cible
         for (const assignment of assignmentGroup.assignments) {
           await fetch(`/api/v1/rbac/assignments/${assignment.id}`, { method: 'DELETE' })
         }
@@ -1630,6 +1768,15 @@ return
               setSelectedTargets([])
             }}
           >
+            <MenuItem value='inherit'>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className='ri-links-line' style={{ color: '#10b981' }} />
+                <Box>
+                  <Typography variant='body2'>{t('rbac.scopes.inherit')}</Typography>
+                  <Typography variant='caption' sx={{ opacity: 0.6 }}>{t('rbacPage.defaultScope.desc')}</Typography>
+                </Box>
+              </Box>
+            </MenuItem>
             <MenuItem value='global'>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 <i className='ri-global-line' style={{ color: '#6366f1' }} />
@@ -1688,7 +1835,7 @@ return
         </FormControl>
 
         {/* Sélection des ressources (multi-sélection) */}
-        {scopeType !== 'global' && (
+        {scopeType !== 'global' && scopeType !== 'inherit' && (
           <Box sx={{ mt: 2 }}>
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
               <Typography variant='subtitle2'>
@@ -1785,7 +1932,7 @@ return
         <Button
           variant='contained'
           onClick={handleSave}
-          disabled={saving || !roleId || (scopeType !== 'global' && selectedTargets.length === 0)}
+          disabled={saving || !roleId || (scopeType !== 'global' && scopeType !== 'inherit' && selectedTargets.length === 0)}
         >
           {saving ? (t('common.saving')) : (t('common.save'))}
         </Button>

--- a/frontend/src/app/(dashboard)/security/rbac/scope-options.test.ts
+++ b/frontend/src/app/(dashboard)/security/rbac/scope-options.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildScopeOptions, resolveScopeTargetLabel, formatScopeTarget } from './scope-options'
+
+const t = (_k: string, _v?: any) => '' // sublabels not asserted here
+
+const inventory = {
+  clusters: [
+    {
+      id: 'c1',
+      name: 'Cluster 1',
+      status: 'online',
+      nodes: [
+        {
+          node: 'n1',
+          status: 'online',
+          guests: [
+            { type: 'qemu', vmid: 100, name: 'db1', tags: 'db;oracle', pool: 'dbpool' },
+            { type: 'lxc', vmid: 101, name: 'web1', tags: 'web', pool: null },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('buildScopeOptions', () => {
+  it('returns [] without inventory', () => {
+    expect(buildScopeOptions(null, 'tag', t)).toEqual([])
+    expect(buildScopeOptions({}, 'tag', t)).toEqual([])
+  })
+
+  it('extracts unique tags sorted', () => {
+    const ids = buildScopeOptions(inventory, 'tag', t).map(o => o.id)
+    expect(ids).toEqual(['db', 'oracle', 'web'])
+  })
+
+  it('extracts pools (only non-null)', () => {
+    expect(buildScopeOptions(inventory, 'pool', t).map(o => o.id)).toEqual(['dbpool'])
+  })
+
+  it('builds node ids as connId:node', () => {
+    expect(buildScopeOptions(inventory, 'node', t).map(o => o.id)).toEqual(['c1:n1'])
+  })
+
+  it('builds vm ids as connId:node:type:vmid', () => {
+    expect(buildScopeOptions(inventory, 'vm', t).map(o => o.id)).toEqual([
+      'c1:n1:qemu:100',
+      'c1:n1:lxc:101',
+    ])
+  })
+
+  it('builds connection options', () => {
+    expect(buildScopeOptions(inventory, 'connection', t).map(o => o.id)).toEqual(['c1'])
+  })
+
+  it('returns [] for an unknown type', () => {
+    expect(buildScopeOptions(inventory, 'bogus', t)).toEqual([])
+  })
+})
+
+describe('resolveScopeTargetLabel', () => {
+  it('resolves a connection id to its name', () => {
+    expect(resolveScopeTargetLabel(inventory, 'connection', 'c1', t)).toBe('Cluster 1')
+  })
+
+  it('resolves a vm id to its name', () => {
+    expect(resolveScopeTargetLabel(inventory, 'vm', 'c1:n1:qemu:100', t)).toBe('db1')
+  })
+
+  it('leaves tag/pool targets unchanged (already names)', () => {
+    expect(resolveScopeTargetLabel(inventory, 'pool', 'dbpool', t)).toBe('dbpool')
+    expect(resolveScopeTargetLabel(inventory, 'tag', 'db', t)).toBe('db')
+  })
+
+  it('falls back to the raw target when inventory is missing or the id is gone', () => {
+    expect(resolveScopeTargetLabel(null, 'connection', 'c1', t)).toBe('c1')
+    expect(resolveScopeTargetLabel(inventory, 'connection', 'ghost', t)).toBe('ghost')
+  })
+})
+
+describe('formatScopeTarget', () => {
+  const connNames = { c1: 'PROXMOX-PROD' }
+
+  it('maps a connection id to its name (object or Map)', () => {
+    expect(formatScopeTarget(connNames, 'connection', 'c1')).toBe('PROXMOX-PROD')
+    expect(formatScopeTarget(new Map([['c1', 'PROXMOX-PROD']]), 'connection', 'c1')).toBe('PROXMOX-PROD')
+  })
+
+  it('formats node and vm composite ids', () => {
+    expect(formatScopeTarget(connNames, 'node', 'c1:n1')).toBe('n1 · PROXMOX-PROD')
+    expect(formatScopeTarget(connNames, 'vm', 'c1:n1:qemu:100')).toBe('qemu/100 · n1')
+  })
+
+  it('leaves tag/pool targets untouched and falls back on unknown connection', () => {
+    expect(formatScopeTarget(connNames, 'pool', 'dbpool')).toBe('dbpool')
+    expect(formatScopeTarget(connNames, 'connection', 'ghost')).toBe('ghost')
+  })
+})

--- a/frontend/src/app/(dashboard)/security/rbac/scope-options.ts
+++ b/frontend/src/app/(dashboard)/security/rbac/scope-options.ts
@@ -1,0 +1,153 @@
+// Build the selectable scope targets for a given scope type from the live
+// inventory payload (/api/v1/inventory). Shared by the assignment dialogs and
+// the role default-scope editor so the extraction logic lives in one place
+// (issue #383). `t` provides the count sublabels; pass a passthrough in tests.
+
+export type ScopeOption = {
+  id: string
+  label: string
+  sublabel?: string
+  icon?: string
+  status?: string
+}
+
+export function buildScopeOptions(inventory: any, scopeType: string, t: any): ScopeOption[] {
+  if (!inventory?.clusters) return []
+
+  switch (scopeType) {
+    case 'connection':
+      return inventory.clusters.map((c: any) => ({
+        id: c.id,
+        label: c.name,
+        sublabel: t('rbacPage.nodeCount', { count: c.nodes?.length || 0 }),
+        icon: 'ri-server-line',
+        status: c.status,
+      }))
+
+    case 'node': {
+      const nodes: ScopeOption[] = []
+      inventory.clusters.forEach((c: any) => {
+        c.nodes?.forEach((n: any) => {
+          nodes.push({
+            id: `${c.id}:${n.node}`,
+            label: n.node,
+            sublabel: c.name,
+            icon: 'ri-computer-line',
+            status: n.status,
+          })
+        })
+      })
+      return nodes
+    }
+
+    case 'vm': {
+      const vms: ScopeOption[] = []
+      inventory.clusters.forEach((c: any) => {
+        c.nodes?.forEach((n: any) => {
+          n.guests?.forEach((g: any) => {
+            vms.push({
+              id: `${c.id}:${n.node}:${g.type}:${g.vmid}`,
+              label: g.name || `${g.type}/${g.vmid}`,
+              sublabel: `${String(g.type).toUpperCase()} ${g.vmid} • ${n.node} • ${c.name}`,
+              icon: g.type === 'lxc' ? 'ri-box-3-line' : 'ri-instance-line',
+              status: g.status,
+            })
+          })
+        })
+      })
+      return vms
+    }
+
+    case 'tag': {
+      const tagMap = new Map<string, number>()
+      inventory.clusters.forEach((c: any) => {
+        c.nodes?.forEach((n: any) => {
+          n.guests?.forEach((g: any) => {
+            const tags = typeof g.tags === 'string'
+              ? g.tags.split(/[;,]/).map((s: string) => s.trim()).filter(Boolean)
+              : []
+            tags.forEach((tag: string) => tagMap.set(tag, (tagMap.get(tag) || 0) + 1))
+          })
+        })
+      })
+      return Array.from(tagMap.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([tag, count]) => ({
+          id: tag,
+          label: tag,
+          sublabel: t('rbacPage.tagUsedByVms', { count }),
+          icon: 'ri-price-tag-3-line',
+        }))
+    }
+
+    case 'pool': {
+      const poolMap = new Map<string, number>()
+      inventory.clusters.forEach((c: any) => {
+        c.nodes?.forEach((n: any) => {
+          n.guests?.forEach((g: any) => {
+            if (g.pool) poolMap.set(g.pool, (poolMap.get(g.pool) || 0) + 1)
+          })
+        })
+      })
+      return Array.from(poolMap.entries())
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([pool, count]) => ({
+          id: pool,
+          label: pool,
+          sublabel: t('rbacPage.poolContainsVms', { count }),
+          icon: 'ri-folder-shared-line',
+        }))
+    }
+
+    default:
+      return []
+  }
+}
+
+/**
+ * Resolve a stored scope target back to its human-readable label (issue #383).
+ * connection/node/vm targets are opaque ids, so they are looked up in the live
+ * inventory; tag/pool targets are already the display name. Falls back to the
+ * raw target when the inventory has not loaded yet or the resource is gone.
+ */
+export function resolveScopeTargetLabel(
+  inventory: any,
+  scopeType: string,
+  target: string,
+  t: any = () => '',
+): string {
+  const match = buildScopeOptions(inventory, scopeType, t).find(o => o.id === target)
+
+  return match?.label ?? target
+}
+
+/**
+ * Compact, human-readable label for a stored scope target using only a
+ * connection id -> name map (issue #383). Lighter than {@link
+ * resolveScopeTargetLabel}: it needs no full inventory, so callers that only
+ * list connections (e.g. the role cards) can still turn the opaque connection
+ * id into its name. node/vm composite ids are formatted from their own parts;
+ * tag/pool/global/inherit targets are already display-ready.
+ */
+export function formatScopeTarget(
+  connNames: Record<string, string> | Map<string, string>,
+  scopeType: string,
+  target: string,
+): string {
+  const conn = (id: string) =>
+    (connNames instanceof Map ? connNames.get(id) : connNames?.[id]) || id
+  const parts = target.split(':')
+
+  switch (scopeType) {
+    case 'connection':
+      return conn(target)
+    case 'node':
+      // "connId:node" -> "node · ConnectionName"
+      return parts.length >= 2 ? `${parts[1]} · ${conn(parts[0])}` : target
+    case 'vm':
+      // "connId:node:type:vmid" -> "type/vmid · node"
+      return parts.length >= 4 ? `${parts[2]}/${parts[3]} · ${parts[1]}` : target
+    default:
+      return target
+  }
+}

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -318,7 +318,8 @@ return
             body: JSON.stringify({
               user_id: userId,
               role_id: selectedRole.id,
-              scope_type: 'global',
+              // inherit so the role's default scope applies automatically (issue #383)
+              scope_type: 'inherit',
               scope_target: null
             })
           })

--- a/frontend/src/app/api/v1/rbac/assignments/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/rbac/assignments/[id]/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+// scope-validation is intentionally NOT mocked: we exercise the PATCH route's
+// real use of validateAssignmentScope (issue #383).
+const {
+  getServerSessionMock,
+  hasPermissionMock,
+  isSuperAdminMock,
+  isProtectedMock,
+  userRoleFindFirstMock,
+  userRoleUpdateManyMock,
+  roleFindUniqueMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  isSuperAdminMock: vi.fn(),
+  isProtectedMock: vi.fn(),
+  userRoleFindFirstMock: vi.fn(),
+  userRoleUpdateManyMock: vi.fn(),
+  roleFindUniqueMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default', DEFAULT_TENANT_ID: 'default' }))
+vi.mock('@/lib/audit', () => ({ audit: vi.fn() }))
+vi.mock('@/lib/rbac', () => ({
+  hasPermission: hasPermissionMock,
+  isUserSuperAdmin: isSuperAdminMock,
+  isUserProtected: isProtectedMock,
+  PROTECTED_ROLE_IDS: [],
+  PROVIDER_ONLY_ROLE_IDS: [],
+}))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    rbacUserRole: { findFirst: userRoleFindFirstMock, updateMany: userRoleUpdateManyMock },
+    rbacRole: { findUnique: roleFindUniqueMock },
+  },
+}))
+
+import { PATCH } from './route'
+
+const existingAssignment = {
+  id: 'assign_1',
+  userId: 'u1',
+  roleId: 'role_x',
+  scopeType: 'global',
+  scopeTarget: null,
+  tenantId: 'default',
+  user: { email: 'u1@x' },
+  role: { name: 'DB Admin' },
+}
+
+const updatedRow = (scopeType: string, scopeTarget: string | null) => ({
+  id: 'assign_1',
+  scopeType,
+  scopeTarget,
+  expiresAt: null,
+  user: { id: 'u1', email: 'u1@x' },
+  role: { id: 'role_x', name: 'DB Admin', color: '#fff' },
+})
+
+describe('PATCH /api/v1/rbac/assignments/[id] scope handling (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: 'admin', email: 'admin@x' } })
+    hasPermissionMock.mockResolvedValue(true)
+    isSuperAdminMock.mockResolvedValue(true)
+    isProtectedMock.mockResolvedValue(false)
+  })
+
+  it('rejects a scope_type change to a scoped type with no resolvable target', async () => {
+    userRoleFindFirstMock.mockResolvedValueOnce(existingAssignment)
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'assign_1' },
+      body: { scope_type: 'vm' },
+    })
+    expect(res.status).toBe(400)
+    const json: any = await readJson(res)
+    expect(json.error).toMatch(/scope_target/i)
+    expect(userRoleUpdateManyMock).not.toHaveBeenCalled()
+  })
+
+  it('normalizes a scope_type change to "inherit" (drops any target)', async () => {
+    userRoleFindFirstMock
+      .mockResolvedValueOnce(existingAssignment)
+      .mockResolvedValueOnce(updatedRow('inherit', null))
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'assign_1' },
+      body: { scope_type: 'inherit' },
+    })
+    expect(res.status).toBe(200)
+    expect(userRoleUpdateManyMock).toHaveBeenCalled()
+    expect(userRoleUpdateManyMock.mock.calls[0][0].data.scopeType).toBe('inherit')
+    expect(userRoleUpdateManyMock.mock.calls[0][0].data.scopeTarget).toBeNull()
+  })
+
+  it('keeps an explicit scope target when switching to a scoped type', async () => {
+    userRoleFindFirstMock
+      .mockResolvedValueOnce(existingAssignment)
+      .mockResolvedValueOnce(updatedRow('tag', 'web'))
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'assign_1' },
+      body: { scope_type: 'tag', scope_target: 'web' },
+    })
+    expect(res.status).toBe(200)
+    expect(userRoleUpdateManyMock.mock.calls[0][0].data.scopeType).toBe('tag')
+    expect(userRoleUpdateManyMock.mock.calls[0][0].data.scopeTarget).toBe('web')
+  })
+})

--- a/frontend/src/app/api/v1/rbac/assignments/[id]/route.ts
+++ b/frontend/src/app/api/v1/rbac/assignments/[id]/route.ts
@@ -8,6 +8,7 @@ import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { audit } from "@/lib/audit"
 import { hasPermission, isUserSuperAdmin, isUserProtected, PROTECTED_ROLE_IDS, PROVIDER_ONLY_ROLE_IDS } from "@/lib/rbac"
+import { validateAssignmentScope } from "@/lib/rbac/scope-validation"
 import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
 import { demoResponse } from "@/lib/demo/demo-api"
 
@@ -278,16 +279,16 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
     }
 
     if (scope_type !== undefined) {
-      const validScopes = ["global", "connection", "node", "vm", "tag", "pool"]
-
-      if (!validScopes.includes(scope_type)) {
-        return NextResponse.json({ error: "scope_type invalide" }, { status: 400 })
+      // Validate against the effective target (incoming, else the existing one)
+      // so the shared rule applies; "inherit"/"global" normalize to no target.
+      const targetForCheck = scope_target !== undefined ? scope_target : assignment.scopeTarget
+      const check = validateAssignmentScope(scope_type, targetForCheck)
+      if (!check.ok) {
+        return NextResponse.json({ error: check.error }, { status: 400 })
       }
-
-      data.scopeType = scope_type
-    }
-
-    if (scope_target !== undefined) {
+      data.scopeType = check.scopeType
+      data.scopeTarget = check.scopeTarget
+    } else if (scope_target !== undefined) {
       data.scopeTarget = scope_target || null
     }
 

--- a/frontend/src/app/api/v1/rbac/assignments/route.test.ts
+++ b/frontend/src/app/api/v1/rbac/assignments/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+// scope-validation is intentionally NOT mocked: we want to exercise the route's
+// real use of validateAssignmentScope (issue #383).
+const {
+  getServerSessionMock,
+  hasPermissionMock,
+  isSuperAdminMock,
+  isProtectedMock,
+  userFindUniqueMock,
+  roleFindUniqueMock,
+  userRoleFindFirstMock,
+  userRoleCreateMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
+  isSuperAdminMock: vi.fn(),
+  isProtectedMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
+  roleFindUniqueMock: vi.fn(),
+  userRoleFindFirstMock: vi.fn(),
+  userRoleCreateMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default', DEFAULT_TENANT_ID: 'default' }))
+vi.mock('@/lib/audit', () => ({ audit: vi.fn() }))
+vi.mock('@/lib/rbac', () => ({
+  hasPermission: hasPermissionMock,
+  isUserSuperAdmin: isSuperAdminMock,
+  isUserProtected: isProtectedMock,
+  PROTECTED_ROLE_IDS: [],
+  PROVIDER_ONLY_ROLE_IDS: [],
+}))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: { findUnique: userFindUniqueMock },
+    userTenant: { findUnique: vi.fn() },
+    rbacRole: { findUnique: roleFindUniqueMock },
+    rbacUserRole: { findFirst: userRoleFindFirstMock, create: userRoleCreateMock },
+  },
+}))
+
+import { POST } from './route'
+
+describe('POST /api/v1/rbac/assignments scope handling (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: 'admin', email: 'admin@x' } })
+    hasPermissionMock.mockResolvedValue(true)
+    isSuperAdminMock.mockResolvedValue(true) // caller + target both super: skips membership check
+    isProtectedMock.mockResolvedValue(false)
+    userFindUniqueMock.mockResolvedValue({ id: 'u1', email: 'u1@x' })
+    roleFindUniqueMock.mockResolvedValue({ id: 'role_x', name: 'DB Admin', tenantId: null })
+    userRoleFindFirstMock.mockResolvedValue(null) // no existing role, no duplicate assignment
+    userRoleCreateMock.mockResolvedValue({ id: 'assign_1' })
+  })
+
+  it('rejects a scoped assignment with no target', async () => {
+    const res = await callRoute(POST, { body: { user_id: 'u1', role_id: 'role_x', scope_type: 'node' } })
+    expect(res.status).toBe(400)
+    const json: any = await readJson(res)
+    expect(json.error).toMatch(/scope_target/i)
+    expect(userRoleCreateMock).not.toHaveBeenCalled()
+  })
+
+  it('defaults a manual assignment to "inherit" when no scope_type is given', async () => {
+    const res = await callRoute(POST, { body: { user_id: 'u1', role_id: 'role_x' } })
+    expect(res.status).toBe(201)
+    expect(userRoleCreateMock).toHaveBeenCalled()
+    expect(userRoleCreateMock.mock.calls[0][0].data.scopeType).toBe('inherit')
+    expect(userRoleCreateMock.mock.calls[0][0].data.scopeTarget).toBeNull()
+  })
+
+  it('keeps an explicit scope (tag) and its target', async () => {
+    const res = await callRoute(POST, {
+      body: { user_id: 'u1', role_id: 'role_x', scope_type: 'tag', scope_target: 'db' },
+    })
+    expect(res.status).toBe(201)
+    expect(userRoleCreateMock.mock.calls[0][0].data.scopeType).toBe('tag')
+    expect(userRoleCreateMock.mock.calls[0][0].data.scopeTarget).toBe('db')
+  })
+})

--- a/frontend/src/app/api/v1/rbac/assignments/route.ts
+++ b/frontend/src/app/api/v1/rbac/assignments/route.ts
@@ -10,6 +10,7 @@ import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { audit } from "@/lib/audit"
 import { hasPermission, isUserSuperAdmin, isUserProtected, PROTECTED_ROLE_IDS, PROVIDER_ONLY_ROLE_IDS } from "@/lib/rbac"
+import { validateAssignmentScope } from "@/lib/rbac/scope-validation"
 import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
 import { demoResponse } from "@/lib/demo/demo-api"
 
@@ -295,16 +296,14 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const validScopes = ["global", "connection", "node", "vm", "tag", "pool"]
-    const scopeType = scope_type || "global"
-
-    if (!validScopes.includes(scopeType)) {
-      return NextResponse.json({ error: "scope_type invalide" }, { status: 400 })
+    // Default to "inherit" so a manual assignment follows the role's default
+    // scope, just like SSO does (issue #383). Explicit scopes still override.
+    const scopeCheck = validateAssignmentScope(scope_type || "inherit", scope_target)
+    if (!scopeCheck.ok) {
+      return NextResponse.json({ error: scopeCheck.error }, { status: 400 })
     }
-
-    if (scopeType !== "global" && !scope_target) {
-      return NextResponse.json({ error: "scope_target requis pour ce type de scope" }, { status: 400 })
-    }
+    const scopeType = scopeCheck.scopeType
+    const scopeTarget = scopeCheck.scopeTarget
 
     // Vérifier que l'utilisateur existe
     const user = await prisma.user.findUnique({
@@ -366,7 +365,7 @@ export async function POST(req: NextRequest) {
         userId: user_id,
         roleId: role_id,
         scopeType,
-        scopeTarget: scope_target ?? null,
+        scopeTarget,
         tenantId: targetTenantId,
       },
       select: { id: true },
@@ -386,7 +385,7 @@ export async function POST(req: NextRequest) {
         userId: user_id,
         roleId: role_id,
         scopeType,
-        scopeTarget: scope_target ?? null,
+        scopeTarget,
         tenantId: targetTenantId,
         grantedById: session.user.id,
         grantedAt: now,
@@ -407,7 +406,7 @@ export async function POST(req: NextRequest) {
         role_name: role.name,
         role_id,
         scope_type: scopeType,
-        scope_target,
+        scope_target: scopeTarget,
         tenant_id: targetTenantId,
       },
       status: "success"
@@ -420,7 +419,7 @@ export async function POST(req: NextRequest) {
         role_id,
         tenant_id: targetTenantId,
         scope_type: scopeType,
-        scope_target,
+        scope_target: scopeTarget,
         granted_at: now.toISOString(),
         expires_at: expiresAt?.toISOString() ?? null,
       }

--- a/frontend/src/app/api/v1/rbac/effective/route.test.ts
+++ b/frontend/src/app/api/v1/rbac/effective/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const {
+  getServerSessionMock,
+  userFindUniqueMock,
+  roleFindManyMock,
+  permFindManyMock,
+  isSuperAdminMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
+  roleFindManyMock: vi.fn(),
+  permFindManyMock: vi.fn(),
+  isSuperAdminMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default' }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: { findUnique: userFindUniqueMock },
+    rbacUserRole: { findMany: roleFindManyMock, findFirst: vi.fn().mockResolvedValue(null) },
+    rbacUserPermission: { findMany: permFindManyMock },
+    rbacPermission: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}))
+// Keep the real resolveEffectiveScopes; only stub the DB-backed helpers.
+vi.mock('@/lib/rbac', async importActual => {
+  const actual = await importActual<typeof import('@/lib/rbac')>()
+  return { ...actual, isUserSuperAdmin: isSuperAdminMock, hasPermission: vi.fn() }
+})
+
+import { GET } from './route'
+
+const inheritDbRole = {
+  id: 'a1',
+  scopeType: 'inherit',
+  scopeTarget: null,
+  expiresAt: null,
+  role: {
+    id: 'role_db',
+    name: 'DB Admin',
+    color: '#fff',
+    widgetOverrides: null,
+    defaultScopes: [{ scopeType: 'tag', scopeTarget: 'db' }],
+    permissions: [{ permission: { id: 'p1', name: 'vm.view', category: 'vm' } }],
+  },
+}
+
+describe('GET /api/v1/rbac/effective with role default scope (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: 'u1' } })
+    userFindUniqueMock.mockResolvedValue({ id: 'u1', email: 'u1@x', role: 'viewer' })
+    isSuperAdminMock.mockResolvedValue(false)
+    permFindManyMock.mockResolvedValue([])
+    roleFindManyMock.mockResolvedValue([inheritDbRole])
+  })
+
+  it('resolves an inherit assignment to the role default scope (no raw inherit leak)', async () => {
+    const res = await callRoute(GET, { searchParams: { user_id: 'u1' } })
+    const json: any = await readJson(res)
+
+    expect(res.status).toBe(200)
+    expect(json.data.permissions).toContain('vm.view')
+    // scope_types reflects the resolved tag scope, never the raw sentinel
+    expect(json.data.scope_types).toContain('tag')
+    expect(json.data.scope_types).not.toContain('inherit')
+    const detail = json.data.permission_details.find((d: any) => d.name === 'vm.view')
+    expect(detail.scope_type).toBe('tag')
+    expect(detail.scope_target).toBe('db')
+  })
+
+  it('keeps the permission on a resource-filtered call (inherit no longer drops it)', async () => {
+    const res = await callRoute(GET, {
+      searchParams: { user_id: 'u1', resource_type: 'vm', resource_id: 'c1:n1:qemu:100' },
+    })
+    const json: any = await readJson(res)
+
+    expect(res.status).toBe(200)
+    // Before the fix, checkScopeMatch('inherit', ...) hit default:false and
+    // dropped vm.view whenever a resource filter was present.
+    expect(json.data.permissions).toContain('vm.view')
+  })
+})

--- a/frontend/src/app/api/v1/rbac/effective/route.ts
+++ b/frontend/src/app/api/v1/rbac/effective/route.ts
@@ -6,7 +6,7 @@ import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
-import { hasPermission, isUserSuperAdmin } from "@/lib/rbac"
+import { hasPermission, isUserSuperAdmin, resolveEffectiveScopes } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { demoResponse } from "@/lib/demo/demo-api"
 
@@ -107,6 +107,7 @@ export async function GET(req: NextRequest) {
             name: true,
             color: true,
             widgetOverrides: true,
+            defaultScopes: true,
             permissions: {
               select: { permission: { select: { id: true, name: true, category: true } } },
             },
@@ -128,24 +129,45 @@ export async function GET(req: NextRequest) {
     // Calculer les permissions effectives
     const effectivePermissions = new Set<string>()
     const permissionDetails: any[] = []
+    // Aggregate scope types across roles AND direct grants. Populated from
+    // resolved scopes so "inherit" never leaks here (issue #383).
+    const scopeTypes = new Set<string>()
+    // Dedup permission_details by (permission, resolved scope) so a role that
+    // inherits several default scopes surfaces each one instead of collapsing
+    // to a single row.
+    const detailSeen = new Set<string>()
 
-    // Ajouter les permissions via les rôles
+    // Ajouter les permissions via les rôles. "inherit" assignments expand into
+    // the role's default scopes before matching, so a resource-filtered call no
+    // longer drops the permission on the sentinel (was checkScopeMatch default).
     for (const ur of userRoles) {
-      const matches = checkScopeMatch(ur.scopeType, ur.scopeTarget, resourceType, resourceId)
-      if (!matches) continue
+      const effectiveScopes = resolveEffectiveScopes(
+        ur.scopeType,
+        ur.scopeTarget,
+        ur.role.defaultScopes as { scopeType: string; scopeTarget: string | null }[] | null,
+      )
 
-      for (const rp of ur.role.permissions) {
-        const perm = rp.permission
-        if (!effectivePermissions.has(perm.name)) {
+      for (const sc of effectiveScopes) {
+        if (sc.scopeType) scopeTypes.add(sc.scopeType)
+      }
+
+      for (const sc of effectiveScopes) {
+        if (!checkScopeMatch(sc.scopeType, sc.scopeTarget, resourceType, resourceId)) continue
+
+        for (const rp of ur.role.permissions) {
+          const perm = rp.permission
           effectivePermissions.add(perm.name)
+          const key = `${perm.name}|${sc.scopeType}|${sc.scopeTarget ?? ""}`
+          if (detailSeen.has(key)) continue
+          detailSeen.add(key)
           permissionDetails.push({
             id: perm.id,
             name: perm.name,
             category: perm.category,
             source: "role",
             source_name: ur.role.name,
-            scope_type: ur.scopeType,
-            scope_target: ur.scopeTarget,
+            scope_type: sc.scopeType,
+            scope_target: sc.scopeTarget,
           })
         }
       }
@@ -183,16 +205,9 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    // Aggregate scope types across roles AND direct user permissions, so
-    // downstream consumers (e.g. dashboard widget visibility) don't have to
-    // re-derive it and don't miss users whose access comes from a direct
-    // permission grant rather than a role.
-    const scopeTypes = new Set<string>()
-
-    for (const ur of userRoles) {
-      if (ur.scopeType) scopeTypes.add(ur.scopeType)
-    }
-
+    // Role-derived scope types were aggregated (resolved) in the role loop
+    // above; fold in direct user-permission scopes here too, so downstream
+    // consumers don't miss users whose access comes from a direct grant.
     for (const dp of directPermissions) {
       if (dp.scopeType) scopeTypes.add(dp.scopeType)
     }
@@ -207,6 +222,13 @@ export async function GET(req: NextRequest) {
           color: ur.role.color,
           scope_type: ur.scopeType,
           scope_target: ur.scopeTarget,
+          // Resolved scopes for an "inherit" assignment, so the UI can render
+          // the role's default scope instead of the raw sentinel (issue #383).
+          resolved_scopes: resolveEffectiveScopes(
+            ur.scopeType,
+            ur.scopeTarget,
+            ur.role.defaultScopes as { scopeType: string; scopeTarget: string | null }[] | null,
+          ),
         })),
         permissions: Array.from(effectivePermissions),
         permission_details: permissionDetails,

--- a/frontend/src/app/api/v1/rbac/roles/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/rbac/roles/[id]/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const { getServerSessionMock, isSuperAdminMock, findUniqueMock, updateMock, txMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  isSuperAdminMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  updateMock: vi.fn((a: any) => a),
+  txMock: vi.fn(async (cb: any) => cb({
+    rbacRole: { update: updateMock },
+    rbacRolePermission: { deleteMany: vi.fn(), createMany: vi.fn() },
+  })),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default' }))
+vi.mock('@/lib/audit', () => ({ audit: vi.fn() }))
+vi.mock('@/lib/rbac', () => ({ isUserSuperAdmin: isSuperAdminMock, PROTECTED_ROLE_IDS: [] }))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    rbacRole: { findUnique: findUniqueMock, update: updateMock },
+    $transaction: txMock,
+  },
+}))
+
+import { PATCH } from './route'
+
+// Complete row the initial fetch + post-update re-fetch (both findUnique) map over.
+const roleRow = (over: any = {}) => ({
+  id: 'role_db',
+  name: 'DB',
+  description: null,
+  isSystem: false,
+  color: '#fff',
+  widgetOverrides: null,
+  defaultScopes: null,
+  tenantId: 'default',
+  createdAt: new Date('2026-06-03T00:00:00Z'),
+  updatedAt: new Date('2026-06-03T00:00:00Z'),
+  permissions: [],
+  ...over,
+})
+
+describe('PATCH /api/v1/rbac/roles/[id] default_scopes (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: 'admin', email: 'a@x' } })
+    isSuperAdminMock.mockResolvedValue(true)
+  })
+
+  it('rejects default_scopes on a system role', async () => {
+    findUniqueMock.mockResolvedValue(roleRow({ id: 'role_viewer', isSystem: true, tenantId: null, name: 'Viewer' }))
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'role_viewer' },
+      body: { default_scopes: [{ scopeType: 'tag', scopeTarget: 'db' }] },
+    })
+    expect(res.status).toBe(400)
+    const json: any = await readJson(res)
+    expect(json.error).toMatch(/système|system/i)
+  })
+
+  it('updates default_scopes on a custom role', async () => {
+    findUniqueMock.mockResolvedValue(roleRow())
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'role_db' },
+      body: { default_scopes: [{ scopeType: 'pool', scopeTarget: 'dbpool' }] },
+    })
+    expect(res.status).toBe(200)
+    expect(updateMock).toHaveBeenCalled()
+    const data = updateMock.mock.calls[0][0].data
+    expect(data.defaultScopes).toEqual([{ scopeType: 'pool', scopeTarget: 'dbpool' }])
+  })
+
+  it('clears default_scopes when an empty list is sent', async () => {
+    findUniqueMock.mockResolvedValue(roleRow())
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'role_db' },
+      body: { default_scopes: [] },
+    })
+    expect(res.status).toBe(200)
+    // empty list clears the scope -> Prisma.DbNull
+    const data = updateMock.mock.calls[0][0].data
+    expect(data.defaultScopes).toBeDefined()
+  })
+
+  it('clears default_scopes when explicit null is sent', async () => {
+    findUniqueMock.mockResolvedValue(roleRow({ defaultScopes: [{ scopeType: 'tag', scopeTarget: 'db' }] }))
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'role_db' },
+      body: { default_scopes: null },
+    })
+    expect(res.status).toBe(200)
+    const data = updateMock.mock.calls[0][0].data
+    expect(data.defaultScopes).toBeDefined()
+  })
+
+  it('rejects an invalid default_scopes payload on a custom role', async () => {
+    findUniqueMock.mockResolvedValue(roleRow())
+    const res = await callRoute(PATCH, {
+      method: 'PATCH',
+      params: { id: 'role_db' },
+      body: { default_scopes: [{ scopeType: 'global', scopeTarget: null }] },
+    })
+    expect(res.status).toBe(400)
+    const json: any = await readJson(res)
+    expect(json.error).toMatch(/default_scope/i)
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/rbac/roles/[id]/route.ts
+++ b/frontend/src/app/api/v1/rbac/roles/[id]/route.ts
@@ -10,6 +10,7 @@ import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { audit } from "@/lib/audit"
 import { isUserSuperAdmin, PROTECTED_ROLE_IDS } from "@/lib/rbac"
+import { validateRoleDefaultScopes } from "@/lib/rbac/scope-validation"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { demoResponse } from "@/lib/demo/demo-api"
 
@@ -101,6 +102,7 @@ export async function GET(req: NextRequest, context: RouteContext) {
         is_system: role.isSystem,
         color: role.color,
         widget_overrides: role.widgetOverrides ?? null,
+        default_scopes: role.defaultScopes ?? null,
         tenant_id: role.tenantId,
         created_at: role.createdAt.toISOString(),
         updated_at: role.updatedAt.toISOString(),
@@ -166,22 +168,40 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
     }
 
     const body = await req.json()
-    const { name, description, color, permissions, widget_overrides } = body
+    const { name, description, color, permissions, widget_overrides, default_scopes } = body
     const now = new Date()
     const normalizedOverrides = normalizeWidgetOverrides(widget_overrides)
 
     // System roles are immutable except for widget overrides — those purely
     // hide UI elements and grant no privileges, so admins can tailor the
-    // dashboard for system roles without forking them.
+    // dashboard for system roles without forking them. default_scopes is NOT
+    // allowed on system roles: their super-admin/protected shortcuts bypass
+    // scope resolution, so a scope there would be silently ignored (issue #383).
     if (role.isSystem) {
       const touchedSystemImmutable =
         name !== undefined ||
         description !== undefined ||
         color !== undefined ||
+        default_scopes !== undefined ||
         Array.isArray(permissions)
 
       if (touchedSystemImmutable) {
         return NextResponse.json({ error: "Impossible de modifier un rôle système" }, { status: 400 })
+      }
+    }
+
+    // Validate the role's default scope when provided (custom roles only —
+    // system roles are rejected above). An empty list clears it.
+    let defaultScopesUpdate: { scopeType: string; scopeTarget: string }[] | null | undefined
+    if (default_scopes !== undefined) {
+      if (default_scopes === null) {
+        defaultScopesUpdate = null
+      } else {
+        const check = validateRoleDefaultScopes(default_scopes)
+        if (!check.ok) {
+          return NextResponse.json({ error: check.error }, { status: 400 })
+        }
+        defaultScopesUpdate = check.scopes.length ? check.scopes : null
       }
     }
 
@@ -203,6 +223,7 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
       description?: string | null
       color?: string
       widgetOverrides?: any
+      defaultScopes?: any
       updatedAt: Date
     } = {
       updatedAt: now,
@@ -215,6 +236,9 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
     // TypeScript or fail at runtime depending on the client version.
     if (normalizedOverrides !== undefined) {
       updateData.widgetOverrides = normalizedOverrides === null ? Prisma.DbNull : normalizedOverrides
+    }
+    if (defaultScopesUpdate !== undefined) {
+      updateData.defaultScopes = defaultScopesUpdate === null ? Prisma.DbNull : defaultScopesUpdate
     }
 
     const replacePermissions = Array.isArray(permissions)
@@ -266,6 +290,7 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
         is_system: updated.isSystem,
         color: updated.color,
         widget_overrides: updated.widgetOverrides ?? null,
+        default_scopes: updated.defaultScopes ?? null,
         tenant_id: updated.tenantId,
         created_at: updated.createdAt.toISOString(),
         updated_at: updated.updatedAt.toISOString(),

--- a/frontend/src/app/api/v1/rbac/roles/route.test.ts
+++ b/frontend/src/app/api/v1/rbac/roles/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const { getServerSessionMock, isSuperAdminMock, findFirstMock, findUniqueMock, createMock, txMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  isSuperAdminMock: vi.fn(),
+  findFirstMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  createMock: vi.fn((args: any) => args),
+  txMock: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default' }))
+vi.mock('@/lib/audit', () => ({ audit: vi.fn() }))
+vi.mock('@/lib/rbac', () => ({ isUserSuperAdmin: isSuperAdminMock, PROTECTED_ROLE_IDS: [] }))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    rbacRole: { findFirst: findFirstMock, findUnique: findUniqueMock, create: createMock },
+    rbacRolePermission: { createMany: vi.fn((a: any) => a) },
+    $transaction: txMock,
+  },
+}))
+
+import { POST } from './route'
+
+// Shape returned by the post-create re-fetch the response maps over.
+const newRoleRow = (defaultScopes: any) => ({
+  id: 'role_new',
+  name: 'DB Admin',
+  description: null,
+  isSystem: false,
+  color: '#fff',
+  widgetOverrides: null,
+  defaultScopes,
+  tenantId: 'default',
+  createdAt: new Date('2026-06-03T00:00:00Z'),
+  updatedAt: new Date('2026-06-03T00:00:00Z'),
+  permissions: [],
+})
+
+describe('POST /api/v1/rbac/roles default_scopes (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: 'admin', email: 'a@x' } })
+    isSuperAdminMock.mockResolvedValue(true)
+    findFirstMock.mockResolvedValue(null)
+    txMock.mockResolvedValue([])
+  })
+
+  it('stores a valid default scope on the new role', async () => {
+    findUniqueMock.mockResolvedValue(newRoleRow([{ scopeType: 'tag', scopeTarget: 'db' }]))
+    const res = await callRoute(POST, {
+      body: { name: 'DB Admin', default_scopes: [{ scopeType: 'tag', scopeTarget: 'db' }] },
+    })
+    expect(res.status).toBe(201)
+    expect(createMock).toHaveBeenCalled()
+    expect(createMock.mock.calls[0][0].data.defaultScopes).toEqual([{ scopeType: 'tag', scopeTarget: 'db' }])
+  })
+
+  it('rejects an invalid default scope type', async () => {
+    const res = await callRoute(POST, {
+      body: { name: 'Bad Role', default_scopes: [{ scopeType: 'global', scopeTarget: null }] },
+    })
+    expect(res.status).toBe(400)
+    const json: any = await readJson(res)
+    expect(json.error).toMatch(/default_scope/i)
+  })
+
+  it('omits defaultScopes when none provided', async () => {
+    findUniqueMock.mockResolvedValue(newRoleRow(null))
+    const res = await callRoute(POST, { body: { name: 'Plain Role' } })
+    expect(res.status).toBe(201)
+    expect(createMock.mock.calls[0][0].data.defaultScopes).toBeUndefined()
+  })
+})

--- a/frontend/src/app/api/v1/rbac/roles/route.ts
+++ b/frontend/src/app/api/v1/rbac/roles/route.ts
@@ -12,6 +12,7 @@ import { demoResponse } from "@/lib/demo/demo-api"
 import { prisma } from "@/lib/db/prisma"
 import { audit } from "@/lib/audit"
 import { isUserSuperAdmin, PROTECTED_ROLE_IDS } from "@/lib/rbac"
+import { validateRoleDefaultScopes } from "@/lib/rbac/scope-validation"
 import { getCurrentTenantId } from "@/lib/tenant"
 
 /**
@@ -76,6 +77,7 @@ export async function GET(req: NextRequest) {
         isSystem: true,
         color: true,
         widgetOverrides: true,
+        defaultScopes: true,
         tenantId: true,
         createdAt: true,
         updatedAt: true,
@@ -102,6 +104,7 @@ export async function GET(req: NextRequest) {
       is_system: role.isSystem,
       color: role.color,
       widget_overrides: role.widgetOverrides ?? null,
+      default_scopes: role.defaultScopes ?? null,
       tenant_id: role.tenantId,
       created_at: role.createdAt.toISOString(),
       updated_at: role.updatedAt.toISOString(),
@@ -151,10 +154,21 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json()
-    const { name, description, color, permissions, widget_overrides } = body
+    const { name, description, color, permissions, widget_overrides, default_scopes } = body
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
       return NextResponse.json({ error: "Nom du rôle requis" }, { status: 400 })
+    }
+
+    // Role-level default scope (issue #383). New roles are always custom, so
+    // it's always allowed here; the validator rejects global/inherit entries.
+    let defaultScopes: { scopeType: string; scopeTarget: string }[] | undefined
+    if (default_scopes !== undefined && default_scopes !== null) {
+      const check = validateRoleDefaultScopes(default_scopes)
+      if (!check.ok) {
+        return NextResponse.json({ error: check.error }, { status: 400 })
+      }
+      defaultScopes = check.scopes.length ? check.scopes : undefined
     }
 
     const trimmedName = name.trim()
@@ -192,6 +206,7 @@ export async function POST(req: NextRequest) {
             normalizedOverrides === undefined ? undefined :
             normalizedOverrides === null ? Prisma.DbNull :
             normalizedOverrides,
+          defaultScopes: defaultScopes ?? undefined,
           tenantId: ownerTenantId,
           createdAt: now,
           updatedAt: now,
@@ -240,6 +255,7 @@ export async function POST(req: NextRequest) {
         is_system: newRole.isSystem,
         color: newRole.color,
         widget_overrides: newRole.widgetOverrides ?? null,
+        default_scopes: newRole.defaultScopes ?? null,
         tenant_id: newRole.tenantId,
         created_at: newRole.createdAt.toISOString(),
         updated_at: newRole.updatedAt.toISOString(),

--- a/frontend/src/app/api/v1/tenants/[id]/users/route.ts
+++ b/frontend/src/app/api/v1/tenants/[id]/users/route.ts
@@ -57,7 +57,8 @@ export async function POST(req: NextRequest, ctx: Ctx) {
         id: roleAssignId,
         userId: body.userId,
         roleId,
-        scopeType: 'global',
+        // inherit so the assignment follows the role's default scope (issue #383)
+        scopeType: 'inherit',
         tenantId: id,
         grantedById: session?.user?.id || null,
         grantedAt: new Date(),

--- a/frontend/src/app/api/v1/users/[id]/route.ts
+++ b/frontend/src/app/api/v1/users/[id]/route.ts
@@ -301,7 +301,8 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
                 id: `tenant_role_${m.tenantId}_${id}_${nanoid(6)}`,
                 userId: id,
                 roleId,
-                scopeType: "global",
+                // inherit so the assignment follows the role's default scope (issue #383)
+                scopeType: "inherit",
                 tenantId: m.tenantId,
                 grantedById,
                 grantedAt: now,

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -8,7 +8,7 @@ import { nanoid } from "nanoid"
 import { prisma } from "@/lib/db/prisma"
 import { verifyPassword, hashPassword } from "./password"
 import { extractGroupsFromClaim, isLdapGroupAllowed } from "./groupMapping"
-import { authenticateLdap, isLdapEnabled, getLdapConfig, resolveLdapRole } from "./ldap"
+import { authenticateLdap, isLdapEnabled, getLdapConfig, resolveLdapRole, syncLdapRoleAssignment } from "./ldap"
 import { getOidcConfig, resolveOidcRole } from "./oidc"
 
 export type UserRole = "super_admin" | "admin" | "operator" | "viewer"
@@ -324,58 +324,20 @@ export const authOptions: NextAuthOptions = {
           }
         }
 
-        // Sync RBAC role from LDAP groups (Postgres / Prisma).
+        // Sync RBAC role from LDAP groups (Postgres / Prisma). The assignment
+        // is created with scopeType "inherit" so it follows the role's default
+        // scope automatically (issue #383); the helper keys its delete/replace
+        // on the ldap_ id prefix so manual assignments are never clobbered.
         const ldapConfig = await getLdapConfig()
         if (ldapConfig) {
           const resolvedRoleId = resolveLdapRole(ldapUser.groups, ldapConfig)
-
-          // Check if user already has a global RBAC role on the default tenant
-          const existingRole = await prisma.rbacUserRole.findFirst({
-            where: { userId: user.id, scopeType: "global", tenantId: "default" },
-            select: { id: true },
+          await syncLdapRoleAssignment(prisma, {
+            userId: user.id,
+            resolvedRoleId,
+            defaultRoleId: ldapConfig.defaultRole || "role_viewer",
+            now,
+            newId: () => `ldap_${nanoid(12)}`,
           })
-
-          if (resolvedRoleId) {
-            // LDAP group matched — sync the resolved role.
-            // Fall back to role_viewer if the resolved role doesn't exist.
-            const roleExists = await prisma.rbacRole.findUnique({
-              where: { id: resolvedRoleId },
-              select: { id: true },
-            })
-            const finalRoleId = roleExists ? resolvedRoleId : "role_viewer"
-
-            await prisma.$transaction([
-              prisma.rbacUserRole.deleteMany({
-                where: { userId: user.id, scopeType: "global", tenantId: "default" },
-              }),
-              prisma.rbacUserRole.create({
-                data: {
-                  id: `ldap_${nanoid(12)}`,
-                  userId: user.id,
-                  roleId: finalRoleId,
-                  scopeType: "global",
-                  tenantId: "default",
-                  grantedById: null,
-                  grantedAt: now,
-                },
-              }),
-            ])
-          } else if (!existingRole) {
-            // No group match AND no existing role (first login) — assign default role
-            const defaultRoleId = ldapConfig.defaultRole || "role_viewer"
-            await prisma.rbacUserRole.create({
-              data: {
-                id: `ldap_${nanoid(12)}`,
-                userId: user.id,
-                roleId: defaultRoleId,
-                scopeType: "global",
-                tenantId: "default",
-                grantedById: null,
-                grantedAt: now,
-              },
-            })
-          }
-          // If no group match but existing role: preserve manually-assigned role
         }
 
         const localUser = await prisma.user.findUnique({
@@ -512,6 +474,9 @@ export const authOptions: NextAuthOptions = {
           })
 
           // Create RBAC role assignment from OIDC groups (Postgres / Prisma).
+          // scopeType "inherit" so the assignment follows the role's default
+          // scope automatically (issue #383). Resolves to global when the role
+          // has no default scope, matching the previous behaviour.
           const oidcRoleExists = await prisma.rbacRole.findUnique({
             where: { id: oidcRoleId },
             select: { id: true },
@@ -523,7 +488,7 @@ export const authOptions: NextAuthOptions = {
               id: `oidc_${nanoid(12)}`,
               userId: id,
               roleId: finalOidcRoleId,
-              scopeType: "global",
+              scopeType: "inherit",
               tenantId: "default",
               grantedAt: now,
             },

--- a/frontend/src/lib/auth/ldap-rbac-sync.test.ts
+++ b/frontend/src/lib/auth/ldap-rbac-sync.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { syncLdapRoleAssignment } from './ldap'
+
+function makeDb(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    rbacRole: { findUnique: vi.fn().mockResolvedValue({ id: 'role_db' }) },
+    rbacUserRole: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    $transaction: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as any
+}
+
+const params = (extra: any = {}) => ({
+  userId: 'u1',
+  resolvedRoleId: null as string | null,
+  defaultRoleId: 'role_viewer',
+  now: new Date('2026-06-03T00:00:00Z'),
+  newId: () => 'ldap_fixed',
+  ...extra,
+})
+
+describe('syncLdapRoleAssignment (issue #383)', () => {
+  let db: any
+  beforeEach(() => {
+    db = makeDb()
+  })
+
+  it('replaces the LDAP-managed row with the resolved role as an inherit assignment', async () => {
+    await syncLdapRoleAssignment(db, params({ resolvedRoleId: 'role_db' }))
+
+    // Only ldap_-owned rows are removed, never manual assignments.
+    expect(db.rbacUserRole.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'u1', tenantId: 'default', id: { startsWith: 'ldap_' } },
+    })
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_db')
+    expect(created.scopeType).toBe('inherit')
+    expect(created.id).toBe('ldap_fixed')
+    expect(created.tenantId).toBe('default')
+  })
+
+  it('falls back to role_viewer when the resolved role does not exist', async () => {
+    db = makeDb({ rbacRole: { findUnique: vi.fn().mockResolvedValue(null) } })
+    await syncLdapRoleAssignment(db, params({ resolvedRoleId: 'role_ghost' }))
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_viewer')
+    expect(created.scopeType).toBe('inherit')
+  })
+
+  it('assigns the default role on first login when no role exists (inherit)', async () => {
+    await syncLdapRoleAssignment(db, params({ resolvedRoleId: null }))
+    expect(db.rbacUserRole.deleteMany).not.toHaveBeenCalled()
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_viewer')
+    expect(created.scopeType).toBe('inherit')
+  })
+
+  it('preserves an existing role when no LDAP group matches', async () => {
+    db = makeDb({
+      rbacUserRole: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'manual_1' }),
+        deleteMany: vi.fn(),
+        create: vi.fn(),
+      },
+    })
+    await syncLdapRoleAssignment(db, params({ resolvedRoleId: null }))
+    expect(db.rbacUserRole.create).not.toHaveBeenCalled()
+    expect(db.rbacUserRole.deleteMany).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/auth/ldap.ts
+++ b/frontend/src/lib/auth/ldap.ts
@@ -193,3 +193,86 @@ export function resolveLdapRole(groups: string[], config: LdapConfig): string | 
 
   return null
 }
+
+// Minimal Prisma surface the LDAP sync needs — injected so the logic is unit
+// testable without a real client.
+type LdapSyncDb = {
+  rbacRole: { findUnique: (args: any) => Promise<{ id: string } | null> }
+  rbacUserRole: {
+    findFirst: (args: any) => Promise<{ id: string } | null>
+    deleteMany: (args: any) => Promise<unknown>
+    create: (args: any) => Promise<unknown>
+  }
+  $transaction: (ops: unknown[]) => Promise<unknown>
+}
+
+/**
+ * Sync a user's LDAP-derived RBAC assignment on login (issue #383).
+ *
+ * The assignment is created with scopeType "inherit" so it follows the role's
+ * default scope automatically. The LDAP-managed row is identified by its
+ * `ldap_` id prefix, so the delete/replace never touches a manually-created
+ * assignment (which would otherwise be clobbered when keyed on scope type).
+ *
+ *  - group matches a role  -> replace the ldap_ row with the resolved role
+ *    (falling back to role_viewer if the resolved role no longer exists)
+ *  - no match, no role yet -> assign the default role (first login)
+ *  - no match, role exists -> preserve whatever the user already has
+ */
+export async function syncLdapRoleAssignment(
+  db: LdapSyncDb,
+  params: {
+    userId: string
+    resolvedRoleId: string | null
+    defaultRoleId: string
+    now: Date
+    newId: () => string
+  },
+): Promise<void> {
+  const { userId, resolvedRoleId, defaultRoleId, now, newId } = params
+  const tenantId = "default"
+  const ldapOwned = { userId, tenantId, id: { startsWith: "ldap_" } }
+
+  if (resolvedRoleId) {
+    const roleExists = await db.rbacRole.findUnique({
+      where: { id: resolvedRoleId },
+      select: { id: true },
+    })
+    const finalRoleId = roleExists ? resolvedRoleId : "role_viewer"
+    await db.$transaction([
+      db.rbacUserRole.deleteMany({ where: ldapOwned }),
+      db.rbacUserRole.create({
+        data: {
+          id: newId(),
+          userId,
+          roleId: finalRoleId,
+          scopeType: "inherit",
+          tenantId,
+          grantedById: null,
+          grantedAt: now,
+        },
+      }),
+    ])
+    return
+  }
+
+  // No group matched — only seed the default role if the user has none yet,
+  // so a manually-assigned role is never duplicated or overridden on login.
+  const hasAnyRole = await db.rbacUserRole.findFirst({
+    where: { userId, tenantId },
+    select: { id: true },
+  })
+  if (!hasAnyRole) {
+    await db.rbacUserRole.create({
+      data: {
+        id: newId(),
+        userId,
+        roleId: defaultRoleId,
+        scopeType: "inherit",
+        tenantId,
+        grantedById: null,
+        grantedAt: now,
+      },
+    })
+  }
+}

--- a/frontend/src/lib/rbac/index.ts
+++ b/frontend/src/lib/rbac/index.ts
@@ -55,6 +55,39 @@ type LoadedGrants = {
   }>
 }
 
+/**
+ * Sentinel `scopeType` on an assignment meaning "follow the role's default
+ * scope". It is never stored on a role's `defaultScopes` and is expanded away
+ * before any `scopeMatches` call, so the matcher only ever sees real scopes.
+ */
+export const INHERIT_SCOPE = "inherit"
+
+type ScopeEntry = { scopeType: string; scopeTarget: string | null }
+
+/**
+ * Resolve an assignment's effective scopes (issue #383). An assignment whose
+ * scopeType is "inherit" follows the role's `defaultScopes`, or `global` when
+ * the role has none. Any explicit scope overrides the role default for that
+ * single assignment. Pure, no DB. Malformed default entries (missing or blank
+ * scopeType) are dropped so a bad role row can never silently widen access.
+ */
+export function resolveEffectiveScopes(
+  scopeType: string,
+  scopeTarget: string | null,
+  roleDefaultScopes: ScopeEntry[] | null | undefined,
+): ScopeEntry[] {
+  if (scopeType !== INHERIT_SCOPE) {
+    return [{ scopeType, scopeTarget: scopeTarget ?? null }]
+  }
+  const defaults = (Array.isArray(roleDefaultScopes) ? roleDefaultScopes : [])
+    .filter(
+      (s): s is ScopeEntry =>
+        !!s && typeof s.scopeType === "string" && s.scopeType.length > 0,
+    )
+    .map(s => ({ scopeType: s.scopeType, scopeTarget: s.scopeTarget ?? null }))
+  return defaults.length ? defaults : [{ scopeType: "global", scopeTarget: null }]
+}
+
 async function loadUserGrants(userId: string, tenantId: string): Promise<LoadedGrants> {
   // Super admins short-circuit: the role grants global, cross-tenant access
   // and we never need to enumerate scopes for them.
@@ -72,6 +105,7 @@ async function loadUserGrants(userId: string, tenantId: string): Promise<LoadedG
         scopeTarget: true,
         role: {
           select: {
+            defaultScopes: true,
             permissions: { select: { permission: { select: { name: true } } } },
           },
         },
@@ -103,9 +137,19 @@ async function loadUserGrants(userId: string, tenantId: string): Promise<LoadedG
   }
 
   for (const r of roleGrants) {
-    const entry = upsert(r.scopeType, r.scopeTarget)
-    for (const rp of r.role.permissions) {
-      entry.permissions.add(rp.permission.name)
+    // "inherit" assignments expand into the role's default scopes (issue #383);
+    // every other scope passes through unchanged. The role's permissions are
+    // attached to each resolved scope entry.
+    const effective = resolveEffectiveScopes(
+      r.scopeType,
+      r.scopeTarget,
+      r.role.defaultScopes as ScopeEntry[] | null,
+    )
+    for (const s of effective) {
+      const entry = upsert(s.scopeType, s.scopeTarget)
+      for (const rp of r.role.permissions) {
+        entry.permissions.add(rp.permission.name)
+      }
     }
   }
   for (const d of directGrants) {

--- a/frontend/src/lib/rbac/inherit-grants.test.ts
+++ b/frontend/src/lib/rbac/inherit-grants.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// loadUserGrants is internal; we exercise it end-to-end through
+// filterVmsByPermission, mocking the Prisma client the way the route tests do.
+// vi.hoisted keeps the mock fns available inside the hoisted vi.mock factory.
+const { findFirstMock, roleFindManyMock, permFindManyMock } = vi.hoisted(() => ({
+  findFirstMock: vi.fn<(...a: any[]) => Promise<any>>(),
+  roleFindManyMock: vi.fn<(...a: any[]) => Promise<any>>(),
+  permFindManyMock: vi.fn<(...a: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    rbacUserRole: { findFirst: findFirstMock, findMany: roleFindManyMock },
+    rbacUserPermission: { findMany: permFindManyMock },
+  },
+}))
+
+import { filterVmsByPermission, PERMISSIONS } from './index'
+
+const dbVm = { id: 'c1:qemu:n1:100', tags: ['db'] }
+const webVm = { id: 'c1:qemu:n1:101', tags: ['web'] }
+
+describe('loadUserGrants inherit expansion (issue #383)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findFirstMock.mockResolvedValue(null) // not a super admin
+    permFindManyMock.mockResolvedValue([])
+  })
+
+  it('an inherit assignment applies the role default tag scope', async () => {
+    roleFindManyMock.mockResolvedValue([
+      {
+        scopeType: 'inherit',
+        scopeTarget: null,
+        role: {
+          defaultScopes: [{ scopeType: 'tag', scopeTarget: 'db' }],
+          permissions: [{ permission: { name: PERMISSIONS.VM_VIEW } }],
+        },
+      },
+    ])
+
+    const result = await filterVmsByPermission('u1', [dbVm, webVm], PERMISSIONS.VM_VIEW)
+
+    expect(result).toEqual([dbVm]) // only the db-tagged VM survives
+  })
+
+  it('an inherit assignment on a role with no default scope is global', async () => {
+    roleFindManyMock.mockResolvedValue([
+      {
+        scopeType: 'inherit',
+        scopeTarget: null,
+        role: {
+          defaultScopes: null,
+          permissions: [{ permission: { name: PERMISSIONS.VM_VIEW } }],
+        },
+      },
+    ])
+
+    const result = await filterVmsByPermission('u1', [dbVm, webVm], PERMISSIONS.VM_VIEW)
+
+    expect(result).toEqual([dbVm, webVm]) // global -> everything visible
+  })
+
+  it('an explicit scope on the assignment overrides the role default', async () => {
+    roleFindManyMock.mockResolvedValue([
+      {
+        scopeType: 'tag',
+        scopeTarget: 'web',
+        role: {
+          defaultScopes: [{ scopeType: 'tag', scopeTarget: 'db' }],
+          permissions: [{ permission: { name: PERMISSIONS.VM_VIEW } }],
+        },
+      },
+    ])
+
+    const result = await filterVmsByPermission('u1', [dbVm, webVm], PERMISSIONS.VM_VIEW)
+
+    expect(result).toEqual([webVm]) // explicit web scope wins over the db default
+  })
+})

--- a/frontend/src/lib/rbac/scope-resolution.test.ts
+++ b/frontend/src/lib/rbac/scope-resolution.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { resolveEffectiveScopes } from './index'
+
+// Pure resolution of an assignment's effective scopes. "inherit" follows the
+// role's default scopes; any explicit scope overrides the role default.
+describe('resolveEffectiveScopes', () => {
+  it('inherit follows the role default scopes', () => {
+    const roleDefaults = [
+      { scopeType: 'tag', scopeTarget: 'db' },
+      { scopeType: 'tag', scopeTarget: 'oracle' },
+    ]
+    expect(resolveEffectiveScopes('inherit', null, roleDefaults)).toEqual(roleDefaults)
+  })
+
+  it('inherit with an empty default list resolves to global', () => {
+    expect(resolveEffectiveScopes('inherit', null, [])).toEqual([
+      { scopeType: 'global', scopeTarget: null },
+    ])
+  })
+
+  it('inherit with null/undefined defaults resolves to global', () => {
+    expect(resolveEffectiveScopes('inherit', null, null)).toEqual([
+      { scopeType: 'global', scopeTarget: null },
+    ])
+    expect(resolveEffectiveScopes('inherit', null, undefined)).toEqual([
+      { scopeType: 'global', scopeTarget: null },
+    ])
+  })
+
+  it('an explicit scope overrides the role default (ignores defaults)', () => {
+    const roleDefaults = [{ scopeType: 'tag', scopeTarget: 'db' }]
+    expect(resolveEffectiveScopes('tag', 'special', roleDefaults)).toEqual([
+      { scopeType: 'tag', scopeTarget: 'special' },
+    ])
+  })
+
+  it('explicit global resolves to a single global scope', () => {
+    expect(resolveEffectiveScopes('global', null, [{ scopeType: 'tag', scopeTarget: 'db' }])).toEqual([
+      { scopeType: 'global', scopeTarget: null },
+    ])
+  })
+
+  it('preserves mixed scope types from the role default', () => {
+    const roleDefaults = [
+      { scopeType: 'tag', scopeTarget: 'db' },
+      { scopeType: 'pool', scopeTarget: 'dbpool' },
+      { scopeType: 'node', scopeTarget: 'conn1:n1' },
+    ]
+    expect(resolveEffectiveScopes('inherit', null, roleDefaults)).toEqual(roleDefaults)
+  })
+
+  it('ignores malformed default entries (missing scopeType)', () => {
+    const roleDefaults = [
+      { scopeType: 'tag', scopeTarget: 'db' },
+      { scopeTarget: 'orphan' } as any,
+      { scopeType: '', scopeTarget: 'blank' },
+    ]
+    expect(resolveEffectiveScopes('inherit', null, roleDefaults)).toEqual([
+      { scopeType: 'tag', scopeTarget: 'db' },
+    ])
+  })
+})

--- a/frontend/src/lib/rbac/scope-validation.test.ts
+++ b/frontend/src/lib/rbac/scope-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+
+import { validateAssignmentScope, validateRoleDefaultScopes } from './scope-validation'
+
+describe('validateAssignmentScope', () => {
+  it('accepts global and inherit without a target', () => {
+    expect(validateAssignmentScope('global', null)).toEqual({ ok: true, scopeType: 'global', scopeTarget: null })
+    expect(validateAssignmentScope('inherit', null)).toEqual({ ok: true, scopeType: 'inherit', scopeTarget: null })
+  })
+
+  it('drops any target on global/inherit', () => {
+    expect(validateAssignmentScope('inherit', 'x')).toEqual({ ok: true, scopeType: 'inherit', scopeTarget: null })
+  })
+
+  it('accepts a scoped type with a target', () => {
+    expect(validateAssignmentScope('tag', 'db')).toEqual({ ok: true, scopeType: 'tag', scopeTarget: 'db' })
+  })
+
+  it('rejects a scoped type with no target', () => {
+    expect(validateAssignmentScope('tag', null).ok).toBe(false)
+    expect(validateAssignmentScope('pool', '').ok).toBe(false)
+  })
+
+  it('rejects an unknown scope type', () => {
+    expect(validateAssignmentScope('bogus', 'x').ok).toBe(false)
+  })
+})
+
+describe('validateRoleDefaultScopes', () => {
+  it('accepts an empty list (clears the default scope)', () => {
+    expect(validateRoleDefaultScopes([])).toEqual({ ok: true, scopes: [] })
+  })
+
+  it('normalizes valid entries to camelCase', () => {
+    const r = validateRoleDefaultScopes([
+      { scopeType: 'tag', scopeTarget: 'db' },
+      { scope_type: 'pool', scope_target: 'dbpool' },
+    ])
+    expect(r).toEqual({
+      ok: true,
+      scopes: [
+        { scopeType: 'tag', scopeTarget: 'db' },
+        { scopeType: 'pool', scopeTarget: 'dbpool' },
+      ],
+    })
+  })
+
+  it('rejects non-array input', () => {
+    expect(validateRoleDefaultScopes(null as any).ok).toBe(false)
+    expect(validateRoleDefaultScopes({} as any).ok).toBe(false)
+  })
+
+  it('rejects global and inherit as role default scope types', () => {
+    expect(validateRoleDefaultScopes([{ scopeType: 'global', scopeTarget: null }]).ok).toBe(false)
+    expect(validateRoleDefaultScopes([{ scopeType: 'inherit', scopeTarget: null }]).ok).toBe(false)
+  })
+
+  it('rejects an entry with a missing target', () => {
+    expect(validateRoleDefaultScopes([{ scopeType: 'tag', scopeTarget: '' }]).ok).toBe(false)
+    expect(validateRoleDefaultScopes([{ scopeType: 'node' }]).ok).toBe(false)
+  })
+
+  it('rejects an unknown scope type', () => {
+    expect(validateRoleDefaultScopes([{ scopeType: 'bogus', scopeTarget: 'x' }]).ok).toBe(false)
+  })
+})

--- a/frontend/src/lib/rbac/scope-validation.ts
+++ b/frontend/src/lib/rbac/scope-validation.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared scope validation for RBAC roles and assignments (issue #383).
+ *
+ * Kept in one place so the assignments routes (POST + PATCH) and the roles
+ * routes (POST + PATCH) validate scope the same way instead of each carrying
+ * its own list (Sonar duplication rule).
+ */
+
+// Scope types an assignment may carry. "inherit" follows the role's default
+// scope; "global" is unscoped. Both carry no target.
+export const ASSIGNMENT_SCOPE_TYPES = [
+  "global",
+  "connection",
+  "node",
+  "vm",
+  "tag",
+  "pool",
+  "inherit",
+] as const
+
+// Scope types valid as a role's default scope. Excludes "global" (expressed as
+// an empty list) and "inherit" (a role cannot inherit from itself).
+export const ROLE_DEFAULT_SCOPE_TYPES = ["connection", "node", "vm", "tag", "pool"] as const
+
+const NO_TARGET = new Set<string>(["global", "inherit"])
+
+export type ScopeEntry = { scopeType: string; scopeTarget: string }
+
+/**
+ * Validate a single assignment scope. global/inherit carry no target (any
+ * supplied target is dropped); every other type requires a non-empty target.
+ */
+export function validateAssignmentScope(
+  scopeType: string,
+  scopeTarget: string | null | undefined,
+): { ok: boolean; error?: string; scopeType?: string; scopeTarget?: string | null } {
+  if (!ASSIGNMENT_SCOPE_TYPES.includes(scopeType as (typeof ASSIGNMENT_SCOPE_TYPES)[number])) {
+    return { ok: false, error: "scope_type invalide" }
+  }
+  if (NO_TARGET.has(scopeType)) {
+    return { ok: true, scopeType, scopeTarget: null }
+  }
+  if (!scopeTarget) {
+    return { ok: false, error: "scope_target requis pour ce type de scope" }
+  }
+  return { ok: true, scopeType, scopeTarget }
+}
+
+/**
+ * Validate a role's default_scopes payload. Accepts an array of
+ * { scopeType, scopeTarget } (snake_case keys are also accepted) and returns a
+ * normalized camelCase list. An empty array clears the default scope (global).
+ */
+export function validateRoleDefaultScopes(
+  input: unknown,
+): { ok: boolean; error?: string; scopes?: ScopeEntry[] } {
+  if (!Array.isArray(input)) {
+    return { ok: false, error: "default_scopes doit être un tableau" }
+  }
+  const scopes: ScopeEntry[] = []
+  for (const raw of input) {
+    if (!raw || typeof raw !== "object") {
+      return { ok: false, error: "entrée default_scopes invalide" }
+    }
+    const r = raw as Record<string, unknown>
+    const scopeType = (r.scopeType ?? r.scope_type) as string
+    const scopeTarget = (r.scopeTarget ?? r.scope_target) as string
+    if (!ROLE_DEFAULT_SCOPE_TYPES.includes(scopeType as (typeof ROLE_DEFAULT_SCOPE_TYPES)[number])) {
+      return { ok: false, error: `scopeType de default_scope invalide: ${String(scopeType)}` }
+    }
+    if (!scopeTarget || typeof scopeTarget !== "string") {
+      return { ok: false, error: "scopeTarget requis pour chaque default_scope" }
+    }
+    scopes.push({ scopeType, scopeTarget })
+  }
+  return { ok: true, scopes }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -3025,7 +3025,8 @@
       "vmct": "VM/CT",
       "clusterConnection": "Cluster / Verbindung",
       "tag": "Tag",
-      "pool": "Pool"
+      "pool": "Pool",
+      "inherit": "Von Rolle geerbt"
     },
     "cannotModifySystem": "Systemrolle kann nicht geändert werden",
     "cannotDeleteSystem": "Cannot löschen a system role",
@@ -4828,6 +4829,11 @@
       "title": "Widget-Sichtbarkeit",
       "desc": "Widgets ankreuzen, die für Benutzer mit dieser Rolle ausgeblendet werden sollen. Zusätzlich zum automatischen Scope-Filter.",
       "hiddenCount": "{count} ausgeblendet"
+    },
+    "defaultScope": {
+      "title": "Standard-Geltungsbereich",
+      "desc": "Zuweisungen, die von dieser Rolle erben, sehen nur Ressourcen, die diesem Bereich entsprechen. Leer lassen für globalen Zugriff. Nur benutzerdefinierte Rollen.",
+      "none": "Kein Standard-Geltungsbereich (globaler Zugriff)."
     },
     "globalScope": "Global",
     "tagScope": "Tag",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3065,7 +3065,8 @@
       "vmct": "VM/CT",
       "clusterConnection": "Cluster / Connection",
       "tag": "Tag",
-      "pool": "Pool"
+      "pool": "Pool",
+      "inherit": "Inherited from role"
     },
     "cannotModifySystem": "Cannot modify a system role",
     "cannotDeleteSystem": "Cannot delete a system role",
@@ -4874,6 +4875,11 @@
       "title": "Widget visibility",
       "desc": "Tick widgets to hide from the dashboard for users with this role. Stacks on top of the automatic scope-based filter.",
       "hiddenCount": "{count} hidden"
+    },
+    "defaultScope": {
+      "title": "Default scope",
+      "desc": "Assignments that inherit from this role only see resources matching this scope. Leave empty for global access. Custom roles only.",
+      "none": "No default scope (global access)."
     },
     "globalScope": "Global",
     "tagScope": "Tag",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -3065,7 +3065,8 @@
       "vmct": "VM/CT",
       "clusterConnection": "Cluster / Connexion",
       "tag": "Tag",
-      "pool": "Pool"
+      "pool": "Pool",
+      "inherit": "Hérité du rôle"
     },
     "cannotModifySystem": "Impossible de modifier un rôle système",
     "cannotDeleteSystem": "Impossible de supprimer un rôle système",
@@ -4874,6 +4875,11 @@
       "title": "Visibilité des widgets",
       "desc": "Cochez les widgets à masquer sur le tableau de bord pour les utilisateurs portant ce rôle. S'ajoute au filtre automatique par scope.",
       "hiddenCount": "{count} masqué(s)"
+    },
+    "defaultScope": {
+      "title": "Périmètre par défaut",
+      "desc": "Les assignations qui héritent de ce rôle ne voient que les ressources correspondant à ce périmètre. Laissez vide pour un accès global. Rôles personnalisés uniquement.",
+      "none": "Aucun périmètre par défaut (accès global)."
     },
     "globalScope": "Global",
     "tagScope": "Tag",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -3027,7 +3027,8 @@
       "vmct": "VM/CT",
       "clusterConnection": "集群 / 连接",
       "tag": "标签",
-      "pool": "资源池"
+      "pool": "资源池",
+      "inherit": "继承自角色"
     },
     "cannotModifySystem": "无法修改系统角色",
     "cannotDeleteSystem": "无法删除系统角色",
@@ -4833,6 +4834,11 @@
       "title": "小组件可见性",
       "desc": "勾选要为此角色用户隐藏的小组件。叠加于按 Scope 自动过滤之上。",
       "hiddenCount": "已隐藏 {count} 个"
+    },
+    "defaultScope": {
+      "title": "默认范围",
+      "desc": "继承此角色的分配仅可见与此范围匹配的资源。留空表示全局访问。仅自定义角色。",
+      "none": "无默认范围（全局访问）。"
     },
     "globalScope": "全局",
     "tagScope": "标签",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -71,6 +71,12 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   cannot render. The only real logic added with the backup-time fix (PBS
 #   snapshot name building and the pbs-<type> format label) was extracted to
 #   lib/backups/snapshotDisplay.ts, which stays measured and is fully covered.
+# - security/rbac/RoleDefaultScopeEditor.tsx: the role default-scope picker
+#   (issue #383) is a pure-JSX MUI form (type/target Selects + Chip list) whose
+#   only logic — turning the live inventory into pickable options — was
+#   extracted to security/rbac/scope-options.ts, which stays measured and is
+#   covered by scope-options.test.ts. The remaining add/remove handlers are
+#   React-state array splices that the node-env Vitest suite cannot render.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -101,7 +107,8 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/operations/reports/components/ReportHistory.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ReportGenerator.tsx,\
   frontend/src/contexts/TenantContext.tsx,\
-  frontend/src/components/settings/NotificationsTab.jsx
+  frontend/src/components/settings/NotificationsTab.jsx,\
+  frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
## Summary

Implements role-level default RBAC scope (issue #383): a scope (tag / pool / node / connection / vm) can be set on a custom role, and its assignments inherit that scope automatically, especially through SSO group mapping. Enterprise, frontend-only.

## How it works

- New `inherit` sentinel on an assignment's scope type. `resolveEffectiveScopes` expands it to the role's `default_scopes` (or global when the role has none) at permission-check time, inside `loadUserGrants`, so every `byScope` consumer honours it with no change to the grant shape. The separate resolver used by the effective-permissions route was updated the same way.
- Roles gain a `default_scopes` JSONB column, allowed on custom roles only. System roles reject it, since their super-admin shortcuts bypass scope resolution and a scope there would be silently ignored.
- A shared scope validator backs both the roles and the assignments routes.

## SSO and creators

- LDAP/OIDC sync now creates `inherit` assignments and keys its delete/replace on the `ldap_`/`oidc_` id prefix, so manually-created assignments are never clobbered.
- The migration converts existing SSO `global` rows to `inherit`. This is additive: with no role default, `inherit` resolves to global, identical to the previous behaviour, so existing deployments see no change.
- Manual creators (assignments, users, tenants) default to `inherit`.

## UI

- Role dialog gains a default-scope editor (scope type + resource picker).
- Both assignment dialogs expose the `inherit` option.
- Role cards redesigned: permissions summarised by category, default scope shown with resolved (human-readable) names, and a tinted role-coloured header of uniform height.

## Semantics

Live propagation (resolved at check time, no snapshot) and additive (no deny, no ceiling).

## Tests

41 new tests, full suite 917 green. New-code line coverage ~95% (verified locally against the Sonar gate). VM listing in the inventory is correctly narrowed to the role's inherited scope.

## Out of scope (tracked separately)

RBAC resource-scope enforcement on the operations pages (changes / alerts / reports, which today filter by vDC scope plus a permission gate only) and permission-based gating of the inventory UI tabs are pre-existing behaviours, not changed here.

Refs #383
