### PR TITLE
fix(ceph): full cluster config in the Ceph tab + working OSD flag toggles

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -74,6 +74,37 @@ import { AreaPctChart, AreaBpsChart2 } from '../components/RrdCharts'
 import InventorySummary from '../components/InventorySummary'
 import EntityTagManager from '../components/EntityTagManager'
 
+/**
+ * Renders a Ceph config-style text verbatim (indentation preserved) with light
+ * per-line syntax coloring. Returns just the colored lines; the caller wraps
+ * them in the dark code box. Shared by the Ceph "Configuration" (ceph.conf,
+ * lang="ini") and "Crush Map" (lang="crush") panels so both render the same way.
+ */
+function CephConfLines({ text, lang }: { text: string; lang: 'ini' | 'crush' }) {
+  return (
+    <>
+      {String(text).split('\n').map((line: string, i: number) => {
+        const trimmed = line.trim()
+        if (trimmed.length === 0) return <Box key={i}>{' '}</Box>
+        if (trimmed.startsWith('#') || trimmed.startsWith(';')) return <Box key={i} sx={{ color: '#9e9e9e' }}>{line}</Box>
+        if (lang === 'ini') {
+          if (/^\[.*\]$/.test(trimmed)) return <Box key={i} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
+          const eq = line.indexOf('=')
+          if (eq > -1) return <Box key={i}><span style={{ color: '#81c784' }}>{line.slice(0, eq)}</span>{line.slice(eq)}</Box>
+          return <Box key={i}>{line}</Box>
+        }
+        // crush: "host pve1 {" / "rule replicated_rule {" act like section headers
+        if (trimmed.endsWith('{')) return <Box key={i} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
+        if (trimmed === '}') return <Box key={i}>{line}</Box>
+        // color the leading keyword (id/item/weight/device/type/tunable…) green, keep indentation
+        const m = /^(\s*)(\S+)(.*)$/.exec(line)
+        if (m) return <Box key={i}>{m[1]}<span style={{ color: '#81c784' }}>{m[2]}</span>{m[3]}</Box>
+        return <Box key={i}>{line}</Box>
+      })}
+    </>
+  )
+}
+
 export default function NodeTabs(props: any) {
   const t = useTranslations()
   const theme = useTheme()
@@ -2244,7 +2275,7 @@ export default function NodeTabs(props: any) {
                         <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
                           {/* Configuration */}
                           {nodeCephSubTab === 0 && (
-                            <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 300px' }, gap: 2 }}>
+                            <Box sx={{ display: 'grid', gridTemplateColumns: '1fr', gap: 2 }}>
                               <Stack spacing={2}>
                                 {/* Configuration globale */}
                                 <Card variant="outlined">
@@ -2261,7 +2292,10 @@ export default function NodeTabs(props: any) {
                                       whiteSpace: 'pre-wrap',
                                       color: '#e0e0e0'
                                     }}>
-                                      {nodeCephData.config?.global ? (
+                                      {nodeCephData.config?.raw ? (
+                                        /* Fichier ceph.conf brut, rendu verbatim (indentation préservée) avec coloration par ligne */
+                                        <CephConfLines text={nodeCephData.config.raw} lang="ini" />
+                                      ) : nodeCephData.config?.global ? (
                                         Object.entries(nodeCephData.config.global).map(([section, values]: [string, any]) => (
                                           <Box key={section}>
                                             <Box sx={{ color: '#4fc3f7', fontWeight: 700 }}>[{section}]</Box>
@@ -2324,13 +2358,17 @@ export default function NodeTabs(props: any) {
                                     borderRadius: 1, 
                                     p: 2, 
                                     fontFamily: 'monospace', 
-                                    fontSize: 11,
+                                    fontSize: 12,
                                     maxHeight: 500,
                                     overflow: 'auto',
                                     whiteSpace: 'pre-wrap',
                                     color: '#e0e0e0'
                                   }}>
-                                    {nodeCephData.config?.crushMap || 'Crush map not available'}
+                                    {nodeCephData.config?.crushMap ? (
+                                      <CephConfLines text={nodeCephData.config.crushMap} lang="crush" />
+                                    ) : (
+                                      <Typography variant="caption" sx={{ opacity: 0.5 }}>Crush map not available</Typography>
+                                    )}
                                   </Box>
                                 </CardContent>
                               </Card>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -80,28 +80,65 @@ import EntityTagManager from '../components/EntityTagManager'
  * them in the dark code box. Shared by the Ceph "Configuration" (ceph.conf,
  * lang="ini") and "Crush Map" (lang="crush") panels so both render the same way.
  */
-function CephConfLines({ text, lang }: { text: string; lang: 'ini' | 'crush' }) {
+function CephConfLines({ text, lang }: Readonly<{ text: string; lang: 'ini' | 'crush' }>) {
+  // Precompute a stable per-line key (the list is static and never reordered),
+  // so the JSX `key` is not the map index.
+  const rows = String(text).split('\n').map((line, idx) => ({ line, k: `${idx}|${line}` }))
   return (
     <>
-      {String(text).split('\n').map((line: string, i: number) => {
+      {rows.map(({ line, k }) => {
         const trimmed = line.trim()
-        if (trimmed.length === 0) return <Box key={i}>{' '}</Box>
-        if (trimmed.startsWith('#') || trimmed.startsWith(';')) return <Box key={i} sx={{ color: '#9e9e9e' }}>{line}</Box>
+        if (trimmed.length === 0) return <Box key={k}>{' '}</Box>
+        if (trimmed.startsWith('#') || trimmed.startsWith(';')) return <Box key={k} sx={{ color: '#9e9e9e' }}>{line}</Box>
         if (lang === 'ini') {
-          if (/^\[.*\]$/.test(trimmed)) return <Box key={i} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
+          if (/^\[.*\]$/.test(trimmed)) return <Box key={k} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
           const eq = line.indexOf('=')
-          if (eq > -1) return <Box key={i}><span style={{ color: '#81c784' }}>{line.slice(0, eq)}</span>{line.slice(eq)}</Box>
-          return <Box key={i}>{line}</Box>
+          if (eq > -1) return <Box key={k}><span style={{ color: '#81c784' }}>{line.slice(0, eq)}</span>{line.slice(eq)}</Box>
+          return <Box key={k}>{line}</Box>
         }
         // crush: "host pve1 {" / "rule replicated_rule {" act like section headers
-        if (trimmed.endsWith('{')) return <Box key={i} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
-        if (trimmed === '}') return <Box key={i}>{line}</Box>
+        if (trimmed.endsWith('{')) return <Box key={k} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
+        if (trimmed === '}') return <Box key={k}>{line}</Box>
         // color the leading keyword (id/item/weight/device/type/tunable…) green, keep indentation
         const m = /^(\s*)(\S+)(.*)$/.exec(line)
-        if (m) return <Box key={i}>{m[1]}<span style={{ color: '#81c784' }}>{m[2]}</span>{m[3]}</Box>
-        return <Box key={i}>{line}</Box>
+        if (m) return <Box key={k}>{m[1]}<span style={{ color: '#81c784' }}>{m[2]}</span>{m[3]}</Box>
+        return <Box key={k}>{line}</Box>
       })}
     </>
+  )
+}
+
+/**
+ * The Ceph "Configuration" panel body: the raw ceph.conf when available, the
+ * status-derived structured view as a fallback, otherwise an empty-state note.
+ * Kept as a component (rather than a nested ternary in the render) for clarity.
+ */
+function CephConfigurationBlock({ config }: Readonly<{ config: any }>) {
+  if (!config?.raw && !config?.global) {
+    return <Typography variant="caption" sx={{ opacity: 0.5 }}>No configuration available</Typography>
+  }
+  return (
+    <Box sx={{ bgcolor: 'grey.900', borderRadius: 1, p: 2, fontFamily: 'monospace', fontSize: 12, maxHeight: 300, overflow: 'auto', whiteSpace: 'pre-wrap', color: '#e0e0e0' }}>
+      {config.raw ? (
+        /* Fichier ceph.conf brut, rendu verbatim (indentation préservée) avec coloration par ligne */
+        <CephConfLines text={config.raw} lang="ini" />
+      ) : (
+        Object.entries(config.global).map(([section, values]: [string, any]) => (
+          <Box key={section}>
+            <Box sx={{ color: '#4fc3f7', fontWeight: 700 }}>[{section}]</Box>
+            {typeof values === 'object' && values !== null ? (
+              Object.entries(values).map(([k, v]) => (
+                <Box key={k} sx={{ pl: 2 }}>
+                  <span style={{ color: '#81c784' }}>{k}</span> = {String(v)}
+                </Box>
+              ))
+            ) : (
+              <Box sx={{ pl: 2 }}>{String(values)}</Box>
+            )}
+          </Box>
+        ))
+      )}
+    </Box>
   )
 }
 
@@ -2281,39 +2318,7 @@ export default function NodeTabs(props: any) {
                                 <Card variant="outlined">
                                   <CardContent>
                                     <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 2 }}>Configuration</Typography>
-                                    <Box sx={{ 
-                                      bgcolor: 'grey.900', 
-                                      borderRadius: 1, 
-                                      p: 2, 
-                                      fontFamily: 'monospace', 
-                                      fontSize: 12,
-                                      maxHeight: 300,
-                                      overflow: 'auto',
-                                      whiteSpace: 'pre-wrap',
-                                      color: '#e0e0e0'
-                                    }}>
-                                      {nodeCephData.config?.raw ? (
-                                        /* Fichier ceph.conf brut, rendu verbatim (indentation préservée) avec coloration par ligne */
-                                        <CephConfLines text={nodeCephData.config.raw} lang="ini" />
-                                      ) : nodeCephData.config?.global ? (
-                                        Object.entries(nodeCephData.config.global).map(([section, values]: [string, any]) => (
-                                          <Box key={section}>
-                                            <Box sx={{ color: '#4fc3f7', fontWeight: 700 }}>[{section}]</Box>
-                                            {typeof values === 'object' && values !== null ? (
-                                              Object.entries(values).map(([k, v]) => (
-                                                <Box key={k} sx={{ pl: 2 }}>
-                                                  <span style={{ color: '#81c784' }}>{k}</span> = {String(v)}
-                                                </Box>
-                                              ))
-                                            ) : (
-                                              <Box sx={{ pl: 2 }}>{String(values)}</Box>
-                                            )}
-                                          </Box>
-                                        ))
-                                      ) : (
-                                        <Typography variant="caption" sx={{ opacity: 0.5 }}>No configuration available</Typography>
-                                      )}
-                                    </Box>
+                                    <CephConfigurationBlock config={nodeCephData.config} />
                                   </CardContent>
                                 </Card>
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -91,7 +91,7 @@ function CephConfLines({ text, lang }: Readonly<{ text: string; lang: 'ini' | 'c
         if (trimmed.length === 0) return <Box key={k}>{' '}</Box>
         if (trimmed.startsWith('#') || trimmed.startsWith(';')) return <Box key={k} sx={{ color: '#9e9e9e' }}>{line}</Box>
         if (lang === 'ini') {
-          if (/^\[.*\]$/.test(trimmed)) return <Box key={k} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
+          if (trimmed.startsWith('[') && trimmed.endsWith(']')) return <Box key={k} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
           const eq = line.indexOf('=')
           if (eq > -1) return <Box key={k}><span style={{ color: '#81c784' }}>{line.slice(0, eq)}</span>{line.slice(eq)}</Box>
           return <Box key={k}>{line}</Box>
@@ -99,10 +99,13 @@ function CephConfLines({ text, lang }: Readonly<{ text: string; lang: 'ini' | 'c
         // crush: "host pve1 {" / "rule replicated_rule {" act like section headers
         if (trimmed.endsWith('{')) return <Box key={k} sx={{ color: '#4fc3f7', fontWeight: 700 }}>{line}</Box>
         if (trimmed === '}') return <Box key={k}>{line}</Box>
-        // color the leading keyword (id/item/weight/device/type/tunable…) green, keep indentation
-        const m = /^(\s*)(\S+)(.*)$/.exec(line)
-        if (m) return <Box key={k}>{m[1]}<span style={{ color: '#81c784' }}>{m[2]}</span>{m[3]}</Box>
-        return <Box key={k}>{line}</Box>
+        // color the leading keyword (id/item/weight/device/type/tunable…) green, keep
+        // indentation. Plain string ops (no regex) to avoid any backtracking concern.
+        const lead = line.length - line.trimStart().length
+        const body = line.slice(lead)
+        const breaks = [body.indexOf(' '), body.indexOf('\t')].filter((n) => n >= 0)
+        const cut = breaks.length > 0 ? Math.min(...breaks) : body.length
+        return <Box key={k}>{line.slice(0, lead)}<span style={{ color: '#81c784' }}>{body.slice(0, cut)}</span>{body.slice(cut)}</Box>
       })}
     </>
   )

--- a/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.test.ts
@@ -7,7 +7,7 @@ vi.mock("@/lib/rbac", () => ({
 vi.mock("@/lib/connections/getConnection", () => ({
   getConnectionById: vi.fn(async () => ({ id: "c1", baseUrl: "https://h", apiToken: "t" })),
 }))
-const pveFetch = vi.fn(async () => null)
+const pveFetch = vi.fn()
 vi.mock("@/lib/proxmox/client", () => ({
   pveFetch: (...args: unknown[]) => pveFetch(...args),
 }))

--- a/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: vi.fn(async () => null),
+  PERMISSIONS: { NODE_VIEW: "node.view", NODE_MANAGE: "node.manage" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: vi.fn(async () => ({ id: "c1", baseUrl: "https://h", apiToken: "t" })),
+}))
+const pveFetch = vi.fn(async () => null)
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...args: unknown[]) => pveFetch(...args),
+}))
+
+import { GET, PUT, DELETE } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  pveFetch.mockResolvedValue(null)
+})
+
+describe("GET /api/v1/connections/[id]/ceph/flags", () => {
+  it("returns only the active flags (value true or 1)", async () => {
+    pveFetch.mockResolvedValueOnce([
+      { name: "noout", value: true },
+      { name: "norebalance", value: false },
+      { name: "noscrub", value: 1 },
+    ])
+    const res = await callRoute(GET, { params: { id: "c1" } })
+    expect(res.status).toBe(200)
+    const json = await readJson<{ data: { flags: string[] } }>(res)
+    expect(json?.data.flags).toEqual(["noout", "noscrub"])
+  })
+})
+
+describe("Ceph flag set/unset", () => {
+  it("PUT sets the flag via PVE PUT with the required value=1 (form-encoded)", async () => {
+    const res = await callRoute(PUT, { params: { id: "c1" }, method: "PUT", body: { flag: "noout" } })
+    expect(res.status).toBe(200)
+    const [, path, init] = pveFetch.mock.calls[0] as [unknown, string, { method: string; body: URLSearchParams }]
+    expect(path).toBe("/cluster/ceph/flags/noout")
+    expect(init.method).toBe("PUT")
+    expect(init.body.toString()).toBe("value=1")
+  })
+
+  it("DELETE unsets the flag via PVE PUT with value=0 (the single-flag endpoint has no DELETE)", async () => {
+    const res = await callRoute(DELETE, { params: { id: "c1" }, method: "DELETE", body: { flag: "noout" } })
+    expect(res.status).toBe(200)
+    const [, path, init] = pveFetch.mock.calls[0] as [unknown, string, { method: string; body: URLSearchParams }]
+    expect(path).toBe("/cluster/ceph/flags/noout")
+    expect(init.method).toBe("PUT")
+    expect(init.body.toString()).toBe("value=0")
+  })
+
+  it("400s without ever calling PVE when the flag is missing", async () => {
+    const res = await callRoute(PUT, { params: { id: "c1" }, method: "PUT", body: {} })
+    expect(res.status).toBe(400)
+    expect(pveFetch).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/flags/route.ts
@@ -39,34 +39,50 @@ export async function GET(
 }
 
 /**
- * PUT /api/v1/connections/[id]/ceph/flags
+ * Set (value=true) or unset (value=false) a single Ceph OSD flag.
  *
- * Set a Ceph OSD flag. Body: { flag: "noout" }
+ * PVE exposes `PUT /cluster/ceph/flags/{flag}` with a REQUIRED boolean `value`
+ * parameter; there is no DELETE on the single-flag endpoint, so unsetting is
+ * also a PUT with value=false. Params are form-encoded, per the PVE convention
+ * used elsewhere in this codebase.
+ *
+ * Body (both PUT and DELETE): { flag: "noout" }
  */
-export async function PUT(
+async function setCephFlag(
   req: Request,
-  ctx: { params: Promise<{ id: string }> }
+  ctx: { params: Promise<{ id: string }> },
+  value: boolean
 ) {
+  const { id } = await ctx.params
+  const body = await req.json().catch(() => ({}))
+  const flag = body?.flag
+
+  if (!flag || typeof flag !== 'string') {
+    return NextResponse.json({ error: "Missing or invalid 'flag' parameter" }, { status: 400 })
+  }
+
+  const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "connection", id)
+  if (denied) return denied
+
+  const conn = await getConnectionById(id)
+  if (!conn) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+  }
+
+  await pveFetch(conn, `/cluster/ceph/flags/${encodeURIComponent(flag)}`, {
+    method: 'PUT',
+    body: new URLSearchParams({ value: value ? '1' : '0' }),
+  })
+
+  return NextResponse.json({ success: true, flag, value })
+}
+
+/**
+ * PUT /api/v1/connections/[id]/ceph/flags — set a Ceph OSD flag. Body: { flag }
+ */
+export async function PUT(req: Request, ctx: { params: Promise<{ id: string }> }) {
   try {
-    const { id } = await ctx.params
-    const body = await req.json()
-    const flag = body?.flag
-
-    if (!flag || typeof flag !== 'string') {
-      return NextResponse.json({ error: "Missing or invalid 'flag' parameter" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "connection", id)
-    if (denied) return denied
-
-    const conn = await getConnectionById(id)
-    if (!conn) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
-
-    await pveFetch(conn, `/cluster/ceph/flags/${encodeURIComponent(flag)}`, { method: 'PUT' })
-
-    return NextResponse.json({ success: true, flag })
+    return await setCephFlag(req, ctx, true)
   } catch (e: any) {
     console.error("[ceph/flags] PUT Error:", String(e?.message).replace(/[\r\n]/g, ''))
     return NextResponse.json({ error: e?.message || "Failed to set Ceph flag" }, { status: 500 })
@@ -74,34 +90,11 @@ export async function PUT(
 }
 
 /**
- * DELETE /api/v1/connections/[id]/ceph/flags
- *
- * Unset a Ceph OSD flag. Body: { flag: "noout" }
+ * DELETE /api/v1/connections/[id]/ceph/flags — unset a Ceph OSD flag. Body: { flag }
  */
-export async function DELETE(
-  req: Request,
-  ctx: { params: Promise<{ id: string }> }
-) {
+export async function DELETE(req: Request, ctx: { params: Promise<{ id: string }> }) {
   try {
-    const { id } = await ctx.params
-    const body = await req.json()
-    const flag = body?.flag
-
-    if (!flag || typeof flag !== 'string') {
-      return NextResponse.json({ error: "Missing or invalid 'flag' parameter" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "connection", id)
-    if (denied) return denied
-
-    const conn = await getConnectionById(id)
-    if (!conn) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
-
-    await pveFetch(conn, `/cluster/ceph/flags/${encodeURIComponent(flag)}`, { method: 'DELETE' })
-
-    return NextResponse.json({ success: true, flag })
+    return await setCephFlag(req, ctx, false)
   } catch (e: any) {
     console.error("[ceph/flags] DELETE Error:", String(e?.message).replace(/[\r\n]/g, ''))
     return NextResponse.json({ error: e?.message || "Failed to unset Ceph flag" }, { status: 500 })

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/ceph/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/ceph/route.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// RBAC allows; the route gates on NODE_VIEW.
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: vi.fn(async () => null),
+  PERMISSIONS: { NODE_VIEW: "node.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: vi.fn(async () => ({ id: "c1", host: "h", tokenId: "t", tokenSecret: "s" })),
+}))
+const pveFetch = vi.fn()
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...args: unknown[]) => pveFetch(...args),
+}))
+
+import { GET } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const RAW_CONF = [
+  "[global]",
+  "\tauth_client_required = cephx",
+  "\tfsid = af66e363-d2df-4b2f-b25f-933a148224d5",
+  "\tmon_host = 10.0.0.1 10.0.0.2",
+  "\tosd_pool_default_size = 3",
+  "",
+  "[client.crash]",
+  "\tkeyring = /etc/pve/ceph/$cluster.$name.keyring",
+  "",
+  "[mon.pve1]",
+  "\tpublic_addr = 10.0.0.1",
+].join("\n")
+
+const CONFIG_DB = [
+  { section: "global", name: "mon_allow_pool_delete", value: "true", level: "advanced" },
+  { section: "mgr", name: "mgr/balancer/active", value: "true", level: "advanced" },
+]
+
+function mockPve(opts: { rawConfig?: string | Error; configDb?: unknown[] | Error } = {}) {
+  pveFetch.mockImplementation(async (_conn: unknown, path: string) => {
+    if (path.endsWith("/ceph/status")) {
+      return { health: { status: "HEALTH_OK" }, monmap: { fsid: "abc", mons: [{ addr: "10.0.0.1:6789/0" }] } }
+    }
+    if (path.endsWith("/ceph/cfg/raw")) {
+      if (opts.rawConfig instanceof Error) throw opts.rawConfig
+      return opts.rawConfig ?? RAW_CONF
+    }
+    if (path.endsWith("/ceph/cfg/db")) {
+      if (opts.configDb instanceof Error) throw opts.configDb
+      return opts.configDb ?? CONFIG_DB
+    }
+    if (path.endsWith("/ceph/crush")) return "crush-map-text"
+    return null
+  })
+}
+
+type CephResp = {
+  data: {
+    hasCeph: boolean
+    config?: { raw: string | null; global: Record<string, unknown>; database: unknown[]; crushMap: unknown }
+  }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe("GET /api/v1/connections/[id]/nodes/[node]/ceph — config section", () => {
+  it("returns the full ceph.conf and the config database from the real PVE endpoints", async () => {
+    mockPve()
+    const res = await callRoute(GET, { params: { id: "c1", node: "pve1" }, searchParams: { section: "config" } })
+    expect(res.status).toBe(200)
+
+    // It must hit the real endpoints, not fabricate from /ceph/status.
+    const paths = pveFetch.mock.calls.map((c) => c[1] as string)
+    expect(paths).toContain("/nodes/pve1/ceph/cfg/raw")
+    expect(paths).toContain("/nodes/pve1/ceph/cfg/db")
+
+    const json = await readJson<CephResp>(res)
+    // Raw file is returned verbatim (every section + key, not just fsid/mon_host).
+    expect(json?.data.config?.raw).toBe(RAW_CONF)
+    expect(json?.data.config?.raw).toContain("osd_pool_default_size = 3")
+    expect(json?.data.config?.raw).toContain("[client.crash]")
+    // Config database is populated from /ceph/cfg/db.
+    expect(json?.data.config?.database).toEqual(CONFIG_DB)
+  })
+
+  it("falls back to the status-derived view with UNBRACKETED section keys when the raw file is unavailable", async () => {
+    mockPve({ rawConfig: new Error("PVE 403"), configDb: new Error("PVE 403") })
+    const res = await callRoute(GET, { params: { id: "c1", node: "pve1" }, searchParams: { section: "config" } })
+    expect(res.status).toBe(200)
+
+    const json = await readJson<CephResp>(res)
+    expect(json?.data.config?.raw).toBeNull()
+    // Section keys carry NO brackets (the renderer adds them) — guards the [[global]] regression.
+    const sections = Object.keys(json?.data.config?.global ?? {})
+    expect(sections).toContain("global")
+    expect(sections).toContain("client")
+    expect(sections).not.toContain("[global]")
+    // Database degrades to an empty list rather than throwing.
+    expect(json?.data.config?.database).toEqual([])
+  })
+
+  it("reports hasCeph:false when Ceph is not installed on the node", async () => {
+    pveFetch.mockImplementation(async (_conn: unknown, path: string) => {
+      if (path.endsWith("/ceph/status")) throw new Error("PVE 500 ceph not installed")
+      return null
+    })
+    const res = await callRoute(GET, { params: { id: "c1", node: "pve1" }, searchParams: { section: "config" } })
+    expect(res.status).toBe(200)
+    const json = await readJson<{ hasCeph: boolean }>(res)
+    expect(json?.hasCeph).toBe(false)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/ceph/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/ceph/route.ts
@@ -94,31 +94,39 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string; nod
       result.version = initialStatus.versions?.overall?.version || initialStatus.version
     }
 
-    // Configuration - extraite du status car /ceph/config n'existe pas au niveau node
+    // Configuration - Proxmox expose le fichier ceph.conf complet ET la
+    // config database au niveau node, sous /ceph/cfg/ (PVE::API2::Ceph::Cfg) :
+    //   - /ceph/cfg/raw -> /etc/pve/ceph.conf brut (texte) : toutes les
+    //     sections [global]/[client]/[client.crash]/[mon.X] et toutes les clés.
+    //   - /ceph/cfg/db  -> base de configuration (ceph config dump).
+    // (Les chemins /ceph/config et /ceph/configdb n'existent pas : 501.)
     if (section === 'all' || section === 'config') {
-      // La configuration est dans le status - on extrait les informations disponibles
+      const [rawConfig, configDb, crush] = await Promise.all([
+        fetchSafe<string>(`/nodes/${encodeURIComponent(node)}/ceph/cfg/raw`),
+        fetchSafe<any[]>(`/nodes/${encodeURIComponent(node)}/ceph/cfg/db`),
+        fetchSafe<any>(`/nodes/${encodeURIComponent(node)}/ceph/crush`),
+      ])
+
+      // Fallback structuré reconstruit depuis le status, utilisé uniquement si
+      // le fichier brut est indisponible (PVE ancien / token restreint).
+      // Clés de section SANS crochets : le rendu ajoute lui-même les [ ].
       const monmap = initialStatus.monmap || {}
-      const fsid = monmap.fsid || initialStatus.fsid
-      
-      // Construire une représentation de la config à partir des données disponibles
-      const configData: any = {
-        '[global]': {
-          fsid: fsid,
+      const fallbackGlobal: any = {
+        global: {
+          fsid: monmap.fsid || initialStatus.fsid,
           mon_host: (monmap.mons || []).map((m: any) => m.addr?.split('/')[0] || m.public_addr?.split('/')[0]).filter(Boolean).join(' '),
           cluster_network: initialStatus.cluster_network,
           public_network: initialStatus.public_network,
         },
-        '[client]': {
+        client: {
           keyring: '/etc/pve/priv/$cluster.$name.keyring'
         }
       }
-      
-      // Récupérer le crush map si disponible
-      const crush = await fetchSafe<any>(`/nodes/${encodeURIComponent(node)}/ceph/crush`)
-      
+
       result.config = {
-        global: configData,
-        database: [], // Non disponible via l'API node
+        raw: typeof rawConfig === 'string' && rawConfig.trim().length > 0 ? rawConfig : null,
+        global: fallbackGlobal,
+        database: Array.isArray(configDb) ? configDb : [],
         crushMap: crush
       }
     }


### PR DESCRIPTION
Closes the issues raised in discussion #404.

## Configuration tab showed only a stub
The Ceph **Configuration** tab rebuilt a tiny subset of `ceph.conf` (`fsid`, `mon_host`, the client keyring) from `/ceph/status`, because it called endpoints that do not exist on Proxmox (`/ceph/config`, `/ceph/configdb` both return `501 Method not implemented`). It now fetches the real data:

- `GET /nodes/{node}/ceph/cfg/raw` -> the full `/etc/pve/ceph.conf` verbatim (every section and key: all `[global]` keys, `[client.crash]`, the per-`[mon.X]` sections).
- `GET /nodes/{node}/ceph/cfg/db` -> the configuration database (`ceph config dump`), so the "Configuration Database" panel is populated instead of always reading "No custom configuration".

The status-derived subset is kept as a graceful fallback (older PVE / restricted token), and the cosmetic `[[global]]` double-bracket rendering is fixed.

## OSD flag toggles were broken
Toggling an OSD flag (`noout`, `norebalance`, `norecover`, `noscrub`, `nodeep-scrub`, `nobackfill`, `noup`, `nodown`) failed with:

```
PVE 400 /cluster/ceph/flags/noout: {"errors":{"value":"property is missing and it is not optional"}}
```

`PUT /cluster/ceph/flags/{flag}` requires a boolean `value`, and the single-flag endpoint has no `DELETE` (so unset would also have failed). Set and unset now both `PUT value=1/0` (form-encoded), through a shared `setCephFlag` helper.

## Crush Map presentation
The Crush Map was crammed into a narrow sidebar column. It is now a full-width card stacked with the others and rendered with the same colorized code block as Configuration. The line-coloring logic is shared by both panels via a single `CephConfLines` helper (`ini` / `crush` modes).

## Tests
Adds route tests for both Ceph routes: the config fetch (real endpoints + fallback with unbracketed section keys) and the flag set/unset (`value=1`/`value=0`, missing-flag 400).

## Out of scope
Editing the config from the UI (the discussion's "cherry on top") is intentionally not included: Proxmox exposes no safe API to rewrite `ceph.conf`, so this view stays read-only.
