### PR TITLE
fix(docker): writable .next/cache for the non-root runtime user

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -152,6 +152,14 @@ COPY --from=builder --chown=nextjs:nodejs --chmod=0555 /app/package.json ./packa
 
 # No extra runtime dependencies — start.js runs as single process
 
+# Next.js writes its runtime cache (ISR / data / image optimisation) under
+# .next/cache. The standalone tree is copied read-only (chmod 0555) and the
+# app runs as the non-root `nextjs` user, so pre-create a writable cache dir
+# owned by that user. Without it Next floods the logs with
+# "EACCES: permission denied, mkdir '/app/.next/cache'" and serves every
+# route uncached (re-rendered on each request).
+RUN mkdir -p /app/.next/cache && chown -R nextjs:nodejs /app/.next/cache
+
 # Switch to non-root user
 USER nextjs
 


### PR DESCRIPTION
## Problem

On the production image, `.next` is copied read-only (`--chmod=0555`) and the container runs as the non-root `nextjs` user. At runtime Next.js cannot create `/app/.next/cache`, so the container logs fill with:

```
EACCES: permission denied, mkdir '/app/.next/cache'
```

and the SSR / data / image cache is disabled, so every route is re-rendered on each request (extra latency and CPU).

Surfaced while investigating #418 (reverse-proxy timeouts): these EACCES warnings showed up in the reporter's container logs. Note the actual #418 lockout is an edge rate-limiter returning 429 on the burst of `/_next/static` chunk requests, addressed on the reverse-proxy side. This PR only removes the cache-permission regression.

## Fix

Pre-create a writable `/app/.next/cache` owned by `nextjs` before the `USER` switch, so the runtime can write its cache while the application code stays read-only.

## Test

- Docker image build (CI).
- After deploy, the `EACCES ... mkdir '/app/.next/cache'` warnings no longer appear in the container logs.
