### PR TITLE
feat(backups): explain the empty guest Backups tab (no connected PBS vs no snapshots)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -1050,6 +1050,7 @@ export default function InventoryDetails({
     backupsError, setBackupsError,
     backupsStats, setBackupsStats,
     backupsWarnings, setBackupsWarnings,
+    backupsPbsConfigured, setBackupsPbsConfigured,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
     selectedBackup, setSelectedBackup,
@@ -1532,8 +1533,8 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
     if (backupsLoadedForIdRef.current === currentSelectionId) return
     backupsLoadedForIdRef.current = currentSelectionId
 
-    const { type, vmid } = parseVmId(selection.id)
-    loadBackups(vmid, type)
+    const { connId, type, vmid } = parseVmId(selection.id)
+    loadBackups(vmid, type, connId)
     setBackupsPreloaded(true)
   }, [selection?.type, selection?.id, loadBackups])
 
@@ -3287,7 +3288,7 @@ return vm?.isCluster ?? false
           {selection?.type === 'vm' && (
             <VmDetailTabs
               {...{addCephReplicationDialogOpen, addReplicationDialogOpen, availableTargetNodes, backToArchives, backToBackupsList,
-                backups, backupsError, backupsLoading, backupsPreloaded, backupsStats, backupsWarnings, balloon,
+                backups, backupsError, backupsLoading, backupsPreloaded, backupsStats, backupsWarnings, backupsPbsConfigured, balloon,
                 balloonEnabled, browseArchive, canPreview, canShowRrd, cephClusters, cephClustersLoading,
                 cephReplicationJobs, cephReplicationSchedule, compatibleStorages, cpuCores, cpuLimit,
                 cpuFlags, cpuLimitEnabled, cpuModified, cpuSockets, cpuType, createSnapshot,

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -195,7 +195,7 @@ export interface InventoryDialogsProps {
   creatingBackup: boolean
   setCreatingBackup: (v: boolean) => void
   backupStorages: any[]
-  loadBackups: (vmid: string, vmType: string) => void
+  loadBackups: (vmid: string, vmType: string, connId?: string) => void
 
   // Delete VM dialog
   deleteVmDialogOpen: boolean
@@ -1704,9 +1704,9 @@ return
                 // Recharger les backups après un délai
                 setTimeout(() => {
                   if (selection?.type === 'vm') {
-                    const { type: vmType, vmid } = parseVmId(selection.id)
+                    const { connId, type: vmType, vmid } = parseVmId(selection.id)
 
-                    loadBackups(vmid, vmType)
+                    loadBackups(vmid, vmType, connId)
                   }
                 }, 5000)
               } catch (e: any) {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
@@ -364,6 +364,7 @@ export function useHardwareHandlers({
   const [backupsError, setBackupsError] = useState<string | null>(null)
   const [backupsStats, setBackupsStats] = useState<any>(null)
   const [backupsWarnings, setBackupsWarnings] = useState<string[]>([])
+  const [backupsPbsConfigured, setBackupsPbsConfigured] = useState<boolean | null>(null)
   const [backupsPreloaded, setBackupsPreloaded] = useState(false)
   const backupsLoadedForIdRef = useRef<string | null>(null) // Track which selection ID backups were loaded for
   const [selectedBackup, setSelectedBackup] = useState<any>(null)
@@ -569,7 +570,7 @@ export function useHardwareHandlers({
   useCephLogLive(nodeCephLogLive, selection?.type, selection?.id, data?.clusterName, setNodeCephData)
 
   // Charger les sauvegardes d'une VM
-  const loadBackups = useCallback(async (vmid: string, type: string) => {
+  const loadBackups = useCallback(async (vmid: string, type: string, connId?: string) => {
     if (!vmid) return
 
     setBackupsLoading(true)
@@ -577,12 +578,16 @@ export function useHardwareHandlers({
     setBackups([])
     setBackupsStats(null)
     setBackupsWarnings([])
+    setBackupsPbsConfigured(null)
 
     try {
       const params = new URLSearchParams()
 
       if (type === 'lxc') params.set('type', 'ct')
       else if (type === 'qemu') params.set('type', 'vm')
+      // Pass the guest's PVE connection so the route can tell whether a
+      // connected PBS actually backs up this cluster (drives the empty state).
+      if (connId) params.set('connectionId', connId)
 
       const res = await fetch(`/api/v1/guests/${encodeURIComponent(vmid)}/backups?${params}`, { cache: 'no-store' })
       const json = await res.json()
@@ -593,6 +598,7 @@ export function useHardwareHandlers({
         setBackups(json.data?.backups || [])
         setBackupsStats(json.data?.stats || null)
         setBackupsWarnings(json.data?.warnings || [])
+        setBackupsPbsConfigured(json.data?.pbsConfigured ?? null)
       }
     } catch (e: any) {
       setBackupsError(e.message || t('errors.loadingError'))
@@ -1383,6 +1389,7 @@ return explorerFiles.filter((file: any) =>
     backupsError, setBackupsError,
     backupsStats, setBackupsStats,
     backupsWarnings, setBackupsWarnings,
+    backupsPbsConfigured, setBackupsPbsConfigured,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
     selectedBackup, setSelectedBackup,

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -227,6 +227,7 @@ export default function VmDetailTabs(props: any) {
     backupsPreloaded,
     backupsStats,
     backupsWarnings,
+    backupsPbsConfigured,
     balloon,
     balloonEnabled,
     browseArchive,
@@ -2820,9 +2821,22 @@ return (
                   {/* Liste des backups groupés par PBS/datastore */}
                   {!backupsLoading && !selectedBackup && (() => {
                     if (backups.length === 0) {
+                      if (backupsPbsConfigured === false) {
+                        return (
+                          <Alert severity="info" sx={{ mt: 2 }}>
+                            <Typography variant="body2" fontWeight={600}>
+                              {t('backups.noPbsConfiguredTitle')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ mt: 0.5 }}>
+                              {t('backups.noPbsConfiguredHint')}
+                            </Typography>
+                          </Alert>
+                        )
+                      }
+
                       return (
                         <Alert severity="info" sx={{ mt: 2 }}>
-                          {t('common.noData')}
+                          {t('backups.noGuestBackups')}
                         </Alert>
                       )
                     }
@@ -2836,7 +2850,7 @@ return (
                     if (visibleBackups.length === 0) {
                       return (
                         <Alert severity="info" sx={{ mt: 2 }}>
-                          {t('common.noData')}
+                          {t('backups.noGuestBackups')}
                         </Alert>
                       )
                     }

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const pbsFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const getVdcScopeMock = vi.fn<(tenantId?: string) => Promise<any>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const findManyMock = vi.fn<(args: any) => Promise<any[]>>()
+
+vi.mock('@/lib/tenant', () => ({
+  getSessionPrisma: async () => ({ connection: { findMany: findManyMock } }),
+  getCurrentTenantId: async () => 'default',
+}))
+vi.mock('@/lib/db/prisma', () => ({ prisma: { connection: { findMany: findManyMock } } }))
+vi.mock('@/lib/vdc/scope', () => ({ getVdcScope: getVdcScopeMock }))
+vi.mock('@/lib/proxmox/pbs-client', () => ({ pbsFetch: pbsFetchMock }))
+vi.mock('@/lib/proxmox/client', () => ({ pveFetch: pveFetchMock }))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock('@/lib/crypto/secret', () => ({ decryptSecret: (s: string) => `dec:${s}` }))
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { BACKUP_VIEW: 'backup.view' },
+}))
+vi.mock('next/headers', () => ({ cookies: async () => ({ get: () => ({ value: 'en' }) }) }))
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  pbsFetchMock.mockReset().mockResolvedValue([])
+  pveFetchMock.mockReset().mockResolvedValue([])
+  getVdcScopeMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'pve-1', apiToken: 't' })
+  findManyMock.mockReset().mockResolvedValue([])
+})
+
+async function call(connectionId?: string) {
+  const { GET } = await import('./route')
+  const res = await callRoute(GET as any, {
+    params: { vmid: '1105' },
+    searchParams: connectionId ? { connectionId } : undefined,
+  })
+  return readJson<any>(res)
+}
+
+describe('GET /api/v1/guests/[vmid]/backups — pbsConfigured (PBS connection mapped to the cluster)', () => {
+  it('is false when no PBS connection exists at all', async () => {
+    findManyMock.mockResolvedValue([])
+    const body = await call('pve-1')
+    expect(body.data.pbsConfigured).toBe(false)
+  })
+
+  it('is false when the cluster backs up to a PBS that is not a ProxCenter connection', async () => {
+    // Real case: the cluster's pbs storage points to 10.199.199.231, but the
+    // only PBS connection is 10.99.99.204 — they do not match.
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.99.99.204:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([
+      { storage: 'PBS_MASTER_RBX', type: 'pbs', server: '10.199.199.231', datastore: 'VM-BACKUP' },
+      { storage: 'local', type: 'dir' },
+    ])
+    const body = await call('pve-1')
+    expect(body.data.pbsConfigured).toBe(false)
+  })
+
+  it('is true when a ProxCenter PBS connection matches the cluster pbs storage host', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.199.199.231:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([
+      { storage: 'PBS_MASTER_RBX', type: 'pbs', server: '10.199.199.231', datastore: 'VM-BACKUP' },
+    ])
+    const body = await call('pve-1')
+    expect(body.data.pbsConfigured).toBe(true)
+  })
+
+  it('falls back to "a PBS connection exists" when no connectionId is provided', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.99.99.204:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    const body = await call()
+    expect(body.data.pbsConfigured).toBe(true)
+  })
+
+  it('falls back to "a PBS connection exists" when the cluster storage cannot be read', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.99.99.204:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockRejectedValue(new Error('storage unreachable'))
+    const body = await call('pve-1')
+    expect(body.data.pbsConfigured).toBe(true)
+  })
+})

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
@@ -5,12 +5,25 @@ import { getSessionPrisma, getCurrentTenantId } from "@/lib/tenant"
 import { prisma as globalPrisma } from "@/lib/db/prisma"
 import { getVdcScope } from "@/lib/vdc/scope"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
+import { pveFetch } from "@/lib/proxmox/client"
+import { getConnectionById } from "@/lib/connections/getConnection"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { formatBytes } from "@/utils/format"
 import { getDateLocale } from "@/lib/i18n/date"
 
 export const runtime = "nodejs"
+
+/**
+ * Strip scheme, path and port so a PBS connection baseUrl (e.g.
+ * "https://10.0.0.1:8007") can be compared to a PVE pbs-storage `server`
+ * (a bare host or IP, e.g. "10.0.0.1").
+ */
+function normalizeHost(s?: string | null): string {
+  if (!s) return ''
+
+  return s.replace(/^https?:\/\//, '').split('/')[0].split(':')[0].trim().toLowerCase()
+}
 
 /**
  * GET /api/v1/guests/[vmid]/backups
@@ -42,6 +55,7 @@ export async function GET(
 
     const url = new URL(req.url)
     const typeFilter = url.searchParams.get('type') // 'vm' | 'ct'
+    const connectionId = url.searchParams.get('connectionId') // the guest's PVE connection
 
     // Récupérer toutes les connexions PBS visibles. Provider sees its own
     // PBS via tenant prisma; vDC tenants reach PBS connections referenced
@@ -69,9 +83,33 @@ export async function GET(
         data: {
           backups: [],
           stats: { total: 0, totalSize: 0, totalSizeFormatted: '0 B' },
-          message: "Aucun serveur PBS configuré"
+          pbsConfigured: false,
         }
       })
+    }
+
+    // Is one of these PBS connections actually the backup target of THIS guest's
+    // cluster? We compare the cluster's pbs-type storage host(s) against the PBS
+    // connection hosts. A cluster that backs up to a PBS we are not connected to
+    // (different host) counts as "no PBS configured" — we cannot read its
+    // snapshots — which is what drives the empty-state message.
+    let pbsConfigured = pbsConnections.length > 0
+    if (connectionId) {
+      try {
+        const connHosts = new Set(
+          pbsConnections.map(c => normalizeHost(c.baseUrl)).filter(Boolean)
+        )
+        const pveConn = await getConnectionById(connectionId)
+        const pveStorages = await pveFetch<any[]>(pveConn, '/storage')
+
+        pbsConfigured = (pveStorages || []).some(
+          (s: any) => s?.type === 'pbs' && connHosts.has(normalizeHost(s.server))
+        )
+      } catch {
+        // Cannot read the cluster storage config: fall back to "a PBS connection
+        // exists" so we never wrongly claim none is configured.
+        pbsConfigured = pbsConnections.length > 0
+      }
     }
 
     const allBackups: any[] = []
@@ -238,6 +276,7 @@ return []
         backups: allBackups,
         stats,
         warnings,
+        pbsConfigured,
       }
     })
   } catch (e: any) {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2189,7 +2189,10 @@
     "trendsCount": "Anzahl",
     "trendsSize": "Größe",
     "trendsVerification": "Verifizierung",
-    "trendsDistribution": "Typverteilung"
+    "trendsDistribution": "Typverteilung",
+    "noPbsConfiguredTitle": "Kein Proxmox Backup Server konfiguriert",
+    "noPbsConfiguredHint": "Kein verbundener Proxmox Backup Server sichert den Cluster dieses Gasts. Fügen Sie den PBS des Clusters als Verbindung hinzu, um seine Sicherungen hier zu sehen.",
+    "noGuestBackups": "Keine Sicherungen für diese Maschine gefunden."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2221,7 +2221,10 @@
     "trendsCount": "Count",
     "trendsSize": "Size",
     "trendsVerification": "Verification",
-    "trendsDistribution": "Type distribution"
+    "trendsDistribution": "Type distribution",
+    "noPbsConfiguredTitle": "No Proxmox Backup Server configured",
+    "noPbsConfiguredHint": "No connected Proxmox Backup Server backs up this guest's cluster. Add the cluster's PBS as a connection to see its backups here.",
+    "noGuestBackups": "No backups found for this guest."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2221,7 +2221,10 @@
     "trendsCount": "Nombre",
     "trendsSize": "Taille",
     "trendsVerification": "Vérification",
-    "trendsDistribution": "Répartition par type"
+    "trendsDistribution": "Répartition par type",
+    "noPbsConfiguredTitle": "Aucun serveur Proxmox Backup Server configuré",
+    "noPbsConfiguredHint": "Aucun Proxmox Backup Server connecté ne sauvegarde le cluster de cette machine. Ajoutez le PBS du cluster comme connexion pour voir ses sauvegardes ici.",
+    "noGuestBackups": "Aucune sauvegarde trouvée pour cette machine."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2191,7 +2191,10 @@
     "trendsCount": "数量",
     "trendsSize": "大小",
     "trendsVerification": "验证",
-    "trendsDistribution": "类型分布"
+    "trendsDistribution": "类型分布",
+    "noPbsConfiguredTitle": "未配置 Proxmox Backup Server",
+    "noPbsConfiguredHint": "没有已连接的 Proxmox Backup Server 备份此机器的集群。请将该集群的 PBS 添加为连接以在此处查看备份。",
+    "noGuestBackups": "未找到此机器的备份。"
   },
   "backup": {
     "notifAuto": "自动",


### PR DESCRIPTION
## Problem

On a guest's **Backups** tab (Inventory → VM/CT → Backups), an empty list showed a generic "No data". The tab lists **PBS snapshots only**, so the most common reason it is empty is that no Proxmox Backup Server is connected for that guest's cluster, but the UI gave no hint of that.

## Change

Two distinct, internationalised empty states:

- **No connected PBS backs up this guest's cluster** → "No Proxmox Backup Server configured" + a hint to add the cluster's PBS as a connection.
- **A connected PBS exists but the guest has no snapshots** → "No backups found for this guest."

### How "connected PBS for this cluster" is resolved

The signal is computed **server-side** in `GET /api/v1/guests/[vmid]/backups`: it matches the guest's PVE `pbs`-type storage host(s) against the visible PBS connection hosts. This matters because a cluster can back up to a PBS that is **not** registered as a ProxCenter connection (different host) — ProxCenter cannot read its snapshots, so that correctly reads as "not configured" rather than "no backups". A global PBS connection that is not mapped to the cluster does not count either.

The frontend passes the guest's `connectionId` to the route; the route returns a `pbsConfigured` boolean. On any failure reading the cluster storage config it falls back to "a PBS connection exists", so it never wrongly claims none is configured.

## Tests

- 5 route tests (`backups/route.test.ts`), including the real-world case: cluster pbs storage `10.199.199.231` vs PBS connection `10.99.99.204` → `pbsConfigured = false`; matching host → `true`; no connections → `false`; no `connectionId` and storage-read-error fallbacks.
- Full suite green (1062). Strings added in en / fr / de / zh-CN.

Validated in the browser against a cluster whose PBS is not connected to ProxCenter: it now shows "No Proxmox Backup Server configured".