### PR TITLE
fix(ci): bump SonarCloud analyzer heap to 8 GB (main still OOMs at 4 GB)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -110,14 +110,16 @@ jobs:
           # Wait for the Quality Gate result so the workflow status reflects
           # pass/fail. With branch protection requiring this check, a failed
           # gate blocks the merge before the rating can degrade.
-          # node.maxspace gives the JS/TS analyzer's Node bridge a 4 GB heap.
-          # The default heap OOMs on the full main analysis (~182k LOC): every
-          # push to main was failing with "bridge server is unresponsive"
-          # (gRPC Goaway) since 2026-06-14, so the main coverage/rating never
-          # refreshed. PR analysis (changed files only) stayed under the limit.
+          # node.maxspace gives the JS/TS analyzer's Node bridge an 8 GB heap.
+          # The default heap AND 4 GB both OOM on the full main analysis (~182k
+          # LOC): the run logged "running out of memory (heap size limit 4288
+          # MB)" then "bridge server is unresponsive" (gRPC Goaway), failing
+          # every push to main since 2026-06-14 so the main coverage/rating
+          # never refreshed. The runner has ~16 GB, so 8 GB leaves room for the
+          # JVM scanner. PR analysis (changed files only) stayed under the limit.
           args: >
             -Dsonar.qualitygate.wait=true
-            -Dsonar.javascript.node.maxspace=4096
+            -Dsonar.javascript.node.maxspace=8192
 
       - name: Coverage ratchet (main only)
         # The SonarCloud scan above already populated the branch measures.


### PR DESCRIPTION
## What

Follow-up to #450. Raising the SonarCloud JS/TS analyzer Node-bridge heap from 4 GB to **8 GB** (`-Dsonar.javascript.node.maxspace=8192`).

#450 set 4 GB, but the next push-to-main run confirmed 4 GB is still not enough:

```
Configured Node.js --max-old-space-size=4096.
Memory configuration: OS (15993 MB), Node.js (4288 MB).
ERROR The analysis will stop due to the Node.js process running out of memory (heap size limit 4288 MB)
ERROR Try setting "sonar.javascript.node.maxspace" to a higher value
... The bridge server is unresponsive ...
```

The runner has ~16 GB, so 8 GB for the bridge leaves room for the JVM scanner.

## Why it matters

The post-merge `main` analysis is still failing, so `main`'s overall coverage and rating remain frozen at the 2026-06-14 baseline and the overall-coverage ratchet reads a stale measure. This should unblock both.

## Verification

- Workflow YAML validated.
- The real confirmation is the next push-to-main run completing the scan; if 8 GB still OOMs we either go higher or reduce analysis scope.
