### PR TITLE
feat(dashboard): header tenant switcher + per-tenant dashboards for MSP

### DIFF
--- a/frontend/prisma/migrations/20260615000000_dashboard_layout_tenant_unique/migration.sql
+++ b/frontend/prisma/migrations/20260615000000_dashboard_layout_tenant_unique/migration.sql
@@ -1,0 +1,10 @@
+-- Widen the DashboardLayout unique constraint to include tenant_id so that
+-- the same (userId, name) pair can exist independently in each tenant.
+-- The old index only covered (userId, name), which caused the session-scoped
+-- Prisma upsert to collide with the provider's existing "Default" row when a
+-- super-admin also had a dashboard row in the provider scope.
+
+DROP INDEX IF EXISTS "DashboardLayout_userId_name_key";
+
+CREATE UNIQUE INDEX "DashboardLayout_tenantId_userId_name_key"
+  ON "DashboardLayout" (tenant_id, "userId", name);

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -92,7 +92,7 @@ model DashboardLayout {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([userId, name])
+  @@unique([tenantId, userId, name])
 }
 
 model Alert {

--- a/frontend/src/app/api/v1/dashboard/layout/route.test.ts
+++ b/frontend/src/app/api/v1/dashboard/layout/route.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { DEFAULT_LAYOUT } from "@/components/dashboard/types"
+import { callRoute } from "../../../../../__tests__/setup/route-test"
+
+// ── Hoist mocks ──────────────────────────────────────────────────────────────
+const {
+  mockGetServerSession,
+  mockDemoResponse,
+  mockGetCurrentTenantId,
+  dashboardLayoutUpdateMany,
+  dashboardLayoutUpsert,
+  dashboardLayoutFindFirst,
+  tenantFindUnique,
+} = vi.hoisted(() => ({
+  mockGetServerSession: vi.fn(),
+  mockDemoResponse: vi.fn(),
+  mockGetCurrentTenantId: vi.fn(),
+  dashboardLayoutUpdateMany: vi.fn(),
+  dashboardLayoutUpsert: vi.fn(),
+  dashboardLayoutFindFirst: vi.fn(),
+  tenantFindUnique: vi.fn(),
+}))
+
+// Session-scoped prisma (tenant-scoped client)
+vi.mock("@/lib/tenant", () => ({
+  getSessionPrisma: async () => ({
+    dashboardLayout: {
+      updateMany: dashboardLayoutUpdateMany,
+      upsert: dashboardLayoutUpsert,
+      findFirst: dashboardLayoutFindFirst,
+      findMany: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue(0),
+      aggregate: vi.fn().mockResolvedValue({ _max: { sortOrder: 0 } }),
+      create: vi.fn().mockResolvedValue({ id: "new-id", name: "Default", widgets: [], isActive: true, updatedAt: null }),
+      delete: vi.fn().mockResolvedValue({}),
+      deleteMany: vi.fn().mockResolvedValue({}),
+      update: vi.fn().mockResolvedValue({}),
+    },
+  }),
+  getCurrentTenantId: () => mockGetCurrentTenantId(),
+}))
+
+// Global prisma (for tenant table lookups)
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    tenant: {
+      findUnique: tenantFindUnique,
+    },
+  },
+}))
+
+vi.mock("next-auth", () => ({
+  getServerSession: mockGetServerSession,
+}))
+
+vi.mock("@/lib/demo/demo-api", () => ({
+  demoResponse: mockDemoResponse,
+}))
+
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockDemoResponse.mockReturnValue(null)
+  mockGetServerSession.mockResolvedValue({ user: { id: "u1", tenantId: "default" } })
+  mockGetCurrentTenantId.mockResolvedValue("default")
+  dashboardLayoutUpdateMany.mockResolvedValue({})
+  dashboardLayoutUpsert.mockResolvedValue({
+    id: "layout-1",
+    name: "Default",
+    widgets: [],
+    isActive: true,
+    updatedAt: new Date(),
+  })
+  dashboardLayoutFindFirst.mockResolvedValue(null)
+  tenantFindUnique.mockResolvedValue(null)
+})
+
+// ── PUT tests ────────────────────────────────────────────────────────────────
+
+describe("PUT /api/v1/dashboard/layout", () => {
+  it("keys the upsert on { tenantId_userId_name } for a tenant session", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u1", tenantId: "msp-tenant-1" } })
+    mockGetCurrentTenantId.mockResolvedValue("msp-tenant-1")
+
+    const { PUT } = await import("./route")
+    const res = await callRoute(PUT, {
+      method: "PUT",
+      body: { name: "Default", widgets: [{ id: "w1", type: "alerts" }] },
+    })
+
+    expect(res.status).toBe(200)
+
+    expect(dashboardLayoutUpsert).toHaveBeenCalledOnce()
+    const upsertCall = dashboardLayoutUpsert.mock.calls[0][0]
+    expect(upsertCall.where).toEqual({
+      tenantId_userId_name: { tenantId: "msp-tenant-1", userId: "u1", name: "Default" },
+    })
+  })
+
+  it("uses the provider tenantId in the upsert key for a provider session", async () => {
+    mockGetServerSession.mockResolvedValue({ user: { id: "u2", tenantId: "default" } })
+    mockGetCurrentTenantId.mockResolvedValue("default")
+
+    const { PUT } = await import("./route")
+    const res = await callRoute(PUT, {
+      method: "PUT",
+      body: { name: "My Dashboard", widgets: [] },
+    })
+
+    expect(res.status).toBe(200)
+
+    const upsertCall = dashboardLayoutUpsert.mock.calls[0][0]
+    expect(upsertCall.where).toEqual({
+      tenantId_userId_name: { tenantId: "default", userId: "u2", name: "My Dashboard" },
+    })
+  })
+
+  it("returns 400 when widgets is missing", async () => {
+    const { PUT } = await import("./route")
+    const res = await callRoute(PUT, { method: "PUT", body: { name: "Default" } })
+    expect(res.status).toBe(400)
+    expect(dashboardLayoutUpsert).not.toHaveBeenCalled()
+  })
+})
+
+// ── GET active-fallback tests ─────────────────────────────────────────────────
+
+describe("GET /api/v1/dashboard/layout — active-layout fallback", () => {
+  it("returns DEFAULT_LAYOUT widgets when no layout exists and tenant.operatingModel === 'msp'", async () => {
+    mockGetCurrentTenantId.mockResolvedValue("msp-tenant-1")
+    dashboardLayoutFindFirst.mockResolvedValue(null)
+    tenantFindUnique.mockResolvedValue({ operatingModel: "msp" })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.id).toBeNull()
+    expect(body.data.name).toBe("Default")
+    expect(body.data.widgets).toEqual(DEFAULT_LAYOUT)
+  })
+
+  it("returns empty widgets when no layout exists and tenant is provider (operatingModel null)", async () => {
+    mockGetCurrentTenantId.mockResolvedValue("default")
+    dashboardLayoutFindFirst.mockResolvedValue(null)
+    tenantFindUnique.mockResolvedValue({ operatingModel: null })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.widgets).toEqual([])
+  })
+
+  it("returns empty widgets when no layout exists and tenant has operatingModel 'iaas'", async () => {
+    mockGetCurrentTenantId.mockResolvedValue("iaas-tenant-1")
+    dashboardLayoutFindFirst.mockResolvedValue(null)
+    tenantFindUnique.mockResolvedValue({ operatingModel: "iaas" })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.widgets).toEqual([])
+  })
+
+  it("returns empty widgets when no layout exists and prisma.tenant returns null (unknown tenant)", async () => {
+    mockGetCurrentTenantId.mockResolvedValue("ghost-tenant")
+    dashboardLayoutFindFirst.mockResolvedValue(null)
+    tenantFindUnique.mockResolvedValue(null)
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.widgets).toEqual([])
+  })
+
+  it("returns the existing layout when one exists (no fallback needed)", async () => {
+    const storedWidgets = [{ id: "w1", type: "alerts" }]
+    dashboardLayoutFindFirst.mockResolvedValue({
+      id: "layout-99",
+      name: "Default",
+      widgets: storedWidgets,
+      isActive: true,
+      updatedAt: new Date("2026-01-01"),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.id).toBe("layout-99")
+    expect(body.data.widgets).toEqual(storedWidgets)
+    // tenant.findUnique must NOT be called when a layout row exists
+    expect(tenantFindUnique).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/dashboard/layout/route.ts
+++ b/frontend/src/app/api/v1/dashboard/layout/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from "next/server"
 
 import { getServerSession } from "next-auth"
 
-import { getSessionPrisma } from "@/lib/tenant"
+import { getSessionPrisma, getCurrentTenantId } from "@/lib/tenant"
 import { DEFAULT_LAYOUT } from "@/components/dashboard/types"
 import { authOptions } from "@/lib/auth/config"
 import { demoResponse } from "@/lib/demo/demo-api"
+import { prisma as globalPrisma } from "@/lib/db/prisma"
 
 export const runtime = "nodejs"
 
@@ -89,8 +90,14 @@ export async function GET(req: Request) {
       })
     }
 
+    // MSP tenants get the default widget set on first load; provider and IaaS/vDC
+    // tenants get an empty canvas (cloud abstraction hides infra widgets anyway).
+    const tenantId = await getCurrentTenantId()
+    const tenant = await globalPrisma.tenant.findUnique({ where: { id: tenantId }, select: { operatingModel: true } })
+    const defaultWidgets = tenant?.operatingModel === 'msp' ? DEFAULT_LAYOUT : []
+
     return NextResponse.json({
-      data: { id: null, name: 'Default', widgets: [], isActive: true, updatedAt: null }
+      data: { id: null, name: 'Default', widgets: defaultWidgets, isActive: true, updatedAt: null }
     })
   } catch (e: any) {
     console.error("[dashboard/layout] GET error:", e)
@@ -112,6 +119,7 @@ export async function PUT(req: Request) {
     const prisma = await getSessionPrisma()
     const session = await getServerSession(authOptions)
     const userId = getUserId(session)
+    const tenantId = await getCurrentTenantId()
     const body = await req.json()
     const { name = 'Default', widgets } = body
 
@@ -126,7 +134,7 @@ export async function PUT(req: Request) {
     })
 
     const layout = await prisma.dashboardLayout.upsert({
-      where: { userId_name: { userId, name } },
+      where: { tenantId_userId_name: { tenantId, userId, name } },
       create: { userId, name, widgets, isActive: true },
       update: { widgets, isActive: true, updatedAt: new Date() },
     })

--- a/frontend/src/components/layout/shared/TenantSwitcher.jsx
+++ b/frontend/src/components/layout/shared/TenantSwitcher.jsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+
+import {
+  Box,
+  Button,
+  InputAdornment,
+  ListItemIcon,
+  Menu,
+  MenuItem,
+  TextField,
+  Tooltip,
+} from '@mui/material'
+import { useTranslations } from 'next-intl'
+
+import { useTenant } from '@/contexts/TenantContext'
+
+const tooltipSlotProps = {
+  tooltip: {
+    sx: {
+      bgcolor: 'background.paper',
+      color: 'text.primary',
+      border: '1px solid',
+      borderColor: 'divider',
+      borderRadius: 1.5,
+      boxShadow: 3,
+    }
+  }
+}
+
+export default function TenantSwitcher() {
+  const { currentTenant, availableTenants, switchTenant, isMultiTenant, loading } = useTenant()
+  const t = useTranslations('navbar')
+
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [search, setSearch] = useState('')
+
+  // All hooks must run before any early return (Rules of Hooks): loading flips
+  // from true to false on first tenant fetch, so a conditionally-called useMemo
+  // would change the hook count between renders and crash the navbar.
+  const showSearch = availableTenants.length > 8
+
+  const filteredTenants = useMemo(() => {
+    if (!showSearch || !search.trim()) return availableTenants
+    const q = search.trim().toLowerCase()
+    // Keep provider/default always at top
+    const provider = availableTenants.filter(tn => tn.id === 'default')
+    const rest = availableTenants.filter(tn => tn.id !== 'default' && tn.name.toLowerCase().includes(q))
+    return [...provider, ...rest]
+  }, [availableTenants, search, showSearch])
+
+  if (loading || !isMultiTenant || availableTenants.length <= 1) {
+    return null
+  }
+
+  const isDefault = currentTenant?.id === 'default'
+  const leadingIcon = isDefault ? 'ri-stack-line' : 'ri-building-line'
+
+  const handleOpen = (e) => {
+    setAnchorEl(e.currentTarget)
+    setSearch('')
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+    setSearch('')
+  }
+
+  const handleSelect = (tenantId) => {
+    if (tenantId !== currentTenant?.id) {
+      switchTenant(tenantId)
+    }
+    handleClose()
+  }
+
+  return (
+    <>
+      <Tooltip title={t('switchTenant')} slotProps={tooltipSlotProps}>
+        <Button
+          size='small'
+          onClick={handleOpen}
+          sx={{
+            height: 32,
+            px: 1.25,
+            gap: 0.75,
+            color: 'text.primary',
+            borderRadius: 1,
+            textTransform: 'none',
+            fontWeight: 500,
+            fontSize: '0.8125rem',
+            bgcolor: 'transparent',
+            border: '1px solid',
+            borderColor: 'divider',
+            '&:hover': {
+              bgcolor: 'action.hover',
+              borderColor: 'text.secondary',
+            },
+          }}
+        >
+          <i className={leadingIcon} style={{ fontSize: 15, flexShrink: 0 }} />
+          <Box
+            component='span'
+            sx={{
+              maxWidth: 140,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              display: 'block',
+            }}
+          >
+            {currentTenant?.name ?? ''}
+          </Box>
+          <i className='ri-arrow-down-s-line' style={{ fontSize: 15, flexShrink: 0 }} />
+        </Button>
+      </Tooltip>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              minWidth: 200,
+              maxWidth: 280,
+            }
+          }
+        }}
+      >
+        {showSearch && (
+          <Box sx={{ px: 1.5, pt: 1, pb: 0.5 }}>
+            <TextField
+              size='small'
+              autoFocus
+              fullWidth
+              placeholder={t('searchTenants')}
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              onKeyDown={e => e.stopPropagation()}
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position='start'>
+                      <i className='ri-search-line' style={{ fontSize: 14 }} />
+                    </InputAdornment>
+                  ),
+                }
+              }}
+              sx={{ '& .MuiInputBase-input': { fontSize: '0.8125rem' } }}
+            />
+          </Box>
+        )}
+
+        {filteredTenants.map((tenant) => {
+          const isActive = tenant.id === currentTenant?.id
+          const icon = isActive
+            ? 'ri-checkbox-circle-fill'
+            : tenant.id === 'default'
+              ? 'ri-stack-line'
+              : 'ri-building-line'
+
+          return (
+            <MenuItem
+              key={tenant.id}
+              selected={isActive}
+              onClick={() => handleSelect(tenant.id)}
+              sx={{ gap: 0.5, fontSize: '0.875rem' }}
+            >
+              <ListItemIcon sx={{ minWidth: 28, color: isActive ? 'primary.main' : 'inherit' }}>
+                <i className={icon} style={{ fontSize: 16 }} />
+              </ListItemIcon>
+              <Box
+                component='span'
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {tenant.name}
+              </Box>
+            </MenuItem>
+          )
+        })}
+      </Menu>
+    </>
+  )
+}

--- a/frontend/src/components/layout/vertical/NavbarContent.jsx
+++ b/frontend/src/components/layout/vertical/NavbarContent.jsx
@@ -17,7 +17,6 @@ import {
   ListItemIcon,
   Menu,
   MenuItem,
-  Select,
   Tooltip,
   Typography
 } from '@mui/material'
@@ -49,6 +48,9 @@ import WhatsNewDialog, { useWhatsNew } from '@components/dialogs/WhatsNewDialog'
 
 // Command Palette
 import CommandPalette from '@components/layout/shared/CommandPalette'
+
+// Tenant Switcher
+import TenantSwitcher from '@components/layout/shared/TenantSwitcher'
 
 // Page Title Context
 import { usePageTitle } from '@/contexts/PageTitleContext'
@@ -168,7 +170,7 @@ const NavbarContent = ({ targetLayout } = {}) => {
   const { title, subtitle, icon } = usePageTitle()
   const { hasFeature, loading: licenseLoading, status: licenseStatus, isEnterprise } = useLicense()
   const { roles: rbacRoles, hasPermission } = useRBAC()
-  const { currentTenant, availableTenants, switchTenant, isMultiTenant } = useTenant()
+  const { currentTenant } = useTenant()
   // Provider-only notifications (ProxCenter update, license / node limit
   // warnings, DRS recommendations) are gated on this flag. Tenant admins
   // see only the alerts and changes scoped to their own connections.
@@ -693,6 +695,9 @@ return () => window.removeEventListener('keydown', onKeyDown)
               <i className={targetLayout === 'vertical' ? 'ri-layout-left-line' : 'ri-layout-top-line'} />
             </IconButton>
           </Tooltip>
+
+          {/* Tenant Switcher */}
+          <TenantSwitcher />
 
           {/* Profile */}
           <Tooltip title={t('navbar.profile')}>
@@ -1265,41 +1270,6 @@ return () => window.removeEventListener('keydown', onKeyDown)
                  t('pxcore.unknown')}
               </Typography>
             </Box>
-          </Box>
-        )}
-
-        {isMultiTenant && availableTenants.length > 1 && <Divider />}
-        {isMultiTenant && availableTenants.length > 1 && (
-          <Box sx={{ px: 2, py: 1 }}>
-            <Typography variant='caption' sx={{ opacity: 0.6, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.65rem' }}>
-              {t('settings.tenant', { defaultMessage: 'Tenant' })}
-            </Typography>
-            <Select
-              size='small'
-              fullWidth
-              value={currentTenant?.id || ''}
-              onChange={(e) => {
-                if (e.target.value !== currentTenant?.id) {
-                  switchTenant(e.target.value)
-                }
-              }}
-              sx={{ mt: 0.5, height: 32, fontSize: '0.8rem' }}
-              renderValue={(val) => (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <i className={val === 'default' ? 'ri-stack-line' : 'ri-building-line'} style={{ fontSize: 14, opacity: 0.7 }} />
-                  {availableTenants.find(tn => tn.id === val)?.name || val}
-                </Box>
-              )}
-            >
-              {availableTenants.map((tenant) => (
-                <MenuItem key={tenant.id} value={tenant.id}>
-                  <ListItemIcon sx={{ minWidth: 28 }}>
-                    <i className={tenant.id === currentTenant?.id ? 'ri-checkbox-circle-fill' : (tenant.id === 'default' ? 'ri-stack-line' : 'ri-building-line')} style={{ fontSize: 16 }} />
-                  </ListItemIcon>
-                  {tenant.name}
-                </MenuItem>
-              ))}
-            </Select>
           </Box>
         )}
 

--- a/frontend/src/hooks/useWidgetVisibility.test.ts
+++ b/frontend/src/hooks/useWidgetVisibility.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for useWidgetVisibility.
+ *
+ * Environment: node (no jsdom, no @testing-library/react).
+ * Strategy: mock the two context hooks and mock React.useMemo to invoke the
+ * factory synchronously so the hook can be called as a plain function.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+// ── Mock React.useMemo to call the factory synchronously ─────────────────────
+// useMemo(factory, deps) → factory() in the test environment so we can call
+// useWidgetVisibility() as a plain function without a React render tree.
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return {
+    ...actual,
+    useMemo: (factory: () => any, _deps?: any[]) => factory(),
+  }
+})
+
+// ── Mock context hooks ────────────────────────────────────────────────────────
+
+const mockUseRBAC = vi.fn()
+const mockUseTenant = vi.fn()
+
+vi.mock("@/contexts/RBACContext", () => ({
+  useRBAC: () => mockUseRBAC(),
+}))
+
+vi.mock("@/contexts/TenantContext", () => ({
+  useTenant: () => mockUseTenant(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeRbac(overrides: Partial<{ scopeTypes: string[]; isAdmin: boolean; hiddenWidgets: string[]; loading: boolean }> = {}) {
+  return {
+    scopeTypes: [],
+    isAdmin: false,
+    hiddenWidgets: [],
+    loading: false,
+    ...overrides,
+  }
+}
+
+function makeTenant(overrides: Partial<{ isFullClusterView: boolean; loading: boolean }> = {}) {
+  return {
+    isFullClusterView: true,
+    loading: false,
+    ...overrides,
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useWidgetVisibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("MSP tenant (isFullClusterView=true, non-default) admin → hasInfraScope true", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(true)
+    expect(result.loading).toBe(false)
+  })
+
+  it("MSP tenant (isFullClusterView=true) non-admin with connection scope → hasInfraScope true", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: false, scopeTypes: ["connection"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(true)
+    expect(result.loading).toBe(false)
+  })
+
+  it("IaaS/vDC tenant (isFullClusterView=false) → hasInfraScope false regardless of RBAC", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true, scopeTypes: ["global"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: false }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(false)
+    expect(result.loading).toBe(false)
+  })
+
+  it("IaaS/vDC tenant non-admin with no scopes → hasInfraScope false", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: false, scopeTypes: [] }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: false }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(false)
+    expect(result.loading).toBe(false)
+  })
+
+  it("Provider tenant (isFullClusterView=true) admin → hasInfraScope true", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(true)
+    expect(result.loading).toBe(false)
+  })
+
+  it("Provider tenant non-admin with tag-only scope → hasInfraScope false", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: false, scopeTypes: ["tag"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hasInfraScope).toBe(false)
+    expect(result.loading).toBe(false)
+  })
+
+  it("returns loading=true and hasInfraScope=true while tenant is loading", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ loading: false }))
+    mockUseTenant.mockReturnValue(makeTenant({ loading: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.loading).toBe(true)
+    expect(result.hasInfraScope).toBe(true)
+  })
+
+  it("propagates hiddenWidgets from RBAC into the result", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true, hiddenWidgets: ["alerts", "backup"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ isFullClusterView: true }))
+
+    const { useWidgetVisibility } = await import("./useWidgetVisibility")
+    const result = useWidgetVisibility()
+
+    expect(result.hiddenWidgets).toEqual(new Set(["alerts", "backup"]))
+  })
+})

--- a/frontend/src/hooks/useWidgetVisibility.ts
+++ b/frontend/src/hooks/useWidgetVisibility.ts
@@ -27,7 +27,7 @@ export type WidgetVisibility = {
  */
 export function useWidgetVisibility(): WidgetVisibility {
   const { scopeTypes, isAdmin, hiddenWidgets: hiddenWidgetIds, loading } = useRBAC()
-  const { currentTenant, loading: tenantLoading } = useTenant()
+  const { isFullClusterView, loading: tenantLoading } = useTenant()
 
   return useMemo(() => {
     const hiddenWidgets = new Set<string>(
@@ -38,11 +38,11 @@ export function useWidgetVisibility(): WidgetVisibility {
       return { hasInfraScope: true, hiddenWidgets, loading: true }
     }
 
-    // Non-provider tenants get the cloud-style abstraction: nodes / clusters
-    // are an implementation detail, never surfaced regardless of RBAC scope.
-    const isProviderTenant = !currentTenant || currentTenant.id === 'default'
-
-    if (!isProviderTenant) {
+    // IaaS/vDC tenants get the cloud-style abstraction: nodes / clusters are
+    // an implementation detail, never surfaced regardless of RBAC scope.
+    // Provider AND MSP tenants both have full-cluster visibility; MSP data is
+    // already scoped to the tenant's own connections server-side.
+    if (!isFullClusterView) {
       return { hasInfraScope: false, hiddenWidgets, loading: false }
     }
 
@@ -55,5 +55,5 @@ export function useWidgetVisibility(): WidgetVisibility {
     const hasInfra = userScopes.some((s: string) => INFRA_SCOPES.has(s))
 
     return { hasInfraScope: hasInfra, hiddenWidgets, loading: false }
-  }, [scopeTypes, isAdmin, hiddenWidgetIds, loading, currentTenant, tenantLoading])
+  }, [scopeTypes, isAdmin, hiddenWidgetIds, loading, isFullClusterView, tenantLoading])
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -214,7 +214,9 @@
     "french": "Français",
     "english": "English",
     "horizontalLayout": "Horizontales Layout",
-    "verticalLayout": "Vertikales Layout"
+    "verticalLayout": "Vertikales Layout",
+    "switchTenant": "Switch tenant",
+    "searchTenants": "Search tenants"
   },
   "pxcore": {
     "operational": "Betriebsbereit",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -218,7 +218,9 @@
     "french": "Français",
     "english": "English",
     "horizontalLayout": "Horizontal layout",
-    "verticalLayout": "Vertical layout"
+    "verticalLayout": "Vertical layout",
+    "switchTenant": "Switch tenant",
+    "searchTenants": "Search tenants"
   },
   "pxcore": {
     "operational": "Operational",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -218,7 +218,9 @@
     "french": "Français",
     "english": "English",
     "horizontalLayout": "Disposition horizontale",
-    "verticalLayout": "Disposition verticale"
+    "verticalLayout": "Disposition verticale",
+    "switchTenant": "Changer de tenant",
+    "searchTenants": "Rechercher un tenant"
   },
   "pxcore": {
     "operational": "Opérationnel",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -217,7 +217,9 @@
     "french": "Français",
     "english": "English",
     "horizontalLayout": "水平布局",
-    "verticalLayout": "垂直布局"
+    "verticalLayout": "垂直布局",
+    "switchTenant": "Switch tenant",
+    "searchTenants": "Search tenants"
   },
   "pxcore": {
     "operational": "运行正常",


### PR DESCRIPTION
## Summary

Reworks tenant switching and fixes per-tenant dashboards, based on MSP customer feedback: switching was hard to discover, and tenant dashboards were missing widgets and would not save.

### 1. Header tenant switcher
- New `TenantSwitcher` header control placed between the layout-toggle icon and the profile avatar. It shows the current tenant, opens a menu of all available tenants (the active one marked), and is searchable when there are more than 8. Theme-aware tooltip, no monospace.
- Removes the old `Select` that was buried inside the user-avatar menu.

### 2. MSP tenants see all widgets, scoped to their connections
- `useWidgetVisibility` now grants full infrastructure visibility to full-cluster tenants (provider and MSP). IaaS/vDC tenants keep the cloud-style abstraction (no node/cluster widgets). MSP dashboard data is already scoped to the tenant's own connections server-side.
- MSP tenants now receive the default widget layout on first load instead of a blank dashboard.

### 3. Per-tenant dashboard persistence (fixes the "Save error")
- Root cause: `DashboardLayout` was unique on `(userId, name)`. The tenant-scoped Prisma upsert verified ownership against that key, matched the provider's existing `Default` row, and threw `Record not found` whenever a super-admin saved a dashboard inside a tenant.
- Widened the unique constraint to `(tenantId, userId, name)` (with a migration) and keyed the PUT upsert on the composite key. Each tenant now keeps an independent dashboard.

## Migration
`20260615000000_dashboard_layout_tenant_unique`: drops the old `(userId, name)` unique index and adds `(tenant_id, userId, name)`. Existing rows are all `tenant_id = 'default'`, so there is no duplicate-key risk.

## Tests
New unit tests for the dashboard layout route (composite upsert key for provider and tenant sessions, MSP default-layout seeding, provider/IaaS empty fallback) and for `useWidgetVisibility` (provider/MSP/IaaS visibility matrix). 16 tests, all green.

## Validation
Validated in the browser: switcher placement and switching, MSP full widget set, dashboard save and per-tenant persistence.
