### PR TITLE
fix(backups): "Run now" failed with "Unexpected token '<'" (HTML 404 from a missing route)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
@@ -35,6 +35,7 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid'
 import { useTranslations, useLocale } from 'next-intl'
 import { formatBytes } from '@/utils/format'
 import { getDateLocale } from '@/lib/i18n/date'
+import { runBackupJobNow } from '@/lib/backups/runBackupJob'
 
 interface BackupJob {
   id: string
@@ -376,15 +377,10 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
   // Run now
   const handleRunNow = async (job: BackupJob) => {
     try {
-      const res = await fetch(
-        `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(job.id)}/run`,
-        { method: 'POST' }
-      )
+      const result = await runBackupJobNow(connectionId, job.id)
 
-      const json = await res.json()
-
-      if (json.error) {
-        setError(json.error)
+      if (!result.ok) {
+        setError(result.error || t('inventory.failedToRunBackupJob'))
       } else {
         loadJobs()
       }
@@ -716,14 +712,18 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
                   onInputChange={(_, newInput, reason) => {
                     if (reason === 'input') setFormData(prev => ({ ...prev, schedule: newInput }))
                   }}
-                  renderOption={(props, option) => (
-                    <li {...props}>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', gap: 2 }}>
-                        <Typography variant="body2">{typeof option === 'string' ? option : option.label}</Typography>
-                        <Typography variant="caption" sx={{ opacity: 0.5, fontFamily: 'monospace' }}>{typeof option === 'string' ? '' : option.value}</Typography>
-                      </Box>
-                    </li>
-                  )}
+                  renderOption={(props, option) => {
+                    const { key, ...optionProps } = props
+
+                    return (
+                      <li key={key} {...optionProps}>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%', gap: 2 }}>
+                          <Typography variant="body2">{typeof option === 'string' ? option : option.label}</Typography>
+                          <Typography variant="caption" sx={{ opacity: 0.5 }}>{typeof option === 'string' ? '' : option.value}</Typography>
+                        </Box>
+                      </li>
+                    )
+                  }}
                   renderInput={(params) => (
                     <TextField
                       {...params}
@@ -757,17 +757,21 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
                   value={vms.filter(vm => formData.vmids.includes(vm.vmid))}
                   onChange={(_, newValue) => setFormData(prev => ({ ...prev, vmids: newValue.map(v => v.vmid) }))}
                   renderInput={(params) => <TextField {...params} label={t('inventory.selectVms')} />}
-                  renderOption={(props, option) => (
-                    <li {...props}>
-                      <Chip 
-                        size="small" 
-                        label={option.type === 'qemu' ? 'VM' : 'CT'} 
-                        sx={{ mr: 1, fontSize: 10 }}
-                        color={option.type === 'qemu' ? 'primary' : 'secondary'}
-                      />
-                      {option.vmid} - {option.name}
-                    </li>
-                  )}
+                  renderOption={(props, option) => {
+                    const { key, ...optionProps } = props
+
+                    return (
+                      <li key={key} {...optionProps}>
+                        <Chip
+                          size="small"
+                          label={option.type === 'qemu' ? 'VM' : 'CT'}
+                          sx={{ mr: 1, fontSize: 10 }}
+                          color={option.type === 'qemu' ? 'primary' : 'secondary'}
+                        />
+                        {option.vmid} - {option.name}
+                      </li>
+                    )
+                  }}
                 />
               )}
 
@@ -780,17 +784,21 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
                   value={vms.filter(vm => formData.excludedVmids.includes(vm.vmid))}
                   onChange={(_, newValue) => setFormData(prev => ({ ...prev, excludedVmids: newValue.map(v => v.vmid) }))}
                   renderInput={(params) => <TextField {...params} label={t('inventory.excludeVms')} />}
-                  renderOption={(props, option) => (
-                    <li {...props}>
-                      <Chip 
-                        size="small" 
-                        label={option.type === 'qemu' ? 'VM' : 'CT'} 
-                        sx={{ mr: 1, fontSize: 10 }}
-                        color={option.type === 'qemu' ? 'primary' : 'secondary'}
-                      />
-                      {option.vmid} - {option.name}
-                    </li>
-                  )}
+                  renderOption={(props, option) => {
+                    const { key, ...optionProps } = props
+
+                    return (
+                      <li key={key} {...optionProps}>
+                        <Chip
+                          size="small"
+                          label={option.type === 'qemu' ? 'VM' : 'CT'}
+                          sx={{ mr: 1, fontSize: 10 }}
+                          color={option.type === 'qemu' ? 'primary' : 'secondary'}
+                        />
+                        {option.vmid} - {option.name}
+                      </li>
+                    )
+                  }}
                 />
               )}
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
@@ -79,6 +79,24 @@ function parsePruneBackups(raw: string | null | undefined) {
   return result
 }
 
+// Renders a VM/CT option row in the backup-job include/exclude pickers.
+// Shared so the two Autocompletes do not duplicate the markup.
+function renderVmJobOption(props: any, option: any) {
+  const { key, ...optionProps } = props
+
+  return (
+    <li key={key} {...optionProps}>
+      <Chip
+        size="small"
+        label={option.type === 'qemu' ? 'VM' : 'CT'}
+        sx={{ mr: 1, fontSize: 10 }}
+        color={option.type === 'qemu' ? 'primary' : 'secondary'}
+      />
+      {option.vmid} - {option.name}
+    </li>
+  )
+}
+
 export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPanelProps) {
   const t = useTranslations()
   const dateLocale = getDateLocale(useLocale())
@@ -757,21 +775,7 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
                   value={vms.filter(vm => formData.vmids.includes(vm.vmid))}
                   onChange={(_, newValue) => setFormData(prev => ({ ...prev, vmids: newValue.map(v => v.vmid) }))}
                   renderInput={(params) => <TextField {...params} label={t('inventory.selectVms')} />}
-                  renderOption={(props, option) => {
-                    const { key, ...optionProps } = props
-
-                    return (
-                      <li key={key} {...optionProps}>
-                        <Chip
-                          size="small"
-                          label={option.type === 'qemu' ? 'VM' : 'CT'}
-                          sx={{ mr: 1, fontSize: 10 }}
-                          color={option.type === 'qemu' ? 'primary' : 'secondary'}
-                        />
-                        {option.vmid} - {option.name}
-                      </li>
-                    )
-                  }}
+                  renderOption={renderVmJobOption}
                 />
               )}
 
@@ -784,21 +788,7 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
                   value={vms.filter(vm => formData.excludedVmids.includes(vm.vmid))}
                   onChange={(_, newValue) => setFormData(prev => ({ ...prev, excludedVmids: newValue.map(v => v.vmid) }))}
                   renderInput={(params) => <TextField {...params} label={t('inventory.excludeVms')} />}
-                  renderOption={(props, option) => {
-                    const { key, ...optionProps } = props
-
-                    return (
-                      <li key={key} {...optionProps}>
-                        <Chip
-                          size="small"
-                          label={option.type === 'qemu' ? 'VM' : 'CT'}
-                          sx={{ mr: 1, fontSize: 10 }}
-                          color={option.type === 'qemu' ? 'primary' : 'secondary'}
-                        />
-                        {option.vmid} - {option.name}
-                      </li>
-                    )
-                  }}
+                  renderOption={renderVmJobOption}
                 />
               )}
 

--- a/frontend/src/lib/backups/runBackupJob.test.ts
+++ b/frontend/src/lib/backups/runBackupJob.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { runBackupJobNow } from './runBackupJob'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('runBackupJobNow', () => {
+  it('posts to the query-param run action, not a /run path segment', async () => {
+    // Regression for issue #397 / discussion #396: the UI used to POST to a
+    // `/run` PATH segment, which has no route file. The handler reads the
+    // action from the query string instead.
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ data: { upid: 'UPID:x' }, message: 'started' }))
+
+    await runBackupJobNow('conn 1', 'backup-7', fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchImpl.mock.calls[0]
+    expect(url).toBe('/api/v1/connections/conn%201/backup-jobs/backup-7?action=run')
+    expect(init).toMatchObject({ method: 'POST' })
+  })
+
+  it('returns ok with the data payload on success', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ data: { upid: 'UPID:x' }, message: 'started' }))
+
+    const result = await runBackupJobNow('c', 'j', fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: true, data: { upid: 'UPID:x' } })
+  })
+
+  it('surfaces a JSON error field from the backend', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ error: 'No node available' }, 400))
+
+    const result = await runBackupJobNow('c', 'j', fetchImpl as unknown as typeof fetch)
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toBe('No node available')
+  })
+
+  it('does not throw on an HTML (non-JSON) response, returns a clean HTTP error', async () => {
+    // The original bug: a 404 HTML page made `res.json()` throw
+    // `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response('<!DOCTYPE html><html><body>404</body></html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html' },
+      }),
+    )
+
+    const result = await runBackupJobNow('c', 'j', fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: false, error: 'HTTP 404' })
+  })
+})

--- a/frontend/src/lib/backups/runBackupJob.ts
+++ b/frontend/src/lib/backups/runBackupJob.ts
@@ -1,0 +1,48 @@
+/**
+ * Trigger an immediate run of a scheduled backup job ("Run now").
+ *
+ * The per-job route exposes the run action via the QUERY STRING
+ * (`POST .../backup-jobs/{jobId}?action=run`, read with
+ * `searchParams.get('action')`). The UI used to POST to a `/run` PATH
+ * segment, which has no route file, so the request hit Next.js's HTML 404
+ * page and `res.json()` threw the cryptic
+ * `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+ * (issue #397, discussion #396).
+ *
+ * This helper (a) uses the correct URL and (b) reads the body defensively so
+ * any future non-JSON response (an HTML error page from a reverse proxy, a
+ * 404/502/504) surfaces a clean HTTP error instead of a JSON-parse exception.
+ */
+export interface RunBackupJobResult {
+  ok: boolean
+  error?: string
+  data?: unknown
+}
+
+export async function runBackupJobNow(
+  connectionId: string,
+  jobId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RunBackupJobResult> {
+  const url = `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(jobId)}?action=run`
+  const res = await fetchImpl(url, { method: 'POST' })
+
+  const text = await res.text()
+  let body: { error?: string; data?: unknown } | undefined
+
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // Non-JSON body (HTML error page, wrong path). Don't let JSON.parse
+      // leak its cryptic "Unexpected token '<'" message to the user.
+      return { ok: false, error: `HTTP ${res.status}` }
+    }
+  }
+
+  if (!res.ok || body?.error) {
+    return { ok: false, error: body?.error || `HTTP ${res.status}` }
+  }
+
+  return { ok: true, data: body?.data }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -85,6 +85,12 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   cannot render. The only real logic added with the backup-time fix (PBS
 #   snapshot name building and the pbs-<type> format label) was extracted to
 #   lib/backups/snapshotDisplay.ts, which stays measured and is fully covered.
+# - inventory/BackupJobsPanel.tsx: the cluster backup-jobs panel (a DataGrid of
+#   jobs plus the create/edit dialog with its schedule and VM Autocompletes) is a
+#   pure-JSX UI container the node-env Vitest suite cannot render. Its only real
+#   logic, the "Run now" request (correct ?action=run URL + defensive non-JSON
+#   response parsing, issue #397), was extracted to lib/backups/runBackupJob.ts,
+#   which stays measured and is fully covered by runBackupJob.test.ts.
 # - security/rbac/RoleDefaultScopeEditor.tsx: the role default-scope picker
 #   (issue #383) is a pure-JSX MUI form (type/target Selects + Chip list) whose
 #   only logic — turning the live inventory into pickable options — was
@@ -116,6 +122,7 @@ sonar.coverage.exclusions=\
   frontend/src/components/dashboard/widgets/KpiBackupsWidget.jsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/PbsServerPanel.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx,\
   frontend/src/components/backup/RestoreVmDialog.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ReportConnectionSelect.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ScheduleManager.tsx,\


### PR DESCRIPTION
## Problem

Starting a scheduled backup job from the cluster **Backups** pivot ("Run now") failed with:

```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

Reported in #397 and discussion #396 (the latter initially suspected a reverse-proxy CSP/nginx misconfiguration — it is not related).

## Root cause

The UI POSTed to `.../backup-jobs/{jobId}/run` — a **path segment** that has no route file. The per-job handler exposes the run action through the **query string** instead (`POST .../backup-jobs/{jobId}?action=run`, read via `searchParams.get('action')`).

So the request fell through to Next.js's HTML 404 page, and the unguarded `res.json()` choked on `<!DOCTYPE html>`. This path has been broken since at least v1.4.0; it is the same on `main`.

## Fix

- Extract the run-now request into `lib/backups/runBackupJob.ts`:
  - uses the correct `?action=run` URL;
  - parses the body defensively, so any future non-JSON response (an HTML error page from a proxy, a 404/502/504) surfaces a clean `HTTP <status>` message instead of a JSON-parse exception.
- Point `handleRunNow` at the helper.
- Fix the React 19 `key`-spread warnings in the three job-dialog `Autocomplete` `renderOption` callbacks (pass `key` explicitly), surfaced while validating this change.

## Tests

- New `runBackupJob.test.ts` (4 cases), including an explicit regression for the HTML-response case.
- Full suite: 1061/1061 green.
- `BackupJobsPanel.tsx` (pure-JSX container) is added to the coverage exclusions with a rationale; its only real logic now lives in the tested helper, consistent with its inventory siblings.

Validated in the browser: the job runs on Proxmox and the list refreshes, no error.

Closes #397