### PR TITLE
fix(migration): bound thick-target zero-fill so it can't ENOSPC-fail (#445)

### DIFF
--- a/frontend/src/lib/migration/warm/warm-pipeline.test.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { planPasses } from "./warm-pipeline"
+import { planPasses, buildThickZeroScript } from "./warm-pipeline"
 
 const GiB = 1024 ** 3
 const MiB = 1024 * 1024
@@ -31,5 +31,48 @@ describe("planPasses", () => {
     const actions = planPasses(stats, cfg)
     expect(actions.every(a => a.action === "delta")).toBe(true)
     expect(actions).toHaveLength(3)
+  })
+})
+
+describe("buildThickZeroScript", () => {
+  const dev = "/dev/vg-ld6-isp/vm-116-disk-1"
+
+  it("queries the exact device size and bounds the zero-fill to it", () => {
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain("blockdev --getsize64")
+    // the bound is the byte size read back from the device
+    expect(cmd).toContain('head -c "$sz" /dev/zero')
+  })
+
+  it("does NOT emit the unbounded dd that ENOSPCs past end-of-device (#445)", () => {
+    // A bare `dd if=/dev/zero of=DEV bs=4M oflag=direct` with no count fills the
+    // device, then writes one block past the end -> ENOSPC -> exit 1, even after
+    // a full zero. Guard that the broken form never comes back.
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).not.toMatch(/dd if=\/dev\/zero of=/)
+  })
+
+  it("prefers blkdiscard -z and only streams zeros on its failure", () => {
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain(`blkdiscard -z '${dev}'`)
+    // blkdiscard || stream: the stream is the fallback, not the primary path
+    expect(cmd.indexOf("blkdiscard -z")).toBeLessThan(cmd.indexOf("|| head -c"))
+  })
+
+  it("keeps O_DIRECT with full 4 MiB blocks reassembled across the pipe", () => {
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain("bs=4M iflag=fullblock oflag=direct")
+  })
+
+  it("single-quotes the device in every write/read position", () => {
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain(`blockdev --getsize64 '${dev}'`)
+    expect(cmd).toContain(`blkdiscard -z '${dev}'`)
+    expect(cmd).toContain(`dd of='${dev}'`)
+  })
+
+  it("escapes an embedded single quote in the device path", () => {
+    const cmd = buildThickZeroScript("/dev/x'y")
+    expect(cmd).toContain(`'/dev/x'\\''y'`)
   })
 })

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -104,6 +104,29 @@ const SNAPSHOT_PREFIX = "proxcenter-warm"
 const SOAP_KEEPALIVE_INTERVAL_MS = 60_000
 
 /**
+ * Build the node-side command that zeroes a freshly-allocated *thick* block
+ * device before the CBT copy. Unwritten regions on a thick LV are not
+ * guaranteed to read as zero, and the CBT pass only writes the allocated/changed
+ * map, so any gap left un-zeroed would surface a previous tenant's bytes (a
+ * correctness AND information-leak bug). We prefer `blkdiscard -z` (offloaded
+ * write-zeroes where the array supports it) and fall back to streaming zeros.
+ *
+ * The fallback streams `head -c <size> /dev/zero | dd …` rather than the earlier
+ * `dd if=/dev/zero of=DEV` (no count): a bare unbounded dd fills the device and
+ * then issues one write *past* end-of-device, which returns ENOSPC and makes dd
+ * exit 1 — even though every block was already zeroed — so the thick-zero step
+ * could never succeed (this is what broke #445's disk 1 after a full 45-min
+ * zero). Bounding the stream to `blockdev --getsize64` writes exactly the device
+ * and exits 0. `iflag=fullblock` reassembles 4 MiB blocks across the pipe so
+ * O_DIRECT accepts every write, including a sub-4 MiB final block (still
+ * logical-block aligned because a device size is always a sector multiple).
+ */
+export function buildThickZeroScript(dev: string): string {
+  const d = shellEscape(dev)
+  return `sz=$(blockdev --getsize64 ${d}); blkdiscard -z ${d} 2>&1 || head -c "$sz" /dev/zero | dd of=${d} bs=4M iflag=fullblock oflag=direct status=none 2>&1`
+}
+
+/**
  * Warm migration orchestrator (ESXi-direct source, Proxmox block target).
  * Keeps the source online through a full copy + N delta passes, then a short
  * cutover with a CONFIRMED power-off. CBT (QueryChangedDiskAreas) is the
@@ -253,9 +276,11 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       if (preZeroed) {
         await executeSSH(config.targetConnectionId, nodeIp, `blkdiscard ${shellEscape(dev)} 2>/dev/null || true`)
       } else {
-        const z = await executeSSH(config.targetConnectionId, nodeIp,
-          `blkdiscard -z ${shellEscape(dev)} 2>&1 || dd if=/dev/zero of=${shellEscape(dev)} bs=4M oflag=direct status=none 2>&1`, APPLY_TIMEOUT_MS)
-        if (!z.success) throw new Error(`Failed to zero thick target ${dev} before warm copy (unwritten regions would expose stale data): ${z.error || z.output}`)
+        const z = await executeSSH(config.targetConnectionId, nodeIp, buildThickZeroScript(dev), APPLY_TIMEOUT_MS)
+        // Surface z.output first: the script merges stderr into stdout (2>&1), so
+        // the real cause (e.g. "No space left on device", an array I/O error)
+        // lands in output while error is just "Exit code N" on the ssh2 path.
+        if (!z.success) throw new Error(`Failed to zero thick target ${dev} before warm copy (unwritten regions would expose stale data): ${z.output || z.error}`)
         await appendLog(jobId, `Disk ${i}: zeroed thick target ${dev}`)
       }
       await appendLog(jobId, `Disk ${i}: target ${alloc.volumeId} → ${dev} (${(disk.capacityBytes / 1073741824).toFixed(1)} GB)`)


### PR DESCRIPTION
## Why

Warm migration zeroes each freshly-allocated thick LVM volume before the CBT
copy so unwritten regions read as zero (otherwise a freshly-allocated thick LV
can surface a previous tenant's bytes). The fallback used a bare
`dd if=/dev/zero of=DEV` with no count: it fills the device and then writes one
block past the end, the device returns ENOSPC, and `dd` exits 1, even though
every block was already zeroed. So the thick-zero step could never succeed once
`blkdiscard -z` is unavailable on the target array.

Reported in #445: a 1.43 TB vSphere VM to a thick iSCSI LVM target. Disk 0
zeroed fine; disk 1 failed with a bare `Exit code 1` after a full ~45-minute
zero. Two bugs combined: the unbounded `dd` above, and the failure message
surfacing `z.error` ("Exit code N") instead of the merged stdout/stderr that
actually held the cause.

## What

- Extract `buildThickZeroScript()` and bound the fallback to the exact device
  size via `blockdev --getsize64` + `head -c "$sz" /dev/zero | dd ... iflag=fullblock oflag=direct`.
  It writes exactly the device and exits 0; `iflag=fullblock` keeps every write
  4 MiB-aligned for O_DIRECT, including a sub-4 MiB final block.
- Surface `z.output || z.error` in the failure message so the real cause
  (e.g. an array I/O error) is no longer swallowed.

## Validation

- Unit tests: `buildThickZeroScript` (6 cases, incl. a guard against the
  unbounded-`dd` regression) plus the existing `planPasses`. 10 green.
- Reproduced on a real Proxmox thick LVM volume (deliberately non-4 MiB-aligned
  size, worst case): old command -> `No space left on device`, exit 1; new
  command -> exit 0 and the device fully zeroed after prefilling 0xFF garbage.

## Coupling

The node-side zero command shape is pinned in the orchestrator SSH allowlist,
so this needs the paired orchestrator change (same branch name) to run brokered.
Recommended deploy order: orchestrator first, then this. `warm-pipeline.ts` is
in `sonar.coverage.exclusions`, so the change is coverage-neutral; the new
helper is unit-tested regardless.
