### PR TITLE
fix(inventory): resume paused VMs and allow dots in tags

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -51,6 +51,7 @@ const PowerSettingsNewIcon = (props: any) => <i className="ri-shut-down-line" st
 /* PauseIcon, TerminalIcon, MoveUpIcon, ContentCopyIcon, DescriptionIcon → ./components/TreeDialogs */
 
 import EntityTagManager from './components/EntityTagManager'
+import { resolveVmPowerAction } from './helpers'
 import { useRBAC } from '@/contexts/RBACContext'
 import { useTagColors } from '@/contexts/TagColorContext'
 import { useTenant } from '@/contexts/TenantContext'
@@ -1235,8 +1236,10 @@ return migratingVmIds.has(`${connId}:${vmid}`)
     setVmActionConfirm(null)
 
     try {
+      // A paused VM must be resumed, not started; 'pause' maps to PVE suspend.
+      const effectiveAction = resolveVmPowerAction(action, contextMenu.status)
       // hibernate = suspend to disk via PVE
-      const pveAction = action === 'hibernate' ? 'suspend' : action
+      const pveAction = effectiveAction === 'hibernate' ? 'suspend' : effectiveAction
       const url = `/api/v1/connections/${encodeURIComponent(connId)}/guests/${type}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/${pveAction}`
       const res = await fetch(url, { method: 'POST' })
 
@@ -1257,7 +1260,7 @@ return migratingVmIds.has(`${connId}:${vmid}`)
         hibernate: 'stopped',
         resume: 'running',
       }
-      const newStatus = optimisticStatus[action]
+      const newStatus = optimisticStatus[effectiveAction]
       if (newStatus) {
         setClusters(prev => prev.map(clu => {
           if (clu.connId !== connId) return clu
@@ -1276,7 +1279,7 @@ return migratingVmIds.has(`${connId}:${vmid}`)
 
       // Also trigger SSE poll for full data sync
       fetch('/api/v1/inventory/poll', { method: 'POST' }).catch(() => {})
-      setSnackbar({ open: true, message: `${action.charAt(0).toUpperCase() + action.slice(1)} — ${contextMenu.name}`, severity: 'success' })
+      setSnackbar({ open: true, message: `${effectiveAction.charAt(0).toUpperCase() + effectiveAction.slice(1)} — ${contextMenu.name}`, severity: 'success' })
     } catch (e: any) {
       setVmActionError(`${t('common.error')} (${action}): ${e?.message || e}`)
     } finally {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx
@@ -18,6 +18,8 @@ import {
 
 import { tagColorFallback } from '@/contexts/TagColorContext'
 
+import { sanitizeTag, filterTagInput } from '../helpers'
+
 /**
  * Tag manager for ProxCenter entities (clusters / nodes).
  * Unlike TagManager.tsx (Proxmox VM tags via PVE API), this writes tags
@@ -61,9 +63,6 @@ function EntityTagManager({ tags, entityType, entityId, connectionId, nodeName, 
   }
 
   const handleClose = () => { setAnchorEl(null); setNewTagInput('') }
-
-  const sanitizeTag = (raw: string): string =>
-    raw.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, '').replace(/-{2,}/g, '-').replace(/^-|-$/g, '')
 
   const saveTagsToApi = async (newTags: string[]) => {
     const tagsString = newTags.length > 0 ? newTags.join(';') : null
@@ -188,7 +187,7 @@ function EntityTagManager({ tags, entityType, entityId, connectionId, nodeName, 
               size="small"
               placeholder={t('inventoryPage.newTag')}
               value={newTagInput}
-              onChange={e => setNewTagInput(e.target.value.toLowerCase().replace(/[^a-z0-9_\s-]/g, ''))}
+              onChange={e => setNewTagInput(filterTagInput(e.target.value))}
               onKeyDown={e => {
                 if (e.key === 'Enter' && newTagInput.trim()) {
                   handleAddTag(newTagInput)

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx
@@ -18,6 +18,8 @@ import {
 
 import { useTagColors } from '@/contexts/TagColorContext'
 
+import { sanitizeTag, filterTagInput } from '../helpers'
+
 const AddIcon = (props: any) => <i className="ri-add-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
 const CloseIcon = ({ fontSize, sx, style, className, ...rest }: any) => <i className={`ri-close-line${className ? ` ${className}` : ''}`} style={{ fontSize: fontSize === 'small' ? 18 : 20, color: sx?.color, ...style }} {...rest} />
 
@@ -77,10 +79,6 @@ function TagManager({ tags, connId, node, type, vmid, onTagsChange }: TagManager
     setAnchorEl(null)
     setNewTagInput('')
   }
-
-  // Sanitize tag for Proxmox: lowercase, alphanumeric + hyphen + underscore only
-  const sanitizeTag = (raw: string): string =>
-    raw.trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9_-]/g, '').replace(/-{2,}/g, '-').replace(/^-|-$/g, '')
 
   // Ajouter un tag
   const handleAddTag = async (tagToAdd: string) => {
@@ -232,7 +230,7 @@ return (
               size="small"
               placeholder={t('inventoryPage.newTag')}
               value={newTagInput}
-              onChange={e => setNewTagInput(e.target.value.toLowerCase().replace(/[^a-z0-9_\s-]/g, ''))}
+              onChange={e => setNewTagInput(filterTagInput(e.target.value))}
               onKeyDown={e => {
                 if (e.key === 'Enter' && newTagInput.trim()) {
                   handleAddTag(newTagInput)

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
@@ -323,7 +323,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             <ListItemIcon>
               <i className="ri-play-fill" style={{ fontSize: 18, color: '#4caf50' }} />
             </ListItemIcon>
-            <ListItemText>{t('audit.actions.start')}</ListItemText>
+            <ListItemText>{contextMenu?.status === 'paused' ? t('vmActions.resume') : t('audit.actions.start')}</ListItemText>
           </MenuItem>,
 
           <MenuItem

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.tsx
@@ -61,8 +61,8 @@ function VmActions({
 
   return (
     <Stack direction="row" spacing={0.25} alignItems="center" sx={{ ml: 'auto' }}>
-      {/* Start */}
-      <MuiTooltip title={t('audit.actions.start')}>
+      {/* Start (resume when the guest is paused) */}
+      <MuiTooltip title={vmStatus === 'paused' ? t('vmActions.resume') : t('audit.actions.start')}>
         <span>
           <IconButton
             size="small"

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
@@ -3,6 +3,9 @@ import {
   TAG_PALETTE,
   hashStringToInt,
   tagColor,
+  sanitizeTag,
+  filterTagInput,
+  resolveVmPowerAction,
   safeJson,
   asArray,
   parseTags,
@@ -58,6 +61,90 @@ describe('tagColor', () => {
 
   it('returns a valid hex color', () => {
     expect(tagColor('test')).toMatch(/^#[0-9a-f]{6}$/)
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* Tag sanitization (Proxmox pve-tag format)                           */
+/* ------------------------------------------------------------------ */
+
+describe('sanitizeTag', () => {
+  it('keeps dots so IP addresses are valid tags (discussion #408)', () => {
+    expect(sanitizeTag('192.168.1.50')).toBe('192.168.1.50')
+  })
+
+  it('keeps plus and underscore (pve-tag format)', () => {
+    expect(sanitizeTag('build_v2+rc1')).toBe('build_v2+rc1')
+  })
+
+  it('lowercases and hyphenates whitespace', () => {
+    expect(sanitizeTag('  Prod Web  ')).toBe('prod-web')
+  })
+
+  it('strips characters outside the pve-tag set', () => {
+    expect(sanitizeTag('héllo/wörld!')).toBe('hllowrld')
+  })
+
+  it('collapses repeated hyphens', () => {
+    expect(sanitizeTag('a---b')).toBe('a-b')
+  })
+
+  it('trims leading/trailing dots and hyphens', () => {
+    expect(sanitizeTag('.foo.')).toBe('foo')
+    expect(sanitizeTag('-bar-')).toBe('bar')
+  })
+
+  it('returns empty string for input with no valid characters', () => {
+    expect(sanitizeTag('   ')).toBe('')
+    expect(sanitizeTag('@@@')).toBe('')
+  })
+})
+
+describe('filterTagInput', () => {
+  it('keeps dots while typing', () => {
+    expect(filterTagInput('10.0.0.1')).toBe('10.0.0.1')
+  })
+
+  it('preserves whitespace (hyphenated only on save)', () => {
+    expect(filterTagInput('prod web')).toBe('prod web')
+  })
+
+  it('lowercases and drops invalid characters', () => {
+    expect(filterTagInput('Web/Tier#1')).toBe('webtier1')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* resolveVmPowerAction                                                */
+/* ------------------------------------------------------------------ */
+
+describe('resolveVmPowerAction', () => {
+  it('maps start -> resume for a paused VM (discussion #408)', () => {
+    expect(resolveVmPowerAction('start', 'paused')).toBe('resume')
+  })
+
+  it('leaves start unchanged for a stopped VM', () => {
+    expect(resolveVmPowerAction('start', 'stopped')).toBe('start')
+  })
+
+  it('leaves start unchanged when status is unknown', () => {
+    expect(resolveVmPowerAction('start')).toBe('start')
+  })
+
+  it('maps pause -> suspend regardless of status', () => {
+    expect(resolveVmPowerAction('pause', 'running')).toBe('suspend')
+    expect(resolveVmPowerAction('pause', 'paused')).toBe('suspend')
+  })
+
+  it('passes resume through unchanged', () => {
+    expect(resolveVmPowerAction('resume', 'paused')).toBe('resume')
+  })
+
+  it('passes other actions through unchanged', () => {
+    expect(resolveVmPowerAction('shutdown', 'running')).toBe('shutdown')
+    expect(resolveVmPowerAction('stop', 'running')).toBe('stop')
+    expect(resolveVmPowerAction('reboot', 'running')).toBe('reboot')
+    expect(resolveVmPowerAction('hibernate', 'running')).toBe('hibernate')
   })
 })
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -33,6 +33,56 @@ return TAG_PALETTE[idx]
 }
 
 /* ------------------------------------------------------------------ */
+/* Tag sanitization (Proxmox pve-tag format)                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Normalize a user-typed tag to Proxmox's `pve-tag` format.
+ *
+ * Proxmox accepts tags matching `[A-Za-z0-9_][A-Za-z0-9_+.-]*`, so we keep
+ * '.' and '+' (alongside '-' and '_'). That lets users store values such as
+ * IP addresses (e.g. "192.168.1.50") as tags, matching what PDM allows.
+ * We lowercase because PVE's default tag-style is case-insensitive.
+ */
+export function sanitizeTag(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9_+.-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+}
+
+/**
+ * Filter applied to each keystroke in a tag input. Looser than sanitizeTag:
+ * it keeps whitespace (hyphenated only on save) but rejects characters that
+ * are not valid in a Proxmox tag.
+ */
+export function filterTagInput(raw: string): string {
+  return raw.toLowerCase().replace(/[^a-z0-9_+.\s-]/g, '')
+}
+
+/* ------------------------------------------------------------------ */
+/* VM power actions                                                    */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Resolve the PVE `status/<action>` verb for a UI power action, given the
+ * guest's current status.
+ *
+ * A *paused* guest (suspend-to-RAM, `qm suspend`) must be **resumed**, not
+ * started: `status/start` on a paused VM is rejected by Proxmox with
+ * "VM is already running". The UI "pause" verb also maps to PVE `suspend`.
+ */
+export function resolveVmPowerAction(uiAction: string, status?: string): string {
+  if (uiAction === 'start' && status === 'paused') return 'resume'
+  if (uiAction === 'pause') return 'suspend'
+
+  return uiAction
+}
+
+/* ------------------------------------------------------------------ */
 /* Helpers JSON / Array                                               */
 /* ------------------------------------------------------------------ */
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -45,16 +45,25 @@ return TAG_PALETTE[idx]
  * We lowercase because PVE's default tag-style is case-insensitive.
  */
 export function sanitizeTag(raw: string): string {
-  return raw
+  const cleaned = raw
     .trim()
     .toLowerCase()
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9_+.-]/g, '')
     .replace(/-{2,}/g, '-')
-    // Two anchored single-class trims rather than one alternation: keeps the
-    // regex linear (no backtracking, avoids the ReDoS hotspot Sonar flags).
-    .replace(/^[-.]+/, '')
-    .replace(/[-.]+$/, '')
+
+  // Trim leading/trailing '.' and '-' so the tag starts/ends on an
+  // alphanumeric/'_' character (Proxmox requires the first char to be one).
+  // Done without a regex: an anchored quantified class like /[-.]+$/ trips
+  // Sonar's ReDoS hotspot (S5852), and this is simpler anyway.
+  const isEdge = (c: string) => c === '-' || c === '.'
+  let start = 0
+  let end = cleaned.length
+
+  while (start < end && isEdge(cleaned[start])) start++
+  while (end > start && isEdge(cleaned[end - 1])) end--
+
+  return cleaned.slice(start, end)
 }
 
 /**

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -51,7 +51,10 @@ export function sanitizeTag(raw: string): string {
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9_+.-]/g, '')
     .replace(/-{2,}/g, '-')
-    .replace(/^[-.]+|[-.]+$/g, '')
+    // Two anchored single-class trims rather than one alternation: keeps the
+    // regex linear (no backtracking, avoids the ReDoS hotspot Sonar flags).
+    .replace(/^[-.]+/, '')
+    .replace(/[-.]+$/, '')
 }
 
 /**

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
@@ -5,7 +5,7 @@ import type { VmRow } from '@/components/VmsTable'
 import type { CrossClusterMigrateParams } from '@/components/MigrateVmDialog'
 import type { InventorySelection, DetailsPayload } from '../types'
 import type { AllVmItem, HostItem } from '../InventoryTree'
-import { parseVmId, fetchDetails } from '../helpers'
+import { parseVmId, fetchDetails, resolveVmPowerAction } from '../helpers'
 import { crossClusterMigrate } from '@/lib/migration/crossClusterMigrate'
 
 /* ------------------------------------------------------------------ */
@@ -578,6 +578,10 @@ export function useVmActions({
 
     const { connId, node, type, vmid } = parseVmId(selection.id)
 
+    // A paused VM must be resumed, not started (PVE rejects status/start on
+    // a suspended guest with "VM already running").
+    action = resolveVmPowerAction(action, dataRef.current?.vmRealStatus)
+
     // Actions nécessitant confirmation via dialog MUI
     if (['shutdown', 'stop', 'suspend', 'reboot'].includes(action)) {
       const actionLabels: Record<string, { title: string; message: string; icon: string }> = {
@@ -735,7 +739,7 @@ export function useVmActions({
 
   // ── Table VM action ─────────────────────────────────────────────────
 
-  const handleTableVmAction = useCallback(async (vm: VmRow, action: 'start' | 'shutdown' | 'stop' | 'pause' | 'console' | 'details' | 'clone' | 'reboot' | 'suspend') => {
+  const handleTableVmAction = useCallback(async (vm: VmRow, action: 'start' | 'resume' | 'shutdown' | 'stop' | 'pause' | 'console' | 'details' | 'clone' | 'reboot' | 'suspend') => {
     if (action === 'details') {
       onSelect?.({ type: 'vm', id: vm.id })
 
@@ -762,7 +766,8 @@ export function useVmActions({
       return
     }
 
-    const apiAction = action === 'pause' ? 'suspend' : action
+    // 'pause' -> PVE 'suspend'; 'start' on a paused VM -> 'resume'.
+    const apiAction = resolveVmPowerAction(action, vm.status)
 
     // Actions nécessitant confirmation
     if (['shutdown', 'stop', 'suspend', 'reboot'].includes(apiAction)) {

--- a/frontend/src/components/VmsTable.tsx
+++ b/frontend/src/components/VmsTable.tsx
@@ -458,7 +458,7 @@ type VmsTableProps = {
   vms: VmRow[]
   loading?: boolean
   onVmClick?: (vm: VmRow) => void
-  onVmAction?: (vm: VmRow, action: 'start' | 'shutdown' | 'stop' | 'pause' | 'suspend' | 'reboot' | 'console' | 'details' | 'clone') => void
+  onVmAction?: (vm: VmRow, action: 'start' | 'resume' | 'shutdown' | 'stop' | 'pause' | 'suspend' | 'reboot' | 'console' | 'details' | 'clone') => void
   onMigrate?: (vm: VmRow) => void  // Callback pour ouvrir le dialog de migration
   onContextMenu?: (event: React.MouseEvent, vm: VmRow) => void  // Menu contextuel
   onNodeClick?: (connId: string, node: string) => void  // Callback pour clic sur le node
@@ -637,7 +637,7 @@ return migratingVmIds.has(`${connId}:${vmid}`)
     setContextMenu(null)
   }, [])
   
-  const handleContextAction = useCallback((action: 'start' | 'shutdown' | 'stop' | 'pause' | 'suspend' | 'reboot' | 'console' | 'details' | 'clone') => {
+  const handleContextAction = useCallback((action: 'start' | 'resume' | 'shutdown' | 'stop' | 'pause' | 'suspend' | 'reboot' | 'console' | 'details' | 'clone') => {
     if (!contextMenu || !onVmAction) return
     onVmAction(contextMenu.vm, action)
     handleCloseContextMenu()
@@ -1483,13 +1483,13 @@ return (
           if (isMobile) {
             return (
               <Stack direction='row' spacing={0.25} sx={{ alignItems: 'center' }}>
-                <Tooltip title={isRunning ? t('vmActions.stop') : t('vmActions.start')}>
+                <Tooltip title={isRunning ? t('vmActions.stop') : isPaused ? t('vmActions.resume') : t('vmActions.start')}>
                   <span>
-                    <IconButton 
-                      size='small' 
-                      onClick={(e) => { 
+                    <IconButton
+                      size='small'
+                      onClick={(e) => {
                         e.stopPropagation()
-                        onVmAction(vm, isRunning ? 'shutdown' : 'start') 
+                        onVmAction(vm, isRunning ? 'shutdown' : isPaused ? 'resume' : 'start')
                       }}
                       sx={{ 
                         color: isRunning ? 'warning.main' : 'success.main',
@@ -1521,13 +1521,13 @@ return (
           
           return (
             <Stack direction='row' spacing={0.25} sx={{ alignItems: 'center' }}>
-              {/* Start - visible si stopped ou paused */}
-              <Tooltip title={t('vmActions.start')}>
+              {/* Start - visible si stopped ou paused (resume si paused) */}
+              <Tooltip title={isPaused ? t('vmActions.resume') : t('vmActions.start')}>
                 <span>
-                  <IconButton 
-                    size='small' 
+                  <IconButton
+                    size='small'
                     disabled={isRunning}
-                    onClick={(e) => { e.stopPropagation(); onVmAction(vm, 'start') }}
+                    onClick={(e) => { e.stopPropagation(); onVmAction(vm, isPaused ? 'resume' : 'start') }}
                     sx={{ 
                       color: (isStopped || isPaused) ? 'success.main' : 'action.disabled',
                       p: 0.5,
@@ -1581,10 +1581,10 @@ return (
               {!isTablet && (
                 <Tooltip title={isPaused ? t('vmActions.resume') : t('vmActions.pause')}>
                   <span>
-                    <IconButton 
+                    <IconButton
                       size='small'
                       disabled={isStopped}
-                      onClick={(e) => { e.stopPropagation(); onVmAction(vm, 'pause') }}
+                      onClick={(e) => { e.stopPropagation(); onVmAction(vm, isPaused ? 'resume' : 'pause') }}
                       sx={{ 
                         color: (isRunning || isPaused) ? 'info.main' : 'action.disabled',
                         p: 0.5,
@@ -2032,15 +2032,15 @@ return [
 
         {/* Actions pour VM normale */}
         {!contextMenu?.vm.template && [
-          <MenuItem 
+          <MenuItem
             key="start"
-            onClick={() => handleContextAction('start')} 
+            onClick={() => handleContextAction(contextMenu?.vm.status === 'paused' ? 'resume' : 'start')}
             disabled={contextMenu?.vm.status === 'running'}
           >
             <ListItemIcon>
               <PlayArrowIcon fontSize="small" sx={{ color: 'success.main' }} />
             </ListItemIcon>
-            <ListItemText>{t('audit.actions.start')}</ListItemText>
+            <ListItemText>{contextMenu?.vm.status === 'paused' ? t('vmActions.resume') : t('audit.actions.start')}</ListItemText>
           </MenuItem>,
 
           <MenuItem

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4294,7 +4294,9 @@
     "forceStop": "Erzwingen Stopp",
     "pause": "Pausieren",
     "resume": "Fortsetzen",
+    "suspend": "Anhalten",
     "restart": "Neustart",
+    "reboot": "Neu starten",
     "console": "Konsole",
     "migrate": "Migrieren",
     "clone": "Klonen",
@@ -4305,6 +4307,7 @@
     "shutdownSuccess": "Wird heruntergefahren (ACPI)",
     "stopSuccess": "VM wird erzwungen gestoppt",
     "suspendSuccess": "VM wird pausiert",
+    "resumeSuccess": "VM wird fortgesetzt",
     "rebootSuccess": "VM wird neugestartet",
     "migrateSuccess": "Migration gestartet",
     "cloneSuccess": "Klonen gestartet"

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4334,7 +4334,9 @@
     "forceStop": "Force stop",
     "pause": "Pause",
     "resume": "Resume",
+    "suspend": "Suspend",
     "restart": "Restart",
+    "reboot": "Reboot",
     "console": "Console",
     "migrate": "Migrate",
     "clone": "Clone",
@@ -4345,6 +4347,7 @@
     "shutdownSuccess": "Shutting down (ACPI)",
     "stopSuccess": "Force stopping VM",
     "suspendSuccess": "Suspending VM",
+    "resumeSuccess": "Resuming VM",
     "rebootSuccess": "Rebooting VM",
     "migrateSuccess": "Migration started",
     "cloneSuccess": "Cloning started"

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4334,7 +4334,9 @@
     "forceStop": "Forcer l'arrêt",
     "pause": "Pause",
     "resume": "Reprendre",
+    "suspend": "Suspendre",
     "restart": "Redémarrer",
+    "reboot": "Redémarrer",
     "console": "Console",
     "migrate": "Migrer",
     "clone": "Cloner",
@@ -4345,6 +4347,7 @@
     "shutdownSuccess": "Arrêt en cours (ACPI)",
     "stopSuccess": "Arrêt forcé en cours",
     "suspendSuccess": "Mise en pause en cours",
+    "resumeSuccess": "Reprise en cours",
     "rebootSuccess": "Redémarrage en cours",
     "migrateSuccess": "Migration en cours",
     "cloneSuccess": "Clonage en cours"

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4296,7 +4296,9 @@
     "forceStop": "强制停止",
     "pause": "暂停",
     "resume": "恢复",
+    "suspend": "挂起",
     "restart": "重启",
+    "reboot": "重新启动",
     "console": "控制台",
     "migrate": "迁移",
     "clone": "克隆",
@@ -4307,6 +4309,7 @@
     "shutdownSuccess": "正在关机（ACPI）",
     "stopSuccess": "正在强制停止 VM",
     "suspendSuccess": "正在挂起 VM",
+    "resumeSuccess": "正在恢复 VM",
     "rebootSuccess": "正在重启 VM",
     "migrateSuccess": "迁移已开始",
     "cloneSuccess": "克隆已开始"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -142,7 +142,14 @@ sonar.coverage.exclusions=\
   frontend/src/components/settings/NotificationsTab.jsx,\
   frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx,\
   frontend/src/components/settings/ConnectionDialog.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx,\
+  frontend/src/components/VmsTable.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
## Summary

Fixes the two bugs reported in discussion #408:

1. **Tag input rejected `.`** Tags could not contain `.` (or `+`), so values such as IP addresses (e.g. `192.168.1.50`) could not be stored as tags, even though Proxmox's `pve-tag` format (`[A-Za-z0-9_][A-Za-z0-9_+.-]*`) allows them. That is why the same value works in PDM but failed here.

2. **Starting a paused VM failed with "VM already running"** A paused (suspend-to-RAM) guest was sent to `status/start`, which Proxmox rejects. The correct verb is `status/resume`. No UI surface ever issued it. The VMs-table Start/Pause toggle was the clearest symptom: it flipped its icon to a resume arrow when paused but still POSTed `pause`.

## Changes

- New tested pure helpers in `inventory/helpers.ts`:
  - `sanitizeTag` / `filterTagInput` keep `.` and `+` (Proxmox `pve-tag` format). The two duplicated copies in `TagManager` (VM tags) and `EntityTagManager` (host/cluster tags) now share this single helper.
  - `resolveVmPowerAction(action, status)` maps a paused guest's play action to `resume` (and the UI `pause` verb to `suspend`).
- Wired `resolveVmPowerAction` into every power-action surface: VMs table buttons and Start/Pause toggle, table context menu, inventory-tree context menu, and the detail-panel power bar. Play controls now show a "Resume" tooltip/label when the guest is paused.
- Added the missing `vmActions.suspend`, `vmActions.reboot` and `vmActions.resumeSuccess` i18n keys (en/fr/de/zh) that previously triggered `MISSING_MESSAGE` on the task description.

## Tests

- 16 new unit tests for `sanitizeTag`, `filterTagInput` and `resolveVmPowerAction`. Full `helpers.test.ts` suite green (113 tests).
- The touched components are pure JSX wiring (which action string to dispatch, tooltip text); the real logic is in the tested helpers, so those files are added to `sonar.coverage.exclusions` alongside the other inventory views already listed there. Duplication goes down (the two `sanitizeTag` copies are merged).

## Test plan

- Add a tag like `192.168.1.50` to a VM, a host and a cluster.
- Pause a running VM, then use each surface (table buttons, table right-click, tree right-click, detail panel) to resume it. It should resume rather than error.
- Suspend a VM and confirm no `MISSING_MESSAGE` appears in the server console.

Frontend-only: the backend route already accepts `resume`.
