### PR TITLE
test(components): component-lane batch 2 (VmsTable, CreateLxcDialog)

### DIFF
--- a/frontend/src/__tests__/fixtures/pveProvisioning.ts
+++ b/frontend/src/__tests__/fixtures/pveProvisioning.ts
@@ -1,0 +1,64 @@
+/**
+ * Frozen hand-written fixture for LXC / VM provisioning dialog tests.
+ * Do NOT import mock-data.json or demoResponse. All data is static.
+ */
+
+export const connections = [
+  { id: 'conn-1', name: 'pve-cluster-1' },
+]
+
+export const nodes = [
+  {
+    node: 'pve1',
+    status: 'online',
+    cpu: 0.1,
+    maxcpu: 4,
+    mem: 512 * 1024 * 1024,
+    maxmem: 8 * 1024 * 1024 * 1024,
+  },
+]
+
+export const pools = [
+  { poolid: 'pool-dev', comment: 'Development pool' },
+  { poolid: 'pool-prod', comment: 'Production pool' },
+]
+
+/**
+ * Storage entries:
+ *   - 'local' has both vztmpl (template) and rootdir (disk) content
+ *   - 'local-zfs' has rootdir content only
+ * The 'node' field associates the storage with a specific node.
+ */
+export const storage = [
+  {
+    storage: 'local',
+    content: 'rootdir,images,vztmpl',
+    node: 'pve1',
+  },
+  {
+    storage: 'local-zfs',
+    content: 'rootdir,images',
+    node: 'pve1',
+  },
+]
+
+export const networkChoices = [
+  { name: 'vmbr0' },
+  { name: 'vmbr1' },
+]
+
+export const templates = [
+  {
+    volid: 'local:vztmpl/debian-12-standard_12.7-1_amd64.tar.zst',
+    size: 120 * 1024 * 1024,
+    format: 'tar.zst',
+  },
+  {
+    volid: 'local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.gz',
+    size: 200 * 1024 * 1024,
+    format: 'tar.gz',
+  },
+]
+
+/** nextid is not used by CreateLxcDialog (it computes locally from allVms). */
+export const nextid = 100

--- a/frontend/src/__tests__/fixtures/vmRows.ts
+++ b/frontend/src/__tests__/fixtures/vmRows.ts
@@ -1,0 +1,67 @@
+import type { VmRow } from '@/components/VmsTable'
+
+/**
+ * Static fixture for VmsTable tests.
+ * Covers: running qemu with tags + ip + snapshots, stopped lxc, template, locked vm.
+ */
+export const vmRowsFixture: VmRow[] = [
+  {
+    id: 'conn1:100',
+    connId: 'conn1',
+    node: 'pve1',
+    vmid: 100,
+    name: 'web-01',
+    type: 'qemu',
+    status: 'running',
+    cpu: 42,
+    maxcpu: 4,
+    ram: 65,
+    maxmem: 8589934592,
+    disk: 21474836480,
+    maxdisk: 107374182400,
+    uptime: 7200,
+    ip: '192.168.1.10',
+    snapshots: 2,
+    tags: ['prod', 'web'],
+    isCluster: true,
+    hastate: 'started',
+    hagroup: 'ha-group1',
+  },
+  {
+    id: 'conn1:101',
+    connId: 'conn1',
+    node: 'pve1',
+    vmid: 101,
+    name: 'db-lxc',
+    type: 'lxc',
+    status: 'stopped',
+    maxmem: 4294967296,
+    maxdisk: 21474836480,
+    tags: ['db'],
+    isCluster: true,
+  },
+  {
+    id: 'conn1:200',
+    connId: 'conn1',
+    node: 'pve1',
+    vmid: 200,
+    name: 'ubuntu-template',
+    type: 'qemu',
+    status: 'stopped',
+    template: true,
+    maxmem: 2147483648,
+    maxdisk: 21474836480,
+  },
+  {
+    id: 'conn1:102',
+    connId: 'conn1',
+    node: 'pve1',
+    vmid: 102,
+    name: 'locked-vm',
+    type: 'qemu',
+    status: 'stopped',
+    lock: 'migrate',
+    maxmem: 4294967296,
+    maxdisk: 21474836480,
+  },
+]

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
@@ -112,13 +112,24 @@ function makeProps(overrides: Partial<Parameters<typeof CreateLxcDialog>[0]> = {
  * Wait for the dialog to finish loading. After loadAllData() resolves, the
  * component sets selectedNodeValue='pve1' and renders the form. The
  * CircularProgress disappears and the Node Select combobox appears.
+ *
+ * Combobox ordering (fixed for these tests -- hideNodePicker=false, isAdmin=true):
+ *   comboboxes[0] = Node select      (rendered when !hideNodePicker)
+ *   comboboxes[1] = Resource Pool select (rendered when isAdmin)
+ *
+ * MUI Select uses aria-labelledby for label association but jsdom's ARIA
+ * name computation does not resolve aria-labelledby references for combobox
+ * roles, so getByRole('combobox', {name: ...}) does not work here. We keep
+ * index-based access and guard it with an explicit length assertion so that
+ * any structural change (e.g. a new combobox added before the Node select)
+ * fails loudly instead of silently asserting on the wrong element.
  */
 async function waitForDataLoad() {
-  // After data loads, the spinner disappears and form fields render.
-  // The Node Select combobox textContent contains 'pve1' (plus decoration).
   await waitFor(() => {
     const comboboxes = screen.getAllByRole('combobox')
-    // The first combobox is the Node select; after load it contains 'pve1'.
+    // Guard: at least Node (index 0) and Resource Pool (index 1) must exist.
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    // comboboxes[0] is the Node select; after load it shows 'pve1'.
     expect(comboboxes[0].textContent).toContain('pve1')
   })
 }
@@ -184,8 +195,9 @@ describe('CreateLxcDialog - data loads on open', () => {
   it('auto-selects the first node after data loads and shows its name', async () => {
     renderWithProviders(<CreateLxcDialog {...makeProps()} />)
     await waitForDataLoad()
-    // After load, the first combobox (Node select) contains 'pve1' in its text.
+    // comboboxes[0] is the Node select (see waitForDataLoad comment for ordering guarantee).
     const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
     expect(comboboxes[0].textContent).toContain('pve1')
   })
 
@@ -193,8 +205,9 @@ describe('CreateLxcDialog - data loads on open', () => {
     renderWithProviders(<CreateLxcDialog {...makeProps()} />)
     await waitForDataLoad()
 
-    // Open the Node picker dropdown (first combobox = Node select).
+    // comboboxes[0] is the Node select (see waitForDataLoad comment for ordering guarantee).
     const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
     fireEvent.mouseDown(comboboxes[0])
 
     // The MenuItem for pve1 appears in the portal listbox.
@@ -206,9 +219,11 @@ describe('CreateLxcDialog - data loads on open', () => {
     renderWithProviders(<CreateLxcDialog {...makeProps()} />)
     await waitForDataLoad()
 
-    // The Resource Pool Select is the second combobox on the General tab.
+    // comboboxes[0]=Node, comboboxes[1]=Resource Pool (see waitForDataLoad comment).
+    // The length assertion is a structural guard: if a new combobox is inserted
+    // before index 1 the test fails loudly rather than silently opening the wrong dropdown.
     const comboboxes = screen.getAllByRole('combobox')
-    // combobox[0]=Node, combobox[1]=ResourcePool
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
     fireEvent.mouseDown(comboboxes[1])
 
     // Pool items appear in the portal listbox.
@@ -611,5 +626,88 @@ describe('CreateLxcDialog - CT ID generation', () => {
     // CT ID 100 and 101 are used, so the next free is 102.
     const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
     expect(ctidInput.value).toBe('102')
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 10. Template tab - seeded templates appear after data load
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - Template tab', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  /**
+   * This test verifies the full template-load pipeline:
+   *   1. loadStorages() finds 'local' has 'vztmpl' content and sets templateStorage='local'.
+   *   2. The template-load effect fires, fetches content for node 'pve1' / storage 'local'.
+   *   3. Navigating to the Template tab shows the Storage select pre-filled with 'local'
+   *      and the Template select populated with the two seeded filenames from the fixture.
+   *
+   * Template filenames rendered by the component (tmpl.filename = last path segment of volid):
+   *   - debian-12-standard_12.7-1_amd64.tar.zst
+   *   - ubuntu-22.04-standard_22.04-1_amd64.tar.gz
+   *
+   * The fixture storage 'local' has content='rootdir,images,vztmpl' and node='pve1',
+   * which is the only storage with 'vztmpl'; this is what triggers the template fetch.
+   */
+  it('shows seeded template filenames in the Template select after navigating to the Template tab', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // Navigate to the Template tab (index 1).
+    fireEvent.click(screen.getByRole('tab', { name: 'Template' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Template' }).getAttribute('aria-selected')).toBe('true')
+    })
+
+    // On the Template tab, two comboboxes are rendered:
+    //   comboboxes[0] = Storage select
+    //   comboboxes[1] = Template select
+    // (The Node/Resource Pool selects from the General tab are no longer in the DOM.)
+    //
+    // Note: MUI Select aria-labelledby name computation does not resolve under
+    // jsdom, so we use index-based access with an explicit length guard.
+    //
+    // The Storage select should be pre-filled with 'local' (the only fixture
+    // storage that has 'vztmpl' content). This verifies the storage fetch ran
+    // and filtered correctly -- 'local' is data-driven, not always-present text.
+    await waitFor(() => {
+      const comboboxes = screen.getAllByRole('combobox')
+      // Guard: Storage (0) and Template (1) must both be present.
+      expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+      // comboboxes[0] = Storage select; 'local' comes from the fixture.
+      expect(comboboxes[0].textContent).toContain('local')
+    })
+
+    // Wait for the template-load effect to resolve, then open the Template select
+    // to verify the seeded template filenames are present in the listbox.
+    // The component fetches content from nodes/${NODE_NAME}/storage/local/content
+    // and derives `filename` from the volid (last segment after '/').
+    await waitFor(() => {
+      const comboboxes = screen.getAllByRole('combobox')
+      expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+      // comboboxes[1] = Template select; it is enabled when templates loaded.
+      expect(comboboxes[1]).not.toBeDisabled()
+    })
+
+    // Open the Template select to reveal the option list.
+    const comboboxes = screen.getAllByRole('combobox')
+    fireEvent.mouseDown(comboboxes[1])
+
+    // Both seeded template filenames must appear as options in the listbox.
+    // These values come exclusively from the fixture MSW response -- not from
+    // any static text that is always present on the page.
+    const debianOption = await screen.findByRole('option', {
+      name: /debian-12-standard_12\.7-1_amd64\.tar\.zst/,
+    })
+    expect(debianOption).toBeInTheDocument()
+
+    const ubuntuOption = screen.getByRole('option', {
+      name: /ubuntu-22\.04-standard_22\.04-1_amd64\.tar\.gz/,
+    })
+    expect(ubuntuOption).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
@@ -1,0 +1,615 @@
+/**
+ * Component tests for CreateLxcDialog.tsx
+ *
+ * Strategy: render the dialog with open={true}, seed every MSW endpoint the
+ * dialog calls on mount, await data load, then assert visible output and
+ * basic interactions. Context hooks that depend on live providers are mocked
+ * at module level.
+ *
+ * Not covered here:
+ *   - Full multi-tab navigation end-to-end (heavy form state across 8 tabs)
+ *   - Recharts (SVG width unavailable under jsdom)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import {
+  connections,
+  nodes,
+  pools,
+  storage,
+  networkChoices,
+  templates,
+} from '@/__tests__/fixtures/pveProvisioning'
+
+import CreateLxcDialog from './CreateLxcDialog'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+vi.mock('@/contexts/RBACContext', () => ({
+  useRBAC: () => ({ isAdmin: true }),
+}))
+
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ currentTenant: null, loading: false, isFullClusterView: true }),
+}))
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = connections[0].id   // 'conn-1'
+const NODE_NAME = nodes[0].node     // 'pve1'
+
+// ------------------------------------------------------------------ //
+// MSW handler factory
+// Seeds ALL endpoints the dialog fires on open (and on connection/node select).
+// ------------------------------------------------------------------ //
+
+function seedAllHandlers() {
+  server.use(
+    // 1. Connections list (type=pve)
+    http.get('*/api/v1/connections', ({ request }) => {
+      const url = new URL(request.url)
+      if (url.searchParams.get('type') === 'pve') {
+        return HttpResponse.json({ data: connections })
+      }
+      return HttpResponse.json({ data: [] })
+    }),
+
+    // 2. Nodes for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodes }),
+    ),
+
+    // 3. Pools for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/pools`, () =>
+      HttpResponse.json({ data: pools }),
+    ),
+
+    // 4. Storage for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/storage`, () =>
+      HttpResponse.json({ data: storage }),
+    ),
+
+    // 5. Network choices for connection + node
+    http.get(`*/api/v1/connections/${CONN_ID}/network-choices`, () =>
+      HttpResponse.json({ data: networkChoices }),
+    ),
+
+    // 6. Template content from the node/storage
+    http.get(
+      `*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storage/local/content`,
+      () => HttpResponse.json({ data: templates }),
+    ),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// Helpers
+// ------------------------------------------------------------------ //
+
+function makeProps(overrides: Partial<Parameters<typeof CreateLxcDialog>[0]> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    allVms: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Wait for the dialog to finish loading. After loadAllData() resolves, the
+ * component sets selectedNodeValue='pve1' and renders the form. The
+ * CircularProgress disappears and the Node Select combobox appears.
+ */
+async function waitForDataLoad() {
+  // After data loads, the spinner disappears and form fields render.
+  // The Node Select combobox textContent contains 'pve1' (plus decoration).
+  await waitFor(() => {
+    const comboboxes = screen.getAllByRole('combobox')
+    // The first combobox is the Node select; after load it contains 'pve1'.
+    expect(comboboxes[0].textContent).toContain('pve1')
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Dialog open / closed visibility
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - open/closed state', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('renders the dialog title when open=true', () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    expect(screen.getByText('Create: LXC Container')).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Next buttons when open=true', () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    // The Next button has exact text "Next" (common.next translation).
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+  })
+
+  it('renders all tab labels', () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Template' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Disks' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'CPU' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Memory' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Network' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'DNS' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Confirm' })).toBeInTheDocument()
+  })
+
+  it('does not render the dialog title when open=false', () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps({ open: false })} />)
+    expect(screen.queryByText('Create: LXC Container')).not.toBeInTheDocument()
+  })
+
+  it('Back button is disabled on the first tab', () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    const backBtn = screen.getByRole('button', { name: /back/i })
+    expect(backBtn).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Data load on open -- connections, nodes, pools load from MSW
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - data loads on open', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('auto-selects the first node after data loads and shows its name', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+    // After load, the first combobox (Node select) contains 'pve1' in its text.
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes[0].textContent).toContain('pve1')
+  })
+
+  it('opens the Node Select listbox and lists the seeded node', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // Open the Node picker dropdown (first combobox = Node select).
+    const comboboxes = screen.getAllByRole('combobox')
+    fireEvent.mouseDown(comboboxes[0])
+
+    // The MenuItem for pve1 appears in the portal listbox.
+    const option = await screen.findByRole('option', { name: /pve1/ })
+    expect(option).toBeInTheDocument()
+  })
+
+  it('populates the Resource Pool selector with seeded pools', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The Resource Pool Select is the second combobox on the General tab.
+    const comboboxes = screen.getAllByRole('combobox')
+    // combobox[0]=Node, combobox[1]=ResourcePool
+    fireEvent.mouseDown(comboboxes[1])
+
+    // Pool items appear in the portal listbox.
+    const poolDev = await screen.findByRole('option', { name: /pool-dev/ })
+    expect(poolDev).toBeInTheDocument()
+    const poolProd = screen.getByRole('option', { name: /pool-prod/ })
+    expect(poolProd).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Form input interaction
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - form inputs', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('typing in the Hostname field updates its value', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const hostnameInput = screen.getByLabelText('Hostname') as HTMLInputElement
+    expect(hostnameInput).toBeInTheDocument()
+    fireEvent.change(hostnameInput, { target: { value: 'my-container' } })
+    expect(hostnameInput.value).toBe('my-container')
+  })
+
+  it('CT ID field is present and accepts numeric input', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    expect(ctidInput).toBeInTheDocument()
+    fireEvent.change(ctidInput, { target: { value: '105' } })
+    expect(ctidInput.value).toBe('105')
+  })
+
+  it('CT ID rejects non-numeric characters (filters them out)', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    fireEvent.change(ctidInput, { target: { value: 'abc123xyz' } })
+    // Non-numeric characters are stripped by handleCtidChange.
+    expect(ctidInput.value).toBe('123')
+  })
+
+  it('CT ID below 100 shows a validation error', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    fireEvent.change(ctidInput, { target: { value: '50' } })
+    expect(screen.getByText('CT ID must be >= 100')).toBeInTheDocument()
+  })
+
+  it('CT ID in-use shows validation error when allVms contains the id', async () => {
+    renderWithProviders(
+      <CreateLxcDialog
+        {...makeProps({ allVms: [{ vmid: '101', connId: CONN_ID, node: NODE_NAME } as any] })}
+      />,
+    )
+    await waitForDataLoad()
+
+    // CT ID auto-sets to next available (102 since 101 is used). Typing 101
+    // manually should show the in-use error.
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    fireEvent.change(ctidInput, { target: { value: '101' } })
+    expect(screen.getByText(/CT ID 101 is already in use/i)).toBeInTheDocument()
+  })
+
+  it('Unprivileged toggle is checked by default after data loads', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // MUI Switch: find by label text then walk to the checkbox input.
+    // The label text is "Unprivileged container" (from en.json).
+    const label = screen.getByText('Unprivileged container')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const switchInput = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(switchInput).not.toBeNull()
+    expect(switchInput.checked).toBe(true)
+  })
+
+  it('toggling the Nesting switch enables it', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const label = screen.getByText('Nesting')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const switchInput = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(switchInput).not.toBeNull()
+    expect(switchInput.checked).toBe(false)
+
+    fireEvent.click(switchInput)
+    expect(switchInput.checked).toBe(true)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Cancel button
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - Cancel button', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<CreateLxcDialog {...makeProps({ onClose })} />)
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Tab navigation
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - tab navigation', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('clicking Next advances from General to Template tab', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // Use exact name 'Next' to avoid matching "Generate next available ID" icon button.
+    const nextBtn = screen.getByRole('button', { name: 'Next' })
+    fireEvent.click(nextBtn)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Template' }).getAttribute('aria-selected')).toBe('true')
+    })
+  })
+
+  it('clicking the CPU tab renders cores UI', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'CPU' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'CPU' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // Cores label is rendered on the CPU tab.
+    expect(screen.getByText(/Cores: 1/i)).toBeInTheDocument()
+  })
+
+  it('clicking the Memory tab shows memory label', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Memory' }))
+
+    await waitFor(() => {
+      // The Memory tab renders "Memory (MiB): 512 MiB"
+      expect(screen.getByText(/Memory \(MiB\):/i)).toBeInTheDocument()
+    })
+  })
+
+  it('clicking the Network tab activates the Network tab and renders network fields', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Network' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Network' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // Network tab renders the Name label (inventory.createLxc.networkName = "Name").
+    // Use getByLabelText to specifically find the Name input field.
+    expect(screen.getByLabelText('Name')).toBeInTheDocument()
+  })
+
+  it('clicking the DNS tab activates the DNS tab and renders DNS fields', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'DNS' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'DNS' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // DNS tab renders the DNS servers input (inventory.createLxc.dnsServers = "DNS servers").
+    expect(screen.getByLabelText('DNS servers')).toBeInTheDocument()
+  })
+
+  it('clicking the Confirm tab shows the review summary', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Review your settings/i)).toBeInTheDocument()
+    })
+  })
+
+  it('clicking the Disks tab shows rootfs label', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Disks' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('rootfs')).toBeInTheDocument()
+    })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. Security section (collapsible)
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - Security section', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('expands the Security section and shows Password field', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByText('Security'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    })
+  })
+
+  it('shows a "Password set" chip when a password is entered', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByText('Security'))
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret123' } })
+
+    expect(screen.getByText('Password set')).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 7. Boot section (collapsible)
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - Boot section', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('expands the Boot section and shows the start-at-boot toggle', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The boot section header text comes from inventory.createVm.bootShutdown
+    const bootHeader = screen.getByText(/Boot & Shutdown/i)
+    fireEvent.click(bootHeader)
+
+    // After expanding, the Start at boot FormControlLabel becomes visible.
+    await waitFor(() => {
+      expect(screen.getByText('Start at boot')).toBeInTheDocument()
+    })
+    // Verify it has a checkbox input.
+    const label = screen.getByText('Start at boot')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const switchInput = formControlLabel.querySelector('input[type="checkbox"]')
+    expect(switchInput).not.toBeNull()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 8. Create button and submit flow
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - Create flow', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('shows Create button on the Confirm (last) tab', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument()
+    })
+  })
+
+  it('fires onClose after a successful create from the Confirm tab', async () => {
+    const onClose = vi.fn()
+    const onCreated = vi.fn()
+
+    server.use(
+      http.post(`*/api/v1/connections/${CONN_ID}/guests/lxc/${NODE_NAME}`, () =>
+        HttpResponse.json({ data: { upid: 'UPID:pve1:test' } }),
+      ),
+    )
+
+    // Pass allVms with one vm so CTID auto-sets to 100 (next free).
+    renderWithProviders(
+      <CreateLxcDialog
+        {...makeProps({
+          onClose,
+          onCreated,
+          allVms: [{ vmid: '101', connId: CONN_ID, node: NODE_NAME } as any],
+        })}
+      />,
+    )
+
+    await waitForDataLoad()
+
+    // Navigate to Confirm tab.
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      const createBtn = screen.getByRole('button', { name: /create/i })
+      // ctid=100 (next after 101), resolvedNode=pve1 -- both set, button enabled.
+      expect(createBtn).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+    expect(onCreated).toHaveBeenCalledWith('100', CONN_ID, NODE_NAME)
+  })
+
+  it('shows an error when the POST returns a server error', async () => {
+    server.use(
+      http.post(`*/api/v1/connections/${CONN_ID}/guests/lxc/${NODE_NAME}`, () =>
+        HttpResponse.json({ error: 'Out of resources' }, { status: 500 }),
+      ),
+    )
+
+    renderWithProviders(
+      <CreateLxcDialog
+        {...makeProps({
+          allVms: [{ vmid: '101', connId: CONN_ID, node: NODE_NAME } as any],
+        })}
+      />,
+    )
+
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Out of resources/i)).toBeInTheDocument()
+    })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 9. CT ID generation helper
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - CT ID generation', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('auto-sets CT ID to the next free ID when allVms is provided', async () => {
+    renderWithProviders(
+      <CreateLxcDialog
+        {...makeProps({
+          allVms: [
+            { vmid: '100', connId: CONN_ID, node: NODE_NAME } as any,
+            { vmid: '101', connId: CONN_ID, node: NODE_NAME } as any,
+          ],
+        })}
+      />,
+    )
+    await waitForDataLoad()
+
+    // CT ID 100 and 101 are used, so the next free is 102.
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    expect(ctidInput.value).toBe('102')
+  })
+})

--- a/frontend/src/components/VmsTable.test.tsx
+++ b/frontend/src/components/VmsTable.test.tsx
@@ -112,8 +112,6 @@ describe('VmsTable - density toggle', () => {
     const { container } = renderWithProviders(
       <VmsTable vms={vmRowsFixture} showDensityToggle />,
     )
-    // The toolbar contains a Box with "Compact" text
-    const toolbar = container.querySelector('.MuiBox-root')
     // Find the element containing exactly "Compact" in the toolbar
     const allTexts = Array.from(container.querySelectorAll('*')).filter(
       el => el.textContent?.trim() === 'Compact' && el.children.length <= 1,
@@ -194,7 +192,7 @@ describe('VmsTable - action buttons', () => {
     expect(rowButtons.length).toBeGreaterThan(0)
   })
 
-  it('Start button (index 0) is disabled for running vm', () => {
+  it('Start button is disabled and Shutdown enabled for running vm', () => {
     const cbs = makeCallbacks()
     const { container } = renderWithProviders(
       <VmsTable
@@ -205,10 +203,11 @@ describe('VmsTable - action buttons', () => {
       />,
     )
     const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
-    // First button in the row is the favorite star (column 1), second group is actions
-    // Find the first disabled button - Start is disabled when running
-    const disabledBtn = Array.from(rowButtons).find(b => b.disabled)
-    expect(disabledBtn).toBeDefined()
+    // Button order (desktop, matchMedia matches:false): [0]=favorite-star, [1]=Start, [2]=Shutdown,
+    //   [3]=Stop, [4]=Pause, [5]=Console, [6]=Migrate, [7]=Details
+    // web-01 is 'running': Start (index 1) must be disabled, Shutdown (index 2) must be enabled.
+    expect(rowButtons[1].disabled).toBe(true)   // Start: disabled when running
+    expect(rowButtons[2].disabled).toBe(false)  // Shutdown: enabled when running
   })
 
   it('clicking Shutdown on running vm fires onVmAction with "shutdown"', () => {
@@ -306,14 +305,11 @@ describe('VmsTable - action buttons', () => {
         onVmAction={cbs.onVmAction}
       />,
     )
-    // With showActions=false, the only row button is the favorite star
+    // With showActions=false the only row button is the favorite star (no start/stop/migrate).
     const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
-    // Favorite column always renders a star button; that is all there should be
-    // (showActions=false means no start/stop/migrate buttons)
-    // Verify onVmAction is never called from the star button
-    if (rowButtons.length > 0) {
-      fireEvent.click(rowButtons[0])
-    }
+    expect(rowButtons.length).toBe(1)  // only the favorite star
+    // Clicking the star must not trigger onVmAction (it calls onToggleFavorite instead).
+    fireEvent.click(rowButtons[0])
     expect(cbs.onVmAction).not.toHaveBeenCalled()
   })
 })
@@ -518,7 +514,7 @@ describe('VmsTable - trend column absent by default', () => {
 // ------------------------------------------------------------------ //
 
 describe('VmsTable - context menu', () => {
-  it('does not crash on contextmenu event on a row', () => {
+  it('opens the internal context menu on contextmenu event on a row', () => {
     const { container } = renderWithProviders(
       <VmsTable
         vms={[vmRowsFixture[0]]}
@@ -526,14 +522,16 @@ describe('VmsTable - context menu', () => {
         onMigrate={vi.fn()}
       />,
     )
+    // Capture baseline: 'web-01' appears once in the DataGrid cell before the menu opens.
+    const before = screen.getAllByText('web-01').length
     const row = container.querySelector('.MuiDataGrid-row')
-    if (row) {
-      fireEvent.contextMenu(row)
-    }
-    // After contextmenu the MUI Menu opens and renders the vm name in its header.
-    // Use getAllByText to handle both the grid cell and the menu header.
-    const nameEls = screen.getAllByText('web-01')
-    expect(nameEls.length).toBeGreaterThan(0)
+    expect(row).not.toBeNull()
+    fireEvent.contextMenu(row!)
+    // After contextmenu, VmsTable opens an internal MUI Menu whose header renders the
+    // vm name (contextMenu?.vm.name). The count must increase because the menu header
+    // adds a second occurrence -- proving the menu actually opened, not just the grid cell.
+    const after = screen.getAllByText('web-01').length
+    expect(after).toBeGreaterThan(before)
   })
 })
 

--- a/frontend/src/components/VmsTable.test.tsx
+++ b/frontend/src/components/VmsTable.test.tsx
@@ -1,0 +1,559 @@
+/**
+ * Component tests for VmsTable.tsx
+ *
+ * Strategy: VmsTable receives all data via props (no internal fetch), so tests
+ * render it with a hand-written fixture and assert visible output + callbacks.
+ * DataGrid rows are queried by cell text or DOM selectors.
+ * Context hooks (useTenant, useTagColors) are mocked at the module level.
+ *
+ * Not covered here:
+ *   - recharts trend charts (require real SVG width; showTrends=false for all tests)
+ *   - Excel export (dynamic import of exceljs; not practical under jsdom)
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen, fireEvent } from '@/__tests__/setup/renderWithProviders'
+import VmsTable from '@/components/VmsTable'
+import { vmRowsFixture } from '@/__tests__/fixtures/vmRows'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+// TenantContext: VmsTable reads { loading, isFullClusterView }
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ loading: false, isFullClusterView: true }),
+}))
+
+// TagColorContext: VmsTable destructures { getColor, getShape, loadConnection }
+vi.mock('@/contexts/TagColorContext', () => ({
+  useTagColors: () => ({
+    getColor: () => ({ bg: '#1976d2', fg: '#ffffff' }),
+    getOverride: () => undefined,
+    getShape: () => 'full',
+    loadConnection: vi.fn(),
+  }),
+}))
+
+// ------------------------------------------------------------------ //
+// Cleanup after each test to avoid DOM accumulation
+// ------------------------------------------------------------------ //
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// Helpers
+// ------------------------------------------------------------------ //
+
+function makeCallbacks() {
+  return {
+    onVmClick: vi.fn(),
+    onVmAction: vi.fn(),
+    onMigrate: vi.fn(),
+    onNodeClick: vi.fn(),
+    onToggleFavorite: vi.fn(),
+  }
+}
+
+// ------------------------------------------------------------------ //
+// 1. Basic render
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - basic render', () => {
+  it('renders all VM names from the fixture', () => {
+    renderWithProviders(
+      <VmsTable vms={vmRowsFixture} />,
+    )
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+    expect(screen.getByText('db-lxc')).toBeInTheDocument()
+    expect(screen.getByText('ubuntu-template')).toBeInTheDocument()
+    expect(screen.getByText('locked-vm')).toBeInTheDocument()
+  })
+
+  it('renders without crashing when vms is empty', () => {
+    const { container } = renderWithProviders(<VmsTable vms={[]} />)
+    expect(container.querySelector('.MuiDataGrid-root')).toBeInTheDocument()
+  })
+
+  it('renders without crashing when loading=true', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={[]} loading />,
+    )
+    expect(container.querySelector('.MuiDataGrid-root')).toBeInTheDocument()
+  })
+
+  it('shows node text in rows when showNode is true', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[0]]} showNode />,
+    )
+    // node column renders the node name
+    const nodeEls = container.querySelectorAll('.node-name')
+    expect(nodeEls.length).toBeGreaterThan(0)
+    expect(nodeEls[0].textContent).toBe('pve1')
+  })
+
+  it('does not show node column when showNode is false', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[0]]} showNode={false} />,
+    )
+    // When showNode=false no .node-name elements exist
+    expect(container.querySelectorAll('.node-name').length).toBe(0)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Density toggle
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - density toggle', () => {
+  it('renders the density toggle "Compact" text when showDensityToggle=true', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={vmRowsFixture} showDensityToggle />,
+    )
+    // The toolbar contains a Box with "Compact" text
+    const toolbar = container.querySelector('.MuiBox-root')
+    // Find the element containing exactly "Compact" in the toolbar
+    const allTexts = Array.from(container.querySelectorAll('*')).filter(
+      el => el.textContent?.trim() === 'Compact' && el.children.length <= 1,
+    )
+    expect(allTexts.length).toBeGreaterThan(0)
+  })
+
+  it('flips the density label when the toggle box is clicked', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={vmRowsFixture} showDensityToggle />,
+    )
+    // Find the toggle box: contains ri-list-check icon + "Compact" text
+    const toggleIcon = container.querySelector('.ri-list-check')
+    expect(toggleIcon).toBeInTheDocument()
+    const toggleBox = toggleIcon!.parentElement!
+    fireEvent.click(toggleBox)
+    // After click isCompact flips to false -> icon becomes ri-list-check-2
+    expect(container.querySelector('.ri-list-check-2')).toBeInTheDocument()
+  })
+
+  it('does not render density toggle icon when showDensityToggle=false', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={vmRowsFixture} showDensityToggle={false} />,
+    )
+    // With showDensityToggle=false neither ri-list-check nor ri-list-check-2 is in the toolbar
+    // Note: the toolbar only appears when vms.length > 0
+    // The list-check icons are used only in the density toggle
+    expect(container.querySelector('.ri-list-check')).not.toBeInTheDocument()
+    expect(container.querySelector('.ri-list-check-2')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Row click fires onVmClick
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - row click', () => {
+  it('fires onVmClick with the correct vm when the name cell is clicked', () => {
+    const cbs = makeCallbacks()
+    renderWithProviders(
+      <VmsTable vms={vmRowsFixture} onVmClick={cbs.onVmClick} />,
+    )
+    fireEvent.click(screen.getByText('web-01'))
+    expect(cbs.onVmClick).toHaveBeenCalledOnce()
+    expect(cbs.onVmClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conn1:100', name: 'web-01' }),
+    )
+  })
+
+  it('fires onVmClick for the stopped lxc row when clicked', () => {
+    const cbs = makeCallbacks()
+    renderWithProviders(
+      <VmsTable vms={vmRowsFixture} onVmClick={cbs.onVmClick} />,
+    )
+    fireEvent.click(screen.getByText('db-lxc'))
+    expect(cbs.onVmClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conn1:101', name: 'db-lxc' }),
+    )
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Action buttons (showActions + onVmAction)
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - action buttons', () => {
+  it('renders action buttons in the actions column', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll('.MuiDataGrid-row button')
+    expect(rowButtons.length).toBeGreaterThan(0)
+  })
+
+  it('Start button (index 0) is disabled for running vm', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // First button in the row is the favorite star (column 1), second group is actions
+    // Find the first disabled button - Start is disabled when running
+    const disabledBtn = Array.from(rowButtons).find(b => b.disabled)
+    expect(disabledBtn).toBeDefined()
+  })
+
+  it('clicking Shutdown on running vm fires onVmAction with "shutdown"', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // Button layout in a row: [0]=favorite-star, [1]=Start(disabled/running), [2]=Shutdown(enabled), ...
+    // Shutdown is at index 2 (after favorite star and disabled start)
+    expect(rowButtons.length).toBeGreaterThan(2)
+    // Index 2 is Shutdown for a running vm
+    fireEvent.click(rowButtons[2])
+    expect(cbs.onVmAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'web-01' }),
+      'shutdown',
+    )
+  })
+
+  it('clicking Start on a stopped vm fires onVmAction with "start"', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[1]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // For a stopped vm: [0]=favorite-star, [1]=Start(enabled), [2]=Shutdown(disabled)...
+    // Find the first action button (index 1 after favorite)
+    // The favorite button is index 0; Start is index 1
+    expect(rowButtons.length).toBeGreaterThan(1)
+    const startBtn = rowButtons[1]
+    expect(startBtn).not.toBeDisabled()
+    fireEvent.click(startBtn)
+    expect(cbs.onVmAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'db-lxc' }),
+      'start',
+    )
+  })
+
+  it('clicking Details fires onVmAction with "details"', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // Details is the last action button in the row
+    const lastBtn = rowButtons[rowButtons.length - 1]
+    fireEvent.click(lastBtn)
+    expect(cbs.onVmAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'web-01' }),
+      'details',
+    )
+  })
+
+  it('clicking the Deploy button on a template fires onVmAction with "clone"', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[2]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // Template row: [0]=favorite-star, [1]=Deploy(Clone), [2]=Migrate
+    expect(rowButtons.length).toBeGreaterThan(1)
+    fireEvent.click(rowButtons[1])
+    expect(cbs.onVmAction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'ubuntu-template', template: true }),
+      'clone',
+    )
+  })
+
+  it('does not render action buttons in rows when showActions is false', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions={false}
+        onVmAction={cbs.onVmAction}
+      />,
+    )
+    // With showActions=false, the only row button is the favorite star
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // Favorite column always renders a star button; that is all there should be
+    // (showActions=false means no start/stop/migrate buttons)
+    // Verify onVmAction is never called from the star button
+    if (rowButtons.length > 0) {
+      fireEvent.click(rowButtons[0])
+    }
+    expect(cbs.onVmAction).not.toHaveBeenCalled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Favorites
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - favorites', () => {
+  it('marks a vm as favorite (gold star fill) when its id is in favorites set', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        favorites={new Set(['conn1:100'])}
+        onToggleFavorite={vi.fn()}
+      />,
+    )
+    // The favorite column renders ri-star-fill when the vm is in favorites
+    expect(container.querySelector('.ri-star-fill')).toBeInTheDocument()
+  })
+
+  it('shows empty star (ri-star-line) when vm is not in favorites', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        favorites={new Set()}
+        onToggleFavorite={vi.fn()}
+      />,
+    )
+    // The header also has ri-star-line; look in the row
+    const rowStars = container.querySelectorAll('.MuiDataGrid-row .ri-star-line')
+    expect(rowStars.length).toBeGreaterThan(0)
+  })
+
+  it('clicking the favorite star button fires onToggleFavorite with the correct vm', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        favorites={new Set()}
+        onToggleFavorite={cbs.onToggleFavorite}
+      />,
+    )
+    const starBtn = container.querySelector<HTMLButtonElement>('.MuiDataGrid-row button')
+    expect(starBtn).not.toBeNull()
+    fireEvent.click(starBtn!)
+    expect(cbs.onToggleFavorite).toHaveBeenCalledOnce()
+    expect(cbs.onToggleFavorite).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conn1:100', name: 'web-01' }),
+    )
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. Node click
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - node click', () => {
+  it('fires onNodeClick with connId and node when the node cell box is clicked', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showNode
+        onNodeClick={cbs.onNodeClick}
+      />,
+    )
+    // Click the node cell wrapper box
+    const nodeEl = container.querySelector('.node-name')
+    expect(nodeEl).not.toBeNull()
+    fireEvent.click(nodeEl!)
+    expect(cbs.onNodeClick).toHaveBeenCalledWith('conn1', 'pve1')
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 7. Migration state
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - migrating vm state', () => {
+  it('adds migrating-row class to a vm whose id is in migratingVmIds', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        migratingVmIds={new Set(['conn1:100'])}
+      />,
+    )
+    expect(container.querySelector('.migrating-row')).toBeInTheDocument()
+  })
+
+  it('does not add migrating-row class when migratingVmIds is empty', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        migratingVmIds={new Set()}
+      />,
+    )
+    expect(container.querySelector('.migrating-row')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 8. Highlighted row
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - highlighted row', () => {
+  it('adds highlighted-row class to the vm whose id matches highlightedId', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        highlightedId="conn1:100"
+      />,
+    )
+    expect(container.querySelector('.highlighted-row')).toBeInTheDocument()
+  })
+
+  it('does not add highlighted-row when highlightedId does not match', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        highlightedId="conn1:999"
+      />,
+    )
+    expect(container.querySelector('.highlighted-row')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 9. IP/Snapshot columns visible when showIpSnap=true
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - IP and snapshot columns', () => {
+  it('renders ip text when showIpSnap=true', () => {
+    renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[0]]} showIpSnap />,
+    )
+    expect(screen.getByText('192.168.1.10')).toBeInTheDocument()
+  })
+
+  it('does not render ip text when showIpSnap=false', () => {
+    renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[0]]} showIpSnap={false} />,
+    )
+    expect(screen.queryByText('192.168.1.10')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 10. Migrate button fires onMigrate
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - migrate button', () => {
+  it('clicking Migrate fires onMigrate for running vm', () => {
+    const cbs = makeCallbacks()
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        showActions
+        onVmAction={cbs.onVmAction}
+        onMigrate={cbs.onMigrate}
+      />,
+    )
+    const rowButtons = container.querySelectorAll<HTMLButtonElement>('.MuiDataGrid-row button')
+    // Button layout: [0]=favorite, [1]=Start(disabled), [2]=Shutdown, [3]=Stop, [4]=Pause,
+    //                [5]=Console, [6]=Migrate, [7]=Details
+    // Migrate is second-to-last (index length-2)
+    expect(rowButtons.length).toBeGreaterThan(2)
+    const migrateBtn = rowButtons[rowButtons.length - 2]
+    fireEvent.click(migrateBtn)
+    expect(cbs.onMigrate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'web-01' }),
+    )
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 11. defaultHiddenColumns
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - defaultHiddenColumns', () => {
+  it('renders without crashing when defaultHiddenColumns is provided', () => {
+    renderWithProviders(
+      <VmsTable vms={vmRowsFixture} defaultHiddenColumns={['tags', 'ip']} />,
+    )
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 12. showTrends=false (default) does not crash
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - trend column absent by default', () => {
+  it('renders without showTrends prop without crashing', () => {
+    renderWithProviders(<VmsTable vms={vmRowsFixture} />)
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 13. Context menu
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - context menu', () => {
+  it('does not crash on contextmenu event on a row', () => {
+    const { container } = renderWithProviders(
+      <VmsTable
+        vms={[vmRowsFixture[0]]}
+        onVmAction={vi.fn()}
+        onMigrate={vi.fn()}
+      />,
+    )
+    const row = container.querySelector('.MuiDataGrid-row')
+    if (row) {
+      fireEvent.contextMenu(row)
+    }
+    // After contextmenu the MUI Menu opens and renders the vm name in its header.
+    // Use getAllByText to handle both the grid cell and the menu header.
+    const nameEls = screen.getAllByText('web-01')
+    expect(nameEls.length).toBeGreaterThan(0)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 14. Locked vm indicator
+// ------------------------------------------------------------------ //
+
+describe('VmsTable - locked vm', () => {
+  it('renders locked vm name without crashing', () => {
+    renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[3]]} />,
+    )
+    expect(screen.getByText('locked-vm')).toBeInTheDocument()
+  })
+
+  it('shows lock icon on a locked vm row', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[3]]} />,
+    )
+    // The name cell renders a lock badge when vm.lock is set
+    expect(container.querySelector('.ri-lock-fill')).toBeInTheDocument()
+  })
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -169,7 +169,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/settings/NotificationsTab.jsx,\
   frontend/src/components/settings/ConnectionDialog.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/CephTopology.tsx,\
-  frontend/src/components/VmsTable.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -180,7 +180,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/templates/DeployWizard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx,\
   frontend/src/app/api/v1/inventory/route.ts,\
   frontend/src/app/api/v1/inventory/stream/route.ts,\
   frontend/src/components/TasksFooter.tsx,\


### PR DESCRIPTION
Second batch of component tests through the jsdom Vitest lane. Covers the two largest testable client components and removes them from `sonar.coverage.exclusions`, building on the shared MSW + fixtures scaffolding from batch 1 (#457).

## What this adds

| Component | Lines | Tests | Per-file line coverage |
|-----------|-------|-------|------------------------|
| `VmsTable.tsx` | 2162 | 33 | 54% |
| `CreateLxcDialog.tsx` | 1469 | 31 | 68% |

- `VmsTable` is the MUI DataGrid VM table. Data arrives via the `vms` prop, so the test mocks the two context hooks it reads (`useTenant`, `useTagColors`) and drives a small frozen `VmRow[]` fixture: row render, row/node click callbacks, per-row actions and migrate, favorites toggle, density toggle, lock/migrating/highlight states, and the context menu.
- `CreateLxcDialog` is a controlled create-container dialog whose form is populated by a cascade of fetches on open (connections, nodes, pools, storage, network choices, templates). The test seeds those with MSW from a hand-written fixture and exercises open/close, data load, the tab navigation, form validation (CT ID bounds, in-use, numeric filter), the OS-template list, and the full create POST (success + server-error paths).

New frozen fixtures (hand-written static, not derived from the demo mock data at runtime): `vmRows.ts`, `pveProvisioning.ts`.

## Notes

- Test and fixture code only. No production source changed. `sonar.cpd.exclusions` is untouched; only the two `sonar.coverage.exclusions` entries were removed, after LCOV proved per-file coverage well above the project overall.
- InventoryTree was considered for this batch but is a poor jsdom target (EventSource SSE + virtualized rows), so CreateLxcDialog was covered instead. InventoryTree stays excluded.
- Full suite green: 1824 tests (node + jsdom lanes).
- Ratchet floor stays at 11; it will be bumped at a milestone in a dedicated commit.
