### PR TITLE
test: coverage backfill batch 2 (storage/PBS/HA mutating routes)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/ha/[sid]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ha/[sid]/route.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    NODE_VIEW: 'node.view',
+    NODE_MANAGE: 'node.manage',
+  },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  requireProviderTenant: vi.fn<() => Promise<Response | null>>(),
+}))
+
+import { GET, POST, DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { requireProviderTenant } from '@/lib/tenant'
+
+const checkPermissionMock = checkPermission as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const requireProviderTenantMock = requireProviderTenant as any
+
+const CONN = { id: 'conn-1' }
+const HA_PARAMS = { id: 'conn-1', sid: 'vm:100' }
+
+const HA_RESOURCE = {
+  sid: 'vm:100',
+  state: 'started',
+  group: 'ha-group-1',
+  max_restart: 1,
+  max_relocate: 1,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue(CONN)
+  pveFetchMock.mockResolvedValue(HA_RESOURCE)
+  requireProviderTenantMock.mockResolvedValue(null)
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/connections/[id]/ha/[sid]', () => {
+  it('returns 200 with the HA resource data', async () => {
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toMatchObject({ sid: 'vm:100', state: 'started' })
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/cluster/ha/resources/vm%3A100',
+    )
+  })
+
+  it('403 when NODE_VIEW is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns { data: null } when pveFetch throws a 404-like error', async () => {
+    pveFetchMock.mockRejectedValue(new Error('404 not found'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toBeNull()
+  })
+
+  it('returns { data: null } when error contains "does not exist"', async () => {
+    pveFetchMock.mockRejectedValue(new Error('resource does not exist'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toBeNull()
+  })
+
+  it('returns { data: null } when error contains "no such resource"', async () => {
+    pveFetchMock.mockRejectedValue(new Error('no such resource vm:100'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toBeNull()
+  })
+
+  it('500 on unexpected pveFetch error', async () => {
+    pveFetchMock.mockRejectedValue(new Error('network timeout'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(HA_PARAMS),
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('network timeout')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST (create or update)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/connections/[id]/ha/[sid]', () => {
+  it('creates a new HA resource (POST to /cluster/ha/resources) when resource does not exist', async () => {
+    // First pveFetch (existence check) throws, second pveFetch (create) succeeds
+    pveFetchMock
+      .mockRejectedValueOnce(new Error('does not exist'))
+      .mockResolvedValueOnce(null)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { group: 'ha-group-1', state: 'started', max_restart: 2 },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.message).toBe('HA configuration created')
+
+    // Second call is the CREATE POST — must include sid in body
+    const [, path, opts] = pveFetchMock.mock.calls[1]
+    expect(path).toBe('/cluster/ha/resources')
+    expect(opts.method).toBe('POST')
+    expect(opts.body).toContain('sid=vm%3A100')
+    expect(opts.body).toContain('group=ha-group-1')
+    expect(opts.body).toContain('state=started')
+    expect(opts.body).toContain('max_restart=2')
+  })
+
+  it('updates an existing HA resource (PUT to /cluster/ha/resources/{sid}) when resource exists', async () => {
+    // First pveFetch (existence check) resolves — resource exists
+    pveFetchMock
+      .mockResolvedValueOnce(HA_RESOURCE)
+      .mockResolvedValueOnce(null)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { state: 'stopped', max_relocate: 3 },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.message).toBe('HA configuration updated')
+
+    const [, path, opts] = pveFetchMock.mock.calls[1]
+    expect(path).toBe('/cluster/ha/resources/vm%3A100')
+    expect(opts.method).toBe('PUT')
+    // sid must NOT be in body for updates
+    expect(opts.body).not.toContain('sid=')
+    expect(opts.body).toContain('state=stopped')
+    expect(opts.body).toContain('max_relocate=3')
+  })
+
+  it('includes failback param in POST body when provided', async () => {
+    pveFetchMock
+      .mockRejectedValueOnce(new Error('does not exist'))
+      .mockResolvedValueOnce(null)
+
+    await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { failback: true },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[1]
+    expect(opts.body).toContain('failback=1')
+  })
+
+  it('includes failback=0 when failback is false', async () => {
+    pveFetchMock
+      .mockRejectedValueOnce(new Error('does not exist'))
+      .mockResolvedValueOnce(null)
+
+    await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { failback: false },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[1]
+    expect(opts.body).toContain('failback=0')
+  })
+
+  it('403 when NODE_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: {},
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns requireProviderTenant response when caller is not provider', async () => {
+    const tenantBlocked = new Response(JSON.stringify({ error: 'provider only' }), { status: 403 })
+    requireProviderTenantMock.mockResolvedValue(tenantBlocked)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { state: 'started' },
+    })
+
+    expect(res.status).toBe(403)
+    // No pveFetch calls at all (getConnectionById not even reached)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw during create/update', async () => {
+    pveFetchMock
+      .mockRejectedValueOnce(new Error('no such resource'))
+      .mockRejectedValueOnce(new Error('PVE cluster unreachable'))
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: HA_PARAMS,
+      body: { state: 'started' },
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('PVE cluster unreachable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/connections/[id]/ha/[sid]', () => {
+  it('returns 200 and calls pveFetch DELETE on the HA resource', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: HA_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.message).toBe('HA configuration removed')
+    expect(body.data).toBeNull()
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/cluster/ha/resources/vm%3A100',
+      { method: 'DELETE' },
+    )
+  })
+
+  it('403 when NODE_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: HA_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns requireProviderTenant response when caller is not provider', async () => {
+    const tenantBlocked = new Response(JSON.stringify({ error: 'provider only' }), { status: 403 })
+    requireProviderTenantMock.mockResolvedValue(tenantBlocked)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: HA_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('encodes special characters in sid for the DELETE path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'conn-1', sid: 'ct:200' },
+    })
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/cluster/ha/resources/ct%3A200',
+      { method: 'DELETE' },
+    )
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('HA manager offline'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: HA_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('HA manager offline')
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/[volid]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/[volid]/route.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    CONNECTION_VIEW: 'connection.view',
+  },
+}))
+
+vi.mock('@/lib/vdc/scope', () => ({
+  guardTenantStorageWrite: vi.fn<(connId: string, storage: string) => Promise<Response | null>>(),
+  getTenantInfrastructureScope: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/tenant/infraScope', () => ({
+  getTenantInfrastructureScope: vi.fn<(tenantId: string) => Promise<any>>(),
+  maskingScope: vi.fn<(infra: any) => any>(),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: vi.fn<() => Promise<string>>(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    tenant: {
+      findUnique: vi.fn<(args: any) => Promise<any>>(),
+    },
+  },
+}))
+
+vi.mock('@/lib/audit', () => ({
+  audit: vi.fn<(...args: any[]) => Promise<void>>(),
+}))
+
+import { DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { guardTenantStorageWrite } from '@/lib/vdc/scope'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { maskingScope, getTenantInfrastructureScope } from '@/lib/tenant/infraScope'
+import { getCurrentTenantId } from '@/lib/tenant'
+import { prisma } from '@/lib/db/prisma'
+import { audit } from '@/lib/audit'
+
+const checkPermissionMock = checkPermission as any
+const guardTenantStorageWriteMock = guardTenantStorageWrite as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const maskingScopeMock = maskingScope as any
+const getTenantInfrastructureScopeMock = getTenantInfrastructureScope as any
+const getCurrentTenantIdMock = getCurrentTenantId as any
+const tenantFindUniqueMock = prisma.tenant.findUnique as any
+const auditMock = audit as any
+
+const BASE_PARAMS = {
+  id: 'conn-1',
+  node: 'pve-node-01',
+  storage: 'local',
+  volid: 'local%3Aiso%2Fubuntu-22.04.iso',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  guardTenantStorageWriteMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: 'conn-1' })
+  pveFetchMock.mockResolvedValue(null)
+  maskingScopeMock.mockReturnValue(null) // provider: no tenant restriction
+  getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'provider' })
+  getCurrentTenantIdMock.mockResolvedValue('provider-tenant')
+  tenantFindUniqueMock.mockResolvedValue(null)
+  auditMock.mockResolvedValue(undefined)
+})
+
+describe('DELETE /api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/[volid]', () => {
+  it('returns 200 and calls pveFetch with the decoded volid path', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    // volid is decoded from "local%3Aiso%2Fubuntu-22.04.iso" to "local:iso/ubuntu-22.04.iso"
+    // then re-encoded for the URL segment
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      { id: 'conn-1' },
+      expect.stringContaining('/nodes/pve-node-01/storage/local/content/'),
+      { method: 'DELETE' },
+    )
+  })
+
+  it('403 when checkPermission denies', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('403 when guardTenantStorageWrite blocks', async () => {
+    const blocked = new Response(JSON.stringify({ error: 'Storage not accessible' }), { status: 403 })
+    guardTenantStorageWriteMock.mockResolvedValue(blocked)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('403 when tenant tries to delete an ISO not prefixed with their slug', async () => {
+    maskingScopeMock.mockReturnValue({ something: 'non-null' }) // non-null scope = tenant
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'iaas', vdcScope: {} })
+    getCurrentTenantIdMock.mockResolvedValue('tenant-abc')
+    tenantFindUniqueMock.mockResolvedValue({ slug: 'acme' })
+
+    // volid: "local:iso/ubuntu-22.04.iso" — no custom-acme- prefix
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: {
+        ...BASE_PARAMS,
+        volid: encodeURIComponent('local:iso/ubuntu-22.04.iso'),
+      },
+    })
+
+    expect(res.status).toBe(403)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Volume not accessible')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('200 when tenant deletes an ISO with matching slug prefix', async () => {
+    maskingScopeMock.mockReturnValue({ something: 'non-null' })
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'iaas', vdcScope: {} })
+    getCurrentTenantIdMock.mockResolvedValue('tenant-abc')
+    tenantFindUniqueMock.mockResolvedValue({ slug: 'acme' })
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: {
+        ...BASE_PARAMS,
+        volid: encodeURIComponent('local:iso/custom-acme-my.iso'),
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(pveFetchMock).toHaveBeenCalled()
+  })
+
+  it('200 when tenant deletes a non-controlled content type (backup), no slug check', async () => {
+    maskingScopeMock.mockReturnValue({ something: 'non-null' })
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'iaas', vdcScope: {} })
+    getCurrentTenantIdMock.mockResolvedValue('tenant-abc')
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: {
+        ...BASE_PARAMS,
+        storage: 'backups',
+        volid: encodeURIComponent('backups:backup/vzdump-qemu-100-2024_01_01-00_00_00.vma.zst'),
+      },
+    })
+
+    expect(res.status).toBe(200)
+    expect(pveFetchMock).toHaveBeenCalled()
+    // slug check never needed for 'backup' content type
+    expect(tenantFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to tenantId as slug when tenant row not found', async () => {
+    maskingScopeMock.mockReturnValue({ something: 'non-null' })
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'iaas', vdcScope: {} })
+    getCurrentTenantIdMock.mockResolvedValue('acme123')
+    tenantFindUniqueMock.mockResolvedValue(null) // no slug row
+
+    // filename with matching slug derived from tenantId
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: {
+        ...BASE_PARAMS,
+        volid: encodeURIComponent('local:iso/custom-acme123-test.iso'),
+      },
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('calls audit after successful delete', async () => {
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'delete',
+        category: 'storage',
+        resourceType: 'storage',
+        resourceId: 'local',
+        details: expect.objectContaining({ node: 'pve-node-01', connectionId: 'conn-1' }),
+      }),
+    )
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('PVE unreachable'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('PVE unreachable')
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/[volid]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/[volid]/route.test.ts
@@ -11,7 +11,6 @@ vi.mock('@/lib/rbac', () => ({
 
 vi.mock('@/lib/vdc/scope', () => ({
   guardTenantStorageWrite: vi.fn<(connId: string, storage: string) => Promise<Response | null>>(),
-  getTenantInfrastructureScope: vi.fn<(...args: any[]) => Promise<any>>(),
 }))
 
 vi.mock('@/lib/connections/getConnection', () => ({
@@ -98,7 +97,7 @@ describe('DELETE /api/v1/connections/[id]/nodes/[node]/storage/[storage]/content
     // then re-encoded for the URL segment
     expect(pveFetchMock).toHaveBeenCalledWith(
       { id: 'conn-1' },
-      expect.stringContaining('/nodes/pve-node-01/storage/local/content/'),
+      '/nodes/pve-node-01/storage/local/content/local%3Aiso%2Fubuntu-22.04.iso',
       { method: 'DELETE' },
     )
   })

--- a/frontend/src/app/api/v1/pbs/[id]/backups/[backupId]/route.test.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/backups/[backupId]/route.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    BACKUP_VIEW: 'backup.view',
+  },
+}))
+
+vi.mock('@/lib/vdc/scope', () => ({
+  assertVdcPbsAccess: vi.fn<(connId: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getPbsConnectionById: vi.fn<(id: string) => Promise<any>>(),
+  getPbsConnectionByIdUnscoped: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/pbs-client', () => ({
+  pbsFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/cache/pbsBackupCache', () => ({
+  invalidatePbsBackupCache: vi.fn<(id?: string) => void>(),
+}))
+
+import { DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { assertVdcPbsAccess } from '@/lib/vdc/scope'
+import { getPbsConnectionById, getPbsConnectionByIdUnscoped } from '@/lib/connections/getConnection'
+import { pbsFetch } from '@/lib/proxmox/pbs-client'
+import { invalidatePbsBackupCache } from '@/lib/cache/pbsBackupCache'
+
+const checkPermissionMock = checkPermission as any
+const assertVdcPbsAccessMock = assertVdcPbsAccess as any
+const getPbsConnectionByIdMock = getPbsConnectionById as any
+const getPbsConnectionByIdUnscopedMock = getPbsConnectionByIdUnscoped as any
+const pbsFetchMock = pbsFetch as any
+const invalidatePbsBackupCacheMock = invalidatePbsBackupCache as any
+
+const CONN = { id: 'pbs-1', baseUrl: 'https://pbs.local:8007', apiToken: 'PBS!tok=secret' }
+
+// backupId encodes: datastore/backupType/vmid/timestamp
+// e.g. "mystore/vm/100/1700000000"
+const BACKUP_ID = encodeURIComponent('mystore/vm/100/1700000000')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  assertVdcPbsAccessMock.mockResolvedValue({ kind: 'admin' })
+  getPbsConnectionByIdMock.mockResolvedValue(CONN)
+  getPbsConnectionByIdUnscopedMock.mockResolvedValue(CONN)
+  pbsFetchMock.mockResolvedValue(null)
+  invalidatePbsBackupCacheMock.mockReturnValue(undefined)
+})
+
+describe('DELETE /api/v1/pbs/[id]/backups/[backupId]', () => {
+  it('returns 200 and calls pbsFetch with correct snapshot path', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    expect(pbsFetchMock).toHaveBeenCalledWith(
+      CONN,
+      expect.stringMatching(/\/admin\/datastore\/mystore\/snapshots/),
+      { method: 'DELETE' },
+    )
+    // query string must include the parsed fields
+    const url: string = pbsFetchMock.mock.calls[0][1]
+    expect(url).toContain('backup-type=vm')
+    expect(url).toContain('backup-id=100')
+    expect(url).toContain('backup-time=1700000000')
+  })
+
+  it('uses getPbsConnectionById (scoped) when access.kind === admin', async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({ kind: 'admin' })
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(getPbsConnectionByIdMock).toHaveBeenCalledWith('pbs-1')
+    expect(getPbsConnectionByIdUnscopedMock).not.toHaveBeenCalled()
+  })
+
+  it('uses getPbsConnectionByIdUnscoped when access.kind === tenant', async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({
+      kind: 'tenant',
+      allowed: [{ datastore: 'mystore', namespace: '' }],
+    })
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(getPbsConnectionByIdUnscopedMock).toHaveBeenCalledWith('pbs-1')
+    expect(getPbsConnectionByIdMock).not.toHaveBeenCalled()
+  })
+
+  it('invalidates the PBS backup cache on success', async () => {
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(invalidatePbsBackupCacheMock).toHaveBeenCalledWith('pbs-1')
+  })
+
+  it('400 when id param is missing', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('Missing params')
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('400 when backupId param is missing', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1' },
+    })
+
+    expect(res.status).toBe(400)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('400 when backupId has fewer than 4 path segments', async () => {
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: encodeURIComponent('mystore/vm/100') },
+    })
+
+    expect(res.status).toBe(400)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('Invalid backupId format')
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the RBAC denial when checkPermission denies', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(403)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the assertVdcPbsAccess denial when tenant has no access', async () => {
+    const blocked = new Response(JSON.stringify({ error: 'PBS not accessible' }), { status: 403 })
+    assertVdcPbsAccessMock.mockResolvedValue(blocked)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(403)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('403 when tenant access allowed list does not include the datastore/namespace', async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({
+      kind: 'tenant',
+      // allowed only for 'otherstore', not 'mystore'
+      allowed: [{ datastore: 'otherstore', namespace: '' }],
+    })
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(403)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('not accessible for this tenant')
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('200 when tenant access allowed list includes the datastore/namespace', async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({
+      kind: 'tenant',
+      allowed: [{ datastore: 'mystore', namespace: '' }],
+    })
+
+    // backupId with namespace in path: mystore/ns1/vm/100/1700000000
+    // ns = '' from query string would override, so test pure path-derived ns match
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('uses ns from query string over namespace derived from backupId path', async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({
+      kind: 'tenant',
+      allowed: [{ datastore: 'mystore', namespace: 'custom-ns' }],
+    })
+
+    // backupId has no namespace segments; ns comes from query string
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+      searchParams: { ns: 'custom-ns' },
+    })
+
+    expect(res.status).toBe(200)
+    const url: string = pbsFetchMock.mock.calls[0][1]
+    expect(url).toContain('ns=custom-ns')
+  })
+
+  it('500 on pbsFetch throw', async () => {
+    pbsFetchMock.mockRejectedValue(new Error('PBS connection refused'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'pbs-1', backupId: BACKUP_ID },
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('PBS connection refused')
+    // Cache must NOT be invalidated on error
+    expect(invalidatePbsBackupCacheMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

Phase 0 coverage backfill, batch 2: node-env tests for three more high-risk mutating route handlers (storage/PBS/HA). Tests only, no production code changed. Follows #444 / #447.

### Covered (40 tests)
- **Storage content delete** (`connections/[id]/nodes/[node]/storage/[storage]/content/[volid]` DELETE, 8): RBAC, tenant storage-write guard, tenant slug-prefix check on controlled content, slug fallback, audit, exact encoded PVE path.
- **PBS backup delete** (`pbs/[id]/backups/[backupId]` DELETE, 13): admin vs tenant connection getter, allowed datastore/namespace list, `ns` override, snapshot URL build, cache invalidation, not-invalidated-on-error.
- **HA resource** (`connections/[id]/ha/[sid]` GET/POST/DELETE, 19): sid encoding, create vs update branching (sid only on create, failback flag), provider-tenant guard, delete.

Assertions check status + body + exact outgoing PVE/PBS call. Each file mocks only its own handler's imports (PBS uses `pbsFetch`, not `pveFetch`).

### Verification
- Full node suite green (new tests included).
- No production source changed.

### Known follow-ups (added to the error-swallowing pattern, issue #448)
- HA GET classifies errors by string match (`includes('404')` / `'does not exist'` / `'no such resource'`) and returns `{data:null}`, so a real HTTP 500 carrying one of those phrases is swallowed as a null result.
- Storage delete imports `audit()` inside the try, so an audit failure surfaces as a 500 rather than a logged-only side effect.

Tests document the current behavior; fixes are tracked in #448.
