### PR TITLE
test: coverage backfill batch 1 (high-risk mutating routes)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<any>>(),
+  buildVmResourceId: vi.fn<(...args: any[]) => string>(
+    (connId, node, type, vmid) => `${connId}:${node}:${type}:${vmid}`
+  ),
+  PERMISSIONS: {
+    VM_DELETE: 'vm.delete',
+  },
+}))
+
+vi.mock('@/lib/vdc/ipam', () => ({
+  releaseAllocationsForVm: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/audit', () => ({
+  audit: vi.fn<(...args: any[]) => Promise<void>>(),
+}))
+
+import { DELETE } from './route'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { checkPermission } from '@/lib/rbac'
+import { releaseAllocationsForVm } from '@/lib/vdc/ipam'
+import { audit } from '@/lib/audit'
+
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const checkPermissionMock = checkPermission as any
+const releaseAllocationsForVmMock = releaseAllocationsForVm as any
+const auditMock = audit as any
+
+const CONN_ID = 'conn-1'
+const NODE = 'pve-node-01'
+const VMID = '101'
+
+const baseParams = { id: CONN_ID, type: 'qemu', node: NODE, vmid: VMID }
+
+function makeReq(url = `http://test.local/_`) {
+  return new Request(url)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: CONN_ID })
+  pveFetchMock.mockResolvedValue({ status: 'stopped' })
+  releaseAllocationsForVmMock.mockResolvedValue(undefined)
+  auditMock.mockResolvedValue(undefined)
+})
+
+describe('DELETE /api/v1/connections/[id]/guests/[type]/[node]/[vmid]', () => {
+  it('400 when type is not qemu or lxc', async () => {
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve({ ...baseParams, type: 'template' }),
+    })
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/Invalid type/)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('403 when RBAC denies delete permission', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('409 when VM is locked', async () => {
+    pveFetchMock.mockResolvedValueOnce({ status: 'stopped', lock: 'snapshot' })
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(409)
+    const body = await readJson<any>(res)
+    expect(body.code).toBe('vm_locked')
+    expect(body.lock).toBe('snapshot')
+  })
+
+  it('400 when VM is running', async () => {
+    pveFetchMock.mockResolvedValueOnce({ status: 'running' })
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.code).toBe('vm_running')
+  })
+
+  it('200 happy path: qemu VM deleted, IPAM released, audit called', async () => {
+    pveFetchMock
+      .mockResolvedValueOnce({ status: 'stopped' }) // status check
+      .mockResolvedValueOnce('UPID:delete:task') // DELETE
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    // Status check call
+    expect(pveFetchMock).toHaveBeenNthCalledWith(
+      1,
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}/status/current`,
+      { method: 'GET' }
+    )
+    // Delete call (no purge/destroy flags)
+    expect(pveFetchMock).toHaveBeenNthCalledWith(
+      2,
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}`,
+      { method: 'DELETE' }
+    )
+
+    expect(releaseAllocationsForVmMock).toHaveBeenCalledWith(CONN_ID, 101)
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'delete', resourceId: VMID })
+    )
+  })
+
+  it('200 happy path: qemu VM deleted with purge and destroy-unreferenced-disks flags', async () => {
+    pveFetchMock
+      .mockResolvedValueOnce({ status: 'stopped' })
+      .mockResolvedValueOnce('UPID:delete:task')
+    const url = `http://test.local/_?purge=1&destroy-unreferenced-disks=1`
+    const res = await DELETE(makeReq(url), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    expect(pveFetchMock).toHaveBeenNthCalledWith(
+      2,
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}?purge=1&destroy-unreferenced-disks=1`,
+      { method: 'DELETE' }
+    )
+  })
+
+  it('200 happy path: lxc container deleted, IPAM NOT released', async () => {
+    pveFetchMock
+      .mockResolvedValueOnce({ status: 'stopped' })
+      .mockResolvedValueOnce('UPID:delete:lxc')
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve({ ...baseParams, type: 'lxc' }),
+    })
+    expect(res.status).toBe(200)
+    expect(releaseAllocationsForVmMock).not.toHaveBeenCalled()
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'containers', resourceType: 'lxc' })
+    )
+  })
+
+  it('500 when pveFetch throws on DELETE', async () => {
+    pveFetchMock
+      .mockResolvedValueOnce({ status: 'stopped' })
+      .mockRejectedValueOnce(new Error('PVE 500'))
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('PVE 500')
+  })
+
+  it('IPAM release failure is swallowed (does not affect 200 response)', async () => {
+    pveFetchMock
+      .mockResolvedValueOnce({ status: 'stopped' })
+      .mockResolvedValueOnce('UPID:delete:task')
+    releaseAllocationsForVmMock.mockRejectedValue(new Error('IPAM down'))
+    const res = await DELETE(makeReq(), {
+      params: Promise.resolve(baseParams),
+    })
+    // Handler catches IPAM errors internally and returns 200 anyway
+    expect(res.status).toBe(200)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<any>>(),
+  buildNodeResourceId: vi.fn<(connId: string, node: string) => string>(
+    (connId, node) => `${connId}:${node}`
+  ),
+  PERMISSIONS: {
+    NODE_VIEW: 'node.view',
+    NODE_MANAGE: 'node.manage',
+  },
+}))
+
+vi.mock('@/lib/ssh/exec', () => ({
+  executeSSH: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: vi.fn<(...args: any[]) => Promise<string>>(),
+}))
+
+import { GET, POST, DELETE } from './route'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { checkPermission } from '@/lib/rbac'
+import { executeSSH } from '@/lib/ssh/exec'
+import { getNodeIp } from '@/lib/ssh/node-ip'
+
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const checkPermissionMock = checkPermission as any
+const executeSSHMock = executeSSH as any
+const getNodeIpMock = getNodeIp as any
+
+const CONN_ID = 'conn-1'
+const NODE = 'pve-node-01'
+const NODE_IP = '10.0.0.1'
+
+const baseParams = { id: CONN_ID, node: NODE }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: CONN_ID })
+  pveFetchMock.mockResolvedValue([])
+  getNodeIpMock.mockResolvedValue(NODE_IP)
+  executeSSHMock.mockResolvedValue({ success: true, output: '' })
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+describe('GET /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
+  it('returns maintenance=null when node is not in maintenance', async () => {
+    pveFetchMock.mockResolvedValue([{ node: NODE, hastate: 'started' }])
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.maintenance).toBeNull()
+  })
+
+  it('returns maintenance="maintenance" when hastate is maintenance', async () => {
+    pveFetchMock.mockResolvedValue([{ node: NODE, hastate: 'maintenance' }])
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.maintenance).toBe('maintenance')
+  })
+
+  it('returns maintenance=null when node is not in the resource list', async () => {
+    pveFetchMock.mockResolvedValue([{ node: 'other-node', hastate: 'maintenance' }])
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.maintenance).toBeNull()
+  })
+
+  it('returns maintenance=null when pveFetch rejects (swallowed via .catch)', async () => {
+    pveFetchMock.mockRejectedValue(new Error('cluster unreachable'))
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.maintenance).toBeNull()
+  })
+
+  it('403 when RBAC denies node.view', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('500 when getConnectionById throws', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(500)
+  })
+
+  it('calls pveFetch with correct cluster resources path', async () => {
+    pveFetchMock.mockResolvedValue([])
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      { id: CONN_ID },
+      '/cluster/resources?type=node'
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST (enter maintenance)
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
+  it('403 when RBAC denies node.manage', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockResolvedValue(null)
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('200 happy path: executes enable SSH command and returns output', async () => {
+    executeSSHMock.mockResolvedValue({ success: true, output: 'ok' })
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.method).toBe('ssh')
+    expect(body.output).toBe('ok')
+
+    expect(getNodeIpMock).toHaveBeenCalledWith({ id: CONN_ID }, NODE)
+    expect(executeSSHMock).toHaveBeenCalledWith(
+      CONN_ID,
+      NODE_IP,
+      `ha-manager crm-command node-maintenance enable ${NODE}`
+    )
+  })
+
+  it('500 when SSH command fails (success=false)', async () => {
+    executeSSHMock.mockResolvedValue({ success: false, error: 'permission denied' })
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('permission denied')
+    expect(body.hint).toContain('ha-manager crm-command node-maintenance enable')
+  })
+
+  it('500 when executeSSH throws', async () => {
+    executeSSHMock.mockRejectedValue(new Error('SSH connection refused'))
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('SSH connection refused')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE (exit maintenance)
+// ---------------------------------------------------------------------------
+describe('DELETE /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
+  it('403 when RBAC denies node.manage', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockResolvedValue(null)
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('200 happy path: executes disable SSH command and returns output', async () => {
+    executeSSHMock.mockResolvedValue({ success: true, output: 'done' })
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.method).toBe('ssh')
+
+    expect(executeSSHMock).toHaveBeenCalledWith(
+      CONN_ID,
+      NODE_IP,
+      `ha-manager crm-command node-maintenance disable ${NODE}`
+    )
+  })
+
+  it('500 when SSH command fails (success=false)', async () => {
+    executeSSHMock.mockResolvedValue({ success: false, error: 'not in maintenance' })
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('not in maintenance')
+    expect(body.hint).toContain('ha-manager crm-command node-maintenance disable')
+  })
+
+  it('500 when executeSSH throws', async () => {
+    executeSSHMock.mockRejectedValue(new Error('timeout'))
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('timeout')
+  })
+})

--- a/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ get: () => ({ value: 'en' }) }),
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<any>>(),
+  buildVmResourceId: vi.fn<(...args: any[]) => string>(
+    (connId, node, type, vmid) => `${connId}:${node}:${type}:${vmid}`
+  ),
+  PERMISSIONS: {
+    VM_VIEW: 'vm.view',
+    VM_SNAPSHOT: 'vm.snapshot',
+  },
+}))
+
+vi.mock('@/lib/i18n/date', () => ({
+  getDateLocale: vi.fn<(locale: string) => string>((l) => l),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: vi.fn<() => Promise<string>>(),
+}))
+
+vi.mock('@/lib/vdc/quota', () => ({
+  resolveVdcForTenant: vi.fn<(...args: any[]) => Promise<any>>(),
+  checkVdcQuota: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/audit', () => ({
+  audit: vi.fn<(...args: any[]) => Promise<void>>(),
+}))
+
+import { GET, POST, DELETE } from './route'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { checkPermission } from '@/lib/rbac'
+import { getCurrentTenantId } from '@/lib/tenant'
+import { resolveVdcForTenant, checkVdcQuota } from '@/lib/vdc/quota'
+import { audit } from '@/lib/audit'
+
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const checkPermissionMock = checkPermission as any
+const getCurrentTenantIdMock = getCurrentTenantId as any
+const resolveVdcForTenantMock = resolveVdcForTenant as any
+const checkVdcQuotaMock = checkVdcQuota as any
+const auditMock = audit as any
+
+const VM_KEY = 'conn-1:qemu:pve-node-01:101'
+const CONN_ID = 'conn-1'
+const NODE = 'pve-node-01'
+const VMID = '101'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: CONN_ID })
+  pveFetchMock.mockResolvedValue([])
+  getCurrentTenantIdMock.mockResolvedValue('default')
+  resolveVdcForTenantMock.mockResolvedValue(null)
+  checkVdcQuotaMock.mockResolvedValue({ allowed: true })
+  auditMock.mockResolvedValue(undefined)
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+describe('GET /api/v1/guests/[vmid]/snapshots', () => {
+  it('returns empty list when pveFetch returns []', async () => {
+    pveFetchMock.mockResolvedValue([])
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.snapshots).toEqual([])
+    expect(body.data.count).toBe(0)
+  })
+
+  it('filters out "current" pseudo-snapshot and sorts by snaptime desc', async () => {
+    pveFetchMock.mockResolvedValue([
+      { name: 'current', snaptime: 9999 },
+      { name: 'snap-a', snaptime: 100, description: 'first', vmstate: false },
+      { name: 'snap-b', snaptime: 200, description: 'second', vmstate: true },
+    ])
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.count).toBe(2)
+    expect(body.data.snapshots[0].name).toBe('snap-b')
+    expect(body.data.snapshots[1].name).toBe('snap-a')
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    // getConnection wrapper catches and returns null -> 404
+    expect(res.status).toBe(404)
+  })
+
+  it('403 when RBAC denies vm.view', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('500 on malformed vmKey', async () => {
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: 'bad' }),
+    })
+    expect(res.status).toBe(500)
+  })
+
+  it('calls pveFetch with correct snapshot path', async () => {
+    pveFetchMock.mockResolvedValue([])
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}/snapshot`
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/guests/[vmid]/snapshots', () => {
+  it('400 when name is missing', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { description: 'no name here' },
+    })
+    expect(res.status).toBe(400)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('400 when name contains invalid characters', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'bad name!' },
+    })
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/Invalid snapshot name/)
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1' },
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('403 when RBAC denies vm.snapshot', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('409 when vDC quota exceeded', async () => {
+    resolveVdcForTenantMock.mockResolvedValue({ poolName: 'pool1', quota: { maxSnapshots: 1 } })
+    checkVdcQuotaMock.mockResolvedValue({ allowed: false, violations: ['maxSnapshots'] })
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1' },
+    })
+    expect(res.status).toBe(409)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Quota exceeded')
+  })
+
+  it('403 when vDC quota check throws NODE_NOT_AUTHORIZED', async () => {
+    resolveVdcForTenantMock.mockRejectedValue(Object.assign(new Error('NODE_NOT_AUTHORIZED'), { message: 'NODE_NOT_AUTHORIZED' }))
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('200 happy path: creates snapshot with name + description, calls audit', async () => {
+    pveFetchMock.mockResolvedValue('UPID:snap:task')
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1', description: 'my snap', vmstate: true },
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.success).toBe(true)
+    expect(body.data.upid).toBe('UPID:snap:task')
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}/snapshot`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      })
+    )
+    const callArgs = pveFetchMock.mock.calls[0]
+    expect(callArgs[2].body).toContain('snapname=snap1')
+    expect(callArgs[2].body).toContain('description=my+snap')
+    expect(callArgs[2].body).toContain('vmstate=1')
+
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'snapshot', resourceId: VMID })
+    )
+  })
+
+  it('200: lxc snapshot does not include vmstate in body', async () => {
+    pveFetchMock.mockResolvedValue('UPID:snap:lxc')
+    const lxcKey = 'conn-1:lxc:pve-node-01:201'
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: lxcKey },
+      body: { name: 'snap1', vmstate: true },
+    })
+    expect(res.status).toBe(200)
+    const callArgs = pveFetchMock.mock.calls[0]
+    expect(callArgs[2].body).not.toContain('vmstate')
+  })
+
+  it('500 when pveFetch throws', async () => {
+    pveFetchMock.mockRejectedValue(new Error('PVE error'))
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { vmid: VM_KEY },
+      body: { name: 'snap1' },
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('PVE error')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+describe('DELETE /api/v1/guests/[vmid]/snapshots', () => {
+  it('400 when ?name query param is missing', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { vmid: VM_KEY },
+      url: 'http://test.local/_',
+    })
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/Snapshot name is required/)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('403 when RBAC denies vm.snapshot', async () => {
+    const denied = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { vmid: VM_KEY },
+      searchParams: { name: 'snap1' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { vmid: VM_KEY },
+      searchParams: { name: 'snap1' },
+    })
+    expect(res.status).toBe(404)
+  })
+
+  it('200 happy path: deletes named snapshot and calls audit', async () => {
+    pveFetchMock.mockResolvedValue('UPID:delete-snap:task')
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { vmid: VM_KEY },
+      searchParams: { name: 'snap1' },
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.success).toBe(true)
+    expect(body.data.upid).toBe('UPID:delete-snap:task')
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      { id: CONN_ID },
+      `/nodes/${NODE}/qemu/${VMID}/snapshot/snap1`,
+      { method: 'DELETE' }
+    )
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'delete', resourceId: VMID })
+    )
+  })
+
+  it('500 when pveFetch throws on delete', async () => {
+    pveFetchMock.mockRejectedValue(new Error('PVE 500'))
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { vmid: VM_KEY },
+      searchParams: { name: 'snap1' },
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('PVE 500')
+  })
+})


### PR DESCRIPTION
## What

Phase 0 coverage backfill, batch 1: node-env tests for the three highest-risk **mutating / destructive** API route handlers. Tests only, no production code changed.

### Covered (45 tests)
- **Guest VM delete** (`connections/[id]/guests/[type]/[node]/[vmid]` DELETE, 9 tests): RBAC, locked/running guards, qemu vs lxc, purge + destroy-unreferenced-disks query params, IPAM release, audit.
- **Guest snapshots** (`guests/[vmid]/snapshots` POST/DELETE, 19 tests): name validation, quota, node-authorization, qemu vs lxc vmstate, create/delete proxy calls.
- **Node maintenance** (`connections/[id]/nodes/[node]/maintenance` POST/DELETE, 17 tests): all maintenance-state branches, SSH enable/disable commands, success=false hints.

Assertions check HTTP status + response body + exact outgoing PVE/SSH call, not just that a mock was called. Each file mocks only its own handler's imports.

### Verification
- Full node suite green (1540 + 45 new).
- No production source changed.

### Known follow-ups (observed, documented in tests, NOT fixed here)
These route handlers swallow failures into success/empty responses; the tests document the observed behavior. Candidates for a single consolidated tracking issue:
- VM delete: IPAM release failure swallowed, still returns 200.
- Maintenance GET: cluster fetch `.catch(() => [])` makes an unreachable cluster look like `maintenance=null` rather than an error.
- Snapshots: the `getConnection` soft-404 wrapper masks DB/infra errors as a 404.
- Maintenance POST/DELETE: a dead `if (!conn)` guard (getConnectionById throws before it can be reached).

Continuation of the coverage initiative merged in #444.
