### PR TITLE
feat(inventory): resolve guest VLANs from host bond sub-interfaces

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isSharedStorage } from '@/lib/proxmox/storage'
+import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
 
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
 import { 
@@ -2379,7 +2380,9 @@ return favorites.has(vmKey)
           const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/networks`)
           if (!res.ok) return []
           const json = await res.json()
-          return (json.data || []).map((vm: any) => ({ ...vm, connId }))
+          // Fold each guest's server-computed host VLAN into `tag` so the VLAN tree resolves
+          // traditional bondX.N-bridge layouts instead of bucketing them Untagged (see helper).
+          return (json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))
         } catch { return [] }
       })
     ).then((results) => {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
@@ -23,6 +23,7 @@ import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 import VnetsSection from './VnetsSection'
 import { useTenant } from '@/contexts/TenantContext'
+import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
 
 type VmNetData = {
   vmid: string
@@ -294,7 +295,9 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
           const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/networks`)
           if (!res.ok) return []
           const json = await res.json()
-          return (json.data || []).map((vm: any) => ({ ...vm, connId }))
+          // Fold each guest's server-computed host VLAN into `tag` so the VLAN KPI and
+          // breakdown count traditional bondX.N-bridge layouts, not just NIC-tagged guests.
+          return (json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))
         } catch { return [] }
       })
     ).then((results) => {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import type { InventorySelection } from '../types'
+import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
 
 type NetIface = { id: string; model: string; bridge: string; macaddr?: string; tag?: number; firewall?: boolean; rate?: number }
 type VmNet = { vmid: string; name: string; node: string; type: string; status: string; connId?: string; nets: NetIface[] }
@@ -46,7 +47,9 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     setLoading(true)
     fetch(`/api/v1/connections/${encodeURIComponent(connId)}/networks`)
       .then(r => r.json())
-      .then(json => setNetData((json.data || []).map((vm: any) => ({ ...vm, connId }))))
+      // Fold each guest's server-computed host VLAN into `tag` so guests on a
+      // bondX.N bridge with no per-NIC tag group under their real VLAN (see helper).
+      .then(json => setNetData((json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))))
       .catch(() => setNetData([]))
       .finally(() => setLoading(false))
   }, [connId])

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const getVdcScopeMock = vi.fn<(tenantId?: string) => Promise<any>>()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { VM_VIEW: 'vm.view' },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: pveFetchMock,
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: async () => 'tenant-1',
+}))
+
+vi.mock('@/lib/vdc/scope', () => ({
+  getVdcScope: getVdcScopeMock,
+}))
+
+// DRO34's node network (discussion #389): one bridge per VLAN over bond
+// sub-interfaces, plus a raw-trunk bridge that must stay Untagged.
+const HOST_NETWORK = [
+  { iface: 'bond0', type: 'bond' },
+  { iface: 'bond0.10', type: 'vlan' },
+  { iface: 'vmbr0V10', type: 'bridge', bridge_ports: 'bond0.10', bridge_vlan_aware: 1 },
+  { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+]
+
+const RESOURCES = [
+  { vmid: 100, node: 'pve1', type: 'qemu', name: 'tagged-nic', status: 'running' },
+  { vmid: 101, node: 'pve1', type: 'qemu', name: 'host-vlan', status: 'running' },
+  { vmid: 102, node: 'pve1', type: 'qemu', name: 'raw-trunk', status: 'stopped' },
+]
+
+const CONFIGS: Record<string, any> = {
+  '/nodes/pve1/qemu/100/config': { net0: 'virtio=AA:BB:CC:00:00:01,bridge=vmbrX,tag=200' },
+  '/nodes/pve1/qemu/101/config': { net0: 'virtio=AA:BB:CC:00:00:02,bridge=vmbr0V10' },
+  '/nodes/pve1/qemu/102/config': { net0: 'virtio=AA:BB:CC:00:00:03,bridge=vmbr0' },
+}
+
+function wireProxmox() {
+  pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+    if (path === '/cluster/resources?type=vm') return RESOURCES
+    if (path === '/nodes/pve1/network') return HOST_NETWORK
+    if (path in CONFIGS) return CONFIGS[path]
+    throw new Error(`unexpected pveFetch path: ${path}`)
+  })
+}
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ baseUrl: 'https://10.0.0.1:8006', apiToken: 'tok=secret' })
+  pveFetchMock.mockReset()
+  getVdcScopeMock.mockReset().mockResolvedValue(null)
+})
+
+async function importGET() {
+  const mod = await import('./route')
+  return mod.GET as Parameters<typeof callRoute>[0]
+}
+
+function netOf(body: any, vmid: string) {
+  const vm = body.data.find((v: any) => String(v.vmid) === vmid)
+  return vm.nets[0]
+}
+
+describe('GET /api/v1/connections/[id]/networks — effectiveTag', () => {
+  it('keeps the per-NIC tag as the effective VLAN', async () => {
+    wireProxmox()
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    const net = netOf(body, '100')
+    expect(net.tag).toBe(200)
+    expect(net.effectiveTag).toBe(200)
+  })
+
+  it('resolves an untagged guest VLAN from its host bridge sub-interface', async () => {
+    wireProxmox()
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    const net = netOf(body, '101')
+    expect(net.tag).toBeUndefined()
+    expect(net.effectiveTag).toBe(10)
+  })
+
+  it('leaves an untagged guest on a raw-trunk bridge as untagged', async () => {
+    wireProxmox()
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    const net = netOf(body, '102')
+    expect(net.tag).toBeUndefined()
+    expect(net.effectiveTag).toBeUndefined()
+  })
+
+  it('still succeeds when a node network fetch fails (no effectiveTag enrichment)', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return RESOURCES
+      if (path === '/nodes/pve1/network') throw new Error('network unreachable')
+      if (path in CONFIGS) return CONFIGS[path]
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    // NIC tag still resolves; host-VLAN guest falls back to undefined.
+    expect(netOf(body, '100').effectiveTag).toBe(200)
+    expect(netOf(body, '101').effectiveTag).toBeUndefined()
+  })
+
+  it('returns 400 when the connection id is missing', async () => {
+    const res = await callRoute(await importGET(), { params: { id: '' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('propagates an RBAC denial', async () => {
+    checkPermissionMock.mockResolvedValue(new Response('forbidden', { status: 403 }))
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('parseNetString', () => {
+  it('parses model, mac, bridge, tag, firewall and rate from a net string', async () => {
+    const { parseNetString } = await import('./route')
+    const iface = parseNetString('net0', 'virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,tag=100,firewall=1,rate=10')
+    expect(iface).toMatchObject({
+      id: 'net0',
+      model: 'virtio',
+      macaddr: 'AA:BB:CC:DD:EE:FF',
+      bridge: 'vmbr0',
+      tag: 100,
+      firewall: true,
+      rate: 10,
+    })
+  })
+
+  it('handles an explicit macaddr= and a missing tag', async () => {
+    const { parseNetString } = await import('./route')
+    const iface = parseNetString('net1', 'e1000=00:11:22:33:44:55,bridge=vmbr1')
+    expect(iface.model).toBe('e1000')
+    expect(iface.macaddr).toBe('00:11:22:33:44:55')
+    expect(iface.bridge).toBe('vmbr1')
+    expect(iface.tag).toBeUndefined()
+    expect(iface.firewall).toBeUndefined()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.ts
@@ -5,6 +5,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getVdcScope } from "@/lib/vdc/scope"
+import { buildBridgeVlanMap, resolveEffectiveTag } from "@/lib/proxmox/hostVlanMap"
 
 export const runtime = "nodejs"
 
@@ -18,6 +19,12 @@ type NetIface = {
   bridge: string
   macaddr?: string
   tag?: number
+  /**
+   * VLAN the guest actually rides: the per-NIC `tag` when present, otherwise the
+   * VLAN derived from the host bridge it attaches to (traditional `bondX.N`
+   * sub-interface layouts). Undefined when the guest is genuinely untagged.
+   */
+  effectiveTag?: number
   firewall?: boolean
   rate?: number
 }
@@ -35,7 +42,7 @@ type VmNet = {
  * Parse a Proxmox net string like:
  *   "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,tag=100,firewall=1,rate=10"
  */
-function parseNetString(id: string, raw: string): NetIface {
+export function parseNetString(id: string, raw: string): NetIface {
   const parts = raw.split(",")
   const iface: NetIface = { id, model: "unknown", bridge: "unknown" }
 
@@ -106,6 +113,26 @@ export async function GET(_req: Request, ctx: RouteContext) {
         : []
     }
 
+    // Build a per-node `bridge -> VLAN` map from each node's host networking.
+    // This lets us resolve the effective VLAN of guests on the traditional
+    // layout (a `bondX.N` sub-interface feeding a dedicated bridge), which carry
+    // no per-NIC tag and would otherwise all show up as Untagged (discussion #389).
+    const nodeNames = [...new Set(
+      resources.map((vm: any) => vm?.node).filter((n: any): n is string => typeof n === "string" && n.length > 0)
+    )]
+    const bridgeVlanByNode = new Map<string, Map<string, number>>()
+    await Promise.all(
+      nodeNames.map(async (node) => {
+        try {
+          const ifaces = await pveFetch<any[]>(conn, `/nodes/${encodeURIComponent(node)}/network`)
+          bridgeVlanByNode.set(node, buildBridgeVlanMap(Array.isArray(ifaces) ? ifaces : []))
+        } catch {
+          // Host network unavailable for this node — guests fall back to NIC tags only.
+          bridgeVlanByNode.set(node, new Map())
+        }
+      })
+    )
+
     // Batch fetch configs with concurrency limit
     const CONCURRENCY = 15
     const results: VmNet[] = []
@@ -124,11 +151,14 @@ export async function GET(_req: Request, ctx: RouteContext) {
               `/nodes/${encodeURIComponent(node)}/${vmType}/${encodeURIComponent(vmid)}/config`
             )
 
+            const bridgeVlanMap = bridgeVlanByNode.get(node) ?? new Map<string, number>()
             const nets: NetIface[] = []
             if (config) {
               for (const [key, val] of Object.entries(config)) {
                 if (/^net\d+$/.test(key) && typeof val === "string") {
-                  nets.push(parseNetString(key, val))
+                  const iface = parseNetString(key, val)
+                  iface.effectiveTag = resolveEffectiveTag(iface.tag, iface.bridge, bridgeVlanMap)
+                  nets.push(iface)
                 }
               }
             }

--- a/frontend/src/lib/proxmox/hostVlanMap.test.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  parseVlanTag,
+  buildBridgeVlanMap,
+  resolveEffectiveTag,
+  foldEffectiveVlanTags,
+  type HostNetIface,
+} from './hostVlanMap'
+
+// DRO34's cluster (discussion #389): traditional VLAN segmentation with one
+// bridge per VLAN, each fed by a bond sub-interface. No per-NIC tags on guests.
+const DRO34_IFACES: HostNetIface[] = [
+  { iface: 'bond0', type: 'bond' },
+  { iface: 'bond0.5', type: 'vlan' },
+  { iface: 'bond0.10', type: 'vlan' },
+  { iface: 'bond1', type: 'bond' },
+  { iface: 'bond1.7', type: 'vlan' },
+  { iface: 'vmbr0V5', type: 'bridge', bridge_ports: 'bond0.5', bridge_vlan_aware: 1 },
+  { iface: 'vmbr0V10', type: 'bridge', bridge_ports: 'bond0.10', bridge_vlan_aware: 1 },
+  { iface: 'vmbr1V7', type: 'bridge', bridge_ports: 'bond1.7', bridge_vlan_aware: 1 },
+]
+
+describe('parseVlanTag', () => {
+  it('extracts the VLAN id from a bond sub-interface name', () => {
+    expect(parseVlanTag('bond0.10')).toBe(10)
+    expect(parseVlanTag('bond1.7')).toBe(7)
+  })
+
+  it('extracts the VLAN id from a physical NIC sub-interface name', () => {
+    expect(parseVlanTag('eno1.100')).toBe(100)
+    expect(parseVlanTag('enp3s0.4094')).toBe(4094)
+  })
+
+  it('returns null for a non-VLAN interface (no numeric suffix)', () => {
+    expect(parseVlanTag('bond0')).toBeNull()
+    expect(parseVlanTag('vmbr0')).toBeNull()
+    expect(parseVlanTag('eno1')).toBeNull()
+  })
+
+  it('does not treat a bridge name with an embedded digit as a VLAN', () => {
+    // vmbr0V10 is just a bridge name; the VLAN comes from its uplink, not the name
+    expect(parseVlanTag('vmbr0V10')).toBeNull()
+  })
+
+  it('rejects VLAN ids outside the valid 1-4094 range', () => {
+    expect(parseVlanTag('bond0.0')).toBeNull()
+    expect(parseVlanTag('bond0.4095')).toBeNull()
+    expect(parseVlanTag('bond0.9999')).toBeNull()
+  })
+
+  it('returns null for empty or non-string input', () => {
+    expect(parseVlanTag('')).toBeNull()
+    expect(parseVlanTag(undefined as unknown as string)).toBeNull()
+  })
+})
+
+describe('buildBridgeVlanMap', () => {
+  it("maps DRO34's per-VLAN bridges to their bond sub-interface VLAN", () => {
+    const map = buildBridgeVlanMap(DRO34_IFACES)
+    expect(map.get('vmbr0V5')).toBe(5)
+    expect(map.get('vmbr0V10')).toBe(10)
+    expect(map.get('vmbr1V7')).toBe(7)
+    expect(map.size).toBe(3)
+  })
+
+  it('does not map a bridge whose uplink is a raw trunk (no sub-interface)', () => {
+    // A genuinely VLAN-aware bridge trunking the whole bond carries many VLANs,
+    // so untagged guests on it must stay Untagged.
+    const map = buildBridgeVlanMap([
+      { iface: 'bond0', type: 'bond' },
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+    ])
+    expect(map.has('vmbr0')).toBe(false)
+    expect(map.size).toBe(0)
+  })
+
+  it('maps a bridge when all uplink ports agree on the same VLAN', () => {
+    const map = buildBridgeVlanMap([
+      { iface: 'vmbr2', type: 'bridge', bridge_ports: 'bond0.30 bond1.30' },
+    ])
+    expect(map.get('vmbr2')).toBe(30)
+  })
+
+  it('does not map a bridge whose uplink ports disagree on the VLAN', () => {
+    const map = buildBridgeVlanMap([
+      { iface: 'vmbr3', type: 'bridge', bridge_ports: 'bond0.10 bond1.20' },
+    ])
+    expect(map.has('vmbr3')).toBe(false)
+  })
+
+  it('resolves the VLAN from an explicit vlan-id field when the name is opaque', () => {
+    const map = buildBridgeVlanMap([
+      { iface: 'vlanA', type: 'vlan', 'vlan-id': 42, 'vlan-raw-device': 'bond0' },
+      { iface: 'vmbr4', type: 'bridge', bridge_ports: 'vlanA' },
+    ])
+    expect(map.get('vmbr4')).toBe(42)
+  })
+
+  it('handles OVS bridges via ovs_ports', () => {
+    const map = buildBridgeVlanMap([
+      { iface: 'vmbr5', type: 'OVSBridge', ovs_ports: 'bond0.55' },
+    ])
+    expect(map.get('vmbr5')).toBe(55)
+  })
+
+  it('ignores bridges with no ports and tolerates missing fields', () => {
+    const map = buildBridgeVlanMap([
+      { iface: 'vmbr6', type: 'bridge' },
+      { iface: 'lo', type: 'loopback' },
+    ])
+    expect(map.size).toBe(0)
+  })
+
+  it('returns an empty map for empty or non-array input', () => {
+    expect(buildBridgeVlanMap([]).size).toBe(0)
+    expect(buildBridgeVlanMap(undefined as unknown as HostNetIface[]).size).toBe(0)
+  })
+})
+
+describe('resolveEffectiveTag', () => {
+  const map = buildBridgeVlanMap(DRO34_IFACES)
+
+  it('returns the host bridge VLAN for an untagged guest NIC', () => {
+    expect(resolveEffectiveTag(undefined, 'vmbr0V10', map)).toBe(10)
+    expect(resolveEffectiveTag(undefined, 'vmbr1V7', map)).toBe(7)
+  })
+
+  it('prefers an explicit per-NIC tag over the host bridge VLAN', () => {
+    // Double-tag is unusual, but an explicit NIC tag is the authoritative intent.
+    expect(resolveEffectiveTag(99, 'vmbr0V10', map)).toBe(99)
+  })
+
+  it('returns the NIC tag when the bridge is unknown', () => {
+    expect(resolveEffectiveTag(20, 'someOtherBridge', map)).toBe(20)
+  })
+
+  it('returns undefined for an untagged guest on an unmapped bridge', () => {
+    expect(resolveEffectiveTag(undefined, 'vmbr0', map)).toBeUndefined()
+    expect(resolveEffectiveTag(undefined, undefined, map)).toBeUndefined()
+  })
+})
+
+describe('foldEffectiveVlanTags', () => {
+  type Net = { bridge: string; tag?: number; effectiveTag?: number }
+
+  it('folds the host-derived effectiveTag into tag for grouping', () => {
+    const folded = foldEffectiveVlanTags<Net>([
+      { bridge: 'vmbr0V10', effectiveTag: 10 },
+      { bridge: 'vmbrX', tag: 200, effectiveTag: 200 },
+    ])
+    expect(folded[0].tag).toBe(10)
+    expect(folded[1].tag).toBe(200)
+  })
+
+  it('leaves a genuinely untagged net without a tag', () => {
+    const folded = foldEffectiveVlanTags<Net>([{ bridge: 'vmbr0' }])
+    expect(folded[0].tag).toBeUndefined()
+  })
+
+  it('is null-safe', () => {
+    expect(foldEffectiveVlanTags(undefined)).toEqual([])
+  })
+})

--- a/frontend/src/lib/proxmox/hostVlanMap.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.ts
@@ -1,0 +1,119 @@
+/**
+ * Host-level VLAN resolution for the inventory Network view.
+ *
+ * Proxmox guests can land on a VLAN in two ways:
+ *  - VLAN-aware-bridge model: the guest NIC carries a `tag=N` in its net string
+ *    (handled upstream by parseNetString).
+ *  - Traditional model: a VLAN sub-interface on a bond (`bondX.N`) feeds a
+ *    dedicated bridge, and guests attach to that bridge with no per-NIC tag.
+ *
+ * The inventory Network view historically only saw the first model, so guests
+ * using the traditional layout (discussion #389) all showed up as "Untagged".
+ * These helpers derive a bridge -> VLAN map from the node's network config so an
+ * untagged guest's effective VLAN can be resolved from the bridge it attaches to.
+ */
+
+/** Minimal shape of a Proxmox `/nodes/{node}/network` interface entry. */
+export type HostNetIface = {
+  iface: string
+  type?: string
+  bridge_ports?: string
+  ovs_ports?: string
+  'vlan-id'?: number | string
+  vlan_id?: number | string
+  bridge_vlan_aware?: number | boolean
+  [key: string]: unknown
+}
+
+/**
+ * Parse the VLAN id from a sub-interface name such as `bond0.10` or `eno1.100`.
+ * Returns null when the name has no numeric VLAN suffix or the id is out of the
+ * valid 1-4094 range. A bridge name like `vmbr0V10` is NOT a VLAN sub-interface
+ * (no `.N` suffix), so it returns null on purpose.
+ */
+export function parseVlanTag(name: string): number | null {
+  if (typeof name !== 'string') return null
+  const m = /\.(\d+)$/.exec(name)
+  if (!m) return null
+  const id = Number.parseInt(m[1], 10)
+  if (!Number.isInteger(id) || id < 1 || id > 4094) return null
+  return id
+}
+
+/** The VLAN id an interface represents, preferring an explicit field over the name. */
+function vlanIdOf(iface: HostNetIface): number | null {
+  const explicit = iface['vlan-id'] ?? iface.vlan_id
+  if (explicit != null && explicit !== '') {
+    const id = Number.parseInt(String(explicit), 10)
+    if (Number.isInteger(id) && id >= 1 && id <= 4094) return id
+  }
+  return parseVlanTag(iface.iface)
+}
+
+/**
+ * Build a `bridgeName -> vlanId` map from a node's network interfaces.
+ *
+ * A bridge is mapped only when ALL of its uplink ports resolve to the SAME
+ * single VLAN. A raw-trunk uplink (e.g. `bridge_ports bond0`, no `.N`) resolves
+ * to nothing, so a genuinely multi-VLAN bridge is left unmapped and its untagged
+ * guests correctly stay Untagged. Ambiguous (conflicting) ports are also skipped.
+ */
+export function buildBridgeVlanMap(ifaces: HostNetIface[]): Map<string, number> {
+  const map = new Map<string, number>()
+  if (!Array.isArray(ifaces)) return map
+
+  // Index every interface by name -> its VLAN id (for ports that reference a
+  // named vlan iface whose VLAN lives in an explicit field, not the name).
+  const vlanByName = new Map<string, number>()
+  for (const iface of ifaces) {
+    if (!iface || typeof iface.iface !== 'string') continue
+    const id = vlanIdOf(iface)
+    if (id != null) vlanByName.set(iface.iface, id)
+  }
+
+  for (const iface of ifaces) {
+    if (!iface || typeof iface.iface !== 'string') continue
+    if (iface.type !== 'bridge' && iface.type !== 'OVSBridge') continue
+
+    const raw = String(iface.bridge_ports ?? iface.ovs_ports ?? '').trim()
+    if (!raw) continue
+    const ports = raw.split(/\s+/).filter(Boolean)
+
+    const vlans = new Set<number>()
+    for (const port of ports) {
+      const id = vlanByName.get(port) ?? parseVlanTag(port)
+      if (id != null) vlans.add(id)
+    }
+    if (vlans.size === 1) map.set(iface.iface, [...vlans][0])
+  }
+
+  return map
+}
+
+/**
+ * Resolve a guest NIC's effective VLAN: an explicit per-NIC tag always wins;
+ * otherwise fall back to the host VLAN of the bridge it attaches to. Returns
+ * undefined when neither is known (the guest is genuinely untagged).
+ */
+export function resolveEffectiveTag(
+  nicTag: number | undefined,
+  bridge: string | undefined,
+  bridgeVlanMap: Map<string, number>,
+): number | undefined {
+  if (nicTag != null) return nicTag
+  if (bridge) return bridgeVlanMap.get(bridge)
+  return undefined
+}
+
+/**
+ * Client-side boundary helper: fold each net's server-computed `effectiveTag`
+ * into `tag` so the inventory VLAN grouping (tree, dashboard, detail panel)
+ * resolves traditional `bondX.N`-bridge layouts instead of bucketing untagged
+ * guests under Untagged. Applied once where the `/networks` payload is read so
+ * every downstream grouping site stays a single `tag`-based code path. Null-safe.
+ */
+export function foldEffectiveVlanTags<T extends { tag?: number; effectiveTag?: number }>(
+  nets: T[] | undefined,
+): T[] {
+  return (nets ?? []).map((n) => ({ ...n, tag: n.effectiveTag ?? n.tag }))
+}


### PR DESCRIPTION
## Problem

Addresses discussion #389.

The inventory Network view derived a guest's VLAN only from its NIC `tag=` (the VLAN-aware-bridge model). Clusters that segment VLANs the traditional way, with bond sub-interfaces (`bond0.10`) each feeding a dedicated bridge, attach guests to those bridges with no per-NIC tag, so every guest showed up as "Untagged" and the VLAN counter reflected only the NIC-tagged ones.

## Fix

Resolve the effective VLAN server-side from the host bridge a guest attaches to:

- New `lib/proxmox/hostVlanMap.ts` builds a `bridge -> VLAN` map from a node's network. A bridge maps only when its uplink ports (`bridge_ports` / `ovs_ports`) agree on a single VLAN sub-interface. A raw-trunk uplink (e.g. `bridge_ports bond0`, no `.N`) stays unmapped, so a genuinely multi-VLAN bridge keeps its untagged guests Untagged.
- The `/networks` route fetches each node's network (parallel, fault-tolerant) and sets `effectiveTag = nicTag ?? hostVlan` on every NIC.
- The tree, dashboard and detail panel fold `effectiveTag` into `tag` at the fetch boundary through a shared helper, so all VLAN grouping stays a single code path.

## Validated against the reporter's layout

`vmbr0V5 -> bond0.5` (VLAN 5), `vmbr0V10 -> bond0.10` (VLAN 10), `vmbr1V7 -> bond1.7` (VLAN 7), all `bridge-vlan-aware yes` with a single tagged uplink. Guests now group under 5 / 7 / 10 instead of Untagged.

## Tests

- `hostVlanMap.test.ts`: name parser, map builder (incl. raw-trunk and conflicting-port cases), resolver, fold helper.
- `networks/route.test.ts` via `callRoute`: NIC tag preserved, host VLAN resolved for untagged guests, raw-trunk stays untagged, node-network fetch failure tolerated.
- Full suite green.