### PR TITLE
build(coverage): raise ratchet floor to 11%

### DIFF
--- a/frontend/.coverage-floor.json
+++ b/frontend/.coverage-floor.json
@@ -1,4 +1,4 @@
 {
   "comment": "Overall SonarCloud line coverage must never drop below `floor`. Bump only in a dedicated reviewed commit when a milestone is reached (see spec section 8).",
-  "floor": 7.0
+  "floor": 11.0
 }


### PR DESCRIPTION
## What

Raise the overall-coverage ratchet floor from 7.0 to 11.0.

## Why

With the SonarCloud main analysis unblocked (#451), `main`'s overall coverage refreshed from 7.3% to **11.5%** after the Phase 0 backfill (#444/#447/#449). This locks that gain: the main build now fails if overall coverage drops below 11%. Per-PR coverage stays governed by the SonarCloud new-code gate. 0.5 point of headroom absorbs minor measurement jitter; the floor only ever moves up, in a dedicated reviewed commit per milestone.
