### PR TITLE
test(components): component-lane batch 1 (TreeIcons, VmActions, TagManager, RoleDefaultScopeEditor)

### DIFF
--- a/frontend/src/__tests__/fixtures/inventory.ts
+++ b/frontend/src/__tests__/fixtures/inventory.ts
@@ -1,0 +1,32 @@
+// Frozen static fixture for /api/v1/inventory
+// Hand-written minimal slice -- do NOT import mock-data.json or demoResponse.
+// Shape matches what buildScopeOptions() reads from inventory.clusters.
+// Provides: one tag ("web"), one pool ("infra"), one node ("pve1"),
+// one connection ("conn-1"), and one VM -- enough for all scope types.
+export const inventoryFixture = {
+  data: {
+    clusters: [
+      {
+        id: 'conn-1',
+        name: 'Test Cluster',
+        status: 'online',
+        nodes: [
+          {
+            node: 'pve1',
+            status: 'online',
+            guests: [
+              {
+                vmid: 100,
+                type: 'qemu',
+                name: 'web-vm',
+                tags: 'web',
+                pool: 'infra',
+                status: 'running',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/frontend/src/__tests__/fixtures/resources.ts
+++ b/frontend/src/__tests__/fixtures/resources.ts
@@ -1,0 +1,11 @@
+// Frozen static fixture for /api/v1/connections/:connId/resources
+// Hand-written minimal slice -- do NOT import mock-data.json or demoResponse.
+// Only the fields TagManager.tsx reads: tags (and vmid for identity).
+export const resourcesFixture = {
+  data: [
+    { vmid: 100, type: 'qemu', name: 'web-server', tags: 'prod;web' },
+    { vmid: 101, type: 'qemu', name: 'db-primary', tags: 'prod,db' },
+    { vmid: 102, type: 'lxc',  name: 'monitoring', tags: 'dev' },
+    { vmid: 103, type: 'qemu', name: 'no-tags' },
+  ],
+}

--- a/frontend/src/__tests__/setup/jsdom-setup.ts
+++ b/frontend/src/__tests__/setup/jsdom-setup.ts
@@ -12,3 +12,12 @@ if (!window.matchMedia) {
 class RO { observe() {} unobserve() {} disconnect() {} }
 globalThis.ResizeObserver ||= RO as any
 globalThis.IntersectionObserver ||= RO as any
+
+import { server } from './msw-server'
+import { beforeAll, afterEach, afterAll } from 'vitest'
+
+// Start MSW for the jsdom lane. Unhandled requests error loudly so a missing
+// fixture fails the test instead of silently returning empty data.
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/frontend/src/__tests__/setup/jsdom-setup.ts
+++ b/frontend/src/__tests__/setup/jsdom-setup.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest'
-import { vi } from 'vitest'
+import { vi, beforeAll, afterEach, afterAll } from 'vitest'
+import { server } from './msw-server'
 
 // MUI + DataGrid touch browser APIs jsdom lacks.
 if (!window.matchMedia) {
@@ -12,9 +13,6 @@ if (!window.matchMedia) {
 class RO { observe() {} unobserve() {} disconnect() {} }
 globalThis.ResizeObserver ||= RO as any
 globalThis.IntersectionObserver ||= RO as any
-
-import { server } from './msw-server'
-import { beforeAll, afterEach, afterAll } from 'vitest'
 
 // Start MSW for the jsdom lane. Unhandled requests error loudly so a missing
 // fixture fails the test instead of silently returning empty data.

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.test.tsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import { renderWithProviders, screen, waitFor } from '@/__tests__/setup/renderWithProviders'
+import userEvent from '@testing-library/user-event'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import { resourcesFixture } from '@/__tests__/fixtures/resources'
+import TagManager from './TagManager'
+
+// TagColorContext is not wrapped by the test harness. Mock it so the component
+// can render without a live context provider.
+vi.mock('@/contexts/TagColorContext', () => ({
+  useTagColors: () => ({
+    getColor: () => ({ bg: '#1976d2', fg: '#ffffff' }),
+    getOverride: () => undefined,
+    getShape: () => 'full',
+    loadConnection: () => {},
+  }),
+}))
+
+const CONN_ID = 'test-conn-1'
+const NODE = 'pve1'
+const TYPE = 'qemu'
+const VMID = '100'
+const CONFIG_URL = `*/api/v1/connections/${CONN_ID}/guests/${TYPE}/${NODE}/${VMID}/config`
+const RESOURCES_URL = `*/api/v1/connections/${CONN_ID}/resources`
+
+function makeProps(overrides: Partial<Parameters<typeof TagManager>[0]> = {}) {
+  return {
+    tags: ['prod', 'web'],
+    connId: CONN_ID,
+    node: NODE,
+    type: TYPE,
+    vmid: VMID,
+    onTagsChange: vi.fn(),
+    ...overrides,
+  }
+}
+
+// Find the Add icon-button in the render container.
+// MUI Tooltip uses cloneElement and the resulting button carries
+// data-mui-internal-clone-element; querySelector returns the first match,
+// which is always the real visible button.
+function findAddBtn(container: HTMLElement): HTMLButtonElement {
+  const btn = container.querySelector<HTMLButtonElement>('button[aria-label="Add tag"]')
+  if (!btn) throw new Error('Add-tag button not found')
+  return btn
+}
+
+// After opening the popover, MUI renders it as a portal appended directly to
+// document.body (outside the render container). Find it by the MUI Popover
+// Paper class so we can scope further queries to just the popover content.
+function findPopover(): HTMLElement {
+  const paper = document.querySelector<HTMLElement>('.MuiPopover-paper')
+  if (!paper) throw new Error('MuiPopover-paper not found in document')
+  return paper
+}
+
+// ------------------------------------------------------------------ //
+// 1. Renders existing tags as chips
+// ------------------------------------------------------------------ //
+describe('TagManager — renders existing tags', () => {
+  it('shows each tag from the tags prop as a visible chip label', () => {
+    const { container } = renderWithProviders(<TagManager {...makeProps()} />)
+    expect(within(container).getByText('prod')).toBeInTheDocument()
+    expect(within(container).getByText('web')).toBeInTheDocument()
+  })
+
+  it('renders a chip for every tag in the props array', () => {
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['alpha', 'beta', 'gamma'] })} />,
+    )
+    expect(within(container).getByText('alpha')).toBeInTheDocument()
+    expect(within(container).getByText('beta')).toBeInTheDocument()
+    expect(within(container).getByText('gamma')).toBeInTheDocument()
+  })
+
+  it('renders with an empty tags array without crashing', () => {
+    const { container } = renderWithProviders(<TagManager {...makeProps({ tags: [] })} />)
+    // The Add icon-button is still present (aria-label from the Tooltip title)
+    expect(findAddBtn(container)).not.toBeNull()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Opens popover and loads suggestions from the resources endpoint
+// ------------------------------------------------------------------ //
+describe('TagManager — popover opens and loads suggestions', () => {
+  beforeEach(() => {
+    // Ensure a clean DOM between tests in this describe block.
+    cleanup()
+    server.use(
+      http.get(RESOURCES_URL, () => HttpResponse.json(resourcesFixture)),
+    )
+  })
+
+  it('shows suggestion chips from the fixture after clicking Add', async () => {
+    const user = userEvent.setup()
+    const { container } = renderWithProviders(<TagManager {...makeProps({ tags: [] })} />)
+
+    await user.click(findAddBtn(container))
+
+    // Wait for the popover to open and the fetch to resolve.
+    // The fixture tags (sorted): db, dev, prod, web -- all suggestions since tags=[].
+    const popover = await waitFor(() => findPopover())
+    await within(popover).findByText('db')
+    expect(within(popover).getByText('dev')).toBeInTheDocument()
+  })
+
+  it('does not show suggestions already on the VM as chips', async () => {
+    const user = userEvent.setup()
+    // tags already contains 'prod' and 'web'
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['prod', 'web'] })} />,
+    )
+
+    await user.click(findAddBtn(container))
+
+    // Wait for the popover then confirm db loads (fetch completed)
+    const popover = await waitFor(() => findPopover())
+    await within(popover).findByText('db')
+
+    // 'prod' and 'web' are already on the VM so must NOT appear as suggestions
+    // inside the popover -- they are absent from the suggestion chip list.
+    expect(within(popover).queryByText('prod')).not.toBeInTheDocument()
+    expect(within(popover).queryByText('web')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Adding a tag via the text input triggers onTagsChange
+// ------------------------------------------------------------------ //
+describe('TagManager — adding a tag via input calls onTagsChange', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('calls onTagsChange with the new tag appended after a successful PUT', async () => {
+    const onTagsChange = vi.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      http.get(RESOURCES_URL, () => HttpResponse.json(resourcesFixture)),
+      http.put(CONFIG_URL, () => HttpResponse.json({ data: null })),
+    )
+
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['prod'], onTagsChange })} />,
+    )
+
+    // Open the popover
+    await user.click(findAddBtn(container))
+
+    // Wait for the popover to mount (portal outside container)
+    const popover = await waitFor(() => findPopover())
+
+    // Type a new tag in the text field
+    const input = within(popover).getByPlaceholderText('New tag...')
+    await user.type(input, 'newtag')
+
+    // Click the Add button inside the popover (MUI Button, not the icon-button)
+    await user.click(within(popover).getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(onTagsChange).toHaveBeenCalledWith(['prod', 'newtag'])
+    })
+  })
+
+  it('does not call onTagsChange when the PUT returns an error', async () => {
+    const onTagsChange = vi.fn()
+    const user = userEvent.setup()
+
+    // Stub window.alert so the error path does not throw in jsdom
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {})
+
+    server.use(
+      http.get(RESOURCES_URL, () => HttpResponse.json(resourcesFixture)),
+      http.put(CONFIG_URL, () => HttpResponse.json({ error: 'Permission denied' }, { status: 403 })),
+    )
+
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['prod'], onTagsChange })} />,
+    )
+
+    await user.click(findAddBtn(container))
+
+    const popover = await waitFor(() => findPopover())
+    const input = within(popover).getByPlaceholderText('New tag...')
+    await user.type(input, 'failingtag')
+
+    await user.click(within(popover).getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled()
+    })
+    expect(onTagsChange).not.toHaveBeenCalled()
+
+    alertSpy.mockRestore()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Removing a tag (chip delete) triggers onTagsChange
+// ------------------------------------------------------------------ //
+describe('TagManager — removing a tag calls onTagsChange', () => {
+  beforeEach(() => {
+    cleanup()
+  })
+
+  it('calls onTagsChange with the tag removed after a successful PUT', async () => {
+    const onTagsChange = vi.fn()
+    const user = userEvent.setup()
+
+    server.use(
+      http.put(CONFIG_URL, () => HttpResponse.json({ data: null })),
+    )
+
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['prod', 'web'], onTagsChange })} />,
+    )
+
+    // Find the 'prod' chip then click its MUI delete icon.
+    const prodChip = within(container).getByText('prod').closest('.MuiChip-root') as HTMLElement
+    const deleteBtn = prodChip.querySelector('.MuiChip-deleteIcon') as HTMLElement
+    expect(deleteBtn).not.toBeNull()
+
+    await user.click(deleteBtn)
+
+    await waitFor(() => {
+      expect(onTagsChange).toHaveBeenCalledWith(['web'])
+    })
+  })
+
+  it('sends delete=tags body when the last tag is removed', async () => {
+    const onTagsChange = vi.fn()
+    const user = userEvent.setup()
+
+    let capturedBody: any = null
+    server.use(
+      http.put(CONFIG_URL, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ data: null })
+      }),
+    )
+
+    const { container } = renderWithProviders(
+      <TagManager {...makeProps({ tags: ['only-tag'], onTagsChange })} />,
+    )
+
+    const chip = within(container).getByText('only-tag').closest('.MuiChip-root') as HTMLElement
+    const deleteBtn = chip.querySelector('.MuiChip-deleteIcon') as HTMLElement
+    await user.click(deleteBtn)
+
+    await waitFor(() => {
+      expect(onTagsChange).toHaveBeenCalledWith([])
+    })
+    // Proxmox requires `delete: 'tags'` when removing the last tag (empty string ignored)
+    expect(capturedBody).toEqual({ delete: 'tags' })
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.test.tsx
@@ -58,7 +58,7 @@ function findPopover(): HTMLElement {
 // ------------------------------------------------------------------ //
 // 1. Renders existing tags as chips
 // ------------------------------------------------------------------ //
-describe('TagManager — renders existing tags', () => {
+describe('TagManager - renders existing tags', () => {
   it('shows each tag from the tags prop as a visible chip label', () => {
     const { container } = renderWithProviders(<TagManager {...makeProps()} />)
     expect(within(container).getByText('prod')).toBeInTheDocument()
@@ -84,7 +84,7 @@ describe('TagManager — renders existing tags', () => {
 // ------------------------------------------------------------------ //
 // 2. Opens popover and loads suggestions from the resources endpoint
 // ------------------------------------------------------------------ //
-describe('TagManager — popover opens and loads suggestions', () => {
+describe('TagManager - popover opens and loads suggestions', () => {
   beforeEach(() => {
     // Ensure a clean DOM between tests in this describe block.
     cleanup()
@@ -129,7 +129,7 @@ describe('TagManager — popover opens and loads suggestions', () => {
 // ------------------------------------------------------------------ //
 // 3. Adding a tag via the text input triggers onTagsChange
 // ------------------------------------------------------------------ //
-describe('TagManager — adding a tag via input calls onTagsChange', () => {
+describe('TagManager - adding a tag via input calls onTagsChange', () => {
   beforeEach(() => {
     cleanup()
   })
@@ -201,7 +201,7 @@ describe('TagManager — adding a tag via input calls onTagsChange', () => {
 // ------------------------------------------------------------------ //
 // 4. Removing a tag (chip delete) triggers onTagsChange
 // ------------------------------------------------------------------ //
-describe('TagManager — removing a tag calls onTagsChange', () => {
+describe('TagManager - removing a tag calls onTagsChange', () => {
   beforeEach(() => {
     cleanup()
   })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders'
 import { getVmIcon, StatusIcon, NodeIcon, ClusterIcon } from './TreeIcons'
 
 /* ------------------------------------------------------------------ */

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import { getVmIcon, StatusIcon, NodeIcon, ClusterIcon } from './TreeIcons'
+
+/* ------------------------------------------------------------------ */
+/* getVmIcon (pure function)                                           */
+/* ------------------------------------------------------------------ */
+
+describe('getVmIcon', () => {
+  it('returns template fill icon when isTemplate=true and filled=true (default)', () => {
+    expect(getVmIcon('qemu', true)).toBe('ri-file-copy-fill')
+  })
+
+  it('returns template outline icon when isTemplate=true and filled=false', () => {
+    expect(getVmIcon('qemu', true, false)).toBe('ri-file-copy-line')
+  })
+
+  it('returns lxc fill icon for type lxc', () => {
+    expect(getVmIcon('lxc')).toBe('ri-instance-fill')
+  })
+
+  it('returns lxc outline icon for type lxc with filled=false', () => {
+    expect(getVmIcon('lxc', false, false)).toBe('ri-instance-line')
+  })
+
+  it('returns qemu fill icon for type qemu (default)', () => {
+    expect(getVmIcon('qemu')).toBe('ri-computer-fill')
+  })
+
+  it('returns qemu outline icon for unknown type with filled=false', () => {
+    expect(getVmIcon('qemu', false, false)).toBe('ri-computer-line')
+  })
+
+  it('template takes precedence over lxc type', () => {
+    expect(getVmIcon('lxc', true)).toBe('ri-file-copy-fill')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* StatusIcon                                                          */
+/* ------------------------------------------------------------------ */
+
+describe('StatusIcon', () => {
+  it('renders nothing for type=node', () => {
+    const { container } = renderWithProviders(<StatusIcon type="node" status="online" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a spinner (CircularProgress) when isPendingAction=true', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="stopped" isPendingAction />,
+    )
+    // CircularProgress renders an svg role="progressbar"
+    expect(container.querySelector('[role="progressbar"]')).toBeTruthy()
+  })
+
+  it('renders the icon glyph for a migrating VM', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="running" isMigrating />,
+    )
+    // The icon <i> element and the pulsing dot Box are both rendered
+    const icon = container.querySelector('i.ri-computer-fill')
+    expect(icon).toBeTruthy()
+    // no progress spinner
+    expect(container.querySelector('[role="progressbar"]')).toBeNull()
+  })
+
+  it('renders the template icon with reduced opacity for template=true', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" template />,
+    )
+    const icon = container.querySelector('i.ri-file-copy-fill')
+    expect(icon).toBeTruthy()
+    // no status dot (Box after icon) means no progressbar and no pulsing
+    expect(container.querySelector('[role="progressbar"]')).toBeNull()
+  })
+
+  it('renders a running VM with the computer fill icon', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="running" />,
+    )
+    expect(container.querySelector('i.ri-computer-fill')).toBeTruthy()
+  })
+
+  it('renders an lxc VM with the instance fill icon', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="lxc" status="running" />,
+    )
+    expect(container.querySelector('i.ri-instance-fill')).toBeTruthy()
+  })
+
+  it('renders a lock badge icon when lock prop is set', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="running" lock="migrate" />,
+    )
+    expect(container.querySelector('i.ri-lock-fill')).toBeTruthy()
+  })
+
+  it('does not render a lock badge when lock prop is absent', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="running" />,
+    )
+    expect(container.querySelector('i.ri-lock-fill')).toBeNull()
+  })
+
+  it('renders a stopped VM (no spinner, no migrating animation)', () => {
+    const { container } = renderWithProviders(
+      <StatusIcon type="vm" vmType="qemu" status="stopped" />,
+    )
+    expect(container.querySelector('i.ri-computer-fill')).toBeTruthy()
+    expect(container.querySelector('[role="progressbar"]')).toBeNull()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* NodeIcon                                                            */
+/* ------------------------------------------------------------------ */
+
+describe('NodeIcon', () => {
+  it('renders a Proxmox logo image', () => {
+    const { container } = renderWithProviders(<NodeIcon status="online" />)
+    // alt="" makes the img presentational; query directly
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img!.getAttribute('src')).toMatch(/proxmox-logo/)
+  })
+
+  it('renders with offline status (low opacity)', () => {
+    const { container } = renderWithProviders(<NodeIcon status="offline" />)
+    const img = container.querySelector('img')
+    expect(img).toBeTruthy()
+    expect(img!.style.opacity).toBe('0.4')
+  })
+
+  it('renders with online status (higher opacity)', () => {
+    const { container } = renderWithProviders(<NodeIcon status="online" />)
+    const img = container.querySelector('img')
+    expect(img!.style.opacity).toBe('0.8')
+  })
+
+  it('renders with maintenance=wrench and applies orange tint', () => {
+    const { container } = renderWithProviders(<NodeIcon status="online" maintenance="wrench" />)
+    // maintenance dot shows ri-tools-fill icon
+    expect(container.querySelector('i.ri-tools-fill')).toBeTruthy()
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* ClusterIcon                                                         */
+/* ------------------------------------------------------------------ */
+
+describe('ClusterIcon', () => {
+  it('renders the server fill icon', () => {
+    const { container } = renderWithProviders(
+      <ClusterIcon nodes={[{ status: 'online' }, { status: 'online' }]} />,
+    )
+    expect(container.querySelector('i.ri-server-fill')).toBeTruthy()
+  })
+
+  it('renders without crashing for an empty nodes array', () => {
+    const { container } = renderWithProviders(<ClusterIcon nodes={[]} />)
+    expect(container.querySelector('i.ri-server-fill')).toBeTruthy()
+  })
+
+  it('renders with a mix of online and offline nodes', () => {
+    const { container } = renderWithProviders(
+      <ClusterIcon nodes={[{ status: 'online' }, { status: 'offline' }]} />,
+    )
+    // Still renders the icon; dot color differs but structure is the same
+    expect(container.querySelector('i.ri-server-fill')).toBeTruthy()
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
@@ -43,7 +43,7 @@ function makeCallbacks() {
 // Branch 1: vmStatus='running'
 // Start disabled; Shutdown/Stop/Pause enabled; ConvertTemplate/Delete disabled
 // ------------------------------------------------------------------ //
-describe('VmActions — vmStatus=running', () => {
+describe('VmActions - vmStatus=running', () => {
   it('renders 8 buttons', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
@@ -110,7 +110,7 @@ describe('VmActions — vmStatus=running', () => {
 // Branch 2: vmStatus='stopped' and vmStatus='unknown'
 // Start enabled; Shutdown/Stop/Pause disabled
 // ------------------------------------------------------------------ //
-describe('VmActions — vmStatus=stopped', () => {
+describe('VmActions - vmStatus=stopped', () => {
   it('Start button (index 0) is enabled when stopped', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
@@ -145,7 +145,7 @@ describe('VmActions — vmStatus=stopped', () => {
   })
 })
 
-describe('VmActions — vmStatus=unknown', () => {
+describe('VmActions - vmStatus=unknown', () => {
   it('Start button is enabled when status is unknown', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="unknown" />)
@@ -161,11 +161,11 @@ describe('VmActions — vmStatus=unknown', () => {
 
 // ------------------------------------------------------------------ //
 // Branch 3: vmStatus='paused'
-// Start acts as Resume — the tooltip switches to the resume label.
+// Start acts as Resume - the tooltip switches to the resume label.
 // 'paused' is NOT in the isStopped guard (isStopped = stopped | unknown),
 // so Start is enabled (not running) and Shutdown/Stop/Pause are disabled.
 // ------------------------------------------------------------------ //
-describe('VmActions — vmStatus=paused', () => {
+describe('VmActions - vmStatus=paused', () => {
   it('Start button (index 0) is enabled when paused', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
@@ -209,7 +209,7 @@ describe('VmActions — vmStatus=paused', () => {
 // ------------------------------------------------------------------ //
 // Branch 4: canMigrate=false hides the Migrate button entirely
 // ------------------------------------------------------------------ //
-describe('VmActions — canMigrate=false', () => {
+describe('VmActions - canMigrate=false', () => {
   it('renders one fewer button when canMigrate is false', () => {
     const cbs = makeCallbacks()
     const { container: c1 } = renderWithProviders(
@@ -238,7 +238,7 @@ describe('VmActions — canMigrate=false', () => {
 // ------------------------------------------------------------------ //
 // Branch 5: isLocked / onUnlock
 // ------------------------------------------------------------------ //
-describe('VmActions — isLocked with onUnlock', () => {
+describe('VmActions - isLocked with onUnlock', () => {
   it('Unlock button appears when isLocked=true and onUnlock is provided', () => {
     const cbs = makeCallbacks()
     const onUnlock = vi.fn()
@@ -294,9 +294,9 @@ describe('VmActions — isLocked with onUnlock', () => {
 })
 
 // ------------------------------------------------------------------ //
-// Branch 6: disabled=true — all action buttons become disabled
+// Branch 6: disabled=true - all action buttons become disabled
 // ------------------------------------------------------------------ //
-describe('VmActions — disabled=true', () => {
+describe('VmActions - disabled=true', () => {
   it('all buttons are disabled when disabled=true', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(
@@ -320,7 +320,7 @@ describe('VmActions — disabled=true', () => {
 // ------------------------------------------------------------------ //
 // Clone and ConvertTemplate
 // ------------------------------------------------------------------ //
-describe('VmActions — Clone and ConvertTemplate', () => {
+describe('VmActions - Clone and ConvertTemplate', () => {
   it('clicking Clone (index 5) fires onClone', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderWithProviders, screen, fireEvent } from '@/__tests__/setup/renderWithProviders'
+import VmActions from './VmActions'
+
+/**
+ * Translation keys used by VmActions (resolved from en.json):
+ *   audit.actions.start          -> 'Start'
+ *   vmActions.resume             -> 'Resume'
+ *   inventoryPage.shutdownClean  -> 'Shutdown (clean stop)'
+ *   audit.actions.stop           -> 'Stop'
+ *   audit.actions.suspend        -> 'Suspend'
+ *   audit.actions.migrate        -> 'Migrate'
+ *   audit.actions.clone          -> 'Clone'
+ *   templates.convertToTemplate  -> 'Convert to Template'
+ *   inventory.vmRunningWarning   -> 'Stop the VM before deleting it'
+ *   inventory.deleteVm           -> 'Delete VM'
+ *   inventory.unlock             -> 'Unlock'
+ *
+ * Button order (canMigrate=true):
+ *   [0] Start/Resume  [1] Shutdown  [2] Stop  [3] Pause
+ *   [4] Migrate  [5] Clone  [6] ConvertTemplate  [7] Delete
+ *   [8] Unlock (only when isLocked && onUnlock provided)
+ *
+ * Note: userEvent.click cannot reach buttons through MUI's tooltip <span>
+ * wrapper when pointer-events styling is involved; fireEvent.click is used
+ * for callback assertions throughout.
+ */
+
+function makeCallbacks() {
+  return {
+    onStart: vi.fn(),
+    onShutdown: vi.fn(),
+    onStop: vi.fn(),
+    onPause: vi.fn(),
+    onMigrate: vi.fn(),
+    onClone: vi.fn(),
+    onConvertTemplate: vi.fn(),
+    onDelete: vi.fn(),
+  }
+}
+
+// ------------------------------------------------------------------ //
+// Branch 1: vmStatus='running'
+// Start disabled; Shutdown/Stop/Pause enabled; ConvertTemplate/Delete disabled
+// ------------------------------------------------------------------ //
+describe('VmActions — vmStatus=running', () => {
+  it('renders 8 buttons', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    expect(container.querySelectorAll('button').length).toBe(8)
+  })
+
+  it('Start button (index 0) is disabled', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[0]).toBeDisabled()
+  })
+
+  it('Shutdown (index 1) and Stop (index 2) are enabled', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[1]).not.toBeDisabled() // Shutdown
+    expect(buttons[2]).not.toBeDisabled() // Stop
+  })
+
+  it('Pause (index 3) is enabled', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[3]).not.toBeDisabled()
+  })
+
+  it('clicking Shutdown fires onShutdown', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    fireEvent.click(container.querySelectorAll('button')[1])
+    expect(cbs.onShutdown).toHaveBeenCalledOnce()
+  })
+
+  it('clicking Stop fires onStop', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    fireEvent.click(container.querySelectorAll('button')[2])
+    expect(cbs.onStop).toHaveBeenCalledOnce()
+  })
+
+  it('clicking Pause fires onPause', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    fireEvent.click(container.querySelectorAll('button')[3])
+    expect(cbs.onPause).toHaveBeenCalledOnce()
+  })
+
+  it('ConvertTemplate (index 6) is disabled while running', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    expect(container.querySelectorAll('button')[6]).toBeDisabled()
+  })
+
+  it('Delete (index 7) is disabled while running', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    expect(container.querySelectorAll('button')[7]).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Branch 2: vmStatus='stopped' and vmStatus='unknown'
+// Start enabled; Shutdown/Stop/Pause disabled
+// ------------------------------------------------------------------ //
+describe('VmActions — vmStatus=stopped', () => {
+  it('Start button (index 0) is enabled when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    expect(container.querySelectorAll('button')[0]).not.toBeDisabled()
+  })
+
+  it('Shutdown (index 1) is disabled when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    expect(container.querySelectorAll('button')[1]).toBeDisabled()
+  })
+
+  it('Stop (index 2) and Pause (index 3) are disabled when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[2]).toBeDisabled()
+    expect(buttons[3]).toBeDisabled()
+  })
+
+  it('clicking Start fires onStart when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    fireEvent.click(container.querySelectorAll('button')[0])
+    expect(cbs.onStart).toHaveBeenCalledOnce()
+  })
+
+  it('Delete (index 7) is enabled when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    expect(container.querySelectorAll('button')[7]).not.toBeDisabled()
+  })
+})
+
+describe('VmActions — vmStatus=unknown', () => {
+  it('Start button is enabled when status is unknown', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="unknown" />)
+    expect(container.querySelectorAll('button')[0]).not.toBeDisabled()
+  })
+
+  it('Shutdown is disabled when status is unknown', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="unknown" />)
+    expect(container.querySelectorAll('button')[1]).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Branch 3: vmStatus='paused'
+// Start acts as Resume — the tooltip switches to the resume label.
+// 'paused' is NOT in the isStopped guard (isStopped = stopped | unknown),
+// so Start is enabled (not running) and Shutdown/Stop/Pause are disabled.
+// ------------------------------------------------------------------ //
+describe('VmActions — vmStatus=paused', () => {
+  it('Start button (index 0) is enabled when paused', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
+    expect(container.querySelectorAll('button')[0]).not.toBeDisabled()
+  })
+
+  it('Shutdown and Stop are disabled when paused', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons[1]).toBeDisabled() // Shutdown
+    expect(buttons[2]).toBeDisabled() // Stop
+  })
+
+  it('clicking the Start/Resume button when paused fires onStart', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
+    fireEvent.click(container.querySelectorAll('button')[0])
+    expect(cbs.onStart).toHaveBeenCalledOnce()
+  })
+
+  it('tooltip aria-label switches to Resume when paused (not Start)', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
+    // MUI Tooltip sets an aria-label on its internal clone <span> wrapper.
+    // When paused the component passes t('vmActions.resume') = 'Resume'.
+    const startSpan = container.querySelectorAll('button')[0].closest('span')
+    expect(startSpan?.getAttribute('aria-label')).toBe('Resume')
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Branch 4: canMigrate=false hides the Migrate button entirely
+// ------------------------------------------------------------------ //
+describe('VmActions — canMigrate=false', () => {
+  it('renders one fewer button when canMigrate is false', () => {
+    const cbs = makeCallbacks()
+    const { container: c1 } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" canMigrate />,
+    )
+    const { container: c2 } = renderWithProviders(
+      <VmActions {...makeCallbacks()} vmStatus="stopped" canMigrate={false} />,
+    )
+    expect(c2.querySelectorAll('button').length).toBe(
+      c1.querySelectorAll('button').length - 1,
+    )
+  })
+
+  it('Clone is still present and clickable when canMigrate is false', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" canMigrate={false} />,
+    )
+    // Without migrate: [0]=Start [1]=Shutdown [2]=Stop [3]=Pause [4]=Clone [5]=ConvertTemplate [6]=Delete
+    const buttons = container.querySelectorAll('button')
+    fireEvent.click(buttons[4])
+    expect(cbs.onClone).toHaveBeenCalledOnce()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Branch 5: isLocked / onUnlock
+// ------------------------------------------------------------------ //
+describe('VmActions — isLocked with onUnlock', () => {
+  it('Unlock button appears when isLocked=true and onUnlock is provided', () => {
+    const cbs = makeCallbacks()
+    const onUnlock = vi.fn()
+    const { container: cLocked } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" isLocked onUnlock={onUnlock} />,
+    )
+    const { container: cUnlocked } = renderWithProviders(
+      <VmActions {...makeCallbacks()} vmStatus="stopped" />,
+    )
+    expect(cLocked.querySelectorAll('button').length).toBe(
+      cUnlocked.querySelectorAll('button').length + 1,
+    )
+  })
+
+  it('clicking Unlock fires onUnlock', () => {
+    const cbs = makeCallbacks()
+    const onUnlock = vi.fn()
+    const { container } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" isLocked onUnlock={onUnlock} lockType="migrate" />,
+    )
+    const buttons = container.querySelectorAll('button')
+    // Unlock is the last button (index 8)
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(onUnlock).toHaveBeenCalledOnce()
+  })
+
+  it('Unlock button absent when isLocked is false', () => {
+    const cbs = makeCallbacks()
+    const onUnlock = vi.fn()
+    const { container: cFalse } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" isLocked={false} onUnlock={onUnlock} />,
+    )
+    const { container: cBase } = renderWithProviders(
+      <VmActions {...makeCallbacks()} vmStatus="stopped" />,
+    )
+    expect(cFalse.querySelectorAll('button').length).toBe(
+      cBase.querySelectorAll('button').length,
+    )
+  })
+
+  it('Unlock button absent when onUnlock callback is not provided', () => {
+    const cbs = makeCallbacks()
+    const { container: cLocked } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" isLocked />,
+    )
+    const { container: cBase } = renderWithProviders(
+      <VmActions {...makeCallbacks()} vmStatus="stopped" />,
+    )
+    expect(cLocked.querySelectorAll('button').length).toBe(
+      cBase.querySelectorAll('button').length,
+    )
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Branch 6: disabled=true — all action buttons become disabled
+// ------------------------------------------------------------------ //
+describe('VmActions — disabled=true', () => {
+  it('all buttons are disabled when disabled=true', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" disabled />,
+    )
+    const buttons = container.querySelectorAll('button')
+    buttons.forEach((btn) => {
+      expect(btn).toBeDisabled()
+    })
+  })
+
+  it('Migrate button (index 4) is disabled when disabled=true', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmActions {...cbs} vmStatus="stopped" disabled canMigrate />,
+    )
+    expect(container.querySelectorAll('button')[4]).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Clone and ConvertTemplate
+// ------------------------------------------------------------------ //
+describe('VmActions — Clone and ConvertTemplate', () => {
+  it('clicking Clone (index 5) fires onClone', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    fireEvent.click(container.querySelectorAll('button')[5])
+    expect(cbs.onClone).toHaveBeenCalledOnce()
+  })
+
+  it('clicking ConvertTemplate (index 6) fires onConvertTemplate when stopped', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    fireEvent.click(container.querySelectorAll('button')[6])
+    expect(cbs.onConvertTemplate).toHaveBeenCalledOnce()
+  })
+
+  it('ConvertTemplate (index 6) is disabled when running', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="running" />)
+    expect(container.querySelectorAll('button')[6]).toBeDisabled()
+  })
+
+  it('clicking Migrate (index 4) fires onMigrate', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    fireEvent.click(container.querySelectorAll('button')[4])
+    expect(cbs.onMigrate).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.test.tsx
@@ -190,10 +190,19 @@ describe('VmActions — vmStatus=paused', () => {
   it('tooltip aria-label switches to Resume when paused (not Start)', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="paused" />)
-    // MUI Tooltip sets an aria-label on its internal clone <span> wrapper.
+    // MUI places the Tooltip accessible name as aria-label on the wrapper <span> (not the <button>), so the span is queried deliberately.
     // When paused the component passes t('vmActions.resume') = 'Resume'.
     const startSpan = container.querySelectorAll('button')[0].closest('span')
     expect(startSpan?.getAttribute('aria-label')).toBe('Resume')
+  })
+
+  it('tooltip aria-label is Start when not paused (stopped)', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(<VmActions {...cbs} vmStatus="stopped" />)
+    // MUI places the Tooltip accessible name as aria-label on the wrapper <span> (not the <button>), so the span is queried deliberately.
+    // When not paused the component passes t('audit.actions.start') = 'Start'.
+    const startSpan = container.querySelectorAll('button')[0].closest('span')
+    expect(startSpan?.getAttribute('aria-label')).toBe('Start')
   })
 })
 

--- a/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.test.tsx
+++ b/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { cleanup, within, fireEvent, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 import { inventoryFixture } from '@/__tests__/fixtures/inventory'
@@ -19,7 +19,7 @@ function seedInventory() {
 // ------------------------------------------------------------------ //
 // 1. Renders existing scope entries as chips and remove deletes them
 // ------------------------------------------------------------------ //
-describe('RoleDefaultScopeEditor — chip rendering and removal', () => {
+describe('RoleDefaultScopeEditor - chip rendering and removal', () => {
   beforeEach(() => {
     cleanup()
     seedInventory()
@@ -70,7 +70,7 @@ describe('RoleDefaultScopeEditor — chip rendering and removal', () => {
 // ------------------------------------------------------------------ //
 // 2. Adding a new entry: open target Select, pick option, click Add
 // ------------------------------------------------------------------ //
-describe('RoleDefaultScopeEditor — adding a new scope entry', () => {
+describe('RoleDefaultScopeEditor - adding a new scope entry', () => {
   beforeEach(() => {
     cleanup()
     seedInventory()
@@ -114,7 +114,7 @@ describe('RoleDefaultScopeEditor — adding a new scope entry', () => {
 // ------------------------------------------------------------------ //
 // 3. Guard: clicking Add with no target selected does not call onChange
 // ------------------------------------------------------------------ //
-describe('RoleDefaultScopeEditor — Add guard (no target selected)', () => {
+describe('RoleDefaultScopeEditor - Add guard (no target selected)', () => {
   beforeEach(() => {
     cleanup()
     seedInventory()
@@ -127,7 +127,7 @@ describe('RoleDefaultScopeEditor — Add guard (no target selected)', () => {
     )
 
     // The Add button is disabled when target='', so it cannot be clicked directly.
-    // Verify it is disabled — this is the guard the component enforces.
+    // Verify it is disabled - this is the guard the component enforces.
     const addBtn = screen.getByRole('button', { name: 'common.add' })
     expect(addBtn).toBeDisabled()
 

--- a/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.test.tsx
+++ b/frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { cleanup, within, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import { inventoryFixture } from '@/__tests__/fixtures/inventory'
+import RoleDefaultScopeEditor, { type RoleScopeEntry } from './RoleDefaultScopeEditor'
+
+// Translate stub: return the key unchanged. The component receives `t` as a prop
+// (not the next-intl hook) so no module mock is required.
+const t = (k: string) => k
+
+// Seed the inventory endpoint used by every test.
+function seedInventory() {
+  server.use(
+    http.get('/api/v1/inventory', () => HttpResponse.json(inventoryFixture)),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// 1. Renders existing scope entries as chips and remove deletes them
+// ------------------------------------------------------------------ //
+describe('RoleDefaultScopeEditor — chip rendering and removal', () => {
+  beforeEach(() => {
+    cleanup()
+    seedInventory()
+  })
+
+  it('renders a chip for each entry in value', async () => {
+    const value: RoleScopeEntry[] = [{ scopeType: 'tag', scopeTarget: 'prod' }]
+    renderWithProviders(
+      <RoleDefaultScopeEditor value={value} onChange={vi.fn()} t={t} />,
+    )
+
+    // After the inventory fetch resolves the chip label uses resolveScopeTargetLabel.
+    // For a 'tag' type, the label is: "rbac.scopes.tag: prod" (t returns the key).
+    // The chip should at minimum contain the target text.
+    expect(await screen.findByText(/prod/)).toBeInTheDocument()
+  })
+
+  it('calls onChange with the entry removed when the chip delete icon is clicked', async () => {
+    const onChange = vi.fn()
+    const value: RoleScopeEntry[] = [{ scopeType: 'tag', scopeTarget: 'prod' }]
+    const { container } = renderWithProviders(
+      <RoleDefaultScopeEditor value={value} onChange={onChange} t={t} />,
+    )
+
+    // Wait for chip to appear (inventory fetch must complete first)
+    await screen.findByText(/prod/)
+
+    const chip = container.querySelector('.MuiChip-root') as HTMLElement
+    expect(chip).not.toBeNull()
+
+    const deleteBtn = chip.querySelector('.MuiChip-deleteIcon') as HTMLElement
+    expect(deleteBtn).not.toBeNull()
+
+    fireEvent.click(deleteBtn)
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('shows "no scopes" caption when value is empty', () => {
+    renderWithProviders(
+      <RoleDefaultScopeEditor value={[]} onChange={vi.fn()} t={t} />,
+    )
+    // The caption uses the translation key directly via our stub.
+    expect(screen.getByText('rbacPage.defaultScope.none')).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Adding a new entry: open target Select, pick option, click Add
+// ------------------------------------------------------------------ //
+describe('RoleDefaultScopeEditor — adding a new scope entry', () => {
+  beforeEach(() => {
+    cleanup()
+    seedInventory()
+  })
+
+  it('calls onChange with the new entry after selecting a target and clicking Add', async () => {
+    const onChange = vi.fn()
+    const { container } = renderWithProviders(
+      <RoleDefaultScopeEditor value={[]} onChange={onChange} t={t} />,
+    )
+
+    // The target Select is disabled={!inventory} until the inventory fetch resolves.
+    // MUI adds Mui-disabled class to the Select root div when disabled.
+    // Wait until that class disappears, signalling the inventory fetch is done.
+    await waitFor(() => {
+      const selectRoots = container.querySelectorAll('.MuiSelect-root')
+      expect(selectRoots.length).toBeGreaterThanOrEqual(2)
+      expect(selectRoots[1].classList.contains('Mui-disabled')).toBe(false)
+    })
+
+    // Open the target Select (second combobox).
+    // MUI Select under jsdom requires fireEvent.mouseDown to open the dropdown.
+    // Note: userEvent.click does not open MUI Select reliably under jsdom.
+    const comboboxes = screen.getAllByRole('combobox')
+    const targetCombobox = comboboxes[1]
+    fireEvent.mouseDown(targetCombobox)
+
+    // Options render in a MUI portal appended to document.body; findByRole waits.
+    const option = await screen.findByRole('option', { name: /web/ })
+    fireEvent.click(option)
+
+    // Click the Add button (enabled after a target is selected).
+    const addBtn = screen.getByRole('button', { name: 'common.add' })
+    await waitFor(() => expect(addBtn).not.toBeDisabled())
+    fireEvent.click(addBtn)
+
+    expect(onChange).toHaveBeenCalledWith([{ scopeType: 'tag', scopeTarget: 'web' }])
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Guard: clicking Add with no target selected does not call onChange
+// ------------------------------------------------------------------ //
+describe('RoleDefaultScopeEditor — Add guard (no target selected)', () => {
+  beforeEach(() => {
+    cleanup()
+    seedInventory()
+  })
+
+  it('does not call onChange when Add is clicked with no target selected', async () => {
+    const onChange = vi.fn()
+    renderWithProviders(
+      <RoleDefaultScopeEditor value={[]} onChange={onChange} t={t} />,
+    )
+
+    // The Add button is disabled when target='', so it cannot be clicked directly.
+    // Verify it is disabled — this is the guard the component enforces.
+    const addBtn = screen.getByRole('button', { name: 'common.add' })
+    expect(addBtn).toBeDisabled()
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -177,7 +177,6 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeIcons.tsx,\
   frontend/src/components/hardware/CloneVmDialog.tsx,\
   frontend/src/components/dialogs/WhatsNewDialog.tsx,\
   frontend/src/components/settings/TenantsTab.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -173,7 +173,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/VmsTable.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/VmActions.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -167,7 +167,6 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/operations/reports/components/ReportGenerator.tsx,\
   frontend/src/contexts/TenantContext.tsx,\
   frontend/src/components/settings/NotificationsTab.jsx,\
-  frontend/src/app/(dashboard)/security/rbac/RoleDefaultScopeEditor.tsx,\
   frontend/src/components/settings/ConnectionDialog.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx,\
   frontend/src/components/VmsTable.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -173,7 +173,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/VmsTable.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/TagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\
   frontend/src/components/hardware/CloneVmDialog.tsx,\


### PR DESCRIPTION
First batch of component tests through the jsdom Vitest lane stood up in #456. Covers four previously-excluded client components and builds the reusable scaffolding (shared MSW lifecycle + frozen fixtures + context-mock patterns) that the larger containers will reuse in later batches.

## What this adds

Component tests (each removes the file from `sonar.coverage.exclusions` only after LCOV proved coverage):

| Component | Tests | Line coverage |
|-----------|-------|---------------|
| `TreeIcons.tsx` | 23 | 100% |
| `VmActions.tsx` | 33 | 100% |
| `TagManager.tsx` | 9 | 87% |
| `RoleDefaultScopeEditor.tsx` | 5 | 97% |

Shared test infrastructure (reused by every later fetch-driven component test):
- MSW server lifecycle wired into the jsdom setup file (`server.listen({ onUnhandledRequest: 'error' })` + reset/close), scoped to the jsdom lane only. The node lane is untouched.
- New `src/__tests__/fixtures/` directory with hand-written, deterministic fixtures derived from (not imported from) the demo mock data.
- Patterns established: per-test context-hook mocks, `fireEvent.mouseDown` to open MUI Select under jsdom, and Popover portal scoping.

## Notes

- Test and infra code only. No production source changed, so there is no behavior change to validate.
- Full suite green: 1760 tests (1687 node lane + 73 jsdom lane).
- Removing the four exclusions lets these components count toward overall coverage; the ratchet floor stays at 11 and will be bumped at a milestone in a dedicated commit.
