### PR TITLE
fix(rbac): scope RRD performance graphs to the resource, not the connection

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/rrd/batch/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/rrd/batch/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const getRBACContextMock = vi.fn<() => Promise<any>>()
+const hasPermissionMock = vi.fn<(check: any) => Promise<boolean>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+
+vi.mock('@/lib/rbac', () => ({
+  getRBACContext: getRBACContextMock,
+  hasPermission: hasPermissionMock,
+  PERMISSIONS: { VM_VIEW: 'vm.view', NODE_VIEW: 'node.view' },
+  buildVmResourceId: (c: string, n: string, t: string, v: string) => `${c}:${n}:${t}:${v}`,
+  buildNodeResourceId: (c: string, n: string) => `${c}:${n}`,
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: pveFetchMock,
+}))
+
+// Dynamic import so the route (and its mocked deps) loads after the mock
+// consts above are initialized — the repo convention for route tests.
+const importPOST = async () => (await import('./route')).POST
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getRBACContextMock.mockResolvedValue({ userId: 'u1', isAdmin: false, tenantId: 'default' })
+  getConnectionByIdMock.mockResolvedValue({ id: 'conn1' })
+  pveFetchMock.mockImplementation(async (_conn: any, rrdPath: string) => [{ path: rrdPath }])
+})
+
+describe('POST /api/v1/connections/:id/rrd/batch', () => {
+  it('401s when unauthenticated', async () => {
+    getRBACContextMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importPOST(), {
+      params: { id: 'conn1' },
+      body: { paths: ['/nodes/pve1'], timeframe: 'hour' },
+    })
+
+    expect(res.status).toBe(401)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('drops paths the caller cannot see and only fetches the allowed ones', async () => {
+    // pve1 allowed, pve2 denied.
+    hasPermissionMock.mockImplementation(async (check) => check.resourceId === 'conn1:pve1')
+
+    const res = await callRoute(await importPOST(), {
+      params: { id: 'conn1' },
+      body: { paths: ['/nodes/pve1', '/nodes/pve2'], timeframe: 'hour' },
+    })
+
+    expect(res.status).toBe(200)
+    // Each node path checked against node.view on its node resource.
+    expect(hasPermissionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ permission: 'node.view', resourceType: 'node', resourceId: 'conn1:pve1' }),
+    )
+    const json = await readJson<{ data: Record<string, unknown> }>(res)
+    expect(Object.keys(json!.data)).toEqual(['/nodes/pve1'])
+    // Only the allowed node was fetched.
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an empty map when no path is allowed', async () => {
+    hasPermissionMock.mockResolvedValue(false)
+
+    const res = await callRoute(await importPOST(), {
+      params: { id: 'conn1' },
+      body: { paths: ['/nodes/pve1', '/nodes/pve2'], timeframe: 'hour' },
+    })
+
+    expect(res.status).toBe(200)
+    const json = await readJson<{ data: Record<string, unknown> }>(res)
+    expect(json?.data).toEqual({})
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/rrd/batch/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/rrd/batch/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server"
 
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { getRBACContext, hasPermission } from "@/lib/rbac"
+import { resolveRrdScope } from "@/lib/rbac/rrdScope"
 
 export const runtime = "nodejs"
 
@@ -19,8 +20,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   try {
     if (!id) return NextResponse.json({ error: "Missing params.id" }, { status: 400 })
 
-    const denied = await checkPermission(PERMISSIONS.CONNECTION_VIEW, "connection", id)
-    if (denied) return denied
+    const rbac = await getRBACContext()
+    if (!rbac) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+    }
 
     const body = await req.json()
     const paths: string[] = body.paths || []
@@ -35,6 +38,31 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       return NextResponse.json({ error: "Too many paths (max 50)" }, { status: 400 })
     }
 
+    // Gate each path on the resource it addresses (node.view for a node path,
+    // vm.view for a VM path). Paths the caller can't see are dropped from the
+    // batch rather than failing the whole request, so a scoped user still gets
+    // graphs for the nodes they can see. See resolveRrdScope (issue #378).
+    const allowedPaths = (
+      await Promise.all(
+        paths.map(async (path) => {
+          const scope = resolveRrdScope(id, path)
+          if (!scope) return null
+          const ok = await hasPermission({
+            userId: rbac.userId,
+            permission: scope.permission,
+            resourceType: scope.resourceType,
+            resourceId: scope.resourceId,
+            tenantId: rbac.tenantId,
+          })
+          return ok ? path : null
+        }),
+      )
+    ).filter((p): p is string => p !== null)
+
+    if (allowedPaths.length === 0) {
+      return NextResponse.json({ data: {} })
+    }
+
     const allowed = new Set(["hour", "day", "week", "month", "year"])
     const tf = allowed.has(timeframe) ? timeframe : "hour"
 
@@ -42,10 +70,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
 
     // Fetch all RRD data in parallel
     const results = await Promise.allSettled(
-      paths.map(async (path) => {
-        if (!path.startsWith("/nodes/")) {
-          return { path, data: null, error: "Invalid path" }
-        }
+      allowedPaths.map(async (path) => {
         const rrdPath = `${path.replace(/\/$/, "")}/rrddata?timeframe=${encodeURIComponent(tf)}&cf=AVERAGE`
         const data = await pveFetch<any[]>(conn, rrdPath)
         return { path, data }

--- a/frontend/src/app/api/v1/connections/[id]/rrd/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/rrd/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const demoResponseMock = vi.fn<(req: Request) => Response | null>()
+
+// Mock the rbac barrel: checkPermission is the gate under test; the pure
+// PERMISSIONS / build* helpers are reimplemented so the REAL resolveRrdScope
+// (not mocked) produces the resource ids we assert on.
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { VM_VIEW: 'vm.view', NODE_VIEW: 'node.view', CONNECTION_VIEW: 'connection.view' },
+  buildVmResourceId: (c: string, n: string, t: string, v: string) => `${c}:${n}:${t}:${v}`,
+  buildNodeResourceId: (c: string, n: string) => `${c}:${n}`,
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: getConnectionByIdMock,
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: pveFetchMock,
+}))
+
+vi.mock('@/lib/demo/demo-api', () => ({
+  demoResponse: demoResponseMock,
+}))
+
+// Dynamic import so the route (and its mocked deps) loads after the mock
+// consts above are initialized — the repo convention for route tests.
+const importGET = async () => (await import('./route')).GET
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  demoResponseMock.mockReturnValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: 'conn1' })
+  pveFetchMock.mockResolvedValue([{ time: 1, cpu: 0.5 }])
+})
+
+describe('GET /api/v1/connections/:id/rrd', () => {
+  it('gates a VM path on vm.view scoped to the VM resource', async () => {
+    checkPermissionMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), {
+      params: { id: 'conn1' },
+      searchParams: { path: '/nodes/pve1/qemu/100', timeframe: 'hour' },
+    })
+
+    expect(checkPermissionMock).toHaveBeenCalledWith('vm.view', 'vm', 'conn1:pve1:qemu:100')
+    expect(res.status).toBe(200)
+    const json = await readJson<{ data: unknown[] }>(res)
+    expect(json?.data).toEqual([{ time: 1, cpu: 0.5 }])
+  })
+
+  it('gates a node path on node.view scoped to the node resource', async () => {
+    checkPermissionMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), {
+      params: { id: 'conn1' },
+      searchParams: { path: '/nodes/pve1', timeframe: 'day' },
+    })
+
+    expect(checkPermissionMock).toHaveBeenCalledWith('node.view', 'node', 'conn1:pve1')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns the 403 from checkPermission when the user lacks the scope', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse('Permission denied: vm.view'))
+
+    const res = await callRoute(await importGET(), {
+      params: { id: 'conn1' },
+      searchParams: { path: '/nodes/pve1/qemu/100' },
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid path before any permission check', async () => {
+    const res = await callRoute(await importGET(), {
+      params: { id: 'conn1' },
+      searchParams: { path: '/cluster/resources' },
+    })
+
+    expect(res.status).toBe(400)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it('400s when the connection id is missing', async () => {
+    const res = await callRoute(await importGET(), {
+      params: {},
+      searchParams: { path: '/nodes/pve1' },
+    })
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/rrd/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/rrd/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from "next/server"
 
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission } from "@/lib/rbac"
+import { resolveRrdScope } from "@/lib/rbac/rrdScope"
 import { demoResponse } from "@/lib/demo/demo-api"
 
 export const runtime = "nodejs"
@@ -24,12 +25,17 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> |
   try {
     if (!id) return NextResponse.json({ error: "Missing params.id" }, { status: 400 })
 
-    const denied = await checkPermission(PERMISSIONS.CONNECTION_VIEW, "connection", id)
-    if (denied) return denied
-
-    if (!path.startsWith("/nodes/")) {
+    // Gate on the resource the path actually addresses (vm.view for a VM path,
+    // node.view for a node/storage path) so VM- and node-scoped users can read
+    // the Performance graphs of resources they already see in the inventory.
+    // A connection-scoped check would 403 them (see resolveRrdScope).
+    const scope = resolveRrdScope(id, path)
+    if (!scope) {
       return NextResponse.json({ error: "Invalid path (must start with /nodes/)" }, { status: 400 })
     }
+
+    const denied = await checkPermission(scope.permission, scope.resourceType, scope.resourceId)
+    if (denied) return denied
 
     const allowed = new Set(["hour", "day", "week", "month", "year"])
     const tf = allowed.has(timeframe) ? timeframe : "hour"

--- a/frontend/src/lib/rbac/rrdScope.test.ts
+++ b/frontend/src/lib/rbac/rrdScope.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// resolveRrdScope only needs the pure constants/formatters from @/lib/rbac.
+// Mock them with faithful reimplementations so the test stays hermetic
+// (importing the real barrel pulls next-auth/prisma), matching how the route
+// tests stub @/lib/rbac.
+vi.mock('@/lib/rbac', () => ({
+  PERMISSIONS: { VM_VIEW: 'vm.view', NODE_VIEW: 'node.view' },
+  buildVmResourceId: (c: string, n: string, t: string, v: string) => `${c}:${n}:${t}:${v}`,
+  buildNodeResourceId: (c: string, n: string) => `${c}:${n}`,
+}))
+
+import { resolveRrdScope } from './rrdScope'
+
+describe('resolveRrdScope', () => {
+  it('maps a QEMU path to vm.view on the VM resource', () => {
+    expect(resolveRrdScope('conn1', '/nodes/pve1/qemu/100')).toEqual({
+      permission: 'vm.view',
+      resourceType: 'vm',
+      resourceId: 'conn1:pve1:qemu:100',
+    })
+  })
+
+  it('maps an LXC path to vm.view on the VM resource', () => {
+    expect(resolveRrdScope('conn1', '/nodes/pve1/lxc/200')).toEqual({
+      permission: 'vm.view',
+      resourceType: 'vm',
+      resourceId: 'conn1:pve1:lxc:200',
+    })
+  })
+
+  it('maps a bare node path to node.view on the node resource', () => {
+    expect(resolveRrdScope('conn1', '/nodes/pve1')).toEqual({
+      permission: 'node.view',
+      resourceType: 'node',
+      resourceId: 'conn1:pve1',
+    })
+  })
+
+  it('maps a storage-on-node path to node.view (node-level resource)', () => {
+    expect(resolveRrdScope('conn1', '/nodes/pve1/storage/local')).toEqual({
+      permission: 'node.view',
+      resourceType: 'node',
+      resourceId: 'conn1:pve1',
+    })
+  })
+
+  it('tolerates a trailing slash on the node path', () => {
+    expect(resolveRrdScope('conn1', '/nodes/pve1/')).toEqual({
+      permission: 'node.view',
+      resourceType: 'node',
+      resourceId: 'conn1:pve1',
+    })
+  })
+
+  it('returns null for a non-/nodes path', () => {
+    expect(resolveRrdScope('conn1', '/cluster/resources')).toBeNull()
+  })
+
+  it('returns null for /nodes with no node name', () => {
+    expect(resolveRrdScope('conn1', '/nodes/')).toBeNull()
+    expect(resolveRrdScope('conn1', '/nodes')).toBeNull()
+  })
+
+  it('falls back to node.view when the guest type is unknown or vmid missing', () => {
+    // Not qemu/lxc -> treated as a node-level path.
+    expect(resolveRrdScope('conn1', '/nodes/pve1/qemu')).toEqual({
+      permission: 'node.view',
+      resourceType: 'node',
+      resourceId: 'conn1:pve1',
+    })
+  })
+})

--- a/frontend/src/lib/rbac/rrdScope.ts
+++ b/frontend/src/lib/rbac/rrdScope.ts
@@ -1,0 +1,60 @@
+// src/lib/rbac/rrdScope.ts
+//
+// Maps a Proxmox RRD path to the RBAC permission + resource it should be
+// gated on. RRD endpoints used to gate on a connection-SCOPED `connection.view`
+// (checkPermission(CONNECTION_VIEW, "connection", id)), which a VM- or
+// node-scoped user can never satisfy — scopeMatches() only lines a vm/node
+// grant up against a vm/node resource, never against a "connection" resource.
+// The result was a 403 ("RRD: Permission denied: connection.view") on the
+// Performance tab for VM Admin / VM User / Viewer users assigned at a narrow
+// scope, even for VMs they can see in the inventory (issue #378 follow-up).
+//
+// We instead gate on the resource the path actually addresses — the same model
+// the inventory list (vm.view / node.view filtered) already uses, so a user who
+// can see a VM/node can see its graphs and one who can't never reaches the tab.
+//
+// Path shapes (always /nodes/<node>... per the RRD routes):
+//   /nodes/<node>                     -> node   -> node.view
+//   /nodes/<node>/qemu/<vmid>         -> vm     -> vm.view
+//   /nodes/<node>/lxc/<vmid>          -> vm     -> vm.view
+//   /nodes/<node>/storage/<store>     -> node   -> node.view
+
+import { PERMISSIONS, buildVmResourceId, buildNodeResourceId } from "@/lib/rbac"
+
+export interface RrdScope {
+  permission: string
+  resourceType: "vm" | "node"
+  resourceId: string
+}
+
+/**
+ * Resolve the RBAC scope an RRD path must be checked against. Pure, no DB.
+ * Returns null when the path is not a valid /nodes/<node>... RRD path.
+ *
+ * Parsed by splitting on "/" (no regex) to avoid a ReDoS hotspot.
+ */
+export function resolveRrdScope(connId: string, path: string): RrdScope | null {
+  // ["nodes", "<node>", maybe "qemu"|"lxc"|"storage"|..., maybe "<vmid>", ...]
+  const parts = path.split("/").filter(Boolean)
+  if (parts[0] !== "nodes" || !parts[1]) return null
+
+  const node = parts[1]
+  const kind = parts[2]
+  const vmid = parts[3]
+
+  if ((kind === "qemu" || kind === "lxc") && vmid) {
+    return {
+      permission: PERMISSIONS.VM_VIEW,
+      resourceType: "vm",
+      resourceId: buildVmResourceId(connId, node, kind, vmid),
+    }
+  }
+
+  // Bare node, storage-on-node, or anything else under /nodes/<node>: a
+  // node-level resource. node.view is the inventory gate for node detail too.
+  return {
+    permission: PERMISSIONS.NODE_VIEW,
+    resourceType: "node",
+    resourceId: buildNodeResourceId(connId, node),
+  }
+}


### PR DESCRIPTION
## Problem

On the VM/node **Performance** tab, the RRD graphs (CPU, Memory, Network, Disk) failed with `RRD: Permission denied: connection.view` for users holding `VM Admin`, `VM User`, or `Viewer` when those roles were assigned at a **VM- or node-level scope**. The inventory itself worked (scoping was fixed in v1.4.3); only the performance graphs were broken.

## Root cause

The RRD routes gated on a **connection-scoped** permission check:

```ts
checkPermission(CONNECTION_VIEW, "connection", id)
```

Those roles *do* hold `connection.view`, but a `vm`- or `node`-scoped grant can never satisfy a check against a `"connection"` resource: `scopeMatches()` only lines a `vm`/`node` grant up against a `vm`/`node` resource. The inventory list and node-detail routes don't hit this because they check the permission **unscoped** (with an explicit comment to that effect).

## Fix

Gate each RRD request on **the resource the path actually addresses**, via a small pure helper `resolveRrdScope()`:

- VM path (`/nodes/<n>/qemu|lxc/<vmid>`) → `vm.view` on that VM
- node / storage path (`/nodes/<n>...`) → `node.view` on that node

This mirrors how the inventory VM/node lists are already filtered (`vm.view` / `node.view`), so a user who can see a resource can see its graphs, and one who can't never reaches the tab. Every built-in role that has `connection.view` also has `vm.view` + `node.view`, so there is **no regression** for existing users, and a scoped user can no longer pull RRD outside their scope.

- `lib/rbac/rrdScope.ts` (new): path → `{ permission, resourceType, resourceId }`. Parsed by splitting on `/` (no regex, avoids the S5852 hotspot).
- `…/rrd/route.ts`: single-path gate via `resolveRrdScope`.
- `…/rrd/batch/route.ts`: per-path check; paths the caller cannot see are dropped from the batch rather than failing the whole request, so a scoped user still gets graphs for the nodes they can see.

`ceph/rrd` is intentionally left connection-scoped: it serves cluster-wide Ceph data (the cluster Ceph tab), which a VM/node-scoped user never opens.

## Tests

3 new files, 16 cases: `resolveRrdScope` mapping (VM/LXC/node/storage/invalid), and both route handlers (correct scoped check per path shape, 403 propagation, invalid path, unauthenticated, per-path batch filtering).

Follow-up to #378.
