### PR TITLE
fix(ci): stop SonarCloud main analysis OOM (bridge server unresponsive)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -110,8 +110,14 @@ jobs:
           # Wait for the Quality Gate result so the workflow status reflects
           # pass/fail. With branch protection requiring this check, a failed
           # gate blocks the merge before the rating can degrade.
+          # node.maxspace gives the JS/TS analyzer's Node bridge a 4 GB heap.
+          # The default heap OOMs on the full main analysis (~182k LOC): every
+          # push to main was failing with "bridge server is unresponsive"
+          # (gRPC Goaway) since 2026-06-14, so the main coverage/rating never
+          # refreshed. PR analysis (changed files only) stayed under the limit.
           args: >
             -Dsonar.qualitygate.wait=true
+            -Dsonar.javascript.node.maxspace=4096
 
       - name: Coverage ratchet (main only)
         # The SonarCloud scan above already populated the branch measures.


### PR DESCRIPTION
## What

The post-merge SonarCloud analysis on `main` has failed on **every push since 2026-06-14** with `The bridge server is unresponsive ... it might be because you don't have enough memory` (the JS/TS analyzer's Node bridge OOMs, gRPC `Received Goaway`) on the full ~182k-LOC scan. PR analyses only scan changed files, stay under the limit, and kept passing, so the failure went unnoticed: the PR gate stayed green while `main`'s coverage and rating quietly stopped refreshing.

This adds `-Dsonar.javascript.node.maxspace=4096` to the scanner args, giving the Node bridge a 4 GB heap.

## Why it matters

- `main`'s overall coverage and AAA rating are frozen at the 2026-06-14 baseline; everything merged since (including the recent test-coverage backfill) is not reflected on the dashboard.
- The overall-coverage ratchet reads the `main` coverage measure, which cannot refresh while the analysis keeps failing.

## Verification

- Workflow YAML validated.
- The real confirmation is the next push-to-main run completing the SonarCloud scan; the `main` coverage measure should then recompute and pick up the merged tests.
