### PR TITLE
feat(inventory): clone a VM from a snapshot restore point

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -710,7 +710,7 @@ return migratingVmIds.has(`${connId}:${vmid}`)
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false)
   const [cloneTarget, setCloneTarget] = useState<VmContextMenu>(null)
 
-  const handleCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean }) => {
+  const handleCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean; snapname?: string }) => {
     if (!cloneTarget) throw new Error('No VM selected for cloning')
 
     const payload: Record<string, any> = {
@@ -721,6 +721,7 @@ return migratingVmIds.has(`${connId}:${vmid}`)
       format: params.format || undefined,
       pool: params.pool || undefined,
       full: params.full ? 1 : 0,
+      snapname: params.snapname || undefined,
     }
 
     const res = await fetch(

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -1183,6 +1183,7 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
               currentNode={node}
               vmName={data?.name || `VM ${vmid}`}
               vmid={vmid}
+              vmType={type}
               nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
               existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
               pools={[]}
@@ -1218,6 +1219,7 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
           currentNode={tableCloneVm.node}
           vmName={tableCloneVm.name}
           vmid={tableCloneVm.vmid}
+          vmType={tableCloneVm.type}
           nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
           existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
           pools={[]}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
@@ -902,6 +902,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
           currentNode={cloneTarget.node}
           vmName={cloneTarget.name || `VM ${cloneTarget.vmid}`}
           vmid={cloneTarget.vmid}
+          vmType={cloneTarget.type}
           nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
           existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
           pools={[]}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
@@ -263,7 +263,7 @@ export function useVmActions({
 
   // ── Clone (selected VM panel) ───────────────────────────────────────
 
-  const handleCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean }) => {
+  const handleCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean; snapname?: string }) => {
     if (selection?.type !== 'vm') throw new Error('No VM selected')
 
     const { connId, node, type, vmid } = parseVmId(selection.id)
@@ -280,7 +280,8 @@ export function useVmActions({
           storage: params.targetStorage || undefined,
           format: params.format || undefined,
           pool: params.pool || undefined,
-          full: params.full
+          full: params.full,
+          snapname: params.snapname || undefined
         })
       }
     )
@@ -391,7 +392,7 @@ export function useVmActions({
 
   // ── Table clone ─────────────────────────────────────────────────────
 
-  const handleTableCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean }) => {
+  const handleTableCloneVm = useCallback(async (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean; snapname?: string }) => {
     if (!tableCloneVm) throw new Error('No VM selected for cloning')
 
     const { connId, node, type, vmid } = tableCloneVm
@@ -413,6 +414,10 @@ export function useVmActions({
 
     if (params.pool) {
       body.pool = params.pool
+    }
+
+    if (params.snapname) {
+      body.snapname = params.snapname
     }
 
     const res = await fetch(

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/clone/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/clone/route.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute } from '@/__tests__/setup/route-test'
+
+// Capture the after() callbacks so the test can drive the post-clone work.
+const h = vi.hoisted(() => ({
+  afterCbs: [] as Array<() => Promise<void>>,
+}))
+
+vi.mock('next/server', async (io) => {
+  const actual = await io<typeof import('next/server')>()
+  return { ...actual, after: (fn: () => Promise<void>) => { h.afterCbs.push(fn) } }
+})
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const resolveVdcForTenantMock = vi.fn<(...args: any[]) => Promise<any>>()
+const checkVdcQuotaMock = vi.fn<(...args: any[]) => Promise<any>>()
+const getAllowedBridgesForTenantMock = vi.fn<(...args: any[]) => Promise<any>>()
+const resolveSubnetForBridgeMock = vi.fn<(...args: any[]) => Promise<any>>()
+const syncIpamForVmConfigMock = vi.fn<(...args: any[]) => Promise<any>>()
+const waitForTaskMock = vi.fn<(...args: any[]) => Promise<any>>()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  buildVmResourceId: () => 'res',
+  PERMISSIONS: { VM_CLONE: 'vm.clone' },
+}))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock('@/lib/proxmox/client', () => ({ pveFetch: pveFetchMock }))
+vi.mock('@/lib/cache/inventoryCache', () => ({ invalidateInventoryCache: vi.fn() }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'tenant-1' }))
+vi.mock('@/lib/vdc/quota', () => ({
+  resolveVdcForTenant: resolveVdcForTenantMock,
+  checkVdcQuota: checkVdcQuotaMock,
+}))
+vi.mock('@/lib/vdc/vnets', () => ({
+  getAllowedBridgesForTenant: getAllowedBridgesForTenantMock,
+  // Use the real regex so the IPAM detection + after() MAC regen behave faithfully.
+  parseBridgeFromNet: (s: string) => { const m = String(s || '').match(/bridge=([^,]+)/); return m ? m[1] : null },
+  resolveSubnetForBridge: resolveSubnetForBridgeMock,
+}))
+vi.mock('@/lib/vdc/ipamSync', () => ({ syncIpamForVmConfig: syncIpamForVmConfigMock }))
+vi.mock('@/lib/vdc/ipam', () => ({ releaseAllocationsForVm: vi.fn() }))
+vi.mock('@/lib/proxmox/tasks', () => ({ waitForTask: waitForTaskMock }))
+vi.mock('@/lib/audit', () => ({ audit: vi.fn() }))
+
+async function loadPost() {
+  const mod = await import('./route')
+  return mod.POST as Parameters<typeof callRoute>[0]
+}
+
+const baseParams = { id: 'conn-1', type: 'qemu', node: 'pve3', vmid: '100' }
+
+/** Pull the URLSearchParams sent to the PVE clone POST. */
+function cloneCallBody() {
+  const call = pveFetchMock.mock.calls.find(
+    (c) => String(c[1]).endsWith('/clone') && c[2]?.method === 'POST',
+  )
+  return new URLSearchParams(String(call?.[2]?.body ?? ''))
+}
+
+beforeEach(() => {
+  h.afterCbs.length = 0
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'conn-1' })
+  resolveVdcForTenantMock.mockReset().mockResolvedValue(null)
+  checkVdcQuotaMock.mockReset().mockResolvedValue({ allowed: true })
+  getAllowedBridgesForTenantMock.mockReset().mockResolvedValue(null)
+  resolveSubnetForBridgeMock.mockReset().mockResolvedValue(null)
+  syncIpamForVmConfigMock.mockReset().mockResolvedValue({ bodyOverrides: {}, rollback: vi.fn() })
+  waitForTaskMock.mockReset().mockResolvedValue(undefined)
+  // Default: config reads return an empty config, clone POST returns a UPID.
+  pveFetchMock.mockReset().mockImplementation(async (_conn, _path, opts?: any) => {
+    if (opts?.method === 'POST') return 'UPID:clone:1'
+    if (opts?.method === 'PUT') return null
+    return {}
+  })
+})
+
+describe('POST clone — full flag normalization', () => {
+  it('sends full=1 (not the string "true") and never sends `unique`', async () => {
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { newid: 101, full: true } })
+
+    expect(res.status).toBe(200)
+    const body = cloneCallBody()
+    expect(body.get('full')).toBe('1')
+    expect(body.get('newid')).toBe('101')
+    expect(body.has('unique')).toBe(false)
+  })
+
+  it('sends full=0 for a linked clone', async () => {
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { newid: 102, full: false } })
+
+    expect(res.status).toBe(200)
+    expect(cloneCallBody().get('full')).toBe('0')
+  })
+})
+
+describe('POST clone — IPAM-managed source', () => {
+  it('regenerates the MAC on managed NICs after the clone instead of using `unique`', async () => {
+    // Source + clone configs both carry a NIC on the IPAM-managed bridge.
+    pveFetchMock.mockImplementation(async (_conn, _path, opts?: any) => {
+      if (opts?.method === 'POST') return 'UPID:clone:1'
+      if (opts?.method === 'PUT') return null
+      return { net0: 'virtio=AA:00:00:00:00:01,bridge=tenantA' }
+    })
+    resolveSubnetForBridgeMock.mockImplementation(async (_id, bridge) =>
+      bridge === 'tenantA' ? { subnetId: 's1' } : null,
+    )
+
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { newid: 101, full: true } })
+    expect(res.status).toBe(200)
+
+    // The clone call itself must not carry `unique`.
+    expect(cloneCallBody().has('unique')).toBe(false)
+
+    // Drive the scheduled after() work.
+    for (const cb of h.afterCbs) await cb()
+
+    // A PUT to the clone's config strips the inherited MAC so PVE regenerates it.
+    const putCall = pveFetchMock.mock.calls.find(
+      (c) => String(c[1]).endsWith('/qemu/101/config') && c[2]?.method === 'PUT',
+    )
+    expect(putCall).toBeTruthy()
+    expect(new URLSearchParams(String(putCall?.[2]?.body)).get('net0')).toBe('virtio,bridge=tenantA')
+
+    // IPAM allocation is then reconciled against the fresh config.
+    expect(syncIpamForVmConfigMock).toHaveBeenCalled()
+  })
+
+  it('does not touch MACs when no NIC is on a managed VNet', async () => {
+    pveFetchMock.mockImplementation(async (_conn, _path, opts?: any) => {
+      if (opts?.method === 'POST') return 'UPID:clone:1'
+      if (opts?.method === 'PUT') return null
+      return { net0: 'virtio=AA:00:00:00:00:01,bridge=vmbr0' }
+    })
+    // bridge never resolves to a subnet → cloneTouchesIpam stays false
+
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { newid: 101, full: true } })
+    expect(res.status).toBe(200)
+
+    for (const cb of h.afterCbs) await cb()
+
+    const putCall = pveFetchMock.mock.calls.find((c) => c[2]?.method === 'PUT')
+    expect(putCall).toBeUndefined()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/clone/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/clone/route.ts
@@ -9,6 +9,7 @@ import { getCurrentTenantId } from "@/lib/tenant"
 import { resolveVdcForTenant, checkVdcQuota } from "@/lib/vdc/quota"
 import { getAllowedBridgesForTenant, parseBridgeFromNet, resolveSubnetForBridge } from "@/lib/vdc/vnets"
 import { syncIpamForVmConfig } from "@/lib/vdc/ipamSync"
+import { stripMacFromNet } from "@/lib/vdc/ipamScan"
 import { releaseAllocationsForVm } from "@/lib/vdc/ipam"
 import { waitForTask } from "@/lib/proxmox/tasks"
 
@@ -108,12 +109,11 @@ export async function POST(
     }
 
     // ── IPAM-managed clone hardening (qemu only) ──
-    // PVE's clone keeps the source MACs by default, which would create
-    // both a network-level MAC collision AND an IPAM (subnet, mac) UNIQUE
-    // collision when allocating for the new vmid. If the source has any
-    // NIC on an IPAM-managed VNet, force `unique=1` so PVE regenerates
-    // every MAC. The post-clone sync below then allocates fresh IPs for
-    // those new MACs.
+    // PVE's clone keeps the source MACs by default, which would create both a
+    // network-level MAC collision AND an IPAM (subnet, mac) UNIQUE collision
+    // when allocating for the new vmid. If the source has any NIC on an
+    // IPAM-managed VNet, the after() block below regenerates those MACs once
+    // the clone task finishes, then allocates fresh IPs for the new MACs.
     let cloneTouchesIpam = false
     if (type === 'qemu') {
       try {
@@ -139,9 +139,19 @@ export async function POST(
     const formData = new URLSearchParams()
 
     for (const [key, value] of Object.entries(body)) {
+      if (key === 'full') continue // normalized below to a canonical 1/0
       if (value !== undefined && value !== null && value !== '') {
         formData.append(key, String(value))
       }
+    }
+
+    // PVE's clone API branches its parameter schema on `full`: a full clone
+    // accepts storage/format, a linked clone rejects them. Send a canonical
+    // 1/0 so a JS boolean (which stringifies to "true"/"false") can't land in
+    // the linked-clone branch and trip "property is not defined in schema".
+    const isFullClone = body.full === true || body.full === 1
+    if (body.full !== undefined) {
+      formData.set('full', isFullClone ? '1' : '0')
     }
 
     // Force pool assignment if tenant has a vDC
@@ -149,12 +159,10 @@ export async function POST(
       formData.set('pool', vdcPoolName)
     }
 
-    if (cloneTouchesIpam) {
-      // unique=1 tells PVE to regenerate every MAC on the clone's NICs.
-      // Without it, two VMs would share MACs which collides at L2 and
-      // breaks the IPAM (subnet, mac) UNIQUE constraint.
-      formData.set('unique', '1')
-    }
+    // NB: PVE clones keep the source MACs. We do NOT use the clone API's
+    // `unique` flag to regenerate them — it isn't portable (older PVE builds
+    // reject it as an unknown property). For IPAM-managed NICs the MACs are
+    // instead regenerated post-clone in the after() block below.
 
     // Appeler l'API Proxmox pour cloner la VM
     const result = await pveFetch<any>(conn, endpoint, {
@@ -179,13 +187,35 @@ export async function POST(
       const cloneNode = String(body.target || node)
       const cloneName = body.name ? String(body.name) : null
 
+      const cloneConfigPath = `/nodes/${encodeURIComponent(cloneNode)}/qemu/${encodeURIComponent(String(newVmid))}/config`
+
       after(async () => {
         try {
           if (upid) await waitForTask(conn, cloneNode, upid)
-          const cloneConfig = await pveFetch<any>(
-            conn,
-            `/nodes/${encodeURIComponent(cloneNode)}/qemu/${encodeURIComponent(String(newVmid))}/config`
-          )
+          let cloneConfig = await pveFetch<any>(conn, cloneConfigPath)
+
+          // ── Regenerate MACs on IPAM-managed NICs ──
+          // The clone inherited the source MACs. For NICs on an IPAM-managed
+          // VNet that collides at L2 and on the (subnet, mac) UNIQUE constraint
+          // the sync below would hit, so strip the pinned MAC and let PVE
+          // assign a fresh one, then re-read the config before allocating.
+          const macPatch = new URLSearchParams()
+          for (const k of Object.keys(cloneConfig || {})) {
+            if (!/^net\d+$/.test(k)) continue
+            const val = String(cloneConfig[k] || '')
+            const bridge = parseBridgeFromNet(val)
+            if (bridge && await resolveSubnetForBridge(id, bridge)) {
+              macPatch.set(k, stripMacFromNet(val))
+            }
+          }
+          if (Array.from(macPatch.keys()).length > 0) {
+            await pveFetch<any>(conn, cloneConfigPath, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+              body: macPatch.toString(),
+            })
+            cloneConfig = await pveFetch<any>(conn, cloneConfigPath)
+          }
 
           const sync = await syncIpamForVmConfig({
             before: null,
@@ -203,15 +233,11 @@ export async function POST(
             const patch = new URLSearchParams()
             for (const [k, v] of Object.entries(sync.bodyOverrides)) patch.set(k, v)
             try {
-              await pveFetch<any>(
-                conn,
-                `/nodes/${encodeURIComponent(cloneNode)}/qemu/${encodeURIComponent(String(newVmid))}/config`,
-                {
-                  method: 'PUT',
-                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                  body: patch.toString(),
-                }
-              )
+              await pveFetch<any>(conn, cloneConfigPath, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: patch.toString(),
+              })
             } catch (err: any) {
               console.error(`[clone-ipam-sync] PVE PUT config failed for vmid=${newVmid}: ${err?.message ?? err}`)
               try { await sync.rollback() } catch { /* tolerate */ }

--- a/frontend/src/components/hardware/CloneVmDialog.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.tsx
@@ -36,17 +36,18 @@ import { useTenant } from '@/contexts/TenantContext'
 type CloneVmDialogProps = {
   open: boolean
   onClose: () => void
-  onClone: (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean }) => Promise<void>
+  onClone: (params: { targetNode: string; newVmid: number; name: string; targetStorage?: string; format?: string; pool?: string; full: boolean; snapname?: string }) => Promise<void>
   connId: string
   currentNode: string
   vmName: string
   vmid: string
+  vmType?: string  // 'qemu' | 'lxc' — needed to read the source snapshots
   nextVmid: number
   pools?: string[]
   existingVmids?: number[]  // Liste des VMIDs déjà utilisés
 }
 
-export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmName, vmid, nextVmid, pools = [], existingVmids = [] }: CloneVmDialogProps) {
+export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmName, vmid, vmType, nextVmid, pools = [], existingVmids = [] }: CloneVmDialogProps) {
   const t = useTranslations()
   const theme = useTheme()
   const isDark = theme.palette.mode === 'dark'
@@ -73,6 +74,12 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
   const [format, setFormat] = useState('qcow2')
   const [pool, setPool] = useState('')
   const [fullClone, setFullClone] = useState(true)
+
+  // Snapshot source — clone from a snapshot restore point (PDM parity).
+  // PVE's clone API accepts an optional `snapname`; empty = current state.
+  const [snapshots, setSnapshots] = useState<{ name: string; snaptimeFormatted: string; vmstate?: boolean }[]>([])
+  const [snapname, setSnapname] = useState('')
+  const [snapshotsLoading, setSnapshotsLoading] = useState(false)
 
   // Generate a random available VMID
   const generateRandomVmid = () => {
@@ -203,6 +210,40 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
     setTargetStorage('')
   }, [open, connId, targetNode])
 
+  // Charger les snapshots de la VM source (pour cloner depuis un point de
+  // restauration). Lus depuis le node source (currentNode), pas le node cible.
+  useEffect(() => {
+    if (!open || !connId || !vmType || !vmid || !currentNode) return
+    let cancelled = false
+
+    const loadSnapshots = async () => {
+      setSnapshotsLoading(true)
+
+      try {
+        const vmKey = `${connId}:${vmType}:${currentNode}:${vmid}`
+        const res = await fetch(`/api/v1/guests/${encodeURIComponent(vmKey)}/snapshots`, { cache: 'no-store' })
+        const json = await res.json()
+        const list = json?.data?.snapshots
+
+        if (!cancelled && Array.isArray(list)) {
+          setSnapshots(list.map((s: any) => ({
+            name: s.name,
+            snaptimeFormatted: s.snaptimeFormatted || '',
+            vmstate: s.vmstate,
+          })))
+        }
+      } catch {
+        // Tolerate — without a snapshot list we simply hide the picker.
+      } finally {
+        if (!cancelled) setSnapshotsLoading(false)
+      }
+    }
+
+    loadSnapshots()
+
+    return () => { cancelled = true }
+  }, [open, connId, vmType, vmid, currentNode])
+
   // Reset form when dialog opens
   useEffect(() => {
     if (open) {
@@ -218,6 +259,7 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
       setFormat('qcow2')
       setPool('')
       setFullClone(true)
+      setSnapname('')
       setError(null)
     }
   }, [open, currentNode, nextVmid, isProviderTenant])
@@ -273,7 +315,8 @@ return currentScore > bestScore ? current : best
         targetStorage: targetStorage || undefined,
         format: targetStorage ? format : undefined,
         pool: pool || undefined,
-        full: fullClone
+        full: fullClone,
+        snapname: snapname || undefined
       })
       onClose()
     } catch (e: any) {
@@ -293,6 +336,49 @@ return currentScore > bestScore ? current : best
 
       <DialogContent>
         {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+
+        {/* Clone-from-snapshot selector — only shown when the source VM has
+            snapshots. Empty value clones the current (live) state, otherwise
+            the clone is taken from the chosen snapshot's restore point. */}
+        {snapshots.length > 0 && (
+          <Box sx={{ mt: 2, mb: 2 }}>
+            <FormControl fullWidth size="small">
+              <InputLabel>Clone from</InputLabel>
+              <Select
+                value={snapname}
+                onChange={(e) => setSnapname(e.target.value)}
+                label="Clone from"
+                disabled={snapshotsLoading}
+                MenuProps={{ PaperProps: { sx: { maxHeight: 320 } } }}
+              >
+                <MenuItem value="">
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <i className="ri-focus-3-line" style={{ fontSize: 14, opacity: 0.7 }} />
+                    <Typography variant="body2">Current state</Typography>
+                  </Box>
+                </MenuItem>
+
+                <Divider sx={{ my: 0.5 }} />
+
+                {snapshots.map((s) => (
+                  <MenuItem key={s.name} value={s.name} sx={{ py: 0.75 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                      <i className="ri-camera-line" style={{ fontSize: 14, opacity: 0.7 }} />
+                      <Box>
+                        <Typography variant="body2" fontWeight={500}>{s.name}</Typography>
+                        {s.snaptimeFormatted && (
+                          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', fontSize: '0.65rem' }}>
+                            {s.snaptimeFormatted}
+                          </Typography>
+                        )}
+                      </Box>
+                    </Box>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        )}
 
         {/* Tenant view — single name field. Target node stays the source
             node, target storage falls back to "same as source", VMID is

--- a/frontend/src/lib/vdc/ipamScan.test.ts
+++ b/frontend/src/lib/vdc/ipamScan.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest'
 import {
   parseNetLine,
   parseIpconfigLine,
+  stripMacFromNet,
   scanUsedIpsForSubnet,
   scannedToIntSet,
   invalidateScanCache,
@@ -245,5 +246,36 @@ describe('scanUsedIpsForSubnet', () => {
       connectionId: 'conn-1',
     })
     expect(out).toEqual([{ vmid: 101, mac: 'AA:00:00:00:00:02', ip: '10.42.0.6' }])
+  })
+})
+
+describe('stripMacFromNet', () => {
+  it('drops the MAC from the canonical model=MAC form so PVE regenerates it', () => {
+    expect(stripMacFromNet('virtio=BC:24:11:AA:BB:CC,bridge=tenantA,tag=10'))
+      .toBe('virtio,bridge=tenantA,tag=10')
+  })
+
+  it('drops the macaddr= token from the alt form', () => {
+    expect(stripMacFromNet('virtio,bridge=tenantA,macaddr=BC:24:11:AA:BB:CC,firewall=1'))
+      .toBe('virtio,bridge=tenantA,firewall=1')
+  })
+
+  it('handles every supported model token', () => {
+    expect(stripMacFromNet('e1000=AA:BB:CC:DD:EE:FF,bridge=b')).toBe('e1000,bridge=b')
+    expect(stripMacFromNet('rtl8139=AA:BB:CC:DD:EE:FF,bridge=b')).toBe('rtl8139,bridge=b')
+    expect(stripMacFromNet('vmxnet3=AA:BB:CC:DD:EE:FF,bridge=b')).toBe('vmxnet3,bridge=b')
+  })
+
+  it('leaves a line with no pinned MAC unchanged', () => {
+    expect(stripMacFromNet('virtio,bridge=vmbr0')).toBe('virtio,bridge=vmbr0')
+  })
+
+  it('preserves the other NIC options and their order', () => {
+    expect(stripMacFromNet('virtio=BC:24:11:00:00:01,bridge=tenantA,tag=20,firewall=1,mtu=1400'))
+      .toBe('virtio,bridge=tenantA,tag=20,firewall=1,mtu=1400')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(stripMacFromNet('')).toBe('')
   })
 })

--- a/frontend/src/lib/vdc/ipamScan.ts
+++ b/frontend/src/lib/vdc/ipamScan.ts
@@ -141,6 +141,42 @@ export function parseNetLine(value: string): { bridge: string | null; mac: strin
 }
 
 /**
+ * Rewrite a `netN` line so PVE assigns a fresh MAC on the next config write.
+ *
+ * PVE's clone keeps the source MACs and the clone API's `unique` flag is not
+ * portable across PVE versions (older builds reject it as an unknown
+ * property). For NICs on an IPAM-managed VNet the duplicated MAC collides both
+ * on the wire and on the (subnet, mac) UNIQUE constraint, so we strip the
+ * pinned MAC — both the canonical `model=MAC` form and the `macaddr=` form —
+ * and let PVE auto-generate one. A line with no pinned MAC is returned as-is.
+ */
+export function stripMacFromNet(value: string): string {
+  const parts = String(value || '').split(',')
+  const out: string[] = []
+
+  for (const part of parts) {
+    const eq = part.indexOf('=')
+
+    if (eq >= 0) {
+      const k = part.slice(0, eq).trim()
+
+      // Canonical `model=MAC` → keep just the bare model token (drop the MAC).
+      if (NET_MODEL_TOKENS.has(k)) {
+        out.push(k)
+        continue
+      }
+
+      // Alt `macaddr=MAC` → drop the token entirely.
+      if (k === 'macaddr') continue
+    }
+
+    out.push(part)
+  }
+
+  return out.join(',')
+}
+
+/**
  * Parse an `ipconfigN` line. Returns the static IP if the line is in
  * `ip=A.B.C.D[/prefix],...` form. `ip=dhcp`, missing `ip=`, and SLAAC
  * (`ip6=...`) all yield null — we only track static v4 in the IPAM.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -106,6 +106,10 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 # - inventory/components/CephTopology.tsx: the Ceph CRUSH topology view. Pure
 #   presentational JSX (tree rows, details panel, pools table); its only logic
 #   (buildCrushTopology/capacityColor) lives in cephTopology.ts and is unit-tested.
+# - components/hardware/CloneVmDialog.tsx: the clone-VM dialog is a pure-JSX MUI
+#   form (node/storage/pool selectors, clone-from-snapshot picker). Its side
+#   effects only fetch lists to populate dropdowns; the clone itself is driven by
+#   the measured clone route (connections/**/clone) and the useVmActions handlers.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -150,7 +154,8 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.tsx
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.tsx,\
+  frontend/src/components/hardware/CloneVmDialog.tsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
## What

Adds clone-from-snapshot to the VM clone dialog (PDM parity), answering a request on discussion #408.

- New "Clone from" selector in the clone dialog. It defaults to "Current state" and only appears when the source VM has snapshots, so the common case (and the minimal tenant form) is unchanged.
- The selected snapshot is threaded through all three clone entry points: the detail panel, the table row action and the tree context menu.
- The clone route and Zod schema already accepted `snapname`, so no API contract change was needed.

## Clone reliability fix (IPAM-managed sources)

While testing, IPAM-managed clones failed with `PVE 400 ... {"errors":{"unique":"property is not defined in schema..."}}` on Proxmox builds that do not expose the clone API's `unique` flag. This is independent of the snapshot feature (it also fires when cloning from the current state).

- The route no longer sends `unique`.
- It now sends a canonical `full=1`/`0`. A JS boolean previously stringified to `"true"`, which can land in PVE's linked-clone schema branch.
- For NICs on an IPAM-managed VNet, the inherited MACs are regenerated after the clone (new `stripMacFromNet` helper), then IPAM is reconciled against the fresh config.

## Tests

- `stripMacFromNet` unit tests (canonical `model=MAC` and `macaddr=` forms, every model token, no-op).
- New clone route tests: `full` normalization (1/0, never `unique`), and the post-clone MAC regeneration for managed NICs.
- Full suite green (1122 tests).

The pure-JSX `CloneVmDialog` is added to the Sonar coverage exclusions with a rationale, matching the sibling dialogs.
