### PR TITLE
fix(migration): partial-VM cleanup leaked the VMID after a failed conversion

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -2204,7 +2204,7 @@ return
                     }}
                   />
                   {/* Migration type selector — hidden for Hyper-V / Nutanix (cold only).
-                      vCenter and direct ESXi both support cold + live. */}
+                      vCenter and direct ESXi both support cold + warm. */}
                   {esxiMigrateVm?.hostType !== 'hyperv' && esxiMigrateVm?.hostType !== 'nutanix' && (
                   <Box>
                     <Typography variant="subtitle2" sx={{ mb: 0.75, color: 'text.secondary', fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5 }}>
@@ -2213,10 +2213,10 @@ return
                     <Stack direction="row" spacing={1}>
                       {([
                         { value: 'cold' as const, icon: 'ri-shut-down-line', color: 'info.main', labelKey: 'migrationTypeCold', descKey: 'migrationTypeColdDesc' },
-                        // Warm (CBT, no in-transit data loss) is ESXi-direct only (hostType
-                        // 'vmware'). vCenter keeps its existing Live, and any other source that
-                        // reaches this selector (e.g. XCP-ng) keeps Live too — the backend rejects
-                        // warm for non-VMware sources.
+                        // Warm (CBT, no in-transit data loss) covers both direct ESXi (hostType
+                        // 'vmware') and vCenter. Any other source that reaches this selector
+                        // (e.g. XCP-ng) keeps Live, since the backend rejects warm for
+                        // non-VMware sources.
                         (esxiMigrateVm?.hostType === 'vmware' || esxiMigrateVm?.hostType === 'vcenter')
                           ? { value: 'warm' as const, icon: 'ri-flashlight-line', color: 'success.main', labelKey: 'migrationTypeWarm', descKey: 'migrationTypeWarmDesc' }
                           : { value: 'live' as const, icon: 'ri-flashlight-line', color: 'success.main', labelKey: 'migrationTypeLive', descKey: 'migrationTypeLiveDesc' },

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -25,7 +25,7 @@ import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, buildVmdkDownloa
 import { mapEsxiToPveConfig, isWindowsVm } from "./configMapper"
 import type { SoapSession, EsxiVmConfig, EsxiDiskInfo, NfcLeaseDeviceUrl } from "@/lib/vmware/soap"
 import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
-import { pveSetVmConfig } from "./pve-vm-config"
+import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
@@ -2908,11 +2908,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
     if (targetVmid && config.targetConnectionId) {
       try {
         const pveConn = await getConnectionById(config.targetConnectionId)
-        await pveFetch<any>(
-          pveConn,
-          `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}`,
-          { method: "DELETE", body: new URLSearchParams({ purge: "1", "destroy-unreferenced-disks": "1" }) }
-        )
+        await destroyPveVm(pveConn, config.targetNode, targetVmid)
         await appendLog(jobId, `Cleaned up partial VM ${targetVmid}`, "warn")
       } catch {
         // Cleanup failed — leave for manual intervention

--- a/frontend/src/lib/migration/pve-vm-config.test.ts
+++ b/frontend/src/lib/migration/pve-vm-config.test.ts
@@ -63,3 +63,38 @@ describe('pveSetVmConfig', () => {
     ).rejects.toThrow('PVE 500')
   })
 })
+
+describe('destroyPveVm', () => {
+  // The whole point of this helper (issue #400): purge + destroy-unreferenced-disks
+  // MUST be in the query string and the request MUST NOT carry a body. PVE rejects a
+  // body on DELETE with 501 "Unexpected content for method 'DELETE'", which silently
+  // leaked the VMID + its disk on failed-migration cleanup.
+  it('DELETEs with purge flags in the query string and NO request body (issue #400)', async () => {
+    const { destroyPveVm } = await import('./pve-vm-config')
+
+    await destroyPveVm(pveConn, 'pve-node-1', 112)
+
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+    const [conn, path, init] = pveFetchMock.mock.calls[0]
+    expect(conn).toBe(pveConn)
+    expect(path).toBe('/nodes/pve-node-1/qemu/112?purge=1&destroy-unreferenced-disks=1')
+    expect(init.method).toBe('DELETE')
+    expect(init.body).toBeUndefined()
+  })
+
+  it('accepts a string vmid and URL-encodes the node name', async () => {
+    const { destroyPveVm } = await import('./pve-vm-config')
+
+    await destroyPveVm(pveConn, 'node with space', '101')
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/nodes/node%20with%20space/qemu/101?purge=1&destroy-unreferenced-disks=1')
+  })
+
+  it('propagates pveFetch errors to the caller (cleanup is best-effort at call sites)', async () => {
+    pveFetchMock.mockReset().mockRejectedValueOnce(new Error('PVE 500 /qemu/112: boom'))
+    const { destroyPveVm } = await import('./pve-vm-config')
+
+    await expect(destroyPveVm(pveConn, 'n', 112)).rejects.toThrow('PVE 500')
+  })
+})

--- a/frontend/src/lib/migration/pve-vm-config.ts
+++ b/frontend/src/lib/migration/pve-vm-config.ts
@@ -26,3 +26,26 @@ export async function pveSetVmConfig(
     { timeoutMs: PVE_CONFIG_PUT_TIMEOUT_MS },
   )
 }
+
+/**
+ * Destroy a VM (`DELETE /nodes/{node}/qemu/{vmid}`), purging it from the cluster
+ * config and reclaiming any disks no longer referenced.
+ *
+ * The `purge` and `destroy-unreferenced-disks` flags MUST travel in the query
+ * string. PVE's DELETE handler rejects a request body outright with
+ * `501 Unexpected content for method 'DELETE'`, which silently aborts the
+ * cleanup and leaks the VMID plus its disk on a failed migration (issue #400).
+ * Centralised here so every failed-migration cleanup path uses the query-string
+ * form and the body footgun can't be reintroduced on a new call site.
+ */
+export async function destroyPveVm(
+  pveConn: ProxmoxClientOptions,
+  node: string,
+  vmid: number | string,
+): Promise<void> {
+  await pveFetch<unknown>(
+    pveConn,
+    `/nodes/${encodeURIComponent(node)}/qemu/${encodeURIComponent(String(vmid))}?purge=1&destroy-unreferenced-disks=1`,
+    { method: "DELETE" },
+  )
+}

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -47,7 +47,7 @@ import {
   soapPowerOffVm,
 } from "@/lib/vmware/soap"
 import type { SoapSession, NfcLeaseDeviceUrl, EsxiVmConfig } from "@/lib/vmware/soap"
-import { pveSetVmConfig } from "./pve-vm-config"
+import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
 
@@ -2820,11 +2820,7 @@ export async function runV2vMigrationPipeline(
     if (targetVmid && config.targetConnectionId) {
       try {
         const pveConn = await getConnectionById(config.targetConnectionId)
-        await pveFetch<any>(
-          pveConn,
-          `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}`,
-          { method: "DELETE", body: new URLSearchParams({ purge: "1", "destroy-unreferenced-disks": "1" }) }
-        )
+        await destroyPveVm(pveConn, config.targetNode, targetVmid)
         await appendLog(jobId, `Cleaned up partial VM ${targetVmid}`, "warn")
       } catch (delErr: any) {
         await appendLog(

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -33,7 +33,7 @@ import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
-import { pveSetVmConfig } from "./pve-vm-config"
+import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
 
@@ -893,11 +893,7 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     if (targetVmid && config.targetConnectionId) {
       try {
         const pveConn = await getConnectionById(config.targetConnectionId)
-        await pveFetch<any>(
-          pveConn,
-          `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}`,
-          { method: "DELETE", body: new URLSearchParams({ purge: "1", "destroy-unreferenced-disks": "1" }) }
-        )
+        await destroyPveVm(pveConn, config.targetNode, targetVmid)
         await appendLog(jobId, `Cleaned up partial VM ${targetVmid}`, "warn")
       } catch {
         // Cleanup failed — leave for manual intervention


### PR DESCRIPTION
## Problem

When a VMware / cold / XCP-ng migration fails partway, ProxCenter tries to destroy the half-created target VM. The cleanup sent `purge` and `destroy-unreferenced-disks` as a **DELETE request body**, which Proxmox rejects:

```
PVE 501 /nodes/<node>/qemu/<vmid>: Unexpected content for method 'DELETE'
```

So the partial VM and its disk were never reclaimed, leaking the VMID and its storage on every failed migration. This is the orphaned VMID 112 seen in the log on issue #400.

## Fix

- New shared `destroyPveVm(conn, node, vmid)` helper in `pve-vm-config.ts` that passes the flags in the **query string** (`?purge=1&destroy-unreferenced-disks=1`) with no request body, mirroring the sibling `pveSetVmConfig()` so the footgun cannot be reintroduced on a new call site.
- Repointed the three affected cleanup paths: `v2v-pipeline.ts`, `pipeline.ts`, `xcpng-pipeline.ts`.
- Refreshed a stale migrate-dialog comment (vCenter now routes to Warm / CBT, not Live).

The two source-VM delete sites (`tasks` route, cross-cluster watcher) were already using the correct query-string form, so they are left unchanged.

## Tests

3 new tests in `pve-vm-config.test.ts` assert the query-string form, the absence of a request body, node-name URL-encoding, and error propagation. Full file 7/7 green.

## Scope note

This addresses the cleanup bug seen in #400. The primary "virt-v2v: No root device" report in that issue is a crash-consistent Live snapshot of a Windows guest and is separately resolved by Warm migration (CBT).
