### PR TITLE
test: coverage backfill batch 3 (replication/HA-groups/network routes)

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/ha/groups/[groupId]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ha/groups/[groupId]/route.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    CONNECTION_VIEW: 'connection.view',
+    CONNECTION_MANAGE: 'connection.manage',
+  },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+import { GET, PUT, DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+
+const checkPermissionMock = checkPermission as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+
+const CONN = { id: 'conn-1' }
+const BASE_PARAMS = { id: 'conn-1', groupId: 'ha-grp-prod' }
+
+const HA_GROUP = {
+  group: 'ha-grp-prod',
+  nodes: 'pve1:2,pve2:1',
+  restricted: 0,
+  nofailback: 0,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue(CONN)
+  pveFetchMock.mockResolvedValue(HA_GROUP)
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/connections/[id]/ha/groups/[groupId]', () => {
+  it('200 returns group data', async () => {
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toMatchObject({ group: 'ha-grp-prod', nodes: 'pve1:2,pve2:1' })
+    expect(pveFetchMock).toHaveBeenCalledWith(CONN, '/cluster/ha/groups/ha-grp-prod')
+  })
+
+  it('encodes groupId with special characters in the pveFetch path', async () => {
+    pveFetchMock.mockResolvedValue({})
+
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ id: 'conn-1', groupId: 'grp/special:1' }),
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/cluster/ha/groups/grp%2Fspecial%3A1')
+  })
+
+  it('403 when CONNECTION_VIEW is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('404 when pveFetch throws a 404-containing error', async () => {
+    pveFetchMock.mockRejectedValue(new Error('404 not found'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Groupe HA non trouvé')
+  })
+
+  it('404 when pveFetch throws a "does not exist" error', async () => {
+    pveFetchMock.mockRejectedValue(new Error('group does not exist'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Groupe HA non trouvé')
+  })
+
+  it('500 on unexpected pveFetch error', async () => {
+    pveFetchMock.mockRejectedValue(new Error('cluster manager offline'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('cluster manager offline')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PUT
+// ---------------------------------------------------------------------------
+
+describe('PUT /api/v1/connections/[id]/ha/groups/[groupId]', () => {
+  it('200 happy path with nodes, restricted, nofailback and comment', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        nodes: 'pve1:2,pve2:1',
+        restricted: true,
+        nofailback: false,
+        comment: 'prod group',
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.message).toBe('Groupe HA mis à jour avec succès')
+
+    const [, path, opts] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/cluster/ha/groups/ha-grp-prod')
+    expect(opts.method).toBe('PUT')
+    expect(opts.headers).toEqual({ 'Content-Type': 'application/x-www-form-urlencoded' })
+    expect(opts.body).toContain('nodes=pve1%3A2%2Cpve2%3A1')
+    expect(opts.body).toContain('restricted=1')
+    expect(opts.body).toContain('nofailback=0')
+    expect(opts.body).toContain('comment=prod+group')
+  })
+
+  it('sends delete param when provided', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { delete: 'comment' },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    expect(opts.body).toContain('delete=comment')
+  })
+
+  it('omits optional fields when not present in request body', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { nodes: 'pve1:1' },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    expect(opts.body).toContain('nodes=pve1%3A1')
+    expect(opts.body).not.toContain('restricted')
+    expect(opts.body).not.toContain('nofailback')
+    expect(opts.body).not.toContain('comment')
+  })
+
+  it('encodes groupId in the PUT path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: { id: 'conn-1', groupId: 'grp:special' },
+      body: {},
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/cluster/ha/groups/grp%3Aspecial')
+  })
+
+  it('403 when CONNECTION_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {},
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('HA group locked'))
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { nodes: 'pve1:1' },
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('HA group locked')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/connections/[id]/ha/groups/[groupId]', () => {
+  it('200 happy path: calls pveFetch DELETE and returns success message', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.message).toBe('Groupe HA supprimé avec succès')
+    expect(body.data).toBeNull()
+
+    expect(pveFetchMock).toHaveBeenCalledWith(CONN, '/cluster/ha/groups/ha-grp-prod', {
+      method: 'DELETE',
+    })
+  })
+
+  it('encodes groupId in the DELETE path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'conn-1', groupId: 'grp:prod' },
+    })
+
+    expect(pveFetchMock).toHaveBeenCalledWith(CONN, '/cluster/ha/groups/grp%3Aprod', {
+      method: 'DELETE',
+    })
+  })
+
+  it('403 when CONNECTION_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('HA daemon unreachable'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('HA daemon unreachable')
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/ha/groups/[groupId]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ha/groups/[groupId]/route.test.ts
@@ -147,10 +147,7 @@ describe('PUT /api/v1/connections/[id]/ha/groups/[groupId]', () => {
     expect(path).toBe('/cluster/ha/groups/ha-grp-prod')
     expect(opts.method).toBe('PUT')
     expect(opts.headers).toEqual({ 'Content-Type': 'application/x-www-form-urlencoded' })
-    expect(opts.body).toContain('nodes=pve1%3A2%2Cpve2%3A1')
-    expect(opts.body).toContain('restricted=1')
-    expect(opts.body).toContain('nofailback=0')
-    expect(opts.body).toContain('comment=prod+group')
+    expect(opts.body).toBe('nodes=pve1%3A2%2Cpve2%3A1&restricted=1&nofailback=0&comment=prod+group')
   })
 
   it('sends delete param when provided', async () => {
@@ -163,7 +160,7 @@ describe('PUT /api/v1/connections/[id]/ha/groups/[groupId]', () => {
     })
 
     const [, , opts] = pveFetchMock.mock.calls[0]
-    expect(opts.body).toContain('delete=comment')
+    expect(opts.body).toBe('delete=comment')
   })
 
   it('omits optional fields when not present in request body', async () => {
@@ -176,7 +173,7 @@ describe('PUT /api/v1/connections/[id]/ha/groups/[groupId]', () => {
     })
 
     const [, , opts] = pveFetchMock.mock.calls[0]
-    expect(opts.body).toContain('nodes=pve1%3A1')
+    expect(opts.body).toBe('nodes=pve1%3A1')
     expect(opts.body).not.toContain('restricted')
     expect(opts.body).not.toContain('nofailback')
     expect(opts.body).not.toContain('comment')

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/network/[iface]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/network/[iface]/route.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  buildNodeResourceId: vi.fn<(connId: string, node: string) => string>(
+    (connId, node) => `${connId}:${node}`
+  ),
+  PERMISSIONS: {
+    NODE_NETWORK: 'node.network',
+  },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+import { GET, PUT, DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+
+const checkPermissionMock = checkPermission as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+
+const CONN = { id: 'conn-1' }
+const BASE_PARAMS = { id: 'conn-1', node: 'pve-node-01', iface: 'vmbr0' }
+
+const IFACE_DATA = {
+  iface: 'vmbr0',
+  type: 'bridge',
+  address: '192.168.1.10',
+  netmask: '255.255.255.0',
+  bridge_ports: 'eth0',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue(CONN)
+  pveFetchMock.mockResolvedValue(IFACE_DATA)
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/connections/[id]/nodes/[node]/network/[iface]', () => {
+  it('200 returns interface data', async () => {
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toMatchObject({ iface: 'vmbr0', type: 'bridge' })
+    expect(pveFetchMock).toHaveBeenCalledWith(CONN, '/nodes/pve-node-01/network/vmbr0')
+  })
+
+  it('encodes node and iface in the pveFetch path', async () => {
+    pveFetchMock.mockResolvedValue({})
+
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ id: 'conn-1', node: 'node/x', iface: 'bond:0' }),
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/nodes/node%2Fx/network/bond%3A0')
+  })
+
+  it('403 when NODE_NETWORK is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('network manager down'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('network manager down')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PUT
+// ---------------------------------------------------------------------------
+
+describe('PUT /api/v1/connections/[id]/nodes/[node]/network/[iface]', () => {
+  it('200 happy path: bridge type sends bridge_ports and bridge_vlan_aware', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'bridge',
+        address: '192.168.1.10',
+        netmask: '255.255.255.0',
+        gateway: '192.168.1.1',
+        bridge_ports: 'eth0',
+        bridge_vlan_aware: true,
+        autostart: true,
+        mtu: 1500,
+      },
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    const [, path, opts] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/nodes/pve-node-01/network/vmbr0')
+    const params: URLSearchParams = opts.body
+    expect(params.get('type')).toBe('bridge')
+    expect(params.get('address')).toBe('192.168.1.10')
+    expect(params.get('netmask')).toBe('255.255.255.0')
+    expect(params.get('gateway')).toBe('192.168.1.1')
+    expect(params.get('bridge_ports')).toBe('eth0')
+    expect(params.get('bridge_vlan_aware')).toBe('1')
+    expect(params.get('autostart')).toBe('1')
+    expect(params.get('mtu')).toBe('1500')
+  })
+
+  it('converts IPv4 CIDR address to cidr param and removes address+netmask', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'bridge',
+        address: '192.168.1.10/24',
+      },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('cidr')).toBe('192.168.1.10/24')
+    expect(params.get('address')).toBeNull()
+    expect(params.get('netmask')).toBeNull()
+  })
+
+  it('converts IPv6 CIDR address6 to cidr6 param and removes address6+netmask6', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'bridge',
+        address6: '2001:db8::1/64',
+      },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('cidr6')).toBe('2001:db8::1/64')
+    expect(params.get('address6')).toBeNull()
+    expect(params.get('netmask6')).toBeNull()
+  })
+
+  it('bond type sends bond_mode, bond-primary, bond_xmit_hash_policy and slaves', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'bond',
+        bond_mode: 'active-backup',
+        'bond-primary': 'eth0',
+        bond_xmit_hash_policy: 'layer2',
+        slaves: 'eth0 eth1',
+      },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('type')).toBe('bond')
+    expect(params.get('bond_mode')).toBe('active-backup')
+    expect(params.get('bond-primary')).toBe('eth0')
+    expect(params.get('bond_xmit_hash_policy')).toBe('layer2')
+    expect(params.get('slaves')).toBe('eth0 eth1')
+  })
+
+  it('vlan type sends vlan-id and vlan-raw-device', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'vlan',
+        'vlan-id': '100',
+        'vlan-raw-device': 'eth0',
+      },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('vlan-id')).toBe('100')
+    expect(params.get('vlan-raw-device')).toBe('eth0')
+  })
+
+  it('OVS type sends ovs_* fields', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: {
+        type: 'OVSBridge',
+        ovs_ports: 'eth0',
+        ovs_tag: '100',
+      },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('type')).toBe('OVSBridge')
+    expect(params.get('ovs_ports')).toBe('eth0')
+    expect(params.get('ovs_tag')).toBe('100')
+  })
+
+  it('autostart false sends autostart=0', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { type: 'bridge', autostart: false },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('autostart')).toBe('0')
+  })
+
+  it('skips fields with empty string values', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { type: 'bridge', gateway: '', mtu: '' },
+    })
+
+    const [, , opts] = pveFetchMock.mock.calls[0]
+    const params: URLSearchParams = opts.body
+    expect(params.get('gateway')).toBeNull()
+    expect(params.get('mtu')).toBeNull()
+  })
+
+  it('encodes node and iface in the PUT path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(PUT as any, {
+      method: 'PUT',
+      params: { id: 'conn-1', node: 'node/x', iface: 'eth:0' },
+      body: { type: 'eth' },
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/nodes/node%2Fx/network/eth%3A0')
+  })
+
+  it('403 when NODE_NETWORK is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { type: 'bridge' },
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('interface in use'))
+
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      params: BASE_PARAMS,
+      body: { type: 'bridge' },
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('interface in use')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/connections/[id]/nodes/[node]/network/[iface]', () => {
+  it('200 happy path: calls pveFetch DELETE and returns success', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/nodes/pve-node-01/network/vmbr0',
+      { method: 'DELETE' },
+    )
+  })
+
+  it('encodes node and iface in the DELETE path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'conn-1', node: 'node/x', iface: 'eth:0' },
+    })
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/nodes/node%2Fx/network/eth%3A0',
+      { method: 'DELETE' },
+    )
+  })
+
+  it('403 when NODE_NETWORK is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('interface not found'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('interface not found')
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/replication/[jobId]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/replication/[jobId]/route.test.ts
@@ -98,7 +98,7 @@ describe('GET /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => 
     })
 
     const [, path] = pveFetchMock.mock.calls[0]
-    expect(path).toContain('limit=100')
+    expect(path).toBe('/nodes/pve-node-01/replication/1-pve-node-02/log?limit=100')
   })
 
   it('defaults to limit=50 when no query param', async () => {
@@ -109,7 +109,7 @@ describe('GET /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => 
     })
 
     const [, path] = pveFetchMock.mock.calls[0]
-    expect(path).toContain('limit=50')
+    expect(path).toBe('/nodes/pve-node-01/replication/1-pve-node-02/log?limit=50')
   })
 
   it('encodes node and jobId in the pveFetch path', async () => {
@@ -120,7 +120,7 @@ describe('GET /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => 
     })
 
     const [, path] = pveFetchMock.mock.calls[0]
-    expect(path).toContain('/nodes/node%2Fwith%2Fslash/replication/job%3Aid/log')
+    expect(path).toBe('/nodes/node%2Fwith%2Fslash/replication/job%3Aid/log?limit=50')
   })
 
   it('404 when connection not found', async () => {

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/replication/[jobId]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/replication/[jobId]/route.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    NODE_VIEW: 'node.view',
+    NODE_MANAGE: 'node.manage',
+  },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+import { GET, POST, DELETE } from './route'
+import { checkPermission } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+
+const checkPermissionMock = checkPermission as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+
+const CONN = { id: 'conn-1' }
+const BASE_PARAMS = { id: 'conn-1', node: 'pve-node-01', jobId: '1-pve-node-02' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue(CONN)
+  pveFetchMock.mockResolvedValue([])
+})
+
+// ---------------------------------------------------------------------------
+// GET
+// ---------------------------------------------------------------------------
+
+describe('GET /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => {
+  it('returns 200 with formatted log entries (string entries)', async () => {
+    pveFetchMock.mockResolvedValue(['line one', 'line two'])
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toEqual(['line one', 'line two'])
+  })
+
+  it('returns 200 with formatted log entries (object entries with .t field)', async () => {
+    pveFetchMock.mockResolvedValue([{ t: 'replicated 1024 bytes', n: 1 }, { t: 'done', n: 2 }])
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toEqual(['replicated 1024 bytes', 'done'])
+  })
+
+  it('returns 200 with JSON-stringified entries when entry has no .t field', async () => {
+    pveFetchMock.mockResolvedValue([{ level: 'info', msg: 'ok' }])
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data[0]).toBe('{"level":"info","msg":"ok"}')
+  })
+
+  it('returns empty data array when pveFetch returns a non-array', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toEqual([])
+  })
+
+  it('uses the limit query param when provided', async () => {
+    pveFetchMock.mockResolvedValue([])
+
+    await GET(new Request('http://test.local/_?limit=100'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toContain('limit=100')
+  })
+
+  it('defaults to limit=50 when no query param', async () => {
+    pveFetchMock.mockResolvedValue([])
+
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toContain('limit=50')
+  })
+
+  it('encodes node and jobId in the pveFetch path', async () => {
+    pveFetchMock.mockResolvedValue([])
+
+    await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ id: 'conn-1', node: 'node/with/slash', jobId: 'job:id' }),
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toContain('/nodes/node%2Fwith%2Fslash/replication/job%3Aid/log')
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockResolvedValue(null)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Connection not found')
+  })
+
+  it('403 when NODE_VIEW is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('PVE unreachable'))
+
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(BASE_PARAMS),
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('PVE unreachable')
+    // data should still be present as empty array in error response
+    expect(body.data).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST (schedule now)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => {
+  it('200 happy path: calls schedule_now and returns result', async () => {
+    pveFetchMock.mockResolvedValue('upid-abc123')
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.data).toBe('upid-abc123')
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/nodes/pve-node-01/replication/1-pve-node-02/schedule_now',
+      { method: 'POST' },
+    )
+  })
+
+  it('encodes node and jobId in the schedule_now path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(POST as any, {
+      method: 'POST',
+      params: { id: 'conn-1', node: 'node/x', jobId: 'job:1' },
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/nodes/node%2Fx/replication/job%3A1/schedule_now')
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockResolvedValue(null)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Connection not found')
+  })
+
+  it('403 when NODE_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('scheduler unavailable'))
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('scheduler unavailable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+describe('DELETE /api/v1/connections/[id]/nodes/[node]/replication/[jobId]', () => {
+  it('200 happy path: calls cluster/replication DELETE and returns success', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      CONN,
+      '/cluster/replication/1-pve-node-02',
+      { method: 'DELETE' },
+    )
+  })
+
+  it('encodes jobId in the cluster DELETE path', async () => {
+    pveFetchMock.mockResolvedValue(null)
+
+    await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'conn-1', node: 'pve-node-01', jobId: 'job:special' },
+    })
+
+    const [, path] = pveFetchMock.mock.calls[0]
+    expect(path).toBe('/cluster/replication/job%3Aspecial')
+  })
+
+  it('404 when connection not found', async () => {
+    getConnectionByIdMock.mockResolvedValue(null)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toBe('Connection not found')
+  })
+
+  it('403 when NODE_MANAGE is denied', async () => {
+    const denied = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermissionMock.mockResolvedValue(denied)
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('500 on pveFetch throw', async () => {
+    pveFetchMock.mockRejectedValue(new Error('replication job not found'))
+
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: BASE_PARAMS,
+    })
+
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toContain('replication job not found')
+  })
+})


### PR DESCRIPTION
## What

Phase 0 coverage backfill, batch 3: node-env tests for three more mutating route handlers. Tests only, no production code changed. Follows #444 / #447 / #449.

### Covered (55 tests)
- **Node replication job** (`connections/[id]/nodes/[node]/replication/[jobId]` GET/POST/DELETE, 20): log parsing (string + object entries, fallback), custom/default limit, cluster delete path, exact encoded paths, 403/404/500.
- **HA group** (`connections/[id]/ha/groups/[groupId]` GET/PUT/DELETE, 16): create/update body (exact form-encoded string), delete param, optional-field omission, 404 via PVE error strings, 403/500.
- **Node network interface** (`connections/[id]/nodes/[node]/network/[iface]` GET/PUT/DELETE, 19): bridge/bond/VLAN/OVS, IPv4 + IPv6 CIDR, autostart, empty-field skip, 403/500.

Assertions check status + body + exact outgoing PVE call (encoded paths and form bodies asserted as exact strings). Each file mocks only its own handler's imports.

### Verification
- Full node suite green (1681 tests).
- No production source changed.

### Known follow-ups (issue #448, error-swallowing pattern)
- `replication` GET returns `{ data: [], error }` on failure (unusual shape).
- `ha/groups` and `network/[iface]` have no explicit null-connection guard, so a null connection throws into the catch and yields a misleading 500 instead of a clean 404.

Tests document current behavior; fixes tracked in #448.
