### PR TITLE
fix(rbac): re-sync OIDC role from IdP groups on every login

### DIFF
--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -9,7 +9,7 @@ import { prisma } from "@/lib/db/prisma"
 import { verifyPassword, hashPassword } from "./password"
 import { extractGroupsFromClaim, isLdapGroupAllowed } from "./groupMapping"
 import { authenticateLdap, isLdapEnabled, getLdapConfig, resolveLdapRole, syncLdapRoleAssignment } from "./ldap"
-import { getOidcConfig, resolveOidcRole } from "./oidc"
+import { getOidcConfig, oidcRoleId, syncOidcRoleAssignment } from "./oidc"
 
 export type UserRole = "super_admin" | "admin" | "operator" | "viewer"
 
@@ -399,7 +399,9 @@ export const authOptions: NextAuthOptions = {
         if (existing) {
           if (!existing.enabled) return false
 
-          // Update existing user
+          // Update existing user. The legacy users.role column is left as-is
+          // (mirrors LDAP); the authoritative RBAC assignment is re-synced from
+          // the current groups below (issue #383).
           await prisma.user.update({
             where: { id: existing.id },
             data: {
@@ -446,17 +448,16 @@ export const authOptions: NextAuthOptions = {
           if (!oidcConfig.autoProvision) return false
 
           const id = nanoid()
-          const resolvedRole = resolveOidcRole(groups, oidcConfig)
-          // Normalize: support both "role_viewer" (new) and "viewer" (legacy) formats
-          const oidcRoleId = resolvedRole.startsWith('role_') ? resolvedRole : `role_${resolvedRole}`
-          const role = oidcRoleId.replace(/^role_/, '') // Simple name for users table
+          // Legacy users.role display column (the authoritative RBAC assignment
+          // is created by syncOidcRoleAssignment below).
+          const roleName = oidcRoleId(groups, oidcConfig).replace(/^role_/, '')
 
           await prisma.user.create({
             data: {
               id,
               email,
               name,
-              role,
+              role: roleName,
               authProvider: "oidc",
               oidcSub: sub,
               enabled: true,
@@ -473,33 +474,24 @@ export const authOptions: NextAuthOptions = {
             create: { userId: id, tenantId: "default", isDefault: true, joinedAt: now },
           })
 
-          // Create RBAC role assignment from OIDC groups (Postgres / Prisma).
-          // scopeType "inherit" so the assignment follows the role's default
-          // scope automatically (issue #383). Resolves to global when the role
-          // has no default scope, matching the previous behaviour.
-          const oidcRoleExists = await prisma.rbacRole.findUnique({
-            where: { id: oidcRoleId },
-            select: { id: true },
-          })
-          const finalOidcRoleId = oidcRoleExists ? oidcRoleExists.id : "role_viewer"
-
-          await prisma.rbacUserRole.create({
-            data: {
-              id: `oidc_${nanoid(12)}`,
-              userId: id,
-              roleId: finalOidcRoleId,
-              scopeType: "inherit",
-              tenantId: "default",
-              grantedAt: now,
-            },
-          })
-
           user.id = id
           user.email = email
           user.name = name
-          user.role = role as UserRole
+          user.role = roleName as UserRole
           user.authProvider = 'oidc'
         }
+
+        // Re-sync the RBAC assignment from the current IdP groups on every
+        // login (new or existing), mirroring the LDAP path. scopeType "inherit"
+        // follows the role's default scope; only the oidc_ row is touched, so
+        // manual assignments are preserved (issue #383).
+        await syncOidcRoleAssignment(prisma, {
+          userId: user.id,
+          groups,
+          config: oidcConfig,
+          now,
+          newId: () => `oidc_${nanoid(12)}`,
+        })
       }
 
       return true

--- a/frontend/src/lib/auth/ldap.ts
+++ b/frontend/src/lib/auth/ldap.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
+import { syncProviderRoleAssignment, type ProviderSyncDb } from "./roleSync"
 
 export interface LdapUser {
   dn: string
@@ -194,33 +195,15 @@ export function resolveLdapRole(groups: string[], config: LdapConfig): string | 
   return null
 }
 
-// Minimal Prisma surface the LDAP sync needs — injected so the logic is unit
-// testable without a real client.
-type LdapSyncDb = {
-  rbacRole: { findUnique: (args: any) => Promise<{ id: string } | null> }
-  rbacUserRole: {
-    findFirst: (args: any) => Promise<{ id: string } | null>
-    deleteMany: (args: any) => Promise<unknown>
-    create: (args: any) => Promise<unknown>
-  }
-  $transaction: (ops: unknown[]) => Promise<unknown>
-}
-
 /**
  * Sync a user's LDAP-derived RBAC assignment on login (issue #383).
  *
- * The assignment is created with scopeType "inherit" so it follows the role's
- * default scope automatically. The LDAP-managed row is identified by its
- * `ldap_` id prefix, so the delete/replace never touches a manually-created
- * assignment (which would otherwise be clobbered when keyed on scope type).
- *
- *  - group matches a role  -> replace the ldap_ row with the resolved role
- *    (falling back to role_viewer if the resolved role no longer exists)
- *  - no match, no role yet -> assign the default role (first login)
- *  - no match, role exists -> preserve whatever the user already has
+ * Thin wrapper over the provider-agnostic core: LDAP owns the `ldap_`-prefixed
+ * row. resolveLdapRole returns null when no group matches, so an existing role
+ * is preserved (LDAP never demotes on a missing group). See roleSync.ts.
  */
 export async function syncLdapRoleAssignment(
-  db: LdapSyncDb,
+  db: ProviderSyncDb,
   params: {
     userId: string
     resolvedRoleId: string | null
@@ -229,50 +212,5 @@ export async function syncLdapRoleAssignment(
     newId: () => string
   },
 ): Promise<void> {
-  const { userId, resolvedRoleId, defaultRoleId, now, newId } = params
-  const tenantId = "default"
-  const ldapOwned = { userId, tenantId, id: { startsWith: "ldap_" } }
-
-  if (resolvedRoleId) {
-    const roleExists = await db.rbacRole.findUnique({
-      where: { id: resolvedRoleId },
-      select: { id: true },
-    })
-    const finalRoleId = roleExists ? resolvedRoleId : "role_viewer"
-    await db.$transaction([
-      db.rbacUserRole.deleteMany({ where: ldapOwned }),
-      db.rbacUserRole.create({
-        data: {
-          id: newId(),
-          userId,
-          roleId: finalRoleId,
-          scopeType: "inherit",
-          tenantId,
-          grantedById: null,
-          grantedAt: now,
-        },
-      }),
-    ])
-    return
-  }
-
-  // No group matched — only seed the default role if the user has none yet,
-  // so a manually-assigned role is never duplicated or overridden on login.
-  const hasAnyRole = await db.rbacUserRole.findFirst({
-    where: { userId, tenantId },
-    select: { id: true },
-  })
-  if (!hasAnyRole) {
-    await db.rbacUserRole.create({
-      data: {
-        id: newId(),
-        userId,
-        roleId: defaultRoleId,
-        scopeType: "inherit",
-        tenantId,
-        grantedById: null,
-        grantedAt: now,
-      },
-    })
-  }
+  return syncProviderRoleAssignment(db, { ...params, idPrefix: "ldap_" })
 }

--- a/frontend/src/lib/auth/oidc-rbac-sync.test.ts
+++ b/frontend/src/lib/auth/oidc-rbac-sync.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { syncOidcRoleAssignment, oidcRoleId } from './oidc'
+import type { OidcConfig } from './oidc'
+
+function makeConfig(mapping: Record<string, string>, defaultRole = 'role_viewer'): OidcConfig {
+  return {
+    enabled: true,
+    providerName: 'SSO',
+    issuerUrl: 'https://idp.example.com',
+    clientId: 'cid',
+    clientSecret: null,
+    scopes: 'openid profile email',
+    authorizationUrl: null,
+    tokenUrl: null,
+    userinfoUrl: null,
+    claimEmail: 'email',
+    claimName: 'name',
+    claimGroups: 'groups',
+    autoProvision: true,
+    defaultRole,
+    groupRoleMapping: mapping,
+    showLocalLogin: true,
+    forceSsoRedirect: false,
+  }
+}
+
+function makeDb(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    rbacRole: { findUnique: vi.fn().mockResolvedValue({ id: 'role_db' }) },
+    rbacUserRole: {
+      findFirst: vi.fn().mockResolvedValue(null),
+      deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      create: vi.fn().mockResolvedValue({}),
+    },
+    $transaction: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as any
+}
+
+const baseParams = (extra: any = {}) => ({
+  userId: 'u1',
+  groups: ['db'] as string[] | undefined,
+  config: makeConfig({ db: 'role_db' }),
+  now: new Date('2026-06-18T00:00:00Z'),
+  newId: () => 'oidc_fixed',
+  ...extra,
+})
+
+describe('oidcRoleId', () => {
+  it('normalises a bare mapping value to a role_ id', () => {
+    expect(oidcRoleId(['ops'], makeConfig({ ops: 'ops' }))).toBe('role_ops')
+  })
+
+  it('passes through an already-prefixed mapping value', () => {
+    expect(oidcRoleId(['ops'], makeConfig({ ops: 'role_ops' }))).toBe('role_ops')
+  })
+
+  it('normalises the default role when no group matches', () => {
+    expect(oidcRoleId(['nope'], makeConfig({ ops: 'role_ops' }, 'viewer'))).toBe('role_viewer')
+  })
+})
+
+describe('syncOidcRoleAssignment (issue #383)', () => {
+  let db: any
+  beforeEach(() => {
+    db = makeDb()
+  })
+
+  it('replaces the OIDC-managed row with the mapped role as an inherit assignment', async () => {
+    await syncOidcRoleAssignment(db, baseParams())
+
+    // Only oidc_-owned rows are removed, never manual or ldap_ assignments.
+    expect(db.rbacUserRole.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'u1', tenantId: 'default', id: { startsWith: 'oidc_' } },
+    })
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_db')
+    expect(created.scopeType).toBe('inherit')
+    expect(created.id).toBe('oidc_fixed')
+    expect(created.tenantId).toBe('default')
+  })
+
+  it('demotes the OIDC row to the default role when no group matches (full re-sync)', async () => {
+    // Unlike LDAP, OIDC always resolves a concrete role, so leaving every
+    // mapped group reverts the user to the default role on the next login.
+    db = makeDb({ rbacRole: { findUnique: vi.fn().mockResolvedValue({ id: 'role_viewer' }) } })
+    await syncOidcRoleAssignment(
+      db,
+      baseParams({ groups: ['unmapped'], config: makeConfig({ db: 'role_db' }, 'role_viewer') }),
+    )
+
+    expect(db.rbacUserRole.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'u1', tenantId: 'default', id: { startsWith: 'oidc_' } },
+    })
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_viewer')
+    expect(created.scopeType).toBe('inherit')
+  })
+
+  it('falls back to role_viewer when the resolved role no longer exists', async () => {
+    db = makeDb({ rbacRole: { findUnique: vi.fn().mockResolvedValue(null) } })
+    await syncOidcRoleAssignment(db, baseParams({ config: makeConfig({ db: 'role_ghost' }) }))
+    const created = db.rbacUserRole.create.mock.calls[0][0].data
+    expect(created.roleId).toBe('role_viewer')
+    expect(created.scopeType).toBe('inherit')
+  })
+})

--- a/frontend/src/lib/auth/oidc.ts
+++ b/frontend/src/lib/auth/oidc.ts
@@ -5,6 +5,7 @@
 
 import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
+import { syncProviderRoleAssignment, type ProviderSyncDb } from "./roleSync"
 
 export interface OidcConfig {
   enabled: boolean
@@ -101,4 +102,38 @@ export function resolveOidcRole(
   }
 
   return config.defaultRole
+}
+
+/**
+ * Normalise a resolved OIDC role into a `role_`-prefixed RBAC role id. The
+ * group->role mapping accepts both "role_db" (new) and "db" (legacy) values,
+ * and the default role is stored either way too.
+ */
+export function oidcRoleId(groups: string[] | undefined, config: OidcConfig): string {
+  const resolved = resolveOidcRole(groups, config)
+  return resolved.startsWith("role_") ? resolved : `role_${resolved}`
+}
+
+/**
+ * Re-sync a user's OIDC-derived RBAC assignment on every login (issue #383).
+ *
+ * Unlike LDAP, resolveOidcRole always resolves to a concrete role (its default
+ * on no match), so this is a full re-evaluation: the user follows their current
+ * IdP groups on each sign-in, and leaving a mapped group demotes them to the
+ * default role at the next login. The `oidc_`-prefixed row is the only one
+ * touched, so manual assignments are preserved (assignments are additive).
+ */
+export async function syncOidcRoleAssignment(
+  db: ProviderSyncDb,
+  params: { userId: string; groups: string[] | undefined; config: OidcConfig; now: Date; newId: () => string },
+): Promise<void> {
+  const { userId, groups, config, now, newId } = params
+  await syncProviderRoleAssignment(db, {
+    userId,
+    resolvedRoleId: oidcRoleId(groups, config),
+    defaultRoleId: "role_viewer",
+    now,
+    idPrefix: "oidc_",
+    newId,
+  })
 }

--- a/frontend/src/lib/auth/roleSync.ts
+++ b/frontend/src/lib/auth/roleSync.ts
@@ -1,0 +1,100 @@
+// src/lib/auth/roleSync.ts
+//
+// Provider-agnostic core for syncing a user's IdP-derived RBAC assignment on
+// login (issue #383). Shared by the LDAP and OIDC sign-in paths so both
+// providers re-evaluate group membership the same way on every login, instead
+// of only at account creation.
+//
+// The provider-managed row is identified by its id prefix ("ldap_" / "oidc_"),
+// so the delete/replace only ever touches the row this provider owns and never
+// clobbers a manually-created assignment. Assignments are additive (no deny),
+// so a manual elevation always survives a re-sync.
+
+// Minimal Prisma surface the sync needs — injected so the logic is unit
+// testable without a real client.
+export type ProviderSyncDb = {
+  rbacRole: { findUnique: (args: any) => Promise<{ id: string } | null> }
+  rbacUserRole: {
+    findFirst: (args: any) => Promise<{ id: string } | null>
+    deleteMany: (args: any) => Promise<unknown>
+    create: (args: any) => Promise<unknown>
+  }
+  $transaction: (ops: unknown[]) => Promise<unknown>
+}
+
+/**
+ * Sync a user's provider-derived RBAC assignment on login (issue #383).
+ *
+ * The assignment is created with scopeType "inherit" so it follows the role's
+ * default scope automatically. The provider-managed row is identified by
+ * `idPrefix`, so the delete/replace never touches a manually-created
+ * assignment (which would otherwise be clobbered when keyed on scope type).
+ *
+ *  - role resolved      -> replace the provider row with the resolved role
+ *    (falling back to role_viewer if the resolved role no longer exists)
+ *  - null, no role yet  -> assign the default role (first login)
+ *  - null, role exists  -> preserve whatever the user already has
+ *
+ * LDAP passes null when no group matches (preserve existing). OIDC always
+ * resolves to a concrete role (its default on no match), so an OIDC re-sync is
+ * a full re-evaluation: leaving a mapped group demotes the provider row to the
+ * default role on the next login, while manual assignments stay untouched.
+ */
+export async function syncProviderRoleAssignment(
+  db: ProviderSyncDb,
+  params: {
+    userId: string
+    resolvedRoleId: string | null
+    defaultRoleId: string
+    now: Date
+    idPrefix: string
+    newId: () => string
+  },
+): Promise<void> {
+  const { userId, resolvedRoleId, defaultRoleId, now, idPrefix, newId } = params
+  const tenantId = "default"
+  const owned = { userId, tenantId, id: { startsWith: idPrefix } }
+
+  if (resolvedRoleId) {
+    const roleExists = await db.rbacRole.findUnique({
+      where: { id: resolvedRoleId },
+      select: { id: true },
+    })
+    const finalRoleId = roleExists ? resolvedRoleId : "role_viewer"
+    await db.$transaction([
+      db.rbacUserRole.deleteMany({ where: owned }),
+      db.rbacUserRole.create({
+        data: {
+          id: newId(),
+          userId,
+          roleId: finalRoleId,
+          scopeType: "inherit",
+          tenantId,
+          grantedById: null,
+          grantedAt: now,
+        },
+      }),
+    ])
+    return
+  }
+
+  // No role resolved — only seed the default role if the user has none yet,
+  // so a manually-assigned role is never duplicated or overridden on login.
+  const hasAnyRole = await db.rbacUserRole.findFirst({
+    where: { userId, tenantId },
+    select: { id: true },
+  })
+  if (!hasAnyRole) {
+    await db.rbacUserRole.create({
+      data: {
+        id: newId(),
+        userId,
+        roleId: defaultRoleId,
+        scopeType: "inherit",
+        tenantId,
+        grantedById: null,
+        grantedAt: now,
+      },
+    })
+  }
+}


### PR DESCRIPTION
## Summary

OIDC applied the group-to-role mapping only at account creation. On later logins of an existing account the groups were not re-evaluated, so a change to a user's IdP groups, or to the mapping itself, was never picked up. LDAP, by contrast, re-syncs the role on every login. The most important consequence: removing a user from a privileged group in the IdP did not revoke the role in ProxCenter.

This aligns OIDC with LDAP: the RBAC assignment is re-synced from the current IdP groups on every OIDC login.

Reported on #383 (follow-up to the role-level scope feature, #386).

## Changes

- New `lib/auth/roleSync.ts`: provider-agnostic `syncProviderRoleAssignment`, the existing LDAP sync core extracted and parameterized by the provider id prefix (`ldap_` / `oidc_`).
- `lib/auth/ldap.ts`: `syncLdapRoleAssignment` is now a thin wrapper over the shared core. LDAP behaviour is unchanged.
- `lib/auth/oidc.ts`: adds `oidcRoleId` (normalizes a resolved role to a `role_` id) and `syncOidcRoleAssignment`.
- `lib/auth/config.ts`: the OIDC `signIn` callback re-syncs the assignment from the current groups on every login (new and existing users), replacing the create-once-at-provisioning logic.

## Behaviour

- Moving a user between mapped groups takes effect at their next sign-in, in both directions. Because `resolveOidcRole` resolves to the default role when no group matches, leaving every mapped group demotes the user to the default role.
- Only the `oidc_`-prefixed assignment is touched. Manual assignments are preserved and RBAC is additive, so a manual elevation always survives a re-sync and there is no lockout risk.
- The legacy `users.role` column is left as-is on re-login (mirrors LDAP). The permission engine and the RBAC users page read `rbac_user_roles`, not that column.
- The role's default scope is already live for inheriting users (shipped in #386); this PR closes the remaining gap on the group-to-role binding.

## Tests

- New `oidc-rbac-sync.test.ts`: mapped-role replacement, demotion to the default role on no match, the `role_viewer` existence fallback, and that only `oidc_` rows are deleted/replaced.
- Existing `ldap-rbac-sync.test.ts` stays green via the wrapper. Full `lib/auth` suite: 119 passing. Typecheck clean on the changed files.

## Verification note

This runs on the OIDC login path and was not exercised against a live IdP (no test IdP available). The core is the proven LDAP sync code and the new path is unit-tested, but the end-to-end SSO flow should be validated against a real IdP before this rides a release.
