### PR TITLE
fix(migrate): offer local migration from the cluster Guests tab (#381)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   TAG_PALETTE,
   hashStringToInt,
@@ -16,6 +16,7 @@ import {
   getMetricIcon,
   pickNumber,
   buildSeriesFromRrd,
+  fetchDetails,
 } from './helpers'
 
 /* ------------------------------------------------------------------ */
@@ -529,5 +530,54 @@ describe('buildSeriesFromRrd', () => {
   it('extracts loadavg', () => {
     const result = buildSeriesFromRrd([{ time: 1, loadavg: 2.5 }])
     expect(result[0].loadAvg).toBe(2.5)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* fetchDetails — cluster pivot tags allVms with isCluster (issue #381) */
+/* ------------------------------------------------------------------ */
+
+describe('fetchDetails — cluster allVms isCluster', () => {
+  const connId = 'conn1'
+
+  const jsonRes = (body: any, ok = true) => ({ ok, json: async () => body }) as Response
+
+  // Route the 5 parallel cluster-pivot fetches by URL. Only the node list
+  // varies between tests; the single guest lives on a multi-node cluster.
+  function stubFetch(nodes: any[]) {
+    vi.stubGlobal('fetch', vi.fn((input: any) => {
+      const url = String(input)
+      if (url.includes('/nodes')) return Promise.resolve(jsonRes({ data: nodes }))
+      if (url.includes('/resources')) return Promise.resolve(jsonRes({ data: [
+        { node: 'pve-2-2', vmid: 20004, type: 'qemu', name: 'RDSLic02-W2022', status: 'running' },
+      ] }))
+      if (url.includes('/ceph/status')) return Promise.resolve(jsonRes({ data: { health: 'HEALTH_OK' } }))
+      if (url.includes('/storage')) return Promise.resolve(jsonRes({ data: [] }))
+      return Promise.resolve(jsonRes({ data: { name: 'PVE-2' } })) // bare /connections/:id
+    }))
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('flags allVms entries as isCluster on a multi-node cluster', async () => {
+    stubFetch([
+      { node: 'pve-2-1', status: 'online' },
+      { node: 'pve-2-2', status: 'online' },
+    ])
+
+    const payload = await fetchDetails({ type: 'cluster', id: connId } as any)
+
+    expect(payload?.allVms).toHaveLength(1)
+    expect(payload?.allVms?.[0].isCluster).toBe(true)
+  })
+
+  it('leaves isCluster false for a single-node (standalone) connection', async () => {
+    stubFetch([{ node: 'pve-2-1', status: 'online' }])
+
+    const payload = await fetchDetails({ type: 'cluster', id: connId } as any)
+
+    expect(payload?.allVms?.[0].isCluster).toBe(false)
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -566,6 +566,7 @@ export async function fetchDetails(sel: InventorySelection): Promise<DetailsPayl
       maxdisk: Number(g.maxdisk ?? 0),
       uptime: Number(g.uptime ?? 0),
       tags: parseTags(g.tags),
+      isCluster: nodes.length > 1,
       lock: g.lock,
     }))
 


### PR DESCRIPTION
## Problem

Migrating a VM from **Inventory > Cluster > Guests** offered **cross-cluster migration only**, even when the VM lives on a multi-node cluster. The exact same VM, reached via **Inventory > Host > Guests**, correctly offered both **Local** and **Cross-cluster** migration.

Reported in #381 and reproduced locally: select the cluster node in the left tree → Guests tab → migrate icon shows cross only; select a host of that cluster → Guests tab → migrate icon shows local + cross.

## Root cause

The Guests table is built from the `fetchDetails` payload, which differs by the selected tree node:

- **Host pivot** builds `vmsData` rows **with** `isCluster`.
- **Cluster pivot** builds `allVms` rows **without** `isCluster`.

`MigrateVmDialog` only renders the Local tab when `isCluster === true`. The migrate handler reads `vm.isCluster ?? false`, so the cluster rows fell back to `false` and forced the cross-cluster tab.

`DetailsPayload.allVms` already declared `isCluster?: boolean` in the type — it was simply never populated in the cluster branch.

## Fix

Populate `isCluster: nodes.length > 1` on the cluster `allVms` rows, mirroring the node pivot and using the same `/nodes` source. A standalone host (single node) still resolves to `false`, so it keeps the cross-cluster-only behavior.

## Tests

Adds `fetchDetails` tests (mocked `fetch`) asserting `allVms` rows carry `isCluster: true` on a multi-node cluster and `false` on a single-node connection.