### PR TITLE
fix(inventory): keep NETWORK section stable when a connection blips

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isSharedStorage } from '@/lib/proxmox/storage'
-import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
+import { fetchConnectionsNetworks } from '@/lib/proxmox/fetchConnectionsNetworks'
 
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
 import { 
@@ -2306,6 +2306,7 @@ return favorites.has(vmKey)
   type VmNetData = { vmid: string; name: string; node: string; type: string; status: string; connId?: string; nets: NetIface[] }
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
   const [networkLoading, setNetworkLoading] = useState(false)
+  const [networkFailedConnIds, setNetworkFailedConnIds] = useState<string[]>([])
   const networkFetchedRef = useRef(false)
 
   // Tenant VNet view — replaces the conn/node/VLAN/VM walk for non-provider
@@ -2382,22 +2383,17 @@ return favorites.has(vmKey)
       return
     }
     setNetworkLoading(true)
-    Promise.all(
-      connIds.map(async (connId) => {
-        try {
-          const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/networks`)
-          if (!res.ok) return []
-          const json = await res.json()
-          // Fold each guest's server-computed host VLAN into `tag` so the VLAN tree resolves
-          // traditional bondX.N-bridge layouts instead of bucketing them Untagged (see helper).
-          return (json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))
-        } catch { return [] }
-      })
-    ).then((results) => {
-      const all = results.flat()
-      networkCacheRef.current = { connIds: cacheKey, data: all }
-      setNetworkData(all)
+    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, failedConnIds }) => {
+      setNetworkData(data)
       setNetworkLoading(false)
+      setNetworkFailedConnIds(failedConnIds)
+      // Only cache when all connections succeeded so re-opening retries any partial failure
+      if (failedConnIds.length === 0) {
+        networkCacheRef.current = { connIds: cacheKey, data }
+      } else {
+        // Allow the next expand to re-fetch
+        networkFetchedRef.current = false
+      }
     })
   }, [clusters])
   const fetchNetworksRef = useRef(fetchNetworks)
@@ -3904,8 +3900,8 @@ return (
                   label={
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
                       <ClusterIcon nodes={clusters.find(c => c.connId === cId)?.nodes || []} />
-                      <span style={{ fontSize: 13 }}>{connName}</span>
-                      <span style={{ opacity: 0.4, fontSize: 11 }}>({nodes.length} nodes)</span>
+                      <Typography variant="body2" sx={{ fontSize: 13 }}>{connName}</Typography>
+                      <Typography variant="caption" sx={{ opacity: 0.4, fontSize: 11 }}>({nodes.length} nodes)</Typography>
                     </Box>
                   }
                 >
@@ -3970,6 +3966,40 @@ return (
               ))}
               </SimpleTreeView>
             )}
+            {networkFailedConnIds.length > 0 && networkFailedConnIds.map((failedId) => {
+              const connName = clusters.find(c => c.connId === failedId)?.name || failedId
+              return (
+                <Box
+                  key={`net-fail:${failedId}`}
+                  onClick={() => {
+                    networkFetchedRef.current = true
+                    fetchNetworks()
+                  }}
+                  sx={{
+                    display: 'flex', alignItems: 'center', gap: 0.75,
+                    px: 2, py: 0.5, cursor: 'pointer',
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                >
+                  <i
+                    className="ri-error-warning-line"
+                    style={{ fontSize: 14, color: 'inherit' }}
+                  />
+                  <Typography
+                    variant="caption"
+                    sx={{ color: 'warning.main', fontSize: 12 }}
+                  >
+                    {connName}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    sx={{ color: 'text.secondary', fontSize: 11, opacity: 0.7 }}
+                  >
+                    {t('inventory.networkLoadFailed')}
+                  </Typography>
+                </Box>
+              )
+            })}
           </Collapse>
         </>
       )}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
@@ -23,7 +23,7 @@ import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 import VnetsSection from './VnetsSection'
 import { useTenant } from '@/contexts/TenantContext'
-import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
+import { fetchConnectionsNetworks } from '@/lib/proxmox/fetchConnectionsNetworks'
 
 type VmNetData = {
   vmid: string
@@ -289,20 +289,9 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     const ids = connIdsKey.split(',')
     let alive = true
     setLoading(true)
-    Promise.all(
-      ids.map(async (connId) => {
-        try {
-          const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/networks`)
-          if (!res.ok) return []
-          const json = await res.json()
-          // Fold each guest's server-computed host VLAN into `tag` so the VLAN KPI and
-          // breakdown count traditional bondX.N-bridge layouts, not just NIC-tagged guests.
-          return (json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))
-        } catch { return [] }
-      })
-    ).then((results) => {
+    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data }) => {
       if (!alive) return
-      setNetworkData(results.flat())
+      setNetworkData(data)
     }).finally(() => {
       if (!alive) return
       setLoading(false)

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchConnectionsNetworks } from './fetchConnectionsNetworks'
+
+// Build a minimal fetch mock that returns a successful response for a connId
+function makeOkFetch(responsesByConnId: Record<string, { data: any[] }>) {
+  return vi.fn(async (url: string) => {
+    const match = /\/connections\/([^/]+)\/networks/.exec(url)
+    const connId = match ? decodeURIComponent(match[1]) : '__unknown__'
+    const body = responsesByConnId[connId]
+    if (!body) throw new Error(`Unexpected connId: ${connId}`)
+    return new Response(JSON.stringify(body), { status: 200 })
+  })
+}
+
+// Returns a fetch that always responds with a non-ok status for the given connId
+function makeFailFetch(failConnId: string, fallbackData: Record<string, { data: any[] }>) {
+  return vi.fn(async (url: string) => {
+    const match = /\/connections\/([^/]+)\/networks/.exec(url)
+    const connId = match ? decodeURIComponent(match[1]) : '__unknown__'
+    if (connId === failConnId) {
+      return new Response(JSON.stringify({ error: 'Not found' }), { status: 404 })
+    }
+    const body = fallbackData[connId]
+    if (!body) throw new Error(`Unexpected connId: ${connId}`)
+    return new Response(JSON.stringify(body), { status: 200 })
+  })
+}
+
+describe('fetchConnectionsNetworks', () => {
+  it('returns all rows and no failedConnIds when all connections succeed', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: { data: [{ vmid: '100', name: 'vm1', node: 'node1', type: 'qemu', status: 'running', nets: [] }] },
+      conn2: { data: [{ vmid: '200', name: 'vm2', node: 'node2', type: 'lxc', status: 'stopped', nets: [] }] },
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1', 'conn2'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.failedConnIds).toEqual([])
+    expect(result.data).toHaveLength(2)
+    expect(result.data.map((d) => d.vmid)).toContain('100')
+    expect(result.data.map((d) => d.vmid)).toContain('200')
+    // connId must be stamped on each item
+    expect(result.data.find((d) => d.vmid === '100')?.connId).toBe('conn1')
+    expect(result.data.find((d) => d.vmid === '200')?.connId).toBe('conn2')
+  })
+
+  it('puts the failing connId in failedConnIds and keeps other connections data', async () => {
+    const fetchImpl = makeFailFetch('bad-conn', {
+      'good-conn': { data: [{ vmid: '101', name: 'vm-ok', node: 'n1', type: 'qemu', status: 'running', nets: [] }] },
+    })
+
+    const result = await fetchConnectionsNetworks(['good-conn', 'bad-conn'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.failedConnIds).toEqual(['bad-conn'])
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].vmid).toBe('101')
+  })
+
+  it('retries a connection that throws once and succeeds on retry', async () => {
+    let callCount = 0
+    const fetchImpl = vi.fn(async (url: string) => {
+      const match = /\/connections\/([^/]+)\/networks/.exec(url)
+      const connId = match ? decodeURIComponent(match[1]) : ''
+      if (connId === 'flaky') {
+        callCount++
+        if (callCount === 1) throw new Error('temporary network error')
+        return new Response(
+          JSON.stringify({ data: [{ vmid: '999', name: 'flaky-vm', node: 'n1', type: 'qemu', status: 'running', nets: [] }] }),
+          { status: 200 },
+        )
+      }
+      return new Response(JSON.stringify({ data: [] }), { status: 200 })
+    })
+
+    const result = await fetchConnectionsNetworks(['flaky'], {
+      retries: 2,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.failedConnIds).toEqual([])
+    expect(result.data).toHaveLength(1)
+    expect(result.data[0].vmid).toBe('999')
+    expect(callCount).toBe(2)
+  })
+
+  it('folds effectiveTag into tag via foldEffectiveVlanTags', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: {
+        data: [
+          {
+            vmid: '300',
+            name: 'vlan-vm',
+            node: 'n1',
+            type: 'qemu',
+            status: 'running',
+            nets: [{ id: 'net0', model: 'virtio', bridge: 'vmbr0', tag: undefined, effectiveTag: 10 }],
+          },
+        ],
+      },
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.data).toHaveLength(1)
+    const net = result.data[0].nets[0]
+    // foldEffectiveVlanTags should have set tag = effectiveTag = 10
+    expect(net.tag).toBe(10)
+  })
+
+  it('returns empty result immediately for empty connIds input', async () => {
+    const fetchImpl = vi.fn()
+
+    const result = await fetchConnectionsNetworks([], {
+      retries: 2,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.data).toEqual([])
+    expect(result.failedConnIds).toEqual([])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
@@ -1,0 +1,82 @@
+import { foldEffectiveVlanTags } from './hostVlanMap'
+
+export type VmNetItem = {
+  vmid: string
+  name: string
+  node: string
+  type: string
+  status: string
+  connId: string
+  nets: any[]
+}
+
+const DEFAULT_RETRIES = 2
+const DEFAULT_RETRY_DELAY_MS = 300
+
+async function fetchWithRetry(
+  connId: string,
+  retries: number,
+  retryDelayMs: number,
+  fetchImpl: typeof fetch,
+): Promise<{ ok: true; items: VmNetItem[] } | { ok: false }> {
+  let attempt = 0
+  while (attempt <= retries) {
+    try {
+      const res = await fetchImpl(
+        `/api/v1/connections/${encodeURIComponent(connId)}/networks`,
+      )
+      if (!res.ok) return { ok: false }
+      const json = await res.json()
+      const items: VmNetItem[] = (json.data ?? []).map((vm: any) => ({
+        ...vm,
+        connId,
+        nets: foldEffectiveVlanTags(vm.nets),
+      }))
+      return { ok: true, items }
+    } catch {
+      if (attempt < retries) {
+        if (retryDelayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+        }
+        attempt++
+        continue
+      }
+      return { ok: false }
+    }
+  }
+  return { ok: false }
+}
+
+/**
+ * Fetch VM network data from multiple connections concurrently with per-connection
+ * retry logic. Returns flat data plus the list of connection IDs that failed after
+ * all retries. Never rejects — partial failure is surfaced via failedConnIds.
+ */
+export async function fetchConnectionsNetworks(
+  connIds: string[],
+  opts?: { retries?: number; retryDelayMs?: number; fetchImpl?: typeof fetch },
+): Promise<{ data: VmNetItem[]; failedConnIds: string[] }> {
+  if (connIds.length === 0) return { data: [], failedConnIds: [] }
+
+  const retries = opts?.retries ?? DEFAULT_RETRIES
+  const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
+  const fetchImpl = opts?.fetchImpl ?? fetch
+
+  const results = await Promise.all(
+    connIds.map((connId) => fetchWithRetry(connId, retries, retryDelayMs, fetchImpl)),
+  )
+
+  const data: VmNetItem[] = []
+  const failedConnIds: string[] = []
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i]
+    if (result.ok) {
+      data.push(...result.items)
+    } else {
+      failedConnIds.push(connIds[i])
+    }
+  }
+
+  return { data, failedConnIds }
+}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -545,6 +545,7 @@
     "storageSnippets": "Snippets",
     "storageTemplates": "CT Templates",
     "storageEmpty": "No content found in this storage",
+    "networkLoadFailed": "Couldn't load, click to retry",
     "pbsBackupList": "PBS Backups",
     "pbsName": "Name",
     "pbsNotes": "Notes",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -545,6 +545,7 @@
     "storageSnippets": "Snippets",
     "storageTemplates": "Templates CT",
     "storageEmpty": "Aucun contenu trouvé dans ce stockage",
+    "networkLoadFailed": "Chargement échoué, cliquer pour réessayer",
     "pbsBackupList": "Sauvegardes PBS",
     "pbsName": "Nom",
     "pbsNotes": "Notes",


### PR DESCRIPTION
## Summary

Fixes a flaky inventory NETWORK section reported after the 1.4.3 update: a server/cluster connection randomly disappears from the tree's NETWORK section, and a full page reload sometimes brings it back. It was not specific to any one connection.

## Root cause

`InventoryTree`'s `fetchNetworks` fetched `/api/v1/connections/{id}/networks` for every connection via `Promise.all`. On a transient failure it silently returned `[]` for that connection AND cached the resulting partial dataset. Because the fetch is one-shot per mount, a single blip removed a connection for the whole session until a full reload. The standalone Network dashboard self-healed only because it has no cache and refetches on open.

## Fix

- New shared, unit-tested helper `lib/proxmox/fetchConnectionsNetworks.ts`: fetches each connection with per-connection retry on transient failure and returns a flat `{ data, failedConnIds }` (never rejects, partial failure is surfaced rather than swallowed).
- `InventoryTree` now caches only when every connection succeeded, re-fetches on partial failure, and renders a failed connection as a "click to retry" row instead of hiding it.
- `NetworkDashboard` reuses the same helper (removes the duplicated fetch logic).
- i18n string added in EN and FR.

## Verification

- Vitest: 5 new tests on the helper (all success, partial failure not dropped, retry-then-succeed, effective-tag folding, empty input) plus the existing `lib/proxmox` suite, all green.
- `tsc --noEmit`: no errors on the changed files.
- Browser-validated: NETWORK section stays stable across repeated refreshes.

`InventoryTree.tsx` and `NetworkDashboard.tsx` are already in `sonar.coverage.exclusions`; the new helper carries the coverage.
