### PR TITLE
feat(ceph): CRUSH topology view in the cluster Ceph tab

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
@@ -6,6 +6,7 @@ import {
   TableContainer, TableHead, TableRow, Tooltip as MuiTooltip, Typography, useTheme,
 } from '@mui/material'
 import { buildCrushTopology, capacityColor, type CrushNode } from './cephTopology'
+import { formatBytes } from '@/utils/format'
 
 // Theme-aware tooltip styling, mirroring InventoryTree's tooltipSlotProps.
 const useTooltipSlotProps = () => {
@@ -105,18 +106,37 @@ function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId, logoSrc 
   )
 }
 
+function daemonSummary(d: NonNullable<CrushNode['daemons']>): string {
+  return [d.monLeader ? 'mon (leader)' : d.mon ? 'mon' : '', d.mgr ? 'mgr' : '', d.mds ? 'mds' : ''].filter(Boolean).join(', ') || 'none'
+}
+
 function DetailsPanel({ node }: Readonly<{ node: CrushNode | null }>) {
   if (!node) return <Typography variant="caption" sx={{ opacity: 0.6 }}>Select a node to see details.</Typography>
-  const rows: [string, string][] = [['Type', node.type], ['Capacity', node.totalBytes > 0 ? `${node.usedPct}%` : 'n/a']]
-  if (node.osd) rows.push(['Status', `${node.osd.up ? 'up' : 'down'} / ${node.osd.in ? 'in' : 'out'}`], ['Class', node.osd.deviceClass])
-  if (node.daemons) rows.push(['Daemons', [node.daemons.monLeader ? 'mon (leader)' : node.daemons.mon ? 'mon' : '', node.daemons.mgr ? 'mgr' : '', node.daemons.mds ? 'mds' : ''].filter(Boolean).join(', ') || 'none'])
+  const cap = node.totalBytes > 0 ? `${formatBytes(node.usedBytes)} / ${formatBytes(node.totalBytes)} (${node.usedPct}%)` : 'n/a'
+  const rows: [string, string][] = [['Type', node.type], ['Capacity', cap]]
+  if (node.osd) {
+    rows.push(['Status', `${node.osd.up ? 'up' : 'down'} / ${node.osd.in ? 'in' : 'out'}`])
+    rows.push(['Device class', node.osd.deviceClass])
+    if (node.osd.reweight !== undefined) rows.push(['Reweight', String(node.osd.reweight)])
+    if (node.osd.pgs !== undefined) rows.push(['PGs', String(node.osd.pgs)])
+    if (node.osd.applyLatencyMs !== undefined || node.osd.commitLatencyMs !== undefined) {
+      rows.push(['Latency apply/commit', `${node.osd.applyLatencyMs ?? 0} / ${node.osd.commitLatencyMs ?? 0} ms`])
+    }
+    if (node.osd.host) rows.push(['Host', node.osd.host])
+    if (node.osd.version) rows.push(['Version', node.osd.version])
+  } else {
+    rows.push(['OSDs', `${node.osdUp} / ${node.osdCount} up`])
+    if (node.type !== 'host' && node.hostCount > 0) rows.push(['Hosts', String(node.hostCount)])
+    if (node.classes.length > 0) rows.push(['Device classes', node.classes.join(', ')])
+    if (node.daemons) rows.push(['Daemons', daemonSummary(node.daemons)])
+  }
   return (
     <Box>
       <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>{node.name}</Typography>
       {rows.map(([k, v]) => (
-        <Box key={k} sx={{ display: 'flex', justifyContent: 'space-between', py: 0.25, borderBottom: '1px dashed', borderColor: 'divider' }}>
-          <Typography variant="caption" color="text.secondary">{k}</Typography>
-          <Typography variant="caption" fontWeight={600}>{v}</Typography>
+        <Box key={k} sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, py: 0.25, borderBottom: '1px dashed', borderColor: 'divider' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>{k}</Typography>
+          <Typography variant="caption" fontWeight={600} sx={{ textAlign: 'right' }}>{v}</Typography>
         </Box>
       ))}
     </Box>
@@ -185,7 +205,7 @@ export default function CephTopology({ connId }: Readonly<{ connId: string }>) {
         </CardContent></Card>
       </Box>
       <Card variant="outlined"><CardContent>
-        <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>Pools → CRUSH rules</Typography>
+        <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>POOLS</Typography>
         {poolRules.length > 0 ? (
           <TableContainer><Table size="small">
             <TableHead><TableRow>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react'
+import {
+  Box, Card, CardContent, CircularProgress, Stack, Table, TableBody, TableCell,
+  TableContainer, TableHead, TableRow, Tooltip as MuiTooltip, Typography, useTheme,
+} from '@mui/material'
+import { buildCrushTopology, capacityColor, type CrushNode } from './cephTopology'
+
+// Theme-aware tooltip styling, mirroring InventoryTree's tooltipSlotProps.
+const useTooltipSlotProps = () => {
+  const theme = useTheme()
+  return {
+    tooltip: { sx: { bgcolor: 'background.paper', color: 'text.primary', border: `1px solid ${theme.palette.divider}`, boxShadow: 3, fontSize: '0.75rem' } },
+    arrow: { sx: { color: 'background.paper' } },
+  }
+}
+
+function CapacityBar({ pct }: Readonly<{ pct: number }>) {
+  return (
+    <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, ml: 1 }}>
+      <Box sx={{ width: 70, height: 6, borderRadius: 1, bgcolor: 'action.hover', overflow: 'hidden' }}>
+        <Box sx={{ width: `${Math.min(pct, 100)}%`, height: '100%', bgcolor: `${capacityColor(pct)}.main` }} />
+      </Box>
+      <Typography variant="caption" sx={{ minWidth: 34, textAlign: 'right' }}>{pct}%</Typography>
+    </Box>
+  )
+}
+
+function DaemonChips({ d }: Readonly<{ d: NonNullable<CrushNode['daemons']> }>) {
+  const chip = (label: string, on: boolean, color: string) => on ? (
+    <Box component="span" sx={{ ml: 0.5, px: 0.75, py: 0.1, borderRadius: 1, fontSize: '0.65rem', bgcolor: `${color}.dark`, color: `${color}.contrastText` }}>{label}</Box>
+  ) : null
+  return <>{chip(d.monLeader ? 'mon ★' : 'mon', d.mon, 'success')}{chip('mgr', d.mgr, 'info')}{chip('mds', d.mds, 'secondary')}</>
+}
+
+function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId }: Readonly<{
+  node: CrushNode; depth: number; expanded: Set<string>; toggle: (k: string) => void
+  onSelect: (n: CrushNode) => void; selectedId: string
+}>) {
+  const key = `${node.type}:${node.id}:${node.name}`
+  const hasChildren = !!node.children && node.children.length > 0
+  const isOpen = expanded.has(key)
+  return (
+    <Box>
+      <Box
+        onClick={() => onSelect(node)}
+        sx={{
+          display: 'flex', alignItems: 'center', py: 0.25, pl: `${depth * 18}px`, borderRadius: 1, cursor: 'pointer',
+          bgcolor: selectedId === key ? 'action.selected' : 'transparent', '&:hover': { bgcolor: 'action.hover' },
+        }}
+      >
+        <Box
+          component="span"
+          onClick={(e) => { e.stopPropagation(); if (hasChildren) toggle(key) }}
+          sx={{ width: 18, color: 'primary.main', visibility: hasChildren ? 'visible' : 'hidden' }}
+        >
+          <i className={isOpen ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'} />
+        </Box>
+        <Typography variant="body2" component="span" sx={{ color: node.type === 'osd' ? 'text.primary' : 'text.secondary' }}>
+          {node.type !== 'osd' && node.type !== 'root' ? `${node.type} ` : ''}<b>{node.name}</b>
+        </Typography>
+        {node.osd && (
+          <>
+            <Box component="span" sx={{ ml: 0.5, px: 0.75, borderRadius: 1, fontSize: '0.65rem', bgcolor: node.osd.up && node.osd.in ? 'success.dark' : 'error.dark', color: 'common.white' }}>
+              {node.osd.up ? 'up' : 'down'}/{node.osd.in ? 'in' : 'out'}
+            </Box>
+            <Box component="span" sx={{ ml: 0.5, px: 0.75, borderRadius: 1, fontSize: '0.65rem', bgcolor: 'action.hover' }}>{node.osd.deviceClass}</Box>
+          </>
+        )}
+        {node.type === 'host' && node.daemons && <DaemonChips d={node.daemons} />}
+        {node.totalBytes > 0 && <CapacityBar pct={node.usedPct} />}
+      </Box>
+      {hasChildren && isOpen && node.children!.map((c) => (
+        <TreeRow key={`${c.type}:${c.id}:${c.name}`} node={c} depth={depth + 1} expanded={expanded} toggle={toggle} onSelect={onSelect} selectedId={selectedId} />
+      ))}
+    </Box>
+  )
+}
+
+function DetailsPanel({ node }: Readonly<{ node: CrushNode | null }>) {
+  if (!node) return <Typography variant="caption" sx={{ opacity: 0.6 }}>Select a node to see details.</Typography>
+  const rows: [string, string][] = [['Type', node.type], ['Capacity', node.totalBytes > 0 ? `${node.usedPct}%` : 'n/a']]
+  if (node.osd) rows.push(['Status', `${node.osd.up ? 'up' : 'down'} / ${node.osd.in ? 'in' : 'out'}`], ['Class', node.osd.deviceClass])
+  if (node.daemons) rows.push(['Daemons', [node.daemons.monLeader ? 'mon (leader)' : node.daemons.mon ? 'mon' : '', node.daemons.mgr ? 'mgr' : '', node.daemons.mds ? 'mds' : ''].filter(Boolean).join(', ') || 'none'])
+  return (
+    <Box>
+      <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>{node.name}</Typography>
+      {rows.map(([k, v]) => (
+        <Box key={k} sx={{ display: 'flex', justifyContent: 'space-between', py: 0.25, borderBottom: '1px dashed', borderColor: 'divider' }}>
+          <Typography variant="caption" color="text.secondary">{k}</Typography>
+          <Typography variant="caption" fontWeight={600}>{v}</Typography>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export default function CephTopology({ connId }: Readonly<{ connId: string }>) {
+  const [data, setData] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(false)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [selected, setSelected] = useState<CrushNode | null>(null)
+  const tooltipSlotProps = useTooltipSlotProps()
+
+  useEffect(() => {
+    if (!connId) return
+    let cancelled = false
+    setLoading(true); setError(false)
+    fetch(`/api/v1/connections/${encodeURIComponent(connId)}/ceph`, { cache: 'no-store' })
+      .then((r) => r.ok ? r.json() : Promise.reject(new Error(String(r.status))))
+      .then((json) => { if (!cancelled) setData(json.data ?? json) })
+      .catch(() => { if (!cancelled) setError(true) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [connId])
+
+  const { tree, poolRules } = useMemo(() => buildCrushTopology(data ?? {}), [data])
+
+  // Expand the first two levels by default once data arrives.
+  useEffect(() => {
+    if (!tree.length) return
+    const next = new Set<string>()
+    for (const root of tree) {
+      next.add(`${root.type}:${root.id}:${root.name}`)
+      for (const lvl1 of root.children ?? []) next.add(`${lvl1.type}:${lvl1.id}:${lvl1.name}`)
+    }
+    setExpanded(next)
+  }, [tree])
+
+  const toggle = (k: string) => setExpanded((prev) => {
+    const next = new Set(prev)
+    if (next.has(k)) next.delete(k); else next.add(k)
+    return next
+  })
+
+  if (loading) return <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}><CircularProgress size={22} /></Box>
+  if (error) return <Typography variant="body2" sx={{ opacity: 0.6 }}>Ceph not available on this cluster.</Typography>
+  if (!tree.length) return <Typography variant="body2" sx={{ opacity: 0.6 }}>Topology unavailable.</Typography>
+
+  const selectedId = selected ? `${selected.type}:${selected.id}:${selected.name}` : ''
+
+  return (
+    <Stack spacing={2}>
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1.6fr 1fr' }, gap: 2 }}>
+        <Card variant="outlined"><CardContent>
+          <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>CRUSH tree</Typography>
+          {tree.map((n) => (
+            <TreeRow key={`${n.type}:${n.id}:${n.name}`} node={n} depth={0} expanded={expanded} toggle={toggle} onSelect={setSelected} selectedId={selectedId} />
+          ))}
+        </CardContent></Card>
+        <Card variant="outlined"><CardContent>
+          <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>Details</Typography>
+          <DetailsPanel node={selected} />
+        </CardContent></Card>
+      </Box>
+      <Card variant="outlined"><CardContent>
+        <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>Pools → CRUSH rules</Typography>
+        {poolRules.length > 0 ? (
+          <TableContainer><Table size="small">
+            <TableHead><TableRow>
+              <TableCell sx={{ fontWeight: 700 }}>Pool</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>Rule</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>Target</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>Size</TableCell>
+              <TableCell sx={{ fontWeight: 700 }}>%used</TableCell>
+            </TableRow></TableHead>
+            <TableBody>{poolRules.map((p) => (
+              <TableRow key={p.pool}>
+                <TableCell>{p.pool}</TableCell><TableCell>{p.ruleName}</TableCell>
+                <MuiTooltip title="CRUSH rule 'take' target bucket/class" arrow slotProps={tooltipSlotProps}><TableCell>{p.target}</TableCell></MuiTooltip>
+                <TableCell>{p.size}</TableCell><TableCell>{p.usedPct}%</TableCell>
+              </TableRow>
+            ))}</TableBody>
+          </Table></TableContainer>
+        ) : <Typography variant="caption" sx={{ opacity: 0.6 }}>No pools.</Typography>}
+      </CardContent></Card>
+    </Stack>
+  )
+}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
@@ -34,9 +34,35 @@ function DaemonChips({ d }: Readonly<{ d: NonNullable<CrushNode['daemons']> }>) 
   return <>{chip(d.monLeader ? 'mon ★' : 'mon', d.mon, 'success')}{chip('mgr', d.mgr, 'info')}{chip('mds', d.mds, 'secondary')}</>
 }
 
-function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId }: Readonly<{
+// RemixIcon glyph per CRUSH bucket type (osd / chassis / rack / datacenter / …).
+function crushTypeIcon(type: string): string {
+  switch (type) {
+    case 'osd': return 'ri-hard-drive-2-line'
+    case 'chassis': return 'ri-server-line'
+    case 'rack': return 'ri-archive-2-line'
+    case 'row': return 'ri-layout-row-line'
+    case 'pdu': return 'ri-plug-line'
+    case 'pod': return 'ri-archive-stack-line'
+    case 'room': return 'ri-home-4-line'
+    case 'datacenter': return 'ri-building-2-line'
+    case 'zone': return 'ri-global-line'
+    case 'region': return 'ri-earth-line'
+    case 'root': return 'ri-stack-line'
+    default: return 'ri-checkbox-blank-circle-line'
+  }
+}
+
+// Host buckets are PVE nodes → show the Proxmox logo; other bucket types use a glyph.
+function TypeIcon({ type, logoSrc }: Readonly<{ type: string; logoSrc: string }>) {
+  if (type === 'host') {
+    return <Box component="img" src={logoSrc} alt="" sx={{ width: 15, height: 15, flexShrink: 0, mr: 0.75 }} />
+  }
+  return <Box component="i" className={crushTypeIcon(type)} sx={{ fontSize: 15, width: 16, textAlign: 'center', opacity: 0.7, flexShrink: 0, mr: 0.75, color: 'text.secondary' }} />
+}
+
+function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId, logoSrc }: Readonly<{
   node: CrushNode; depth: number; expanded: Set<string>; toggle: (k: string) => void
-  onSelect: (n: CrushNode) => void; selectedId: string
+  onSelect: (n: CrushNode) => void; selectedId: string; logoSrc: string
 }>) {
   const key = `${node.type}:${node.id}:${node.name}`
   const hasChildren = !!node.children && node.children.length > 0
@@ -57,8 +83,9 @@ function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId }: Readon
         >
           <i className={isOpen ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'} />
         </Box>
+        <TypeIcon type={node.type} logoSrc={logoSrc} />
         <Typography variant="body2" component="span" sx={{ color: node.type === 'osd' ? 'text.primary' : 'text.secondary' }}>
-          {node.type !== 'osd' && node.type !== 'root' ? `${node.type} ` : ''}<b>{node.name}</b>
+          {node.type !== 'osd' && node.type !== 'root' && node.type !== 'host' ? `${node.type} ` : ''}<b>{node.name}</b>
         </Typography>
         {node.osd && (
           <>
@@ -72,7 +99,7 @@ function TreeRow({ node, depth, expanded, toggle, onSelect, selectedId }: Readon
         {node.totalBytes > 0 && <CapacityBar pct={node.usedPct} />}
       </Box>
       {hasChildren && isOpen && node.children!.map((c) => (
-        <TreeRow key={`${c.type}:${c.id}:${c.name}`} node={c} depth={depth + 1} expanded={expanded} toggle={toggle} onSelect={onSelect} selectedId={selectedId} />
+        <TreeRow key={`${c.type}:${c.id}:${c.name}`} node={c} depth={depth + 1} expanded={expanded} toggle={toggle} onSelect={onSelect} selectedId={selectedId} logoSrc={logoSrc} />
       ))}
     </Box>
   )
@@ -103,6 +130,8 @@ export default function CephTopology({ connId }: Readonly<{ connId: string }>) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const [selected, setSelected] = useState<CrushNode | null>(null)
   const tooltipSlotProps = useTooltipSlotProps()
+  const theme = useTheme()
+  const logoSrc = theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'
 
   useEffect(() => {
     if (!connId) return
@@ -147,7 +176,7 @@ export default function CephTopology({ connId }: Readonly<{ connId: string }>) {
         <Card variant="outlined"><CardContent>
           <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 1 }}>CRUSH tree</Typography>
           {tree.map((n) => (
-            <TreeRow key={`${n.type}:${n.id}:${n.name}`} node={n} depth={0} expanded={expanded} toggle={toggle} onSelect={setSelected} selectedId={selectedId} />
+            <TreeRow key={`${n.type}:${n.id}:${n.name}`} node={n} depth={0} expanded={expanded} toggle={toggle} onSelect={setSelected} selectedId={selectedId} logoSrc={logoSrc} />
           ))}
         </CardContent></Card>
         <Card variant="outlined"><CardContent>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
@@ -17,7 +17,7 @@ const cephData = {
     ]},
   ],
   osds: { list: [
-    { id: "0", name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 80 },
+    { id: "0", name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 80, reweight: 1, pgs: 33, version: "19.2.3", applyLatencyMs: 2, commitLatencyMs: 3 },
     { id: "1", name: "osd.1", host: "pve1", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 40 },
   ]},
   monitors: { list: [{ name: "pve1", host: "pve1", inQuorum: true, leader: true }] },
@@ -30,11 +30,26 @@ const cephData = {
 }
 
 describe("buildCrushTopology", () => {
-  it("merges osd status/class into the leaf nodes despite STRING ids", () => {
+  it("merges osd status/class/details into the leaf nodes despite STRING ids", () => {
     const { tree } = buildCrushTopology(cephData as any)
     const osd0 = tree[0].children![0].children![0].children![0]
     expect(osd0.usedPct).toBe(80)
-    expect(osd0.osd).toEqual({ up: true, in: true, deviceClass: "hdd" })
+    expect(osd0.osd).toEqual({
+      up: true, in: true, deviceClass: "hdd",
+      reweight: 1, pgs: 33, version: "19.2.3", applyLatencyMs: 2, commitLatencyMs: 3, host: "pve1",
+    })
+  })
+
+  it("computes descendant aggregates (osd counts, classes, host count)", () => {
+    const { tree } = buildCrushTopology(cephData as any)
+    const root = tree[0]
+    expect(root.osdCount).toBe(2)
+    expect(root.osdUp).toBe(2)
+    expect(root.hostCount).toBe(1)
+    expect(root.classes).toEqual(["hdd"])
+    const host = root.children![0].children![0]
+    expect(host.osdCount).toBe(2)
+    expect(host.hostCount).toBe(1)
   })
 
   it("derives usedBytes from usedPct (route usedBytes is unreliable) and rolls capacity up", () => {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
@@ -1,41 +1,47 @@
 import { describe, it, expect } from "vitest"
 import { buildCrushTopology, capacityColor } from "./cephTopology"
 
+// Mirrors real PVE shapes: OSD ids are STRINGS, the /ceph/rules endpoint is
+// bare ({name} only, no id/steps), the pool carries crush_rule_name +
+// autoscale crush_root_id, and the route's osds.list usedBytes is unreliable
+// (0 here) while usedPct/totalBytes are trustworthy.
 const cephData = {
   crushTree: [
     { id: -1, name: "default", type: "root", children: [
       { id: -3, name: "rack-A", type: "rack", children: [
         { id: -2, name: "pve1", type: "host", children: [
-          { id: 0, name: "osd.0", type: "osd", status: "up" },
-          { id: 1, name: "osd.1", type: "osd", status: "up" },
+          { id: "0", name: "osd.0", type: "osd", status: "up" },
+          { id: "1", name: "osd.1", type: "osd", status: "up" },
         ]},
       ]},
     ]},
   ],
   osds: { list: [
-    { id: 0, name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "nvme", totalBytes: 100, usedBytes: 80, usedPct: 80 },
-    { id: 1, name: "osd.1", host: "pve1", up: true, in: true, deviceClass: "nvme", totalBytes: 100, usedBytes: 40, usedPct: 40 },
+    { id: "0", name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 80 },
+    { id: "1", name: "osd.1", host: "pve1", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 40 },
   ]},
   monitors: { list: [{ name: "pve1", host: "pve1", inQuorum: true, leader: true }] },
   managers: { active: { name: "pve1", host: "pve1" }, standbys: [] },
   mds: { list: [{ name: "mds.pve1", host: "pve1", state: "active" }] },
-  pools: { list: [{ id: 1, name: "rbd", size: 3, minSize: 2, crushRule: 0, percentUsed: 41 }] },
-  crushRules: [{ id: 0, name: "replicated_rule", steps: [{ op: "take", item_name: "default" }, { op: "choose_firstn" }] }],
+  pools: { list: [
+    { id: "1", name: "rbd", size: 3, minSize: 2, crushRule: "0", crushRuleName: "replicated_rule", crushRootId: -1, percentUsed: 0.0699853897 },
+  ]},
+  crushRules: [{ name: "replicated_rule" }],
 }
 
 describe("buildCrushTopology", () => {
-  it("merges osd capacity/status into the crush leaf nodes", () => {
+  it("merges osd status/class into the leaf nodes despite STRING ids", () => {
     const { tree } = buildCrushTopology(cephData as any)
     const osd0 = tree[0].children![0].children![0].children![0]
     expect(osd0.usedPct).toBe(80)
-    expect(osd0.osd).toEqual({ up: true, in: true, deviceClass: "nvme" })
+    expect(osd0.osd).toEqual({ up: true, in: true, deviceClass: "hdd" })
   })
 
-  it("aggregates capacity bottom-up for host/rack/root", () => {
+  it("derives usedBytes from usedPct (route usedBytes is unreliable) and rolls capacity up", () => {
     const { tree } = buildCrushTopology(cephData as any)
     const host = tree[0].children![0].children![0]
     expect(host.totalBytes).toBe(200)
-    expect(host.usedBytes).toBe(120)
+    expect(host.usedBytes).toBe(120) // 100*80% + 100*40% — NOT the 0 from osds.list
     expect(host.usedPct).toBe(60)
     expect(tree[0].usedPct).toBe(60) // root aggregates the same
   })
@@ -46,11 +52,19 @@ describe("buildCrushTopology", () => {
     expect(host.daemons).toEqual({ mon: true, monLeader: true, mgr: true, mds: true })
   })
 
-  it("maps pools to their crush rule name and take-step target", () => {
+  it("names the rule from crush_rule_name, resolves target from crush root id, rounds %used", () => {
     const { poolRules } = buildCrushTopology(cephData as any)
     expect(poolRules).toEqual([
-      { pool: "rbd", ruleName: "replicated_rule", target: "default", size: "3/2", usedPct: 41 },
+      { pool: "rbd", ruleName: "replicated_rule", target: "default", size: "3/2", usedPct: 0.1 },
     ])
+  })
+
+  it("uses the rule take-step target when the rules endpoint provides steps", () => {
+    const { poolRules } = buildCrushTopology({
+      pools: { list: [{ name: "p", size: 3, minSize: 2, crushRule: "5", percentUsed: 0 }] },
+      crushRules: [{ id: 5, name: "ssd_rule", steps: [{ op: "take", item_name: "default~ssd" }] }],
+    } as any)
+    expect(poolRules[0]).toEqual({ pool: "p", ruleName: "ssd_rule", target: "default~ssd", size: "3/2", usedPct: 0 })
   })
 
   it("returns empty tree/poolRules for missing data without throwing", () => {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest"
+import { buildCrushTopology, capacityColor } from "./cephTopology"
+
+const cephData = {
+  crushTree: [
+    { id: -1, name: "default", type: "root", children: [
+      { id: -3, name: "rack-A", type: "rack", children: [
+        { id: -2, name: "pve1", type: "host", children: [
+          { id: 0, name: "osd.0", type: "osd", status: "up" },
+          { id: 1, name: "osd.1", type: "osd", status: "up" },
+        ]},
+      ]},
+    ]},
+  ],
+  osds: { list: [
+    { id: 0, name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "nvme", totalBytes: 100, usedBytes: 80, usedPct: 80 },
+    { id: 1, name: "osd.1", host: "pve1", up: true, in: true, deviceClass: "nvme", totalBytes: 100, usedBytes: 40, usedPct: 40 },
+  ]},
+  monitors: { list: [{ name: "pve1", host: "pve1", inQuorum: true, leader: true }] },
+  managers: { active: { name: "pve1", host: "pve1" }, standbys: [] },
+  mds: { list: [{ name: "mds.pve1", host: "pve1", state: "active" }] },
+  pools: { list: [{ id: 1, name: "rbd", size: 3, minSize: 2, crushRule: 0, percentUsed: 41 }] },
+  crushRules: [{ id: 0, name: "replicated_rule", steps: [{ op: "take", item_name: "default" }, { op: "choose_firstn" }] }],
+}
+
+describe("buildCrushTopology", () => {
+  it("merges osd capacity/status into the crush leaf nodes", () => {
+    const { tree } = buildCrushTopology(cephData as any)
+    const osd0 = tree[0].children![0].children![0].children![0]
+    expect(osd0.usedPct).toBe(80)
+    expect(osd0.osd).toEqual({ up: true, in: true, deviceClass: "nvme" })
+  })
+
+  it("aggregates capacity bottom-up for host/rack/root", () => {
+    const { tree } = buildCrushTopology(cephData as any)
+    const host = tree[0].children![0].children![0]
+    expect(host.totalBytes).toBe(200)
+    expect(host.usedBytes).toBe(120)
+    expect(host.usedPct).toBe(60)
+    expect(tree[0].usedPct).toBe(60) // root aggregates the same
+  })
+
+  it("attaches mon (with leader), mgr and mds badges to the host node", () => {
+    const { tree } = buildCrushTopology(cephData as any)
+    const host = tree[0].children![0].children![0]
+    expect(host.daemons).toEqual({ mon: true, monLeader: true, mgr: true, mds: true })
+  })
+
+  it("maps pools to their crush rule name and take-step target", () => {
+    const { poolRules } = buildCrushTopology(cephData as any)
+    expect(poolRules).toEqual([
+      { pool: "rbd", ruleName: "replicated_rule", target: "default", size: "3/2", usedPct: 41 },
+    ])
+  })
+
+  it("returns empty tree/poolRules for missing data without throwing", () => {
+    const { tree, poolRules } = buildCrushTopology({} as any)
+    expect(tree).toEqual([])
+    expect(poolRules).toEqual([])
+  })
+})
+
+describe("capacityColor", () => {
+  it("maps utilization to theme palette keys", () => {
+    expect(capacityColor(10)).toBe("success")
+    expect(capacityColor(75)).toBe("warning")
+    expect(capacityColor(90)).toBe("error")
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.test.ts
@@ -89,6 +89,45 @@ describe("buildCrushTopology", () => {
   })
 })
 
+describe("buildCrushTopology — edge cases", () => {
+  it("uses the route usedBytes when present and skips osds missing from the list", () => {
+    const { tree } = buildCrushTopology({
+      crushTree: [{ id: -1, name: "default", type: "root", children: [
+        { id: -2, name: "pve1", type: "host", children: [
+          { id: "0", name: "osd.0", type: "osd" },
+          { id: "9", name: "osd.9", type: "osd" }, // not present in osds.list
+        ]},
+      ]}],
+      osds: { list: [{ id: "0", name: "osd.0", host: "pve1", up: true, in: true, deviceClass: "ssd", totalBytes: 200, usedBytes: 50, usedPct: 25 }] },
+    } as any)
+    const host = tree[0].children![0]
+    const [osd0, osd9] = host.children!
+    expect(osd0.usedBytes).toBe(50) // route value used directly, not derived
+    expect(osd0.osd?.deviceClass).toBe("ssd")
+    expect(osd9.osd).toBeUndefined() // missing from list → no merge, no crash
+    expect(host.osdCount).toBe(1)
+  })
+
+  it("falls back to String(crushRule) and an empty target when nothing resolves", () => {
+    const { poolRules } = buildCrushTopology({
+      pools: { list: [{ name: "orphan", size: 2, minSize: 1, crushRule: "9", percentUsed: 0 }] },
+      crushRules: [],
+    } as any)
+    expect(poolRules[0]).toEqual({ pool: "orphan", ruleName: "9", target: "", size: "2/1", usedPct: 0 })
+  })
+
+  it("indexes host daemons defensively (host-less mon/mds ignored, standby mgr counted)", () => {
+    const { tree } = buildCrushTopology({
+      crushTree: [{ id: -2, name: "pve2", type: "host", children: [{ id: "1", name: "osd.1", type: "osd" }] }],
+      osds: { list: [{ id: "1", host: "pve2", up: true, in: true, deviceClass: "hdd", totalBytes: 100, usedBytes: 0, usedPct: 0 }] },
+      monitors: { list: [{ name: "x", leader: true }, { name: "pve2", host: "pve2" }] }, // first has no host → ignored
+      mds: { list: [{ name: "y" }] }, // no host → ignored
+      managers: { active: { name: "z" }, standbys: [{ name: "pve2", host: "pve2" }] }, // active host-less, standby on pve2
+    } as any)
+    expect(tree[0].daemons).toEqual({ mon: true, monLeader: false, mgr: true, mds: false })
+  })
+})
+
 describe("capacityColor", () => {
   it("maps utilization to theme palette keys", () => {
     expect(capacityColor(10)).toBe("success")

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
@@ -1,6 +1,18 @@
 // Pure composition logic for the Ceph CRUSH topology view. No JSX, no React —
 // kept separate so it is unit-tested and measured by SonarCloud.
 
+export type OsdDetail = {
+  up: boolean
+  in: boolean
+  deviceClass: string
+  reweight?: number
+  pgs?: number
+  version?: string | null
+  applyLatencyMs?: number
+  commitLatencyMs?: number
+  host?: string
+}
+
 export type CrushNode = {
   id: string | number
   name: string
@@ -9,7 +21,12 @@ export type CrushNode = {
   usedBytes: number
   totalBytes: number
   usedPct: number
-  osd?: { up: boolean; in: boolean; deviceClass: string }
+  // descendant aggregates (osd leaves count themselves)
+  osdCount: number
+  osdUp: number
+  hostCount: number
+  classes: string[]
+  osd?: OsdDetail
   daemons?: { mon: boolean; monLeader: boolean; mgr: boolean; mds: boolean }
   children?: CrushNode[]
 }
@@ -68,7 +85,7 @@ function hostDaemonIndex(data: AnyRec): Map<string, { mon: boolean; monLeader: b
 function enrich(node: AnyRec, osds: Map<string, AnyRec>, hosts: Map<string, any>): CrushNode {
   const base: CrushNode = {
     id: node.id, name: node.name, type: node.type, status: node.status,
-    usedBytes: 0, totalBytes: 0, usedPct: 0,
+    usedBytes: 0, totalBytes: 0, usedPct: 0, osdCount: 0, osdUp: 0, hostCount: 0, classes: [],
   }
   if (node.type === "osd" || (!node.children && Number(node.id) >= 0)) {
     const o = osds.get(String(node.id))
@@ -76,19 +93,30 @@ function enrich(node: AnyRec, osds: Map<string, AnyRec>, hosts: Map<string, any>
       base.totalBytes = o.totalBytes || 0
       base.usedPct = round1(typeof o.usedPct === "number" ? o.usedPct : 0)
       // The route's osds.list usedBytes is unreliable (derived from a kb_used
-      // field PVE doesn't return); derive it from the trustworthy percent_used
-      // so bucket roll-ups are correct.
-      base.usedBytes = Math.round((base.totalBytes * base.usedPct) / 100)
-      base.osd = { up: !!o.up, in: !!o.in, deviceClass: o.deviceClass || "unknown" }
+      // field PVE doesn't return, so 0); fall back to deriving it from the
+      // trustworthy percent_used so bucket roll-ups are correct.
+      base.usedBytes = o.usedBytes || Math.round((base.totalBytes * base.usedPct) / 100)
+      base.osd = {
+        up: !!o.up, in: !!o.in, deviceClass: o.deviceClass || "unknown",
+        reweight: o.reweight, pgs: o.pgs, version: o.version ?? null,
+        applyLatencyMs: o.applyLatencyMs, commitLatencyMs: o.commitLatencyMs, host: o.host,
+      }
       base.status = base.status || (o.up ? "up" : "down")
+      base.osdCount = 1
+      base.osdUp = o.up ? 1 : 0
+      base.classes = base.osd.deviceClass ? [base.osd.deviceClass] : []
     }
     return base
   }
-  const children = (node.children ?? []).map((c: AnyRec) => enrich(c, osds, hosts))
+  const children: CrushNode[] = (node.children ?? []).map((c: AnyRec) => enrich(c, osds, hosts))
   base.children = children
   base.usedBytes = children.reduce((s, c) => s + c.usedBytes, 0)
   base.totalBytes = children.reduce((s, c) => s + c.totalBytes, 0)
   base.usedPct = base.totalBytes > 0 ? round1((base.usedBytes / base.totalBytes) * 100) : 0
+  base.osdCount = children.reduce((s, c) => s + c.osdCount, 0)
+  base.osdUp = children.reduce((s, c) => s + c.osdUp, 0)
+  base.hostCount = node.type === "host" ? 1 : children.reduce((s, c) => s + c.hostCount, 0)
+  base.classes = [...new Set(children.flatMap((c) => c.classes))].sort((a, b) => a.localeCompare(b))
   if (node.type === "host") base.daemons = hosts.get(node.name) ?? { mon: false, monLeader: false, mgr: false, mds: false }
   return base
 }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
@@ -1,0 +1,107 @@
+// Pure composition logic for the Ceph CRUSH topology view. No JSX, no React —
+// kept separate so it is unit-tested and measured by SonarCloud.
+
+export type CrushNode = {
+  id: number
+  name: string
+  type: string
+  status?: string
+  usedBytes: number
+  totalBytes: number
+  usedPct: number
+  osd?: { up: boolean; in: boolean; deviceClass: string }
+  daemons?: { mon: boolean; monLeader: boolean; mgr: boolean; mds: boolean }
+  children?: CrushNode[]
+}
+
+export type PoolRuleRow = {
+  pool: string
+  ruleName: string
+  target: string
+  size: string
+  usedPct: number
+}
+
+export type CephTopology = { tree: CrushNode[]; poolRules: PoolRuleRow[] }
+
+type AnyRec = Record<string, any>
+
+function osdIndex(list: AnyRec[]): Map<number, AnyRec> {
+  const m = new Map<number, AnyRec>()
+  for (const o of list) if (typeof o?.id === "number") m.set(o.id, o)
+  return m
+}
+
+function hostDaemonIndex(data: AnyRec): Map<string, { mon: boolean; monLeader: boolean; mgr: boolean; mds: boolean }> {
+  const m = new Map<string, { mon: boolean; monLeader: boolean; mgr: boolean; mds: boolean }>()
+  const get = (host: string) => {
+    if (!m.has(host)) m.set(host, { mon: false, monLeader: false, mgr: false, mds: false })
+    return m.get(host)!
+  }
+  for (const mon of data?.monitors?.list ?? []) {
+    if (!mon?.host) continue
+    const d = get(mon.host)
+    d.mon = true
+    if (mon.leader) d.monLeader = true
+  }
+  for (const mds of data?.mds?.list ?? []) if (mds?.host) get(mds.host).mds = true
+  const mgrs = data?.managers
+  if (mgrs?.active?.host) get(mgrs.active.host).mgr = true
+  for (const s of mgrs?.standbys ?? []) if (s?.host) get(s.host).mgr = true
+  return m
+}
+
+function enrich(node: AnyRec, osds: Map<number, AnyRec>, hosts: Map<string, any>): CrushNode {
+  const base: CrushNode = {
+    id: node.id, name: node.name, type: node.type, status: node.status,
+    usedBytes: 0, totalBytes: 0, usedPct: 0,
+  }
+  if (node.type === "osd" || (!node.children && typeof node.id === "number" && node.id >= 0)) {
+    const o = osds.get(node.id)
+    if (o) {
+      base.usedBytes = o.usedBytes || 0
+      base.totalBytes = o.totalBytes || 0
+      base.usedPct = typeof o.usedPct === "number" ? o.usedPct : 0
+      base.osd = { up: !!o.up, in: !!o.in, deviceClass: o.deviceClass || "unknown" }
+      base.status = base.status || (o.up ? "up" : "down")
+    }
+    return base
+  }
+  const children = (node.children ?? []).map((c: AnyRec) => enrich(c, osds, hosts))
+  base.children = children
+  base.usedBytes = children.reduce((s, c) => s + c.usedBytes, 0)
+  base.totalBytes = children.reduce((s, c) => s + c.totalBytes, 0)
+  base.usedPct = base.totalBytes > 0 ? Math.round((base.usedBytes / base.totalBytes) * 1000) / 10 : 0
+  if (node.type === "host") base.daemons = hosts.get(node.name) ?? { mon: false, monLeader: false, mgr: false, mds: false }
+  return base
+}
+
+export function buildCrushTopology(data: AnyRec): CephTopology {
+  const crushTree: AnyRec[] = Array.isArray(data?.crushTree) ? data.crushTree : []
+  const osds = osdIndex(data?.osds?.list ?? [])
+  const hosts = hostDaemonIndex(data ?? {})
+  const tree = crushTree.map((n) => enrich(n, osds, hosts))
+
+  const rules: AnyRec[] = Array.isArray(data?.crushRules) ? data.crushRules : []
+  const ruleById = new Map<number, AnyRec>()
+  for (const r of rules) if (typeof r?.id === "number") ruleById.set(r.id, r)
+  const poolRules: PoolRuleRow[] = (data?.pools?.list ?? []).map((p: AnyRec) => {
+    const rule = ruleById.get(p.crushRule)
+    const take = rule?.steps?.find((s: AnyRec) => s?.op === "take")
+    return {
+      pool: p.name,
+      ruleName: rule?.name ?? String(p.crushRule ?? ""),
+      target: take?.item_name ?? "",
+      size: `${p.size ?? "?"}/${p.minSize ?? "?"}`,
+      usedPct: typeof p.percentUsed === "number" ? p.percentUsed : 0,
+    }
+  })
+
+  return { tree, poolRules }
+}
+
+export function capacityColor(pct: number): "success" | "warning" | "error" {
+  if (pct > 85) return "error"
+  if (pct >= 70) return "warning"
+  return "success"
+}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/cephTopology.ts
@@ -2,7 +2,7 @@
 // kept separate so it is unit-tested and measured by SonarCloud.
 
 export type CrushNode = {
-  id: number
+  id: string | number
   name: string
   type: string
   status?: string
@@ -26,9 +26,23 @@ export type CephTopology = { tree: CrushNode[]; poolRules: PoolRuleRow[] }
 
 type AnyRec = Record<string, any>
 
-function osdIndex(list: AnyRec[]): Map<number, AnyRec> {
-  const m = new Map<number, AnyRec>()
-  for (const o of list) if (typeof o?.id === "number") m.set(o.id, o)
+const round1 = (n: number) => Math.round(n * 10) / 10
+
+// PVE returns ids as strings ("2") for OSDs and crush rules but numbers for
+// buckets (-1). Always key/look up by String() so the merges actually match.
+function osdIndex(list: AnyRec[]): Map<string, AnyRec> {
+  const m = new Map<string, AnyRec>()
+  for (const o of list) if (o?.id !== undefined && o?.id !== null) m.set(String(o.id), o)
+  return m
+}
+
+// id -> bucket/osd name, over the whole crush tree (used to resolve a pool's
+// crush root id to a readable target name).
+function bucketNameIndex(nodes: AnyRec[], m: Map<string, string> = new Map()): Map<string, string> {
+  for (const n of nodes ?? []) {
+    if (n?.id !== undefined && n?.id !== null) m.set(String(n.id), n.name)
+    if (Array.isArray(n?.children)) bucketNameIndex(n.children, m)
+  }
   return m
 }
 
@@ -51,17 +65,20 @@ function hostDaemonIndex(data: AnyRec): Map<string, { mon: boolean; monLeader: b
   return m
 }
 
-function enrich(node: AnyRec, osds: Map<number, AnyRec>, hosts: Map<string, any>): CrushNode {
+function enrich(node: AnyRec, osds: Map<string, AnyRec>, hosts: Map<string, any>): CrushNode {
   const base: CrushNode = {
     id: node.id, name: node.name, type: node.type, status: node.status,
     usedBytes: 0, totalBytes: 0, usedPct: 0,
   }
-  if (node.type === "osd" || (!node.children && typeof node.id === "number" && node.id >= 0)) {
-    const o = osds.get(node.id)
+  if (node.type === "osd" || (!node.children && Number(node.id) >= 0)) {
+    const o = osds.get(String(node.id))
     if (o) {
-      base.usedBytes = o.usedBytes || 0
       base.totalBytes = o.totalBytes || 0
-      base.usedPct = typeof o.usedPct === "number" ? o.usedPct : 0
+      base.usedPct = round1(typeof o.usedPct === "number" ? o.usedPct : 0)
+      // The route's osds.list usedBytes is unreliable (derived from a kb_used
+      // field PVE doesn't return); derive it from the trustworthy percent_used
+      // so bucket roll-ups are correct.
+      base.usedBytes = Math.round((base.totalBytes * base.usedPct) / 100)
       base.osd = { up: !!o.up, in: !!o.in, deviceClass: o.deviceClass || "unknown" }
       base.status = base.status || (o.up ? "up" : "down")
     }
@@ -71,7 +88,7 @@ function enrich(node: AnyRec, osds: Map<number, AnyRec>, hosts: Map<string, any>
   base.children = children
   base.usedBytes = children.reduce((s, c) => s + c.usedBytes, 0)
   base.totalBytes = children.reduce((s, c) => s + c.totalBytes, 0)
-  base.usedPct = base.totalBytes > 0 ? Math.round((base.usedBytes / base.totalBytes) * 1000) / 10 : 0
+  base.usedPct = base.totalBytes > 0 ? round1((base.usedBytes / base.totalBytes) * 100) : 0
   if (node.type === "host") base.daemons = hosts.get(node.name) ?? { mon: false, monLeader: false, mgr: false, mds: false }
   return base
 }
@@ -82,18 +99,25 @@ export function buildCrushTopology(data: AnyRec): CephTopology {
   const hosts = hostDaemonIndex(data ?? {})
   const tree = crushTree.map((n) => enrich(n, osds, hosts))
 
+  const bucketNames = bucketNameIndex(crushTree)
   const rules: AnyRec[] = Array.isArray(data?.crushRules) ? data.crushRules : []
-  const ruleById = new Map<number, AnyRec>()
-  for (const r of rules) if (typeof r?.id === "number") ruleById.set(r.id, r)
+  const ruleById = new Map<string, AnyRec>()
+  for (const r of rules) if (r?.id !== undefined && r?.id !== null) ruleById.set(String(r.id), r)
+
   const poolRules: PoolRuleRow[] = (data?.pools?.list ?? []).map((p: AnyRec) => {
-    const rule = ruleById.get(p.crushRule)
+    const rule = ruleById.get(String(p.crushRule))
     const take = rule?.steps?.find((s: AnyRec) => s?.op === "take")
+    // Prefer the pool's own crush_rule_name; the rules endpoint is often bare.
+    const ruleName = p.crushRuleName || rule?.name || String(p.crushRule ?? "")
+    // Target = the rule's take-step bucket/class when available, else the pool's
+    // crush root id resolved to a bucket name (e.g. "default").
+    const rootName = (p.crushRootId !== undefined && p.crushRootId !== null) ? bucketNames.get(String(p.crushRootId)) : undefined
     return {
       pool: p.name,
-      ruleName: rule?.name ?? String(p.crushRule ?? ""),
-      target: take?.item_name ?? "",
+      ruleName,
+      target: take?.item_name ?? rootName ?? "",
       size: `${p.size ?? "?"}/${p.minSize ?? "?"}`,
-      usedPct: typeof p.percentUsed === "number" ? p.percentUsed : 0,
+      usedPct: round1(typeof p.percentUsed === "number" ? p.percentUsed : 0),
     }
   })
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
@@ -70,6 +70,7 @@ import InventorySummary from '../components/InventorySummary'
 import HaGroupDialog from '../HaGroupDialog'
 import HaRuleDialog from '../HaRuleDialog'
 import EntityTagManager from '../components/EntityTagManager'
+import CephTopology from '../components/CephTopology'
 import { AddIcon } from '../components/IconWrappers'
 import { useLicense, Features } from '@/contexts/LicenseContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -3059,6 +3060,14 @@ export default function ClusterTabs(props: any) {
                                 </ChartContainer>
                               </ExpandableChart>
                             </Box>
+                          </CardContent>
+                        </Card>
+
+                        {/* CRUSH Topology */}
+                        <Card variant="outlined">
+                          <CardContent>
+                            <Typography variant="subtitle2" fontWeight={700} sx={{ mb: 2 }}>CRUSH Topology</Typography>
+                            <CephTopology connId={connId} />
                           </CardContent>
                         </Card>
                       </Stack>

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: vi.fn(async () => null),
+  PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: vi.fn(async () => ({ id: "c1", baseUrl: "https://h", apiToken: "t" })),
+}))
+const pveFetch = vi.fn()
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...args: unknown[]) => pveFetch(...args),
+}))
+
+import { GET } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+beforeEach(() => vi.clearAllMocks())
+
+function mockCluster() {
+  pveFetch.mockImplementation(async (_conn: unknown, path: string) => {
+    if (path === "/nodes") return [{ node: "pve1", status: "online" }]
+    if (path.endsWith("/ceph/status")) {
+      return {
+        health: { status: "HEALTH_OK", checks: {} },
+        mgrmap: { active_name: "pve1", standbys: [{ name: "pve2" }] },
+        pgmap: {}, osdmap: {}, monmap: {},
+      }
+    }
+    return [] // osd, mon, pool, mds, rules, fs
+  })
+}
+
+describe("GET /api/v1/connections/[id]/ceph — managers", () => {
+  it("derives managers (active + standbys with host) from status.mgrmap", async () => {
+    mockCluster()
+    const res = await callRoute(GET, { params: { id: "c1" } })
+    expect(res.status).toBe(200)
+    const json = await readJson<{ data: { managers: { active: { name: string; host: string }; standbys: { name: string; host: string }[] } } }>(res)
+    expect(json?.data.managers.active).toEqual({ name: "pve1", host: "pve1" })
+    expect(json?.data.managers.standbys).toEqual([{ name: "pve2", host: "pve2" }])
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
@@ -34,7 +34,14 @@ function mockCluster() {
         autoscale_status: { crush_root_id: -1 }, percent_used: 0.07,
       }]
     }
-    return [] // osd, mon, mds, rules, fs
+    if (path.endsWith("/ceph/osd")) {
+      return { root: { children: [
+        { id: "0", name: "osd.0", type: "osd", status: "up", up: 1, in: 1, device_class: "hdd",
+          crush_weight: 0.05, percent_used: 80, reweight: 1, pgs: 33, ceph_version_short: "19.2.3",
+          apply_latency_ms: 1, commit_latency_ms: 2 },
+      ] } }
+    }
+    return [] // mon, mds, rules, fs
   })
 }
 
@@ -55,5 +62,27 @@ describe("GET /api/v1/connections/[id]/ceph — managers", () => {
     const rbd = json?.data.pools.list.find((p) => p.name === "rbd")
     expect(rbd?.crushRuleName).toBe("replicated_rule")
     expect(rbd?.crushRootId).toBe(-1)
+  })
+
+  it("exposes reweight/pgs/version on osds (for the topology details panel)", async () => {
+    mockCluster()
+    const res = await callRoute(GET, { params: { id: "c1" } })
+    const json = await readJson<{ data: { osds: { list: Array<{ name: string; reweight: number; pgs: number; version: string }> } } }>(res)
+    const osd0 = json?.data.osds.list.find((o) => o.name === "osd.0")
+    expect(osd0?.reweight).toBe(1)
+    expect(osd0?.pgs).toBe(33)
+    expect(osd0?.version).toBe("19.2.3")
+  })
+
+  it("handles a cluster with no active mgr (managers.active null, standbys [])", async () => {
+    pveFetch.mockImplementation(async (_c: unknown, path: string) => {
+      if (path === "/nodes") return [{ node: "pve1", status: "online" }]
+      if (path.endsWith("/ceph/status")) return { health: { status: "HEALTH_OK", checks: {} }, mgrmap: {}, pgmap: {}, osdmap: {}, monmap: {} }
+      return []
+    })
+    const res = await callRoute(GET, { params: { id: "c1" } })
+    const json = await readJson<{ data: { managers: { active: unknown; standbys: unknown[] } } }>(res)
+    expect(json?.data.managers.active).toBeNull()
+    expect(json?.data.managers.standbys).toEqual([])
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.test.ts
@@ -27,7 +27,14 @@ function mockCluster() {
         pgmap: {}, osdmap: {}, monmap: {},
       }
     }
-    return [] // osd, mon, pool, mds, rules, fs
+    if (path.endsWith("/ceph/pool")) {
+      return [{
+        pool: "1", pool_name: "rbd", size: 3, min_size: 2,
+        crush_rule: "0", crush_rule_name: "replicated_rule",
+        autoscale_status: { crush_root_id: -1 }, percent_used: 0.07,
+      }]
+    }
+    return [] // osd, mon, mds, rules, fs
   })
 }
 
@@ -39,5 +46,14 @@ describe("GET /api/v1/connections/[id]/ceph — managers", () => {
     const json = await readJson<{ data: { managers: { active: { name: string; host: string }; standbys: { name: string; host: string }[] } } }>(res)
     expect(json?.data.managers.active).toEqual({ name: "pve1", host: "pve1" })
     expect(json?.data.managers.standbys).toEqual([{ name: "pve2", host: "pve2" }])
+  })
+
+  it("exposes crushRuleName and crushRootId on pools (for the topology rule/target)", async () => {
+    mockCluster()
+    const res = await callRoute(GET, { params: { id: "c1" } })
+    const json = await readJson<{ data: { pools: { list: Array<{ name: string; crushRuleName: string; crushRootId: number }> } } }>(res)
+    const rbd = json?.data.pools.list.find((p) => p.name === "rbd")
+    expect(rbd?.crushRuleName).toBe("replicated_rule")
+    expect(rbd?.crushRootId).toBe(-1)
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
@@ -309,8 +309,11 @@ return {
         // Application (rbd vs cephfs)
         application: cephFSPoolNames.has(poolName) ? 'cephfs' : 'rbd',
 
-        // Crush rule
+        // Crush rule (name comes straight from the pool; the /ceph/rules
+        // endpoint is often bare). crushRootId resolves to a target bucket.
         crushRule: pool.crush_rule || 0,
+        crushRuleName: pool.crush_rule_name || null,
+        crushRootId: pool.autoscale_status?.crush_root_id ?? null,
 
         // Autoscale
         pgAutoscaleMode: pool.pg_autoscale_mode || 'unknown',

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
@@ -138,6 +138,18 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     const numMons = monmap.num_mons || (monList?.length || 0)
     const quorum = status.quorum_names || []
 
+    // Managers (mgr) placement, derived from the mgrmap. mgr daemon names are
+    // the hostname (possibly FQDN), so host = name before the first dot.
+    const mgrmap = status.mgrmap || {}
+    const mgrHost = (n: any) => String(n || "").split(".")[0]
+    const managers = {
+      active: mgrmap.active_name ? { name: mgrmap.active_name, host: mgrHost(mgrmap.active_name) } : null,
+      standbys: (Array.isArray(mgrmap.standbys) ? mgrmap.standbys : []).map((s: any) => {
+        const name = s?.name ?? String(s)
+        return { name, host: mgrHost(name) }
+      }),
+    }
+
     // Mapper les OSDs avec plus de détails
     // Les OSDs peuvent être dans un format arborescent dans Proxmox
     const extractOsdsFromTree = (items: any[]): any[] => {
@@ -404,6 +416,7 @@ return {
       // CRUSH topology
       crushTree,
       crushRules,
+      managers,
     }
 
     return NextResponse.json({ data: cephData })

--- a/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph/route.ts
@@ -267,6 +267,9 @@ return result
           // Stats
           commitLatencyMs: osd.commit_latency_ms || 0,
           applyLatencyMs: osd.apply_latency_ms || 0,
+          reweight: osd.reweight,
+          pgs: osd.pgs ?? osd.num_pgs,
+          version: osd.ceph_version_short || osd.version || null,
         }
       })
       .sort((a: any, b: any) => a.id - b.id)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -103,6 +103,9 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   logic it drives — connection create/update, SSH test, PBS fingerprint
 #   capture — lives in app/api/v1/connections/** routes, which stay measured.
 #   Issue #401 only extended the static token-setup commands and their labels.
+# - inventory/components/CephTopology.tsx: the Ceph CRUSH topology view. Pure
+#   presentational JSX (tree rows, details panel, pools table); its only logic
+#   (buildCrushTopology/capacityColor) lives in cephTopology.ts and is unit-tested.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -138,7 +141,8 @@ sonar.coverage.exclusions=\
   frontend/src/contexts/TenantContext.tsx,\
   frontend/src/components/settings/NotificationsTab.jsx,\
   frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx,\
-  frontend/src/components/settings/ConnectionDialog.tsx
+  frontend/src/components/settings/ConnectionDialog.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
Adds a read-only **CRUSH Topology** section to the cluster-level Ceph tab.

## What it shows
- A collapsible CRUSH tree (root → datacenter/rack → host → OSD) with type icons (the **Proxmox logo for PVE host nodes**), per-node capacity bars, and OSD up/in + device-class chips. Daemon badges on hosts (mon/leader, mgr, mds).
- A **Details** panel: clicking a node shows type and capacity (used/total + %), plus per-type detail — OSD: status, device class, reweight, PGs, apply/commit latency, host, version; buckets: OSD up/total counts, host count, device classes, daemons.
- A **POOLS** table: pool → CRUSH rule name, target bucket, size (size/min_size), %used.

## Data
Self-contained component that lazily fetches the existing cluster `/ceph` route. Composition is a pure, unit-tested `buildCrushTopology()`; the presentational component is coverage-excluded. Additive route fields: `managers` (mgr placement from the mgrmap), `crushRuleName`/`crushRootId` on pools, and `reweight`/`pgs`/`version` on osds.

## Notes
- Read-only (no mutations), consistent with the rest of the Ceph tab.
- Handles real PVE data shapes: string OSD/rule ids, a bare `/ceph/rules` endpoint (rule name taken from the pool's `crush_rule_name`, target resolved from the pool's crush root id), and an unreliable `usedBytes` (derived from `percent_used`).
- No monospace on names; theme-aware (Proxmox light/dark logo, MUI tooltip tokens).
