### PR TITLE
perf(console): serve VM screenshots as JPEG instead of raw PPM

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "flatted": "^3.4.0",
         "form-data": "^4.0.5",
         "html-to-image": "^1.11.13",
+        "jpeg-js": "^0.4.4",
         "leaflet": "^1.9.4",
         "nanoid": "^5.1.11",
         "next": "^16.2.6",
@@ -4802,6 +4803,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4811,7 +4813,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -10428,6 +10430,12 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-cookie": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
@@ -15037,7 +15045,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "flatted": "^3.4.0",
     "form-data": "^4.0.5",
     "html-to-image": "^1.11.13",
+    "jpeg-js": "^0.4.4",
     "leaflet": "^1.9.4",
     "nanoid": "^5.1.11",
     "next": "^16.2.6",

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConsolePreview.tsx
@@ -11,83 +11,6 @@ import {
   Typography,
 } from '@mui/material'
 
-/**
- * Decode a base64-encoded PPM (P6 binary) image and draw it onto a canvas.
- * Returns a data URL (JPEG) or null on failure.
- */
-function decodePpmToDataUrl(b64Data: string): Promise<string | null> {
-  return new Promise((resolve) => {
-    try {
-      const binary = atob(b64Data)
-      const bytes = new Uint8Array(binary.length)
-      for (let i = 0; i < binary.length; i++) bytes[i] = binary.codePointAt(i) ?? 0
-
-      // Parse PPM P6 header: "P6\n<width> <height>\n<maxval>\n"
-      let offset = 0
-      const readLine = (): string => {
-        let line = ''
-        while (offset < bytes.length) {
-          const ch = bytes[offset++]
-          if (ch === 10) break // \n
-          line += String.fromCodePoint(ch)
-        }
-        // Skip comment lines
-        if (line.startsWith('#')) return readLine()
-        return line.trim()
-      }
-
-      const magic = readLine()
-      if (magic !== 'P6') { resolve(null); return }
-
-      // Width and height might be on one line or two
-      let dims = readLine()
-      const parts = dims.split(/\s+/)
-      let width: number, height: number
-      if (parts.length >= 2) {
-        width = Number.parseInt(parts[0])
-        height = Number.parseInt(parts[1])
-      } else {
-        width = Number.parseInt(parts[0])
-        height = Number.parseInt(readLine())
-      }
-
-      const maxVal = Number.parseInt(readLine())
-      if (!width || !height || !maxVal) { resolve(null); return }
-
-      // Create canvas and draw pixel data
-      const canvas = document.createElement('canvas')
-      canvas.width = width
-      canvas.height = height
-      const ctx = canvas.getContext('2d')
-      if (!ctx) { resolve(null); return }
-
-      const imageData = ctx.createImageData(width, height)
-      const data = imageData.data
-      const pixelBytes = maxVal > 255 ? 6 : 3
-
-      for (let i = 0; i < width * height; i++) {
-        const srcIdx = offset + i * pixelBytes
-        if (pixelBytes === 3) {
-          data[i * 4] = bytes[srcIdx]       // R
-          data[i * 4 + 1] = bytes[srcIdx + 1] // G
-          data[i * 4 + 2] = bytes[srcIdx + 2] // B
-        } else {
-          // 16-bit: take high byte
-          data[i * 4] = bytes[srcIdx]
-          data[i * 4 + 1] = bytes[srcIdx + 2]
-          data[i * 4 + 2] = bytes[srcIdx + 4]
-        }
-        data[i * 4 + 3] = 255 // A
-      }
-
-      ctx.putImageData(imageData, 0, 0)
-      resolve(canvas.toDataURL('image/jpeg', 0.75))
-    } catch {
-      resolve(null)
-    }
-  })
-}
-
 function ConsolePreview({
   height = 210,
   connId,
@@ -116,6 +39,9 @@ function ConsolePreview({
   const [screenshotFailed, setScreenshotFailed] = useState(false)
   const [noDisplay, setNoDisplay] = useState(false)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Tracks the active blob: object URL so we can revoke the previous frame and
+  // avoid leaking one Blob per 10s poll.
+  const objectUrlRef = useRef<string | null>(null)
 
   const isLxc = type === 'lxc'
   const base = connId && node && type && vmid
@@ -139,12 +65,27 @@ function ConsolePreview({
       const res = await fetch(
         `/api/v1/connections/${encodeURIComponent(connId)}/guests/${encodeURIComponent(type)}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/screenshot`
       )
-      const json = await res.json()
+      const contentType = res.headers.get('content-type') || ''
+
+      // Happy path: the server returns a ready-to-display JPEG (re-encoded from
+      // the node's PPM). Swap it in via a blob URL and revoke the previous one.
+      if (res.ok && contentType.startsWith('image/')) {
+        const blob = await res.blob()
+        const url = URL.createObjectURL(blob)
+        if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current)
+        objectUrlRef.current = url
+        setScreenshotUrl(url)
+        setScreenshotFailed(false)
+        return
+      }
+
+      // Otherwise it's a JSON status (no_display, ssh_failed, decode_failed, ...).
+      const json = await res.json().catch(() => null)
 
       // Serial-only / headless VM: no graphical framebuffer to capture, ever.
       // Stop polling so we don't hammer a guaranteed-failing screendump every
       // 10s, and let the render show a "serial console" badge.
-      if (json.reason === 'no_display') {
+      if (json?.reason === 'no_display') {
         setNoDisplay(true)
         if (intervalRef.current) {
           clearInterval(intervalRef.current)
@@ -153,15 +94,7 @@ function ConsolePreview({
         return
       }
 
-      if (json.data) {
-        const dataUrl = await decodePpmToDataUrl(json.data)
-        if (dataUrl) {
-          setScreenshotUrl(dataUrl)
-          setScreenshotFailed(false)
-          return
-        }
-      }
-      // No data or decode failed - keep existing screenshot if any, mark as failed for fresh attempts
+      // Transient failure - keep the existing frame, mark failed for fresh attempts.
       setScreenshotFailed(true)
     } catch {
       setScreenshotFailed(true)
@@ -204,11 +137,18 @@ function ConsolePreview({
     }
   }, [fetchScreenshot, isRunning, isQemu])
 
-  // Reset screenshot when VM changes
+  // Reset screenshot when VM changes. The cleanup also runs on unmount, so the
+  // last blob URL is always revoked rather than leaked.
   useEffect(() => {
     setScreenshotUrl(null)
     setScreenshotFailed(false)
     setNoDisplay(false)
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current)
+        objectUrlRef.current = null
+      }
+    }
   }, [vmid, connId])
 
   // Determine OS icon

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
@@ -37,6 +37,13 @@ vi.mock('@/lib/ssh/node-ip', () => ({
 
 import { GET, pruneScreenshotCaches } from './route'
 
+// A minimal valid P6 PPM (2x1: red, green) as the node would return it over
+// SSH: base64-encoded. The route re-encodes this to JPEG.
+const PPM_B64 = Buffer.concat([
+  Buffer.from('P6\n2 1\n255\n', 'ascii'),
+  Buffer.from([255, 0, 0, 0, 255, 0]),
+]).toString('base64')
+
 // Each test uses a unique id/vmid so the module-level screenshot and
 // framebuffer caches (keyed by `id:node:vmid`) never bleed across cases.
 let seq = 0
@@ -85,25 +92,68 @@ describe('GET .../screenshot — display detection', () => {
     expect(executeSSHMock).not.toHaveBeenCalled()
   })
 
-  it('captures a screenshot for a graphical VM (vga: std)', async () => {
+  it('captures a screenshot for a graphical VM (vga: std) and returns image/jpeg', async () => {
     pveFetchMock.mockResolvedValueOnce({ vga: 'std' })
-    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'QkFTRTY0\n' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: `${PPM_B64}\n` })
 
     const res = await GET(new Request('http://localhost'), makeCtx())
-    const body = await res.json()
 
-    expect(body).toMatchObject({ data: 'QkFTRTY0', format: 'ppm' })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('image/jpeg')
+    const bytes = new Uint8Array(await res.arrayBuffer())
+    // JPEG Start-Of-Image marker.
+    expect([bytes[0], bytes[1]]).toEqual([0xff, 0xd8])
     expect(executeSSHMock).toHaveBeenCalledTimes(1)
   })
 
   it('treats an absent vga (default std) as graphical and proceeds to SSH', async () => {
     pveFetchMock.mockResolvedValueOnce({})
-    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'ZGF0YQ==' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: PPM_B64 })
+
+    const res = await GET(new Request('http://localhost'), makeCtx())
+
+    expect(res.headers.get('content-type')).toContain('image/jpeg')
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries on the relocated node and reports it via X-Screenshot-Moved-To', async () => {
+    pveFetchMock.mockResolvedValueOnce({ vga: 'std' })
+    // First node has no such VM (migrated away); locate finds it on pve2.
+    executeSSHMock.mockResolvedValueOnce({ success: false, error: 'no such vm' })
+    locateVmInClusterMock.mockResolvedValueOnce({ node: 'pve2' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: PPM_B64 })
+
+    const res = await GET(new Request('http://localhost'), makeCtx({ node: 'pve1' }))
+
+    expect(res.headers.get('content-type')).toContain('image/jpeg')
+    expect(res.headers.get('x-screenshot-moved-to')).toBe('pve2')
+    expect(executeSSHMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns reason=decode_failed when the capture is not a valid PPM', async () => {
+    pveFetchMock.mockResolvedValueOnce({ vga: 'std' })
+    // 'QkFTRTY0' decodes to "BASE64" — not a P6 PPM, so JPEG encoding fails.
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'QkFTRTY0\n' })
 
     const res = await GET(new Request('http://localhost'), makeCtx())
     const body = await res.json()
 
-    expect(body.format).toBe('ppm')
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(body.reason).toBe('decode_failed')
+  })
+
+  it('serves the cached frame as image/jpeg on the second poll without re-running SSH', async () => {
+    const ctxArgs = { id: 'screenshot-cache', node: 'pve1', vmid: '999' }
+    pveFetchMock.mockResolvedValue({ vga: 'std' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: PPM_B64 })
+
+    const first = await GET(new Request('http://localhost'), makeCtx(ctxArgs))
+    const second = await GET(new Request('http://localhost'), makeCtx(ctxArgs))
+
+    expect(first.headers.get('content-type')).toContain('image/jpeg')
+    expect(second.headers.get('content-type')).toContain('image/jpeg')
+    expect(second.headers.get('x-screenshot-cache')).toBe('hit')
+    // Second poll hit the cache, so SSH ran exactly once.
     expect(executeSSHMock).toHaveBeenCalledTimes(1)
   })
 
@@ -122,12 +172,11 @@ describe('GET .../screenshot — display detection', () => {
 
   it('falls through to the screendump path when the config probe fails', async () => {
     pveFetchMock.mockRejectedValueOnce(new Error('node down'))
-    executeSSHMock.mockResolvedValueOnce({ success: true, output: 'b2s=' })
+    executeSSHMock.mockResolvedValueOnce({ success: true, output: PPM_B64 })
 
     const res = await GET(new Request('http://localhost'), makeCtx())
-    const body = await res.json()
 
-    expect(body.format).toBe('ppm')
+    expect(res.headers.get('content-type')).toContain('image/jpeg')
     expect(executeSSHMock).toHaveBeenCalledTimes(1)
   })
 

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { getConnectionById } from "@/lib/connections/getConnection"
+import { ppmToJpeg } from "@/lib/console/ppm"
 import { pveFetch } from "@/lib/proxmox/client"
 import { locateVmInCluster } from "@/lib/proxmox/locateVm"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
@@ -9,8 +10,10 @@ import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
 
-// In-memory screenshot cache: key = "connId:node:vmid", value = { data, timestamp }
-const screenshotCache = new Map<string, { data: string; timestamp: number }>()
+// In-memory screenshot cache: key = "connId:node:vmid", value = { jpeg, timestamp }.
+// We cache the already-encoded JPEG (not the raw PPM) so cache hits are served
+// without re-running the PPM->JPEG conversion.
+const screenshotCache = new Map<string, { jpeg: Buffer; timestamp: number }>()
 const CACHE_TTL = 5_000 // 5 seconds
 
 // Whether a VM has a graphical framebuffer (vga != serial/none), cached so the
@@ -34,10 +37,28 @@ export function pruneScreenshotCaches(now: number = Date.now()): void {
 // Cleanup old cache entries periodically
 setInterval(() => pruneScreenshotCaches(), 30_000)
 
+// Serve an encoded frame as a binary image/jpeg response. Returning a real
+// image (rather than a base64 PPM wrapped in JSON) is what keeps each poll at
+// ~100 KB instead of multiple MB of uncompressed bitmap.
+function jpegResponse(jpeg: Buffer, extraHeaders?: Record<string, string>): NextResponse {
+  return new NextResponse(new Uint8Array(jpeg), {
+    status: 200,
+    headers: {
+      "Content-Type": "image/jpeg",
+      // Live frame: never let a cache hand back a stale screen. The 5s in-memory
+      // cache above already de-dupes bursts on the server side.
+      "Cache-Control": "no-store",
+      ...extraHeaders,
+    },
+  })
+}
+
 /**
  * GET /api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot
  * Captures a screenshot of a running QEMU VM via SSH.
- * Uses `qm monitor` to run screendump, then reads the PPM file back as base64.
+ * Uses `qm monitor` to run screendump, reads the PPM file back as base64, then
+ * re-encodes it to JPEG server-side and returns a binary `image/jpeg` body.
+ * Non-capture outcomes (lxc, no_display, ssh_failed, ...) are returned as JSON.
  * Only works for QEMU VMs with SSH enabled on the connection.
  */
 export async function GET(
@@ -62,7 +83,7 @@ export async function GET(
   const cached = screenshotCache.get(cacheKey)
 
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-    return NextResponse.json({ data: cached.data, format: 'ppm', cached: true })
+    return jpegResponse(cached.jpeg, { "X-Screenshot-Cache": "hit" })
   }
 
   const conn = await getConnectionById(id)
@@ -127,15 +148,25 @@ export async function GET(
       return NextResponse.json({ data: null, reason: 'ssh_failed', error: sshResult.error, movedTo })
     }
 
-    // Cache the result under the resolved node so subsequent calls coming
-    // through the stale node URL still hit the cache.
-    const b64Data = sshResult.output.trim()
-    screenshotCache.set(`${id}:${resolvedNode}:${vmid}`, { data: b64Data, timestamp: Date.now() })
-    if (resolvedNode !== node) {
-      screenshotCache.set(cacheKey, { data: b64Data, timestamp: Date.now() })
+    // The node returns the framebuffer as a base64-encoded PPM (raw RGB bitmap).
+    // Re-encode it to JPEG here so the browser-facing payload is ~100 KB instead
+    // of several MB. A malformed/partial capture decodes to null — surface that
+    // as JSON so the client treats it like any other transient failure.
+    const ppmBuffer = Buffer.from(sshResult.output.trim(), "base64")
+    const jpeg = ppmToJpeg(ppmBuffer)
+    if (!jpeg) {
+      return NextResponse.json({ data: null, reason: "decode_failed", movedTo })
     }
 
-    return NextResponse.json({ data: b64Data, format: 'ppm', movedTo })
+    // Cache the encoded frame under the resolved node so subsequent calls coming
+    // through the stale node URL still hit the cache.
+    const now = Date.now()
+    screenshotCache.set(`${id}:${resolvedNode}:${vmid}`, { jpeg, timestamp: now })
+    if (resolvedNode !== node) {
+      screenshotCache.set(cacheKey, { jpeg, timestamp: now })
+    }
+
+    return jpegResponse(jpeg, movedTo ? { "X-Screenshot-Moved-To": movedTo } : undefined)
   } catch (e: any) {
     return NextResponse.json({ data: null, reason: 'error', error: e?.message || String(e) })
   }

--- a/frontend/src/lib/console/ppm.test.ts
+++ b/frontend/src/lib/console/ppm.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodePpm, ppmToJpeg } from './ppm'
+
+/** Build a minimal P6 PPM with the given header bytes and pixel payload. */
+function makePpm(header: string, pixels: number[]): Buffer {
+  return Buffer.concat([Buffer.from(header, 'ascii'), Buffer.from(pixels)])
+}
+
+describe('decodePpm', () => {
+  it('decodes a 2x1 P6 image into RGBA', () => {
+    // red, green
+    const buf = makePpm('P6\n2 1\n255\n', [255, 0, 0, 0, 255, 0])
+    const out = decodePpm(buf)
+
+    expect(out).not.toBeNull()
+    expect(out!.width).toBe(2)
+    expect(out!.height).toBe(1)
+    expect(Array.from(out!.data)).toEqual([255, 0, 0, 255, 0, 255, 0, 255])
+  })
+
+  it('handles width/height split across separate lines', () => {
+    const buf = makePpm('P6\n1\n1\n255\n', [10, 20, 30])
+    const out = decodePpm(buf)
+
+    expect(out).not.toBeNull()
+    expect(out!.width).toBe(1)
+    expect(out!.height).toBe(1)
+    expect(Array.from(out!.data)).toEqual([10, 20, 30, 255])
+  })
+
+  it('skips comment lines in the header', () => {
+    const buf = makePpm('P6\n# created by qemu\n1 1\n255\n', [1, 2, 3])
+    const out = decodePpm(buf)
+
+    expect(out).not.toBeNull()
+    expect(Array.from(out!.data)).toEqual([1, 2, 3, 255])
+  })
+
+  it('decodes 16-bit (maxval > 255) by taking the high byte of each channel', () => {
+    // one pixel, big-endian 16-bit: R=0x0102, G=0x0304, B=0x0506 -> high bytes 1,3,5
+    const buf = makePpm('P6\n1 1\n65535\n', [1, 2, 3, 4, 5, 6])
+    const out = decodePpm(buf)
+
+    expect(out).not.toBeNull()
+    expect(Array.from(out!.data)).toEqual([1, 3, 5, 255])
+  })
+
+  it('returns null on a non-P6 magic', () => {
+    expect(decodePpm(makePpm('P3\n1 1\n255\n', [0, 0, 0]))).toBeNull()
+  })
+
+  it('returns null when the pixel payload is truncated', () => {
+    // header claims 2x2 (12 bytes) but only 3 are present
+    expect(decodePpm(makePpm('P6\n2 2\n255\n', [1, 2, 3]))).toBeNull()
+  })
+
+  it('returns null on a malformed header (zero dimensions)', () => {
+    expect(decodePpm(makePpm('P6\n0 0\n255\n', []))).toBeNull()
+  })
+
+  it('returns null on empty input', () => {
+    expect(decodePpm(Buffer.alloc(0))).toBeNull()
+  })
+})
+
+describe('ppmToJpeg', () => {
+  it('encodes a valid PPM into a JPEG buffer (SOI marker)', () => {
+    const buf = makePpm('P6\n2 1\n255\n', [255, 0, 0, 0, 255, 0])
+    const jpeg = ppmToJpeg(buf)
+
+    expect(jpeg).not.toBeNull()
+    // JPEG files start with the Start-Of-Image marker 0xFFD8 and end with EOI 0xFFD9.
+    expect(jpeg![0]).toBe(0xff)
+    expect(jpeg![1]).toBe(0xd8)
+    expect(jpeg!.length).toBeGreaterThan(2)
+    // A real JPEG of a 2px image is far smaller than a hypothetical large raw frame.
+    expect(jpeg!.length).toBeLessThan(buf.length + 1024)
+  })
+
+  it('returns null when the PPM cannot be decoded', () => {
+    expect(ppmToJpeg(makePpm('P3\n1 1\n255\n', [0, 0, 0]))).toBeNull()
+  })
+})

--- a/frontend/src/lib/console/ppm.ts
+++ b/frontend/src/lib/console/ppm.ts
@@ -1,0 +1,102 @@
+import jpeg from "jpeg-js"
+
+/** A decoded PPM frame as packed RGBA bytes, ready for a JPEG encoder. */
+export interface DecodedPpm {
+  width: number
+  height: number
+  /** RGBA, 4 bytes per pixel, length === width * height * 4. */
+  data: Buffer
+}
+
+const SPACE = 0x20
+const TAB = 0x09
+const LF = 0x0a
+const CR = 0x0d
+const HASH = 0x23 // '#'
+
+function isWhitespace(byte: number): boolean {
+  return byte === SPACE || byte === TAB || byte === LF || byte === CR
+}
+
+/**
+ * Decode a binary PPM (P6) frame as produced by `qm monitor ... screendump`
+ * into packed RGBA bytes.
+ *
+ * QEMU emits `P6\n<w> <h>\n<maxval>\n<binary RGB>` with maxval 255, but we parse
+ * the format defensively: tokens may be split across lines, comment lines
+ * (`# ...`) may appear anywhere in the header, and 16-bit channels (maxval > 255)
+ * are downsampled to their high byte. Returns null on any malformed input rather
+ * than throwing, so the caller can fall back to a JSON error response.
+ */
+export function decodePpm(buf: Buffer): DecodedPpm | null {
+  let pos = 0
+
+  const skipWhitespaceAndComments = (): void => {
+    while (pos < buf.length) {
+      const c = buf[pos]
+      if (c === HASH) {
+        // Comment runs to end of line.
+        while (pos < buf.length && buf[pos] !== LF) pos++
+      } else if (isWhitespace(c)) {
+        pos++
+      } else {
+        break
+      }
+    }
+  }
+
+  const readToken = (): string => {
+    skipWhitespaceAndComments()
+    const start = pos
+    while (pos < buf.length && !isWhitespace(buf[pos]) && buf[pos] !== HASH) pos++
+    return buf.toString("ascii", start, pos)
+  }
+
+  if (readToken() !== "P6") return null
+
+  const width = Number.parseInt(readToken(), 10)
+  const height = Number.parseInt(readToken(), 10)
+  const maxVal = Number.parseInt(readToken(), 10)
+  if (!width || !height || !maxVal || width < 0 || height < 0) return null
+
+  // Per spec, exactly one whitespace byte separates maxval from the pixel data.
+  // readToken left `pos` on that separator; the payload begins one byte later.
+  const dataStart = pos + 1
+  const bytesPerChannel = maxVal > 255 ? 2 : 1
+  const pixelBytes = bytesPerChannel * 3
+  const pixelCount = width * height
+
+  if (dataStart + pixelCount * pixelBytes > buf.length) return null
+
+  const rgba = Buffer.allocUnsafe(pixelCount * 4)
+  for (let i = 0; i < pixelCount; i++) {
+    const src = dataStart + i * pixelBytes
+    const dst = i * 4
+    if (bytesPerChannel === 1) {
+      rgba[dst] = buf[src]
+      rgba[dst + 1] = buf[src + 1]
+      rgba[dst + 2] = buf[src + 2]
+    } else {
+      // 16-bit big-endian: keep the high byte of each channel.
+      rgba[dst] = buf[src]
+      rgba[dst + 1] = buf[src + 2]
+      rgba[dst + 2] = buf[src + 4]
+    }
+    rgba[dst + 3] = 255
+  }
+
+  return { width, height, data: rgba }
+}
+
+/**
+ * Convert a binary PPM frame into a JPEG buffer. Returns null when the PPM is
+ * malformed. `quality` is 0-100 (jpeg-js scale); 75 matches the quality the
+ * browser previously used when it did this conversion client-side.
+ */
+export function ppmToJpeg(buf: Buffer, quality = 75): Buffer | null {
+  const decoded = decodePpm(buf)
+  if (!decoded) return null
+
+  const { data } = jpeg.encode({ data: decoded.data, width: decoded.width, height: decoded.height }, quality)
+  return Buffer.from(data)
+}

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -5,3 +5,16 @@ declare module '*.css' {
 }
 
 declare module 'xterm/css/xterm.css'
+
+// jpeg-js ships no type definitions. We only use the encoder.
+declare module 'jpeg-js' {
+  interface RawImageData {
+    data: Uint8Array | Buffer
+    width: number
+    height: number
+  }
+  export function encode(imgData: RawImageData, quality?: number): RawImageData
+  export function decode(jpegData: Uint8Array | Buffer, opts?: Record<string, unknown>): RawImageData
+  const _default: { encode: typeof encode; decode: typeof decode }
+  export default _default
+}


### PR DESCRIPTION
## Problem

The inventory console preview (`ConsolePreview`) polls the screenshot
endpoint every 10s for each visible running QEMU VM. The node captured the
framebuffer as a **PPM** (raw, uncompressed RGB bitmap) via
`qm monitor screendump`, base64-encoded it, and the route returned that
base64 inside JSON. That is roughly **4 MB per frame** (more at 1080p).

The browser then decoded the PPM and re-encoded it to a small JPEG for
display, so the compression was happening on the wrong side of the wire:
we downloaded multiple MB only to throw most of it away.

## Change

Move the PPM-to-JPEG conversion **server-side**. The route now decodes the
node's PPM and returns a binary `image/jpeg` body. Measured payload drops
from ~4 MB to **~40 KB** per frame (>99% on the tested VM).

- New `lib/console/ppm.ts`: pure `decodePpm` + `ppmToJpeg` (via `jpeg-js`,
  pure-JS, no native binary), fully unit-tested.
- `screenshot/route.ts`: returns `image/jpeg`; the in-memory cache stores
  the encoded JPEG; non-capture outcomes (`lxc`, `no_display`,
  `ssh_failed`, `decode_failed`) stay JSON so the client can branch on them.
- `ConsolePreview.tsx`: consumes the binary image via a blob object URL
  (with revoke-on-replace and revoke-on-unmount), removing ~90 lines of
  hand-rolled client-side PPM parsing.

The node-to-server SSH leg still transfers the raw PPM; that is internal
(usually LAN) and out of scope here. It can be gzipped later if remote
clusters need it.

## Tests

- 21 unit tests green (10 for `ppm.ts`, 11 for the route incl. the binary
  response, server-side cache hit, `decode_failed`, and the
  intra-cluster-migration retry path).
- New-code coverage well above the gate; `ConsolePreview.tsx` is already in
  `sonar.coverage.exclusions` (pure-JSX).
- Validated in the browser: the `/screenshot` call now returns `image/jpeg`
  at ~40 KB; serial-only and powered-off VMs behave as before.
