### PR TITLE
Shared migration tasks in the footer (visible across users) + warm-setup docs link

### DIFF
--- a/frontend/prisma/roleCatalogue.ts
+++ b/frontend/prisma/roleCatalogue.ts
@@ -183,6 +183,7 @@ export const ROLES: RoleSeed[] = [
       "backup.job.view", "backup.job.create", "backup.job.edit", "backup.job.delete", "backup.job.run",
       "admin.users", "admin.rbac", "admin.settings", "admin.audit",
       "alerts.view", "alerts.manage",
+      "events.view", "tasks.view",
       "reports.view",
       "sdn.vnet.view", "sdn.vnet.create", "sdn.vnet.edit", "sdn.vnet.delete", "sdn.vnet.firewall",
     ],

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -25,6 +25,7 @@ import {
   InputAdornment,
   InputLabel,
   LinearProgress,
+  Link,
   MenuItem,
   Select,
   Snackbar,
@@ -2298,7 +2299,18 @@ return
                           </Typography>
                         )}
                         <Typography variant="caption" sx={{ opacity: 0.8, display: 'block' }}>
-                          {t('inventoryPage.esxiMigration.warmPreflightDocsHint')}
+                          {t.rich('inventoryPage.esxiMigration.warmPreflightDocsHint', {
+                            link: (chunks) => (
+                              <Link
+                                href="https://docs.proxcenter.io/automation/migration#warm-migration-node-setup"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                sx={{ fontWeight: 600 }}
+                              >
+                                {chunks}
+                              </Link>
+                            ),
+                          })}
                         </Typography>
                       </Alert>
                     )

--- a/frontend/src/app/api/v1/tasks/shared/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/tasks/shared/[id]/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const h = vi.hoisted(() => ({
+  checkPermission: vi.fn(async () => null as any),
+  getCurrentTenantId: vi.fn(async () => "default"),
+  getTenantConnectionIds: vi.fn(async () => new Set<string>(["pve-a"])),
+  session: { user: { id: "u1" } } as any,
+  global: {
+    migrationJob: { findUnique: vi.fn(async () => null as any) },
+    user: { findUnique: vi.fn(async () => null as any) },
+  },
+  sessionClient: {
+    migrationJob: { findUnique: vi.fn(async () => null as any) },
+    user: { findUnique: vi.fn(async () => null as any) },
+  },
+}))
+
+vi.mock("@/lib/rbac", () => ({ checkPermission: h.checkPermission, PERMISSIONS: { TASKS_VIEW: "tasks.view" } }))
+vi.mock("next-auth", () => ({ getServerSession: vi.fn(async () => h.session) }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/db/prisma", () => ({ prisma: h.global }))
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: h.getCurrentTenantId,
+  getSessionPrisma: vi.fn(async () => h.sessionClient),
+  getTenantConnectionIds: h.getTenantConnectionIds,
+  DEFAULT_TENANT_ID: "default",
+}))
+
+import { GET } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const recent = () => new Date(Date.now() - 60 * 1000)
+const job = (over: any = {}) => ({
+  id: "job-1", config: { sourceType: "esxi-direct" }, sourceVmName: "db01", sourceVmId: "vm-1",
+  targetConnectionId: "pve-a", targetNode: "pve1", targetVmid: 200, status: "failed",
+  currentStep: null, progress: 30, totalDisks: 1, currentDisk: 1, bytesTransferred: null,
+  totalBytes: null, transferSpeed: null, error: "boom", createdBy: "u1",
+  createdAt: recent(), startedAt: null, completedAt: null, updatedAt: recent(),
+  logs: [{ t: 1, m: "started" }], ...over,
+})
+
+beforeEach(() => {
+  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.getCurrentTenantId.mockReset().mockResolvedValue("default")
+  h.getTenantConnectionIds.mockReset().mockResolvedValue(new Set(["pve-a"]))
+  h.session = { user: { id: "u1" } }
+  h.global.migrationJob.findUnique.mockReset().mockResolvedValue(null)
+  h.global.user.findUnique.mockReset().mockResolvedValue(null)
+  h.sessionClient.migrationJob.findUnique.mockReset().mockResolvedValue(null)
+  h.sessionClient.user.findUnique.mockReset().mockResolvedValue(null)
+})
+
+describe("GET /api/v1/tasks/shared/[id]", () => {
+  it("403 when denied", async () => {
+    h.checkPermission.mockResolvedValue(new Response("no", { status: 403 }) as any)
+    const res = await callRoute(GET, { method: "GET", params: { id: "job-1" } })
+    expect(res.status).toBe(403)
+  })
+
+  it("404 when not found", async () => {
+    h.global.migrationJob.findUnique.mockResolvedValue(null)
+    const res = await callRoute(GET, { method: "GET", params: { id: "nope" } })
+    expect(res.status).toBe(404)
+  })
+
+  it("404 when the recent job is outside the 30-min window", async () => {
+    h.global.migrationJob.findUnique.mockResolvedValue(job({ status: "failed", updatedAt: new Date(Date.now() - 60 * 60 * 1000) }))
+    const res = await callRoute(GET, { method: "GET", params: { id: "job-1" } })
+    expect(res.status).toBe(404)
+  })
+
+  it("returns the job with logs for an in-scope recent job", async () => {
+    h.global.migrationJob.findUnique.mockResolvedValue(job())
+    h.global.user.findUnique.mockResolvedValue({ name: "Alice", email: "a@x" })
+    const res = await callRoute(GET, { method: "GET", params: { id: "job-1" } })
+    const body = await readJson(res)
+    expect(res.status).toBe(200)
+    expect(body.data.id).toBe("job-1")
+    expect(body.data.createdByName).toBe("Alice")
+    expect(body.data.logs).toEqual([{ t: 1, m: "started" }])
+    expect(body.data.createdBy).toBeUndefined()
+  })
+})

--- a/frontend/src/app/api/v1/tasks/shared/[id]/route.ts
+++ b/frontend/src/app/api/v1/tasks/shared/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { authOptions } from "@/lib/auth/config"
+import {
+  resolveSharedTaskScope,
+  jobInSharedTaskWindow,
+  jobPassesSharedTaskScope,
+  toSharedTask,
+} from "@/lib/tasks/sharedTask"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/tasks/shared/[id]
+ * Read-only detail (incl. logs) for a single shared migration task. Same
+ * tenant/DEFAULT scope and recency window as the list.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const denied = await checkPermission(PERMISSIONS.TASKS_VIEW)
+    if (denied) return denied
+
+    const session = await getServerSession(authOptions)
+    const myId = (session as any)?.user?.id ?? null
+
+    const scope = await resolveSharedTaskScope()
+    const { id } = await params
+    const job = await scope.client.migrationJob.findUnique({ where: { id } })
+
+    const cutoff = new Date(Date.now() - 30 * 60 * 1000)
+    if (!job || !jobPassesSharedTaskScope(job, scope) || !jobInSharedTaskWindow(job, cutoff)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    let createdByName = "Unknown"
+    if (job.createdBy) {
+      const u = await scope.client.user.findUnique({ where: { id: job.createdBy }, select: { name: true, email: true } })
+      createdByName = u?.name || u?.email || "Unknown"
+    }
+
+    return NextResponse.json({
+      data: {
+        ...toSharedTask(job, { isMine: !!myId && job.createdBy === myId, createdByName }),
+        logs: job.logs ?? [],
+      },
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/v1/tasks/shared/route.test.ts
+++ b/frontend/src/app/api/v1/tasks/shared/route.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const h = vi.hoisted(() => ({
+  checkPermission: vi.fn(async () => null as any),
+  getCurrentTenantId: vi.fn(async () => "default"),
+  getTenantConnectionIds: vi.fn(async () => new Set<string>()),
+  session: { user: { id: "u1" } } as any,
+  global: {
+    migrationJob: { findMany: vi.fn(async () => [] as any[]) },
+    user: { findMany: vi.fn(async () => [] as any[]) },
+  },
+  sessionClient: {
+    migrationJob: { findMany: vi.fn(async () => [] as any[]) },
+    user: { findMany: vi.fn(async () => [] as any[]) },
+  },
+}))
+
+vi.mock("@/lib/rbac", () => ({ checkPermission: h.checkPermission, PERMISSIONS: { TASKS_VIEW: "tasks.view" } }))
+vi.mock("next-auth", () => ({ getServerSession: vi.fn(async () => h.session) }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/db/prisma", () => ({ prisma: h.global }))
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: h.getCurrentTenantId,
+  getSessionPrisma: vi.fn(async () => h.sessionClient),
+  getTenantConnectionIds: h.getTenantConnectionIds,
+  DEFAULT_TENANT_ID: "default",
+}))
+
+import { GET } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const job = (over: any = {}) => ({
+  id: "job-1", config: { sourceType: "vcenter" }, sourceVmName: "web01", sourceVmId: "vm-1",
+  targetConnectionId: "pve-a", targetNode: "pve1", targetVmid: 123, status: "transferring",
+  currentStep: "x", progress: 10, totalDisks: 1, currentDisk: 1, bytesTransferred: null,
+  totalBytes: null, transferSpeed: null, error: null, createdBy: "u1",
+  createdAt: new Date("2026-06-16T10:00:00Z"), startedAt: null, completedAt: null,
+  updatedAt: new Date("2026-06-16T10:00:00Z"), ...over,
+})
+
+beforeEach(() => {
+  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.getCurrentTenantId.mockReset().mockResolvedValue("default")
+  h.getTenantConnectionIds.mockReset().mockResolvedValue(new Set<string>())
+  h.session = { user: { id: "u1" } }
+  h.global.migrationJob.findMany.mockReset().mockResolvedValue([])
+  h.global.user.findMany.mockReset().mockResolvedValue([])
+  h.sessionClient.migrationJob.findMany.mockReset().mockResolvedValue([])
+  h.sessionClient.user.findMany.mockReset().mockResolvedValue([])
+})
+
+describe("GET /api/v1/tasks/shared", () => {
+  it("returns 403 when tasks.view is denied", async () => {
+    const denied = new Response("no", { status: 403 })
+    h.checkPermission.mockResolvedValue(denied as any)
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(403)
+  })
+
+  it("DEFAULT uses the global client and returns all jobs with isMine + resolved name", async () => {
+    h.global.migrationJob.findMany.mockResolvedValue([job({ createdBy: "u1" }), job({ id: "job-2", createdBy: "u2" })])
+    h.global.user.findMany.mockResolvedValue([{ id: "u1", name: "Alice", email: "a@x" }, { id: "u2", name: null, email: "b@x" }])
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson(res)
+    expect(h.global.migrationJob.findMany).toHaveBeenCalled()
+    expect(h.sessionClient.migrationJob.findMany).not.toHaveBeenCalled()
+    expect(body.data).toHaveLength(2)
+    expect(body.data[0]).toMatchObject({ id: "job-1", isMine: true, createdByName: "Alice" })
+    expect(body.data[1]).toMatchObject({ id: "job-2", isMine: false, createdByName: "b@x" })
+    expect(body.data[0].createdBy).toBeUndefined()
+  })
+
+  it("non-DEFAULT with an empty reachable set short-circuits to [] without querying", async () => {
+    h.getCurrentTenantId.mockResolvedValue("iaas-1")
+    h.getTenantConnectionIds.mockResolvedValue(new Set<string>())
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson(res)
+    expect(body.data).toEqual([])
+    expect(h.sessionClient.migrationJob.findMany).not.toHaveBeenCalled()
+  })
+
+  it("non-DEFAULT scopes the query to reachable target connections via the session client", async () => {
+    h.getCurrentTenantId.mockResolvedValue("msp-1")
+    h.getTenantConnectionIds.mockResolvedValue(new Set(["pve-a"]))
+    h.sessionClient.migrationJob.findMany.mockResolvedValue([job({ createdBy: "u1" })])
+    h.sessionClient.user.findMany.mockResolvedValue([{ id: "u1", name: "Bob", email: null }])
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson(res)
+    expect(h.global.migrationJob.findMany).not.toHaveBeenCalled()
+    const arg = h.sessionClient.migrationJob.findMany.mock.calls[0][0]
+    expect(arg.where.targetConnectionId).toEqual({ in: ["pve-a"] })
+    expect(body.data[0].createdByName).toBe("Bob")
+  })
+})

--- a/frontend/src/app/api/v1/tasks/shared/route.ts
+++ b/frontend/src/app/api/v1/tasks/shared/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { authOptions } from "@/lib/auth/config"
+import {
+  resolveSharedTaskScope,
+  sharedTaskWindowWhere,
+  jobPassesSharedTaskScope,
+  toSharedTask,
+} from "@/lib/tasks/sharedTask"
+
+export const runtime = "nodejs"
+
+/**
+ * GET /api/v1/tasks/shared
+ * Tenant-scoped list of in-flight / recently-finished external migrations,
+ * for the shared ProxCenter Tasks footer. DEFAULT tenant sees the whole fleet.
+ */
+export async function GET() {
+  try {
+    const denied = await checkPermission(PERMISSIONS.TASKS_VIEW)
+    if (denied) return denied
+
+    const session = await getServerSession(authOptions)
+    const myId = (session as any)?.user?.id ?? null
+
+    const scope = await resolveSharedTaskScope()
+    if (!scope.isDefault && scope.reachableConnectionIds.size === 0) {
+      return NextResponse.json({ data: [] })
+    }
+
+    const cutoff = new Date(Date.now() - 30 * 60 * 1000)
+    const jobs = await scope.client.migrationJob.findMany({
+      where: {
+        ...sharedTaskWindowWhere(cutoff),
+        ...(scope.isDefault
+          ? {}
+          : { targetConnectionId: { in: [...scope.reachableConnectionIds] } }),
+      },
+      orderBy: { updatedAt: "desc" },
+      take: 100,
+    })
+
+    const reachable = jobs.filter((j: any) => jobPassesSharedTaskScope(j, scope))
+
+    const creatorIds = [...new Set(reachable.map((j: any) => j.createdBy).filter(Boolean))] as string[]
+    const users = creatorIds.length
+      ? await scope.client.user.findMany({ where: { id: { in: creatorIds } }, select: { id: true, name: true, email: true } })
+      : []
+    const nameById = new Map<string, string>(users.map((u: any) => [u.id, u.name || u.email || "Unknown"]))
+
+    const data = reachable.map((j: any) =>
+      toSharedTask(j, {
+        isMine: !!myId && j.createdBy === myId,
+        createdByName: j.createdBy ? (nameById.get(j.createdBy) ?? "Unknown") : "Unknown",
+      }),
+    )
+
+    return NextResponse.json({ data })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/frontend/src/components/SharedTaskDetailDialog.tsx
+++ b/frontend/src/components/SharedTaskDetailDialog.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Dialog, DialogTitle, DialogContent, IconButton, Box, Typography, LinearProgress, Chip } from '@mui/material'
+import { useTranslations } from 'next-intl'
+import { useSWRFetch } from '@/hooks/useSWRFetch'
+import type { SharedTask } from '@/lib/tasks/sharedTask'
+
+type DetailResponse = { data: SharedTask & { logs?: unknown[] } }
+
+export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: string | null; onClose: () => void }) {
+  const t = useTranslations()
+  const { data } = useSWRFetch<DetailResponse>(jobId ? `/api/v1/tasks/shared/${jobId}` : null, { refreshInterval: 5000 })
+  const task = data?.data
+
+  return (
+    <Dialog open={!!jobId} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span>{task?.label ?? t('tasks.shared.detailTitle')}</span>
+        <IconButton onClick={onClose} size="small"><i className="ri-close-line" /></IconButton>
+      </DialogTitle>
+      <DialogContent dividers>
+        {!task ? (
+          <LinearProgress />
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Chip
+                size="small"
+                label={task.status === 'cancelled' ? t('tasks.status.cancelled') : task.status}
+                color={task.status === 'failed' || task.status === 'cancelled' ? 'error' : task.status === 'completed' ? 'success' : 'primary'}
+              />
+              <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                {t('tasks.shared.startedBy', { name: task.createdByName })}
+              </Typography>
+            </Box>
+            <LinearProgress variant={task.progress > 0 ? 'determinate' : 'indeterminate'} value={task.progress} />
+            {task.currentStep && <Typography variant="body2">{task.currentStep}</Typography>}
+            {task.error && <Typography variant="body2" color="error">{task.error}</Typography>}
+            {Array.isArray(task.logs) && task.logs.length > 0 && (
+              <Box component="pre" sx={{ fontSize: '0.75rem', maxHeight: 320, overflow: 'auto', bgcolor: 'action.hover', p: 1, borderRadius: 1, whiteSpace: 'pre-wrap' }}>
+                {task.logs.map((l: unknown) => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n')}
+              </Box>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/TasksFooter.tsx
+++ b/frontend/src/components/TasksFooter.tsx
@@ -23,7 +23,10 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid'
 
 import { useTaskEvents } from '@/hooks/useTaskEvents'
 import { useProxCenterTasks, type PCTask } from '@/contexts/ProxCenterTasksContext'
+import { useSharedTasks } from '@/hooks/useSharedTasks'
+import { mergeSharedTasks, type MergedPCTask } from '@/lib/tasks/mergeSharedTasks'
 import TaskDetailDialog from './TaskDetailDialog'
+import SharedTaskDetailDialog from '@/components/SharedTaskDetailDialog'
 
 // ============================================
 // Types
@@ -159,7 +162,10 @@ export default function TasksFooter({
 
   // ProxCenter tasks
   const { tasks: pcTasks, clearDone: clearPCDone, restoreTask } = useProxCenterTasks()
-  const pcRunningCount = pcTasks.filter(t => t.status === 'running').length
+  const { data: sharedResp } = useSharedTasks()
+  const mergedPcTasks: MergedPCTask[] = mergeSharedTasks(pcTasks, sharedResp?.data ?? [])
+  const [detailJobId, setDetailJobId] = useState<string | null>(null)
+  const pcRunningCount = mergedPcTasks.filter(t => t.status === 'running').length
 
   // SWR hook for task events
   const { data: tasksRaw, mutate: mutateTasks, isLoading: loading } = useTaskEvents(50)
@@ -560,10 +566,10 @@ export default function TasksFooter({
                 )}
               </>
             )}
-            {activeTab === 'proxcenter' && pcTasks.length > 0 && (
+            {activeTab === 'proxcenter' && mergedPcTasks.length > 0 && (
               <Chip
                 size="small"
-                label={pcTasks.length}
+                label={mergedPcTasks.length}
                 sx={{
                   height: 18,
                   fontSize: '0.7rem',
@@ -600,16 +606,16 @@ export default function TasksFooter({
           {/* ProxCenter tasks tab */}
           {activeTab === 'proxcenter' && (
             <Box sx={{ height: maxHeight, overflow: 'auto', bgcolor: '#1e1e2d' }}>
-              {pcTasks.length === 0 ? (
+              {mergedPcTasks.length === 0 ? (
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', opacity: 0.4 }}>
                   <Typography variant="body2">No ProxCenter tasks</Typography>
                 </Box>
               ) : (
                 <>
-                  {pcTasks.map((task) => (
+                  {mergedPcTasks.map((task) => (
                     <Box
                       key={task.id}
-                      onClick={() => restoreTask(task.id)}
+                      onClick={() => task.shared ? setDetailJobId(task.jobId ?? task.id.replace(/^migration-/, '')) : restoreTask(task.id)}
                       sx={{
                         px: 2, py: 1,
                         borderBottom: '1px solid rgba(231,227,252,0.08)',
@@ -637,6 +643,11 @@ export default function TasksFooter({
                             {task.detail}
                           </Typography>
                         )}
+                        {task.shared && task.readOnly && task.startedByName && (
+                          <Typography variant="caption" sx={{ opacity: 0.5, fontSize: '0.65rem' }} noWrap>
+                            {t('tasks.shared.startedBy', { name: task.startedByName })}
+                          </Typography>
+                        )}
                       </Box>
                       {/* Progress */}
                       <Box sx={{ width: 120, flexShrink: 0 }}>
@@ -658,7 +669,7 @@ export default function TasksFooter({
                       {/* Status */}
                       <Chip
                         size="small"
-                        label={task.status === 'running' ? t('tasks.status.running') : task.status === 'done' ? 'Done' : 'Error'}
+                        label={task.status === 'running' ? t('tasks.status.running') : task.rawStatus === 'cancelled' ? t('tasks.status.cancelled') : task.status === 'done' ? 'Done' : 'Error'}
                         color={task.status === 'running' ? 'primary' : task.status === 'done' ? 'success' : 'error'}
                         variant={task.status === 'running' ? 'outlined' : 'filled'}
                         icon={task.status === 'running' ? (
@@ -668,7 +679,7 @@ export default function TasksFooter({
                       />
                     </Box>
                   ))}
-                  {pcTasks.some(t => t.status !== 'running') && (
+                  {mergedPcTasks.some(t => t.status !== 'running' && !t.shared) && (
                     <Box sx={{ px: 2, py: 0.75, display: 'flex', justifyContent: 'flex-end' }}>
                       <Typography
                         variant="caption"
@@ -768,6 +779,9 @@ return ''
         }
       `}</style>
     </ThemeProvider>
+
+    {/* Shared Task Detail Dialog - outside dark ThemeProvider so it follows user theme */}
+    <SharedTaskDetailDialog jobId={detailJobId} onClose={() => setDetailJobId(null)} />
 
     {/* Task Detail Dialog - outside dark ThemeProvider so it follows user theme */}
     {selectedTask && (

--- a/frontend/src/hooks/useSharedTasks.ts
+++ b/frontend/src/hooks/useSharedTasks.ts
@@ -1,0 +1,13 @@
+import { useSWRFetch } from "./useSWRFetch"
+import { useRefreshInterval } from "./useRefreshInterval"
+import type { SharedTask } from "@/lib/tasks/sharedTask"
+
+/**
+ * Poll the tenant-scoped shared migration tasks for the ProxCenter footer.
+ * Pauses on a hidden tab (via useRefreshInterval). On a transient error, SWR
+ * retains the last-good data so the footer does not flicker to empty.
+ */
+export function useSharedTasks() {
+  const refreshInterval = useRefreshInterval(30000)
+  return useSWRFetch<{ data: SharedTask[] }>("/api/v1/tasks/shared", { refreshInterval })
+}

--- a/frontend/src/lib/rbac/systemRoles.test.ts
+++ b/frontend/src/lib/rbac/systemRoles.test.ts
@@ -35,3 +35,16 @@ describe('role_vm_user — Inventory read permissions (issue #378)', () => {
     expect(vmUser?.permissions).toContain('vm.view')
   })
 })
+
+describe('role_tenant_admin — task center + events (issue #430)', () => {
+  const tenantAdmin = ROLES.find(r => r.id === 'role_tenant_admin')
+
+  it('exists in the system-role catalogue', () => {
+    expect(tenantAdmin).toBeDefined()
+  })
+
+  it('can view the task center and events (shared tasks footer)', () => {
+    expect(tenantAdmin?.permissions).toContain('tasks.view')
+    expect(tenantAdmin?.permissions).toContain('events.view')
+  })
+})

--- a/frontend/src/lib/tasks/mergeSharedTasks.test.ts
+++ b/frontend/src/lib/tasks/mergeSharedTasks.test.ts
@@ -30,6 +30,7 @@ describe("mergeSharedTasks", () => {
     expect(byId["migration-b"].readOnly).toBe(false)
     expect(byId["migration-c"].status).toBe("error")
     expect(byId["migration-c"].rawStatus).toBe("cancelled")
+    expect(byId["migration-a"].jobId).toBe("a")
   })
 
   it("passes through local non-migration tasks untouched", () => {

--- a/frontend/src/lib/tasks/mergeSharedTasks.test.ts
+++ b/frontend/src/lib/tasks/mergeSharedTasks.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest"
+import { mergeSharedTasks } from "./mergeSharedTasks"
+import type { SharedTask } from "./sharedTask"
+import type { PCTask } from "@/contexts/ProxCenterTasksContext"
+
+const st = (over: Partial<SharedTask> = {}): SharedTask => ({
+  id: "job-1", kind: "migration", label: "web01 (vCenter -> Proxmox)", sourceVmName: "web01",
+  targetNode: "pve1", targetVmid: 1, status: "transferring", currentStep: "x", progress: 20,
+  totalDisks: 1, currentDisk: 1, bytesTransferred: null, totalBytes: null, transferSpeed: null,
+  error: null, isMine: false, createdByName: "Alice", createdAt: "2026-06-16T10:00:00.000Z",
+  startedAt: null, completedAt: null, ...over,
+})
+
+const local = (over: Partial<PCTask> = {}): PCTask => ({
+  id: "migration-job-1", type: "generic", label: "local", progress: 50, status: "running",
+  createdAt: Date.parse("2026-06-16T10:00:00.000Z"), ...over,
+})
+
+describe("mergeSharedTasks", () => {
+  it("maps server rows; active->running, completed->done, failed/cancelled->error; readOnly from !isMine", () => {
+    const out = mergeSharedTasks([], [
+      st({ id: "a", status: "delta_sync", isMine: false }),
+      st({ id: "b", status: "completed", isMine: true }),
+      st({ id: "c", status: "cancelled", isMine: false }),
+    ])
+    const byId = Object.fromEntries(out.map(t => [t.id, t]))
+    expect(byId["migration-a"].status).toBe("running")
+    expect(byId["migration-a"].readOnly).toBe(true)
+    expect(byId["migration-b"].status).toBe("done")
+    expect(byId["migration-b"].readOnly).toBe(false)
+    expect(byId["migration-c"].status).toBe("error")
+    expect(byId["migration-c"].rawStatus).toBe("cancelled")
+  })
+
+  it("passes through local non-migration tasks untouched", () => {
+    const up: PCTask = { id: "up-1", type: "upload", label: "iso", progress: 10, status: "running", createdAt: 1 }
+    const out = mergeSharedTasks([up], [])
+    expect(out.find(t => t.id === "up-1")).toBeTruthy()
+  })
+
+  it("server terminal row ALWAYS wins over a stale local running row", () => {
+    const out = mergeSharedTasks([local({ status: "running", label: "local" })], [st({ status: "failed", label: "server" })])
+    const row = out.find(t => t.id === "migration-job-1")!
+    expect(row.status).toBe("error")
+    expect(row.label).toBe("server")
+    expect((row as any).shared).toBe(true)
+  })
+
+  it("over an ACTIVE server row, a running local row wins (keeps interactivity)", () => {
+    const out = mergeSharedTasks([local({ status: "running", label: "local" })], [st({ status: "transferring" })])
+    const row = out.find(t => t.id === "migration-job-1")!
+    expect(row.label).toBe("local")
+    expect((row as any).shared).toBeUndefined()
+  })
+
+  it("over an ACTIVE server row, an interrupted (error) local row loses to the server", () => {
+    const out = mergeSharedTasks(
+      [local({ status: "error", error: "Interrupted by page reload" })],
+      [st({ status: "transferring", label: "live" })],
+    )
+    const row = out.find(t => t.id === "migration-job-1")!
+    expect(row.status).toBe("running")
+    expect((row as any).shared).toBe(true)
+  })
+
+  it("sorts running first, then createdAt desc", () => {
+    const out = mergeSharedTasks([], [
+      st({ id: "old-done", status: "completed", createdAt: "2026-06-16T09:00:00.000Z" }),
+      st({ id: "new-run", status: "transferring", createdAt: "2026-06-16T11:00:00.000Z" }),
+    ])
+    expect(out[0].id).toBe("migration-new-run")
+  })
+})

--- a/frontend/src/lib/tasks/mergeSharedTasks.ts
+++ b/frontend/src/lib/tasks/mergeSharedTasks.ts
@@ -6,6 +6,7 @@ export interface MergedPCTask extends PCTask {
   readOnly?: boolean
   rawStatus?: string
   startedByName?: string
+  jobId?: string
 }
 
 function statusFor(raw: string): PCTaskStatus {
@@ -28,6 +29,7 @@ function mapServerTask(st: SharedTask): MergedPCTask {
     readOnly: !st.isMine,
     rawStatus: st.status,
     startedByName: st.createdByName,
+    jobId: st.id,
   }
 }
 

--- a/frontend/src/lib/tasks/mergeSharedTasks.ts
+++ b/frontend/src/lib/tasks/mergeSharedTasks.ts
@@ -1,0 +1,68 @@
+import type { PCTask, PCTaskStatus } from "@/contexts/ProxCenterTasksContext"
+import type { SharedTask } from "./sharedTask"
+
+export interface MergedPCTask extends PCTask {
+  shared?: boolean
+  readOnly?: boolean
+  rawStatus?: string
+  startedByName?: string
+}
+
+function statusFor(raw: string): PCTaskStatus {
+  if (raw === "completed") return "done"
+  if (raw === "failed" || raw === "cancelled") return "error"
+  return "running"
+}
+
+function mapServerTask(st: SharedTask): MergedPCTask {
+  return {
+    id: `migration-${st.id}`,
+    type: "generic",
+    label: st.label,
+    detail: st.currentStep ?? undefined,
+    progress: st.progress,
+    status: statusFor(st.status),
+    error: st.error ?? undefined,
+    createdAt: Date.parse(st.createdAt),
+    shared: true,
+    readOnly: !st.isMine,
+    rawStatus: st.status,
+    startedByName: st.createdByName,
+  }
+}
+
+/**
+ * Merge per-session local ProxCenter tasks with server-sourced shared
+ * migration tasks. Dedup by id (`migration-<jobId>`):
+ *  - a terminal server row always wins (never masked by a stale local row);
+ *  - over an active server row, a still-running local row wins to preserve the
+ *    initiator's restore/interactivity; an interrupted/errored local row loses.
+ */
+export function mergeSharedTasks(localTasks: PCTask[], serverTasks: SharedTask[]): MergedPCTask[] {
+  const byId = new Map<string, MergedPCTask>()
+
+  for (const st of serverTasks) {
+    const row = mapServerTask(st)
+    byId.set(row.id, row)
+  }
+
+  for (const lt of localTasks) {
+    const server = byId.get(lt.id)
+    if (!server) {
+      byId.set(lt.id, lt)
+      continue
+    }
+    const serverActive = server.status === "running"
+    if (serverActive && lt.status === "running") {
+      byId.set(lt.id, lt) // local interactive row wins over an active server row
+    }
+    // otherwise keep the server row (terminal server, or non-running local)
+  }
+
+  return [...byId.values()].sort((a, b) => {
+    const ar = a.status === "running" ? 0 : 1
+    const br = b.status === "running" ? 0 : 1
+    if (ar !== br) return ar - br
+    return b.createdAt - a.createdAt
+  })
+}

--- a/frontend/src/lib/tasks/sharedTask.test.ts
+++ b/frontend/src/lib/tasks/sharedTask.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest"
+import {
+  TERMINAL_STATUSES,
+  sourceTypeLabel,
+  sharedTaskWindowWhere,
+  jobInSharedTaskWindow,
+  jobPassesSharedTaskScope,
+  toSharedTask,
+} from "./sharedTask"
+
+const baseJob = {
+  id: "job-1",
+  config: { sourceType: "vcenter" },
+  sourceVmName: "web01",
+  sourceVmId: "vm-100",
+  targetConnectionId: "pve-a",
+  targetNode: "pve1",
+  targetVmid: 123,
+  status: "transferring",
+  currentStep: "transferring disk 1",
+  progress: 42,
+  totalDisks: 2,
+  currentDisk: 1,
+  bytesTransferred: BigInt(10),
+  totalBytes: BigInt(100),
+  transferSpeed: "50 MB/s",
+  error: null,
+  createdBy: "u1",
+  createdAt: new Date("2026-06-16T10:00:00.000Z"),
+  startedAt: new Date("2026-06-16T10:00:05.000Z"),
+  completedAt: null,
+  updatedAt: new Date("2026-06-16T10:05:00.000Z"),
+  logs: [{ t: 1, m: "hi" }],
+}
+
+describe("sourceTypeLabel", () => {
+  it("maps known source types and falls back to the raw value then External", () => {
+    expect(sourceTypeLabel("vcenter")).toBe("vCenter")
+    expect(sourceTypeLabel("esxi-direct")).toBe("ESXi")
+    expect(sourceTypeLabel("xcpng")).toBe("XCP-ng")
+    expect(sourceTypeLabel("weirdthing")).toBe("weirdthing")
+    expect(sourceTypeLabel(null)).toBe("External")
+  })
+})
+
+describe("sharedTaskWindowWhere / jobInSharedTaskWindow", () => {
+  const cutoff = new Date("2026-06-16T10:00:00.000Z")
+
+  it("window where includes active OR recently-updated", () => {
+    expect(sharedTaskWindowWhere(cutoff)).toEqual({
+      OR: [
+        { status: { notIn: TERMINAL_STATUSES } },
+        { updatedAt: { gte: cutoff } },
+      ],
+    })
+  })
+
+  it("active job is always in window regardless of updatedAt", () => {
+    expect(jobInSharedTaskWindow({ status: "delta_sync", updatedAt: new Date("2020-01-01") }, cutoff)).toBe(true)
+  })
+
+  it("terminal job is in window only if updatedAt >= cutoff", () => {
+    expect(jobInSharedTaskWindow({ status: "failed", updatedAt: new Date("2026-06-16T10:01:00Z") }, cutoff)).toBe(true)
+    expect(jobInSharedTaskWindow({ status: "failed", updatedAt: new Date("2026-06-16T09:00:00Z") }, cutoff)).toBe(false)
+  })
+})
+
+describe("jobPassesSharedTaskScope", () => {
+  it("DEFAULT passes everything, even an unreachable/deleted target connection", () => {
+    expect(jobPassesSharedTaskScope({ targetConnectionId: "gone" }, { isDefault: true, reachableConnectionIds: new Set() })).toBe(true)
+  })
+  it("non-DEFAULT passes only reachable target connections", () => {
+    const scope = { isDefault: false, reachableConnectionIds: new Set(["pve-a"]) }
+    expect(jobPassesSharedTaskScope({ targetConnectionId: "pve-a" }, scope)).toBe(true)
+    expect(jobPassesSharedTaskScope({ targetConnectionId: "pve-b" }, scope)).toBe(false)
+  })
+})
+
+describe("toSharedTask", () => {
+  it("maps fields, coerces BigInt, builds label, never includes raw createdBy", () => {
+    const st = toSharedTask(baseJob as any, { isMine: true, createdByName: "Alice" })
+    expect(st.id).toBe("job-1")
+    expect(st.kind).toBe("migration")
+    expect(st.label).toBe("web01 (vCenter -> Proxmox)")
+    expect(st.bytesTransferred).toBe(10)
+    expect(st.totalBytes).toBe(100)
+    expect(st.isMine).toBe(true)
+    expect(st.createdByName).toBe("Alice")
+    expect(st.createdAt).toBe("2026-06-16T10:00:00.000Z")
+    expect(st.completedAt).toBeNull()
+    expect((st as any).createdBy).toBeUndefined()
+    expect((st as any).logs).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/tasks/sharedTask.ts
+++ b/frontend/src/lib/tasks/sharedTask.ts
@@ -1,0 +1,113 @@
+import { getCurrentTenantId, getSessionPrisma, getTenantConnectionIds, DEFAULT_TENANT_ID } from "@/lib/tenant"
+import { prisma as globalPrisma } from "@/lib/db/prisma"
+
+export const TERMINAL_STATUSES = ["completed", "failed", "cancelled"] as const
+
+// config.sourceType / hostType -> display label. Mirrors the mapping used in
+// InventoryDialogs when the migration task is first created.
+export const SOURCE_TYPE_LABELS: Record<string, string> = {
+  esxi: "ESXi",
+  "esxi-direct": "ESXi",
+  vcenter: "vCenter",
+  hyperv: "Hyper-V",
+  nutanix: "Nutanix",
+  xcpng: "XCP-ng",
+}
+
+export function sourceTypeLabel(t?: string | null): string {
+  if (!t) return "External"
+  return SOURCE_TYPE_LABELS[t] ?? t
+}
+
+export interface SharedTask {
+  id: string
+  kind: "migration"
+  label: string
+  sourceVmName: string | null
+  targetNode: string
+  targetVmid: number | null
+  status: string
+  currentStep: string | null
+  progress: number
+  totalDisks: number | null
+  currentDisk: number | null
+  bytesTransferred: number | null
+  totalBytes: number | null
+  transferSpeed: string | null
+  error: string | null
+  isMine: boolean
+  createdByName: string
+  createdAt: string
+  startedAt: string | null
+  completedAt: string | null
+}
+
+export interface SharedTaskScope {
+  tenantId: string
+  isDefault: boolean
+  client: any // tenant-scoped or global Prisma client (same surface for our reads)
+  reachableConnectionIds: Set<string>
+}
+
+/** Resolve the Prisma client + reachable connections for the caller's tenant. */
+export async function resolveSharedTaskScope(): Promise<SharedTaskScope> {
+  const tenantId = await getCurrentTenantId()
+  const isDefault = tenantId === DEFAULT_TENANT_ID
+  const client = isDefault ? globalPrisma : await getSessionPrisma()
+  const reachableConnectionIds = await getTenantConnectionIds()
+  return { tenantId, isDefault, client, reachableConnectionIds }
+}
+
+/** Prisma `where` fragment: active (any pipeline) OR recently-finished. */
+export function sharedTaskWindowWhere(cutoff: Date) {
+  return {
+    OR: [
+      { status: { notIn: TERMINAL_STATUSES as unknown as string[] } },
+      { updatedAt: { gte: cutoff } },
+    ],
+  }
+}
+
+/** Same predicate as sharedTaskWindowWhere, evaluated in memory (detail route). */
+export function jobInSharedTaskWindow(job: { status: string; updatedAt: Date }, cutoff: Date): boolean {
+  return !(TERMINAL_STATUSES as readonly string[]).includes(job.status) || job.updatedAt >= cutoff
+}
+
+/** DEFAULT (NOC) sees everything; others only their reachable target connections. */
+export function jobPassesSharedTaskScope(
+  job: { targetConnectionId: string },
+  scope: { isDefault: boolean; reachableConnectionIds: Set<string> },
+): boolean {
+  return scope.isDefault || scope.reachableConnectionIds.has(job.targetConnectionId)
+}
+
+/** Map a MigrationJob row to the summary DTO. Never emits raw createdBy or logs. */
+export function toSharedTask(
+  job: any,
+  opts: { isMine: boolean; createdByName: string },
+): SharedTask {
+  const vm = job.sourceVmName || job.sourceVmId || (job.targetVmid != null ? String(job.targetVmid) : "")
+  const srcType = sourceTypeLabel((job.config as any)?.sourceType)
+  return {
+    id: job.id,
+    kind: "migration",
+    label: `${vm} (${srcType} -> Proxmox)`,
+    sourceVmName: job.sourceVmName ?? null,
+    targetNode: job.targetNode,
+    targetVmid: job.targetVmid ?? null,
+    status: job.status,
+    currentStep: job.currentStep ?? null,
+    progress: job.progress ?? 0,
+    totalDisks: job.totalDisks ?? null,
+    currentDisk: job.currentDisk ?? null,
+    bytesTransferred: job.bytesTransferred != null ? Number(job.bytesTransferred) : null,
+    totalBytes: job.totalBytes != null ? Number(job.totalBytes) : null,
+    transferSpeed: job.transferSpeed ?? null,
+    error: job.error ?? null,
+    isMine: opts.isMine,
+    createdByName: opts.createdByName,
+    createdAt: job.createdAt.toISOString(),
+    startedAt: job.startedAt ? job.startedAt.toISOString() : null,
+    completedAt: job.completedAt ? job.completedAt.toISOString() : null,
+  }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -1906,7 +1906,7 @@
       "warmPreflightReady": "Zielknoten ist bereit fur die Warm-Migration (nbdkit, nbd-client und das VDDK sind vorhanden).",
       "warmPreflightFailedTitle": "Zielknoten ist nicht bereit fur die Warm-Migration",
       "warmPreflightMissing": "Fehlt auf dem Knoten: {items}.",
-      "warmPreflightDocsHint": "Bereiten Sie zuerst den Proxmox-Knoten vor (nbdkit, das nbdkit-VDDK-Plugin, nbd-client und das Broadcom-VDDK installieren), dann wahlen Sie den Knoten erneut aus. Siehe die Anleitung zur Knotenvorbereitung fur die Warm-Migration.",
+      "warmPreflightDocsHint": "Bereiten Sie zuerst den Proxmox-Knoten vor (nbdkit, das nbdkit-VDDK-Plugin, nbd-client und das Broadcom-VDDK installieren), dann wahlen Sie den Knoten erneut aus. Siehe die <link>Anleitung zur Knotenvorbereitung fur die Warm-Migration</link>.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimentell)",
       "migrationTypeSshfsBootDesc": "Nahezu null Ausfallzeit: VM startet auf Proxmox von entfernten ESXi-Disks in Sekunden. Experimentell: der Gast muss unbeaufsichtigt auf dem Ziel-Controller booten; kann bei EFI-Windows oder Gasten fehlschlagen, die eine Treiberinjektion benotigen. Fur Produktion Live oder Offline bevorzugen.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot ist experimentell und funktioniert nur, wenn der Gast ohne Treiberanpassung auf dem Ziel korrekt bootet. Fur EFI-Windows, vCenter-VMs oder produktionskritische Systeme Live oder Offline verwenden.",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -3343,7 +3343,12 @@
       "running": "In Bearbeitung",
       "ok": "OK",
       "stopped": "Gestoppt",
-      "completed": "Abgeschlossen"
+      "completed": "Abgeschlossen",
+      "cancelled": "Abgebrochen"
+    },
+    "shared": {
+      "detailTitle": "Migrationsaufgabe",
+      "startedBy": "Gestartet von {name}"
     },
     "types": {
       "qmstart": "VM-Start",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1939,7 +1939,7 @@
       "warmPreflightReady": "Target node is ready for warm migration (nbdkit, nbd-client and the VDDK are present).",
       "warmPreflightFailedTitle": "Target node is not ready for warm migration",
       "warmPreflightMissing": "Missing on the node: {items}.",
-      "warmPreflightDocsHint": "Prepare the Proxmox node first (install nbdkit, the nbdkit VDDK plugin, nbd-client and the Broadcom VDDK), then reselect the node. See the warm migration node setup guide.",
+      "warmPreflightDocsHint": "Prepare the Proxmox node first (install nbdkit, the nbdkit VDDK plugin, nbd-client and the Broadcom VDDK), then reselect the node. See the <link>warm migration node setup guide</link>.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimental)",
       "migrationTypeSshfsBootDesc": "Near-zero downtime: VM boots on Proxmox from remote ESXi disks within seconds. Experimental: the guest must boot unattended on the target controller; may fail for EFI Windows or guests needing driver injection. Prefer Live or Offline for production.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot is experimental and only works when the guest boots correctly on the target without driver adaptation. For EFI Windows, vCenter-sourced VMs, or anything production-critical, choose Live or Offline.",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3384,7 +3384,12 @@
       "running": "In progress",
       "ok": "OK",
       "stopped": "Stopped",
-      "completed": "Completed"
+      "completed": "Completed",
+      "cancelled": "Cancelled"
+    },
+    "shared": {
+      "detailTitle": "Migration task",
+      "startedBy": "Started by {name}"
     },
     "types": {
       "qmstart": "VM Start",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -1939,7 +1939,7 @@
       "warmPreflightReady": "Le noeud cible est pret pour la migration a chaud (nbdkit, nbd-client et le VDDK sont presents).",
       "warmPreflightFailedTitle": "Le noeud cible n'est pas pret pour la migration a chaud",
       "warmPreflightMissing": "Manquant sur le noeud : {items}.",
-      "warmPreflightDocsHint": "Preparez d'abord le noeud Proxmox (installez nbdkit, le plugin VDDK de nbdkit, nbd-client et le VDDK Broadcom), puis reselectionnez le noeud. Consultez le guide de preparation du noeud pour la migration a chaud.",
+      "warmPreflightDocsHint": "Preparez d'abord le noeud Proxmox (installez nbdkit, le plugin VDDK de nbdkit, nbd-client et le VDDK Broadcom), puis reselectionnez le noeud. Consultez le <link>guide de preparation du noeud pour la migration a chaud</link>.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimental)",
       "migrationTypeSshfsBootDesc": "Downtime quasi-nul : la VM demarre sur Proxmox depuis les disques ESXi distants en quelques secondes. Experimental : le guest doit booter sans adaptation sur le controleur cible, peut echouer pour Windows EFI ou les guests necessitant une injection de drivers. Preferer Live ou Offline en production.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot est experimental et ne fonctionne que si le guest boote correctement sur la cible sans adaptation de drivers. Pour Windows EFI, les VMs issues de vCenter, ou tout environnement critique, utilisez Live ou Offline.",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -3384,7 +3384,12 @@
       "running": "En cours",
       "ok": "OK",
       "stopped": "Arrêté",
-      "completed": "Terminé"
+      "completed": "Terminé",
+      "cancelled": "Annulé"
+    },
+    "shared": {
+      "detailTitle": "Tâche de migration",
+      "startedBy": "Lancé par {name}"
     },
     "types": {
       "qmstart": "Démarrage VM",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -1908,7 +1908,7 @@
       "warmPreflightReady": "目标节点已就绪，可进行温迁移（nbdkit、nbd-client 和 VDDK 均已就位）。",
       "warmPreflightFailedTitle": "目标节点尚未就绪，无法进行温迁移",
       "warmPreflightMissing": "节点上缺少：{items}。",
-      "warmPreflightDocsHint": "请先准备 Proxmox 节点（安装 nbdkit、nbdkit VDDK 插件、nbd-client 以及 Broadcom VDDK），然后重新选择节点。请参阅温迁移节点准备指南。",
+      "warmPreflightDocsHint": "请先准备 Proxmox 节点（安装 nbdkit、nbdkit VDDK 插件、nbd-client 以及 Broadcom VDDK），然后重新选择节点。请参阅<link>温迁移节点准备指南</link>。",
       "migrationTypeSshfsBoot": "SSHFS 启动（实验性）",
       "migrationTypeSshfsBootDesc": "近零停机：虚拟机在数秒内从远程 ESXi 磁盘启动到 Proxmox。实验性：Guest 必须能在目标控制器上无人值守地启动；可能在 EFI Windows 或需要驱动注入的 Guest 上失败。生产环境请优先使用 Live 或离线迁移。",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS 启动是实验性功能，仅当 Guest 能在目标上无需驱动适配而正确启动时才有效。对于 EFI Windows、来自 vCenter 的虚拟机或任何关键生产场景，请使用 Live 或离线模式。",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -3345,7 +3345,12 @@
       "running": "进行中",
       "ok": "正常",
       "stopped": "已停止",
-      "completed": "已完成"
+      "completed": "已完成",
+      "cancelled": "已取消"
+    },
+    "shared": {
+      "detailTitle": "迁移任务",
+      "startedBy": "由 {name} 发起"
     },
     "types": {
       "qmstart": "VM 启动",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -126,6 +126,13 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 # - dialogs/WhatsNewDialog.tsx: the What's New dialog plus its localStorage
 #   version-seen hook (a mount effect). Pure-JSX plus a React effect the node-env
 #   Vitest suite cannot render, like the other dialog containers above.
+# - components/TasksFooter.tsx, components/SharedTaskDetailDialog.tsx,
+#   hooks/useSharedTasks.ts: the shared-migration-tasks footer (#430). The footer
+#   and the read-only detail dialog are pure-JSX containers, and useSharedTasks is
+#   a thin SWR polling wrapper; none execute under the node-env Vitest suite. The
+#   testable logic they drive — the tenant-scoped read API and the task merge —
+#   lives in app/api/v1/tasks/shared/** and lib/tasks/{sharedTask,mergeSharedTasks}.ts
+#   and stays measured and covered.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -180,7 +187,10 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx,\
   frontend/src/app/api/v1/inventory/route.ts,\
-  frontend/src/app/api/v1/inventory/stream/route.ts
+  frontend/src/app/api/v1/inventory/stream/route.ts,\
+  frontend/src/components/TasksFooter.tsx,\
+  frontend/src/components/SharedTaskDetailDialog.tsx,\
+  frontend/src/hooks/useSharedTasks.ts
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
## Summary

Two related migration-UX changes.

### Shared migration tasks in the footer (#430)

External/import migrations (VMware/ESXi, vCenter, Hyper-V, Nutanix, XCP-ng to Proxmox, including warm/CBT) persist a tenant-scoped migration job, but the footer ProxCenter tab only showed the entry to the browser that started it (it was pushed into that session's storage). Other users, other browsers, and even a reloaded tab saw nothing until the job failed.

This adds a `tasks.view`-gated, tenant-scoped read API that the footer merges with the local per-session tasks, so any permitted user sees in-progress and recent migrations in real time:

- Read-only for non-initiators, and for your own jobs viewed from a fresh tab: clicking a server-sourced row opens a read-only detail dialog (progress + logs, no stop). The initiating tab keeps full interactivity on its live task.
- The DEFAULT tenant sees every tenant's jobs; MSP/IaaS tenants are strictly scoped to their own connections.
- "Started by {name}" is shown on rows owned by another user.
- Tenant Admins now have `tasks.view` / `events.view`.

Active is `status` not in `{completed, failed, cancelled}`; the recency window is keyed on `updatedAt` (the warm pipeline only sets `completedAt` on success, so a failed job would otherwise drop off).

Domain logic (the read endpoints and the merge helper) is unit-tested (27 new tests). The pure-JSX footer/dialog and the SWR polling hook run only in the browser (the Vitest suite is node-only), so they are excluded from coverage with rationale in `sonar-project.properties`.

### Warm-migration setup hint links to the docs (#434)

The warm-migration preflight "node not ready" hint referenced the node setup guide as plain text. It now links to the public docs (`automation/migration#warm-migration-node-setup`) via next-intl rich text, in all four locales.

## Test plan

- Two browsers/profiles, same tenant: start a VMware/ESXi migration in A; B's footer ProxCenter tab shows it read-only with "Started by {name}" and live progress; clicking opens the read-only detail dialog.
- DEFAULT tenant sees cross-tenant jobs; MSP/IaaS tenants see only their own.
- A failed warm job still appears (recency keyed on `updatedAt`).
- Warm migrate dialog on an unprepared node: the "node setup guide" hint is now a clickable link to the docs.

Refs #430, #434.
