### PR TITLE
test(components): component-lane batch 3 (CreateVmDialog, InventoryDialogs)

### DIFF
--- a/frontend/src/__tests__/fixtures/pveProvisioning.ts
+++ b/frontend/src/__tests__/fixtures/pveProvisioning.ts
@@ -62,3 +62,33 @@ export const templates = [
 
 /** nextid is not used by CreateLxcDialog (it computes locally from allVms). */
 export const nextid = 100
+
+// ------------------------------------------------------------------ //
+// VM dialog additions (EXTEND-only -- do NOT mutate the exports above)
+// ------------------------------------------------------------------ //
+
+/**
+ * vmStorage: storage entries used by CreateVmDialog tests.
+ *
+ * The single entry has both 'iso' and 'images' content and shared=true, so:
+ *   - filteredIso (content.includes('iso') && shared) picks 'local-vm' for ISO storage.
+ *   - filteredDisk (content.includes('images') && shared) picks 'local-vm' for disk storage.
+ *
+ * This causes the dialog to auto-select the ISO storage and auto-fill the
+ * first disk's storage field, which unblocks the Create button (resolvedNode
+ * and vmid are set via the nextid fetch; disk storage set here).
+ */
+export const vmStorage = [
+  {
+    storage: 'local-vm',
+    content: 'images,iso,rootdir',
+    shared: true,
+  },
+]
+
+/**
+ * vdcs: empty list -- no vDC quota applies to the provider tenant (admin).
+ * The dialog reads json.data and finds a match by connectionId; no match
+ * means vdcQuota stays null and all quota checks pass unconditionally.
+ */
+export const vdcs: unknown[] = []

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
@@ -1,0 +1,684 @@
+/**
+ * Component tests for CreateVmDialog.tsx
+ *
+ * Strategy: render the dialog with open={true}, seed every MSW endpoint the
+ * dialog calls on mount (and on connection/node resolve), await data load,
+ * then assert visible output and representative interactions. Context hooks
+ * that depend on live providers are mocked at module level.
+ *
+ * The structure here mirrors CreateLxcDialog.test.tsx closely -- same gotchas,
+ * same MSW-on-open seeding pattern, same MUI combobox/index access technique.
+ *
+ * Not covered here:
+ *   - Full multi-tab navigation end-to-end (heavy form state across 8 tabs)
+ *   - Import-disk flow (fires a separate storage/content fetch on user action)
+ *   - Recharts / canvas (SVG width unavailable under jsdom)
+ *   - vDC quota banner (requires a non-empty vdcs response with a matching
+ *     connectionId -- the banner itself is covered by QuotaDonut unit tests)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import {
+  connections,
+  nodes,
+  pools,
+  networkChoices,
+  vmStorage,
+  vdcs,
+} from '@/__tests__/fixtures/pveProvisioning'
+
+import CreateVmDialog from './CreateVmDialog'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+vi.mock('@/contexts/RBACContext', () => ({
+  useRBAC: () => ({ isAdmin: true }),
+}))
+
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ currentTenant: null, loading: false, isFullClusterView: true }),
+}))
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = connections[0].id  // 'conn-1'
+const NODE_NAME = nodes[0].node    // 'pve1'
+const NEXT_VMID = 101
+
+// ------------------------------------------------------------------ //
+// MSW handler factory
+// Seeds ALL endpoints the dialog fires on open (and on connection/node select).
+// ------------------------------------------------------------------ //
+
+function seedAllHandlers() {
+  server.use(
+    // 1. Connections list (type=pve)
+    http.get('*/api/v1/connections', ({ request }) => {
+      const url = new URL(request.url)
+      if (url.searchParams.get('type') === 'pve') {
+        return HttpResponse.json({ data: connections })
+      }
+      return HttpResponse.json({ data: [] })
+    }),
+
+    // 2. Nodes for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodes }),
+    ),
+
+    // 3. Next VMID from cluster API (dialog calls setVmid(String(json.data)))
+    http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+      HttpResponse.json({ data: NEXT_VMID }),
+    ),
+
+    // 4. vDC quota list (empty = no quota applied; provider tenant has no vDC)
+    http.get('*/api/v1/vdcs', () =>
+      HttpResponse.json({ data: vdcs }),
+    ),
+
+    // 5. Pools for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/pools`, () =>
+      HttpResponse.json({ data: pools }),
+    ),
+
+    // 6. Storage for the connection
+    //    vmStorage has content 'images,iso,rootdir' and shared=true so the
+    //    dialog auto-selects it for both isoStorage and disk[0].storage.
+    http.get(`*/api/v1/connections/${CONN_ID}/storage`, () =>
+      HttpResponse.json({ data: vmStorage }),
+    ),
+
+    // 7. Network choices (bridge list) for connection + node
+    //    networkChoices[0] = { name: 'vmbr0' } which matches the default NIC
+    //    bridge so networkBlocked stays false and Create is not blocked.
+    http.get(`*/api/v1/connections/${CONN_ID}/network-choices`, () =>
+      HttpResponse.json({ data: networkChoices }),
+    ),
+
+    // 8. ISO content fetch -- fires automatically when isoStorage is set.
+    //    The storage fetch sets isoStorage='local-vm', which triggers the
+    //    loadIsoImages effect. Seed an empty list so the effect completes
+    //    without an unhandled-request error.
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storage/local-vm/content`, () =>
+      HttpResponse.json({ data: [] }),
+    ),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// Helpers
+// ------------------------------------------------------------------ //
+
+function makeProps(overrides: Partial<Parameters<typeof CreateVmDialog>[0]> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    allVms: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Wait for the dialog to finish loading. After loadAllData() resolves the
+ * component sets selectedNodeValue='pve1' and vmid='101' (from nextid fetch).
+ * The CircularProgress disappears and the comboboxes appear.
+ *
+ * Combobox ordering on the General tab (hideNodePicker=false, isAdmin=true):
+ *   comboboxes[0] = Node select     (rendered when !hideNodePicker)
+ *   comboboxes[1] = Resource Pool select (rendered when isAdmin)
+ *
+ * MUI Select uses aria-labelledby for label association but jsdom's ARIA
+ * name computation does not resolve aria-labelledby references for combobox
+ * roles, so getByRole('combobox', {name: ...}) does not work. We use
+ * index-based access with an explicit length guard so any structural change
+ * (new combobox inserted before Node) fails loudly instead of silently
+ * asserting on the wrong element.
+ *
+ * We also wait for the Next button to become enabled, which ensures bridges
+ * have loaded (networkBlocked=false) and quota is clear (quotaBlocked=false).
+ * Without this, clicking Next immediately after the node appears may still
+ * be blocked by the in-flight network-choices fetch.
+ */
+async function waitForDataLoad() {
+  await waitFor(() => {
+    const comboboxes = screen.getAllByRole('combobox')
+    // Guard: at least Node (index 0) and Resource Pool (index 1) must exist.
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    // comboboxes[0] is the Node select; after load it shows 'pve1'.
+    expect(comboboxes[0].textContent).toContain('pve1')
+  })
+  // Also wait for the Next button to be enabled so bridges and quota are resolved.
+  // Use exact name 'Next' to avoid matching other buttons.
+  await waitFor(() => {
+    const nextBtn = screen.queryByRole('button', { name: 'Next' })
+    if (nextBtn) {
+      expect(nextBtn).not.toBeDisabled()
+    }
+  })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Dialog open / closed visibility
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - open/closed state', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('renders the dialog title when open=true', () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    expect(screen.getByText('Create: Virtual Machine')).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Next buttons when open=true', () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    // The Next button has exact text "Next" -- use exact name to avoid
+    // matching other buttons containing the word.
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument()
+  })
+
+  it('renders all tab labels', () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'OS' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'System' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Disks' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'CPU' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Memory' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Network' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Confirm' })).toBeInTheDocument()
+  })
+
+  it('does not render the dialog title when open=false', () => {
+    renderWithProviders(<CreateVmDialog {...makeProps({ open: false })} />)
+    expect(screen.queryByText('Create: Virtual Machine')).not.toBeInTheDocument()
+  })
+
+  it('Back button is disabled on the first tab', () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    const backBtn = screen.getByRole('button', { name: /back/i })
+    expect(backBtn).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Data load on open -- connections, nodes, vmid load from MSW
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - data loads on open', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('auto-selects the first node after data loads and shows its name', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+    // comboboxes[0] is the Node select (see waitForDataLoad comment for ordering guarantee).
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    expect(comboboxes[0].textContent).toContain('pve1')
+  })
+
+  it('opens the Node Select listbox and lists the seeded node', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // comboboxes[0] is the Node select (see waitForDataLoad comment for ordering guarantee).
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    fireEvent.mouseDown(comboboxes[0])
+
+    // The MenuItem for pve1 appears in the portal listbox.
+    const option = await screen.findByRole('option', { name: /pve1/ })
+    expect(option).toBeInTheDocument()
+  })
+
+  it('populates the Resource Pool selector with seeded pools', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // comboboxes[0]=Node, comboboxes[1]=Resource Pool (see waitForDataLoad comment).
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    fireEvent.mouseDown(comboboxes[1])
+
+    // Pool items appear in the portal listbox.
+    const poolDev = await screen.findByRole('option', { name: /pool-dev/ })
+    expect(poolDev).toBeInTheDocument()
+    const poolProd = screen.getByRole('option', { name: /pool-prod/ })
+    expect(poolProd).toBeInTheDocument()
+  })
+
+  it('sets VM ID to the seeded nextid value from the cluster API', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The nextid fetch returns 101; the component calls setVmid(String(json.data)).
+    // VM ID field label is "VM ID" (hardcoded in JSX, not a translation key).
+    const vmidInput = screen.getByLabelText('VM ID') as HTMLInputElement
+    expect(vmidInput).toBeInTheDocument()
+    expect(vmidInput.value).toBe(String(NEXT_VMID))
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Form input interactions
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - form inputs', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('typing in the Name field updates its value', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The VM name label key is inventory.createVm.vmName = "Name".
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement
+    expect(nameInput).toBeInTheDocument()
+    fireEvent.change(nameInput, { target: { value: 'my-vm' } })
+    expect(nameInput.value).toBe('my-vm')
+  })
+
+  it('VM ID field accepts numeric input', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const vmidInput = screen.getByLabelText('VM ID') as HTMLInputElement
+    fireEvent.change(vmidInput, { target: { value: '200' } })
+    expect(vmidInput.value).toBe('200')
+  })
+
+  it('VM ID below 100 shows a validation error', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const vmidInput = screen.getByLabelText('VM ID') as HTMLInputElement
+    fireEvent.change(vmidInput, { target: { value: '50' } })
+    expect(screen.getByText('VM ID must be >= 100')).toBeInTheDocument()
+  })
+
+  it('VM ID in-use shows validation error when allVms contains the id', async () => {
+    // Use vmid '200' in allVms (different from the nextid API return of 101)
+    // so the field starts at 101, then we type 200 to trigger the in-use error.
+    renderWithProviders(
+      <CreateVmDialog
+        {...makeProps({ allVms: [{ vmid: '200', connId: CONN_ID, node: NODE_NAME } as any] })}
+      />,
+    )
+    await waitForDataLoad()
+
+    const vmidInput = screen.getByLabelText('VM ID') as HTMLInputElement
+    // Type 200 (which is in allVms) to trigger the in-use error.
+    // The handleVmidChange validator checks allVms via parseInt comparison.
+    fireEvent.change(vmidInput, { target: { value: '200' } })
+    expect(screen.getByText(/VM ID 200 is already in use/i)).toBeInTheDocument()
+  })
+
+  it('expanding Boot and Shutdown section shows the Start at boot toggle', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The boot section header text comes from inventory.createVm.bootShutdown = "Boot & Shutdown".
+    fireEvent.click(screen.getByText('Boot & Shutdown'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Start at boot')).toBeInTheDocument()
+    })
+    // MUI Switch: find by label text then walk to the checkbox input.
+    const label = screen.getByText('Start at boot')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const switchInput = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(switchInput).not.toBeNull()
+    expect(switchInput.checked).toBe(false)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Cancel button
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - Cancel button', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<CreateVmDialog {...makeProps({ onClose })} />)
+
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Tab navigation
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - tab navigation', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('clicking Next advances from General to OS tab', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // Use exact name 'Next' to avoid matching other button text.
+    const nextBtn = screen.getByRole('button', { name: 'Next' })
+    fireEvent.click(nextBtn)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'OS' }).getAttribute('aria-selected')).toBe('true')
+    })
+  })
+
+  it('clicking the OS tab renders the OS presets section', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OS' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'OS' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // OS tab renders the quick presets label (inventory.createVm.osPresets = "Quick presets").
+    expect(screen.getByText('Quick presets')).toBeInTheDocument()
+  })
+
+  it('clicking the System tab renders the Hardware section', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'System' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'System' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // System tab renders the hardware section label (inventory.createVm.hardware = "Hardware").
+    expect(screen.getByText('Hardware')).toBeInTheDocument()
+  })
+
+  it('clicking the CPU tab renders cores UI', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'CPU' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'CPU' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // Cores label is rendered on the CPU tab.
+    expect(screen.getByText(/Cores: 1/i)).toBeInTheDocument()
+  })
+
+  it('clicking the Memory tab shows the memory label', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Memory' }))
+
+    await waitFor(() => {
+      // The Memory tab renders a Typography "Memory (MiB): 2 GiB" (the
+      // formatted current value). Use getAllByText since the input label
+      // and the Typography both contain the substring; asserting on the
+      // formatted value text node (the Typography paragraph) is unique.
+      const matches = screen.getAllByText(/Memory \(MiB\)/i)
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+    })
+    // The Memory tab Typography paragraph shows the current value in GiB.
+    // Default memorySize=2048 MiB = 2 GiB (2048 >= 1024 branch in formatGib).
+    expect(screen.getByText(/Memory \(MiB\).*2.*GiB/i)).toBeInTheDocument()
+  })
+
+  it('clicking the Network tab activates the Network tab and renders the NIC card', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Network' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Network' }).getAttribute('aria-selected')).toBe('true')
+    })
+    // Network tab shows the no-network-device toggle label.
+    expect(screen.getByText('No network device')).toBeInTheDocument()
+  })
+
+  it('clicking the Confirm tab shows the ready-to-create message', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      // The Confirm tab shows the ready alert when vmid and resolvedNode are set.
+      expect(screen.getByText(/Ready to create/i)).toBeInTheDocument()
+    })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. Create button and submit flow
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - Create flow', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('shows Create button on the Confirm (last) tab', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create/i })).toBeInTheDocument()
+    })
+  })
+
+  it('fires onCreated and onClose after a successful create from the Confirm tab', async () => {
+    const onClose = vi.fn()
+    const onCreated = vi.fn()
+
+    // Seed the qemu POST. The URL is:
+    //   /api/v1/connections/:connId/guests/qemu/:node
+    // On success, the component calls onCreated(vmid, selectedConnection, resolvedNode)
+    // then onClose().
+    server.use(
+      http.post(`*/api/v1/connections/${CONN_ID}/guests/qemu/${NODE_NAME}`, () =>
+        HttpResponse.json({ data: { upid: 'UPID:pve1:test' } }),
+      ),
+    )
+
+    renderWithProviders(
+      <CreateVmDialog
+        {...makeProps({ onClose, onCreated })}
+      />,
+    )
+
+    await waitForDataLoad()
+
+    // Navigate to Confirm tab.
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      const createBtn = screen.getByRole('button', { name: /create/i })
+      // vmid=101 (from nextid fetch), resolvedNode=pve1 -- both set, button enabled.
+      expect(createBtn).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+    // onCreated is called with (vmid, connId, node) per handleCreate line ~911.
+    expect(onCreated).toHaveBeenCalledWith(String(NEXT_VMID), CONN_ID, NODE_NAME)
+  })
+
+  it('shows an error message when the POST returns a server error', async () => {
+    server.use(
+      http.post(`*/api/v1/connections/${CONN_ID}/guests/qemu/${NODE_NAME}`, () =>
+        HttpResponse.json({ error: 'Out of resources' }, { status: 500 }),
+      ),
+    )
+
+    const onClose = vi.fn()
+    const onCreated = vi.fn()
+
+    renderWithProviders(
+      <CreateVmDialog
+        {...makeProps({ onClose, onCreated })}
+      />,
+    )
+
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Confirm' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /create/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/Out of resources/i)).toBeInTheDocument()
+    })
+    // onCreated and onClose must NOT have been called on error.
+    expect(onCreated).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 7. OS tab interactions
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - OS tab', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('clicking an OS preset highlights it', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OS' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Ubuntu')).toBeInTheDocument()
+    })
+
+    // Click the Ubuntu preset card -- this sets selectedOsPreset='ubuntu'.
+    // The card text is data-driven from the osPresets array, not always-present.
+    fireEvent.click(screen.getByText('Ubuntu'))
+
+    // After clicking, the Debian card is still in the DOM (all presets render).
+    expect(screen.getByText('Debian')).toBeInTheDocument()
+  })
+
+  it('toggling installation media off hides the storage/ISO selects', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OS' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Installation media')).toBeInTheDocument()
+    })
+
+    // The media section has a Switch; find it by label proximity.
+    // The label text "Installation media" is adjacent to the Switch.
+    // After toggling off, osMediaType='none' and the "Do not use any media"
+    // line appears (inventory.createVm.doNotUseMedia).
+    const installMediaSection = screen.getByText('Installation media')
+      .closest('div') as HTMLElement
+    const switchInput = installMediaSection
+      .closest('[class*="MuiBox"]')
+      ?.querySelector('input[type="checkbox"]') as HTMLInputElement | null
+
+    // Fallback: find the switch by traversing to the outer section.
+    // The switch is inside the media box header -- toggling it sets osMediaType.
+    // We use the parent box to locate the switch safely.
+    if (switchInput) {
+      const wasChecked = switchInput.checked
+      fireEvent.click(switchInput)
+      // After toggle, the checked state flips.
+      expect(switchInput.checked).toBe(!wasChecked)
+    } else {
+      // The switch renders within the Installation media section header.
+      // Find all checkboxes on the OS tab and use the one inside the media card.
+      const allSwitches = document.querySelectorAll('input[type="checkbox"]')
+      // At minimum 1 switch (the media toggle) must be present.
+      expect(allSwitches.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 8. System tab interactions
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - System tab', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('renders SeaBIOS and OVMF firmware options on the System tab', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'System' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/SeaBIOS/i)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/OVMF/i)).toBeInTheDocument()
+  })
+
+  it('clicking OVMF (UEFI) firmware preset updates the selection', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'System' }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/OVMF/i)).toBeInTheDocument()
+    })
+
+    // Click the OVMF box -- this calls setBios('ovmf') and shows the UEFI hint.
+    // The hint text (inventory.createVm.uefiHint) mentions "UEFI" and "EFI disk".
+    // It only renders when bios === 'ovmf', so it is behavior-gated.
+    fireEvent.click(screen.getByText('OVMF (UEFI)'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/UEFI requires a q35 machine type/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
@@ -162,11 +162,10 @@ async function waitForDataLoad() {
   })
   // Also wait for the Next button to be enabled so bridges and quota are resolved.
   // Use exact name 'Next' to avoid matching other buttons.
+  // getByRole throws if the button is absent, so this waitFor only resolves
+  // once Next is both present AND enabled (non-skippable invariant).
   await waitFor(() => {
-    const nextBtn = screen.queryByRole('button', { name: 'Next' })
-    if (nextBtn) {
-      expect(nextBtn).not.toBeDisabled()
-    }
+    expect(screen.getByRole('button', { name: 'Next' })).not.toBeDisabled()
   })
 }
 
@@ -585,22 +584,43 @@ describe('CreateVmDialog - OS tab', () => {
     seedAllHandlers()
   })
 
-  it('clicking an OS preset highlights it', async () => {
+  it('clicking an OS preset updates the Guest OS type', async () => {
     renderWithProviders(<CreateVmDialog {...makeProps()} />)
     await waitForDataLoad()
 
     fireEvent.click(screen.getByRole('tab', { name: 'OS' }))
 
     await waitFor(() => {
-      expect(screen.getByText('Ubuntu')).toBeInTheDocument()
+      expect(screen.getByText('Windows 11')).toBeInTheDocument()
     })
 
-    // Click the Ubuntu preset card -- this sets selectedOsPreset='ubuntu'.
-    // The card text is data-driven from the osPresets array, not always-present.
-    fireEvent.click(screen.getByText('Ubuntu'))
+    // The default Guest OS type is Linux (guestOsType='Linux'). Clicking the
+    // "Windows 11" preset card calls setGuestOsType('Windows') + setGuestOsVersion('win11').
+    // The Guest OS type Select then renders "Windows" as its visible value via
+    // renderValue -- this is a behavior-gated DOM change (absent if the click
+    // were a no-op, since the initial value is 'Linux').
+    // Before clicking: the OS type combobox shows "Linux" content.
+    // Locate the OS type combobox: on the OS tab the Guest OS section renders
+    // two comboboxes (OS Type, OS Version). The first one is the type selector.
+    const comboboxesBefore = screen.getAllByRole('combobox')
+    // The OS type combobox textContent contains "Linux" before selection.
+    const osTypeComboboxBefore = comboboxesBefore.find(cb => cb.textContent?.includes('Linux'))
+    expect(osTypeComboboxBefore).toBeTruthy()
 
-    // After clicking, the Debian card is still in the DOM (all presets render).
-    expect(screen.getByText('Debian')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Windows 11'))
+
+    // After clicking, the Guest OS type combobox should now show "Windows".
+    // getAllByRole('combobox') re-queries the live DOM after the state update.
+    await waitFor(() => {
+      const comboboxesAfter = screen.getAllByRole('combobox')
+      const osTypeComboboxAfter = comboboxesAfter.find(cb => cb.textContent?.includes('Windows'))
+      expect(osTypeComboboxAfter).toBeTruthy()
+    })
+    // The "Linux" value must NO LONGER appear in that same OS type combobox,
+    // confirming the preset click genuinely changed state and was not a no-op.
+    const finalComboboxes = screen.getAllByRole('combobox')
+    const stillLinux = finalComboboxes.find(cb => cb.textContent === 'Linux')
+    expect(stillLinux).toBeUndefined()
   })
 
   it('toggling installation media off hides the storage/ISO selects', async () => {
@@ -613,31 +633,30 @@ describe('CreateVmDialog - OS tab', () => {
       expect(screen.getByText('Installation media')).toBeInTheDocument()
     })
 
-    // The media section has a Switch; find it by label proximity.
-    // The label text "Installation media" is adjacent to the Switch.
-    // After toggling off, osMediaType='none' and the "Do not use any media"
-    // line appears (inventory.createVm.doNotUseMedia).
-    const installMediaSection = screen.getByText('Installation media')
-      .closest('div') as HTMLElement
-    const switchInput = installMediaSection
-      .closest('[class*="MuiBox"]')
+    // The Switch sits in the header row next to the "Installation media" label.
+    // Walk up from the label text to find the closest MuiFormControlLabel root
+    // (the FormControlLabel wrapping the Switch), then grab its checkbox input.
+    // This mirrors the pattern used in CreateLxcDialog.test.tsx and avoids
+    // fragile ancestor traversal through unnamed MuiBox containers.
+    const installMediaLabel = screen.getByText('Installation media')
+    // The label and the Switch share a flex row inside a Box; the Switch's
+    // FormControlLabel is the sibling rendered after the Box spacer.
+    // Walking up to the common ancestor Box (the header row div) and querying
+    // down for the checkbox is reliable under jsdom because MUI renders the
+    // FormControlLabel as a direct child of that row.
+    const headerRow = installMediaLabel.closest('div') as HTMLElement
+    const switchInput = headerRow
+      .closest('div')
       ?.querySelector('input[type="checkbox"]') as HTMLInputElement | null
 
-    // Fallback: find the switch by traversing to the outer section.
-    // The switch is inside the media box header -- toggling it sets osMediaType.
-    // We use the parent box to locate the switch safely.
-    if (switchInput) {
-      const wasChecked = switchInput.checked
-      fireEvent.click(switchInput)
-      // After toggle, the checked state flips.
-      expect(switchInput.checked).toBe(!wasChecked)
-    } else {
-      // The switch renders within the Installation media section header.
-      // Find all checkboxes on the OS tab and use the one inside the media card.
-      const allSwitches = document.querySelectorAll('input[type="checkbox"]')
-      // At minimum 1 switch (the media toggle) must be present.
-      expect(allSwitches.length).toBeGreaterThanOrEqual(1)
-    }
+    // The switch must be found -- if this fails the component structure changed.
+    expect(switchInput).not.toBeNull()
+
+    // Record current state, click, and assert the checked value flipped.
+    const wasChecked = switchInput!.checked
+    fireEvent.click(switchInput!)
+    // After toggling off, osMediaType becomes 'none' and the checked state flips.
+    expect(switchInput!.checked).toBe(!wasChecked)
   })
 })
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -1,0 +1,654 @@
+/**
+ * Component tests for InventoryDialogs.tsx
+ *
+ * Strategy: build a makeProps() factory covering the full ~80-field
+ * InventoryDialogsProps interface with safe defaults (all open-flags false,
+ * handlers vi.fn(), nullable state null). Each test flips the one
+ * prop/state under test and asserts real rendered output.
+ *
+ * Dialogs covered:
+ *   - nodeActionDialog (reboot + shutdown variants)
+ *   - editOptionDialog (text / boolean / select / hotplug / vga)
+ *   - createVmDialogOpen / createLxcDialogOpen (embedded static imports)
+ *   - createBackupDialogOpen / deleteVmDialogOpen / convertTemplateDialogOpen
+ *   - unlockErrorDialog / bulkActionDialog / upgradeDialogOpen
+ *   - confirmAction / deleteHaGroupDialog / deleteHaRuleDialog
+ *
+ * Not covered:
+ *   - esxiMigrateVm (driven by internal state + complex cascade)
+ *   - bulkMigOpen (internal state driven)
+ *   - migrateDialogOpen / cloneDialogOpen (require selection.type === 'vm' + parseVmId)
+ *   - haGroupDialog / haRuleDialog (require selection.type === 'cluster')
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import {
+  connections,
+  nodes,
+  pools,
+  networkChoices,
+  vmStorage,
+  vdcs,
+  templates,
+} from '@/__tests__/fixtures/pveProvisioning'
+
+import InventoryDialogs, { type InventoryDialogsProps } from './InventoryDialogs'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+vi.mock('@/contexts/ProxCenterTasksContext', () => ({
+  useProxCenterTasks: () => ({ addTask: vi.fn(), registerOnRestore: vi.fn() }),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock('@/contexts/RBACContext', () => ({
+  useRBAC: () => ({ isAdmin: true }),
+}))
+
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ currentTenant: null, loading: false, isFullClusterView: true }),
+}))
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = connections[0].id  // 'conn-1'
+const NODE_NAME = nodes[0].node    // 'pve1'
+
+// ------------------------------------------------------------------ //
+// MSW handler seeding
+// ------------------------------------------------------------------ //
+
+function seedAllHandlers() {
+  server.use(
+    http.get('*/api/v1/connections', ({ request }) => {
+      const url = new URL(request.url)
+      if (url.searchParams.get('type') === 'pve') {
+        return HttpResponse.json({ data: connections })
+      }
+      return HttpResponse.json({ data: connections })
+    }),
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodes }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+      HttpResponse.json({ data: 101 }),
+    ),
+    http.get('*/api/v1/vdcs', () =>
+      HttpResponse.json({ data: vdcs }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/pools`, () =>
+      HttpResponse.json({ data: pools }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/storage`, () =>
+      HttpResponse.json({ data: vmStorage }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/network-choices`, () =>
+      HttpResponse.json({ data: networkChoices }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storage/local-vm/content`, () =>
+      HttpResponse.json({ data: [] }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storage/local/content`, () =>
+      HttpResponse.json({ data: templates }),
+    ),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// makeProps factory -- all fields with safe defaults
+// ------------------------------------------------------------------ //
+
+function makeProps(overrides: Partial<InventoryDialogsProps> = {}): InventoryDialogsProps {
+  return {
+    // Core data
+    selection: null,
+    data: {},
+    allVms: [],
+    hosts: [],
+
+    // Node action
+    nodeActionDialog: null,
+    setNodeActionDialog: vi.fn(),
+    nodeActionBusy: false,
+    setNodeActionBusy: vi.fn(),
+    nodeActionStep: null,
+    setNodeActionStep: vi.fn(),
+    nodeActionMigrateTarget: '',
+    setNodeActionMigrateTarget: vi.fn(),
+    nodeActionFailedVms: [],
+    setNodeActionFailedVms: vi.fn(),
+    nodeActionShutdownFailed: false,
+    setNodeActionShutdownFailed: vi.fn(),
+    nodeActionLocalVms: new Set(),
+    nodeActionStorageLoading: false,
+    nodeActionShutdownLocal: false,
+    setNodeActionShutdownLocal: vi.fn(),
+
+    // Create VM/LXC
+    createVmDialogOpen: false,
+    setCreateVmDialogOpen: vi.fn(),
+    createLxcDialogOpen: false,
+    setCreateLxcDialogOpen: vi.fn(),
+    effectiveCreateDefaults: {},
+    handleVmCreated: vi.fn(),
+    handleLxcCreated: vi.fn(),
+
+    // Hardware dialogs
+    addDiskDialogOpen: false,
+    setAddDiskDialogOpen: vi.fn(),
+    addNetworkDialogOpen: false,
+    setAddNetworkDialogOpen: vi.fn(),
+    editScsiControllerDialogOpen: false,
+    setEditScsiControllerDialogOpen: vi.fn(),
+    editDiskDialogOpen: false,
+    setEditDiskDialogOpen: vi.fn(),
+    editNetworkDialogOpen: false,
+    setEditNetworkDialogOpen: vi.fn(),
+    addOtherHardwareDialogOpen: false,
+    setAddOtherHardwareDialogOpen: vi.fn(),
+    editOtherHardwareDialogOpen: false,
+    setEditOtherHardwareDialogOpen: vi.fn(),
+    selectedOtherHardware: null,
+    setSelectedOtherHardware: vi.fn(),
+    selectedDisk: null,
+    setSelectedDisk: vi.fn(),
+    editDiskInitialTab: 0,
+    setEditDiskInitialTab: vi.fn(),
+    selectedNetwork: null,
+    setSelectedNetwork: vi.fn(),
+    handleSaveDisk: vi.fn(),
+    handleSaveNetwork: vi.fn(),
+    handleSaveScsiController: vi.fn(),
+    handleEditDisk: vi.fn(),
+    handleDetachDisk: vi.fn(),
+    handleResizeDisk: vi.fn(),
+    handleMoveDisk: vi.fn(),
+    handleDeleteNetwork: vi.fn(),
+
+    // Migrate/Clone from VM detail
+    migrateDialogOpen: false,
+    setMigrateDialogOpen: vi.fn(),
+    cloneDialogOpen: false,
+    setCloneDialogOpen: vi.fn(),
+    handleMigrateVm: vi.fn(),
+    handleCrossClusterMigrate: vi.fn(),
+    handleCloneVm: vi.fn(),
+    selectedVmIsCluster: false,
+
+    // Migrate/Clone from table
+    tableMigrateVm: null,
+    setTableMigrateVm: vi.fn(),
+    tableCloneVm: null,
+    setTableCloneVm: vi.fn(),
+    handleTableMigrateVm: vi.fn(),
+    handleTableCrossClusterMigrate: vi.fn(),
+    handleTableCloneVm: vi.fn(),
+
+    // Edit option
+    editOptionDialog: null,
+    setEditOptionDialog: vi.fn(),
+    editOptionValue: '',
+    setEditOptionValue: vi.fn(),
+    editOptionSaving: false,
+    handleSaveOption: vi.fn().mockResolvedValue(undefined),
+
+    // HA dialogs
+    haGroupDialogOpen: false,
+    setHaGroupDialogOpen: vi.fn(),
+    editingHaGroup: null,
+    setEditingHaGroup: vi.fn(),
+    deleteHaGroupDialog: null,
+    setDeleteHaGroupDialog: vi.fn(),
+    haRuleDialogOpen: false,
+    setHaRuleDialogOpen: vi.fn(),
+    editingHaRule: null,
+    setEditingHaRule: vi.fn(),
+    deleteHaRuleDialog: null,
+    setDeleteHaRuleDialog: vi.fn(),
+    haRuleType: 'node-affinity',
+    clusterHaResources: [],
+    clusterPveMajorVersion: 8,
+    loadClusterHa: vi.fn(),
+
+    // Confirm action
+    confirmAction: null,
+    setConfirmAction: vi.fn(),
+    confirmActionLoading: false,
+
+    // Backup
+    createBackupDialogOpen: false,
+    setCreateBackupDialogOpen: vi.fn(),
+    backupStorage: '',
+    setBackupStorage: vi.fn(),
+    backupMode: 'snapshot',
+    setBackupMode: vi.fn(),
+    backupCompress: 'zstd',
+    setBackupCompress: vi.fn(),
+    backupNote: '',
+    setBackupNote: vi.fn(),
+    creatingBackup: false,
+    setCreatingBackup: vi.fn(),
+    backupStorages: [],
+    loadBackups: vi.fn(),
+
+    // Delete VM
+    deleteVmDialogOpen: false,
+    setDeleteVmDialogOpen: vi.fn(),
+    deleteVmConfirmText: '',
+    setDeleteVmConfirmText: vi.fn(),
+    deletingVm: false,
+    deleteVmPurge: false,
+    setDeleteVmPurge: vi.fn(),
+    handleDeleteVm: vi.fn().mockResolvedValue(undefined),
+
+    // Convert to template
+    convertTemplateDialogOpen: false,
+    setConvertTemplateDialogOpen: vi.fn(),
+    convertingTemplate: false,
+    handleConvertTemplate: vi.fn().mockResolvedValue(undefined),
+
+    // Unlock error
+    unlockErrorDialog: { open: false, error: '' },
+    setUnlockErrorDialog: vi.fn(),
+
+    // Bulk action
+    bulkActionDialog: { open: false, action: null, node: null, targetNode: '' },
+    setBulkActionDialog: vi.fn(),
+    executeBulkAction: vi.fn(),
+
+    // ESXi migration
+    esxiMigrateVm: null,
+    setEsxiMigrateVm: vi.fn(),
+    migTargetConn: '',
+    setMigTargetConn: vi.fn(),
+    migTargetNode: '',
+    setMigTargetNode: vi.fn(),
+    migTargetStorage: '',
+    setMigTargetStorage: vi.fn(),
+    migTargetVmid: '',
+    setMigTargetVmid: vi.fn(),
+    migTargetVmidStatus: 'idle',
+    setMigTargetVmidStatus: vi.fn(),
+    migNetworkBridge: '',
+    setMigNetworkBridge: vi.fn(),
+    migVlanTag: '',
+    setMigVlanTag: vi.fn(),
+    migBridges: [],
+    migStartAfter: false,
+    setMigStartAfter: vi.fn(),
+    migDiskPaths: '',
+    setMigDiskPaths: vi.fn(),
+    migTempStorage: '',
+    setMigTempStorage: vi.fn(),
+    migType: 'cold',
+    setMigType: vi.fn(),
+    migTransferMode: 'auto',
+    setMigTransferMode: vi.fn(),
+    migPveConnections: [],
+    migNodes: [],
+    migStorages: [],
+    migSshfsAvailable: null,
+    vcenterPreflight: null,
+    setVcenterPreflight: vi.fn(),
+    migStarting: false,
+    setMigStarting: vi.fn(),
+    migJobId: null,
+    setMigJobId: vi.fn(),
+    migJob: null,
+    setMigJob: vi.fn(),
+    migNodeOptions: [],
+
+    // Bulk migration
+    bulkMigSelected: new Set(),
+    setBulkMigSelected: vi.fn(),
+    bulkMigOpen: false,
+    setBulkMigOpen: vi.fn(),
+    bulkMigStarting: false,
+    setBulkMigStarting: vi.fn(),
+    bulkMigJobs: [],
+    setBulkMigJobs: vi.fn(),
+    bulkMigProgressExpanded: false,
+    setBulkMigProgressExpanded: vi.fn(),
+    bulkMigLogsExpanded: false,
+    setBulkMigLogsExpanded: vi.fn(),
+    bulkMigLogsFilter: null,
+    setBulkMigLogsFilter: vi.fn(),
+    bulkMigConfigRef: { current: null } as React.MutableRefObject<any>,
+    bulkMigHostInfo: null,
+
+    // Upgrade
+    upgradeDialogOpen: false,
+    setUpgradeDialogOpen: vi.fn(),
+
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// Tests
+// ------------------------------------------------------------------ //
+
+describe('InventoryDialogs', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  // 1. Baseline smoke test
+  it('renders without crashing when all dialogs are closed', () => {
+    renderWithProviders(<InventoryDialogs {...makeProps()} />)
+    expect(document.body).toBeDefined()
+  })
+
+  // 2. nodeActionDialog - reboot
+  it('nodeActionDialog reboot: shows reboot title and cancel fires setter', () => {
+    const setNodeActionDialog = vi.fn()
+    const props = makeProps({
+      nodeActionDialog: { action: 'reboot', nodeName: 'pve1' },
+      setNodeActionDialog,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Reboot node')).toBeInTheDocument()
+    expect(screen.getByText('pve1')).toBeInTheDocument()
+
+    // Click Cancel button (there may be multiple buttons; pick the Cancel one)
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
+    expect(setNodeActionDialog).toHaveBeenCalledWith(null)
+  })
+
+  // 3. nodeActionDialog - shutdown
+  it('nodeActionDialog shutdown: shows shutdown title', () => {
+    const props = makeProps({
+      nodeActionDialog: { action: 'shutdown', nodeName: 'pve2' },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Shutdown node')).toBeInTheDocument()
+    expect(screen.getByText('pve2')).toBeInTheDocument()
+  })
+
+  // 4. editOptionDialog - text
+  it('editOptionDialog text: renders TextField and typing fires setEditOptionValue', () => {
+    const setEditOptionValue = vi.fn()
+    const props = makeProps({
+      editOptionDialog: { key: 'name', label: 'VM Name', value: 'old', type: 'text' },
+      editOptionValue: 'old',
+      setEditOptionValue,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    fireEvent.change(input, { target: { value: 'new-name' } })
+    expect(setEditOptionValue).toHaveBeenCalledWith('new-name')
+  })
+
+  // 5. editOptionDialog - boolean
+  it('editOptionDialog boolean: Switch checked when value=1, toggling fires setEditOptionValue', () => {
+    const setEditOptionValue = vi.fn()
+    const props = makeProps({
+      editOptionDialog: { key: 'onboot', label: 'Start at boot', value: 1, type: 'boolean' },
+      editOptionValue: 1,
+      setEditOptionValue,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    // The Switch renders a checkbox input
+    const label = screen.getByText('Start at boot')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const switchInput = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(switchInput).not.toBeNull()
+    // With editOptionValue=1, the Switch should be checked
+    expect(switchInput.checked).toBe(true)
+
+    // Click to toggle off -> onChange fires setEditOptionValue(0)
+    fireEvent.click(switchInput)
+    expect(setEditOptionValue).toHaveBeenCalledWith(0)
+  })
+
+  // 6. editOptionDialog - select
+  it('editOptionDialog select: opening the Select and clicking an option fires setEditOptionValue', () => {
+    const setEditOptionValue = vi.fn()
+    const props = makeProps({
+      editOptionDialog: {
+        key: 'ostype',
+        label: 'OS Type',
+        value: 'l26',
+        type: 'select',
+        options: [
+          { value: 'l26', label: 'Linux 6.x' },
+          { value: 'win11', label: 'Windows 11' },
+        ],
+      },
+      editOptionValue: 'l26',
+      setEditOptionValue,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    const combobox = screen.getByRole('combobox')
+    fireEvent.mouseDown(combobox)
+
+    const option = screen.getByRole('option', { name: 'Windows 11' })
+    fireEvent.click(option)
+    expect(setEditOptionValue).toHaveBeenCalledWith('win11')
+  })
+
+  // 7. editOptionDialog - hotplug
+  it('editOptionDialog hotplug: checkboxes reflect current value; toggling fires setEditOptionValue', () => {
+    const setEditOptionValue = vi.fn()
+    const props = makeProps({
+      editOptionDialog: {
+        key: 'hotplug',
+        label: 'Hotplug',
+        value: 'disk,network',
+        type: 'hotplug',
+      },
+      editOptionValue: 'disk,network',
+      setEditOptionValue,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    // There should be 5 checkboxes: disk, network, usb, memory, cpu
+    const checkboxes = screen.getAllByRole('checkbox')
+    expect(checkboxes.length).toBeGreaterThanOrEqual(5)
+
+    // Disk checkbox (index 0) should be checked; USB (index 2) should not be checked
+    const diskLabel = screen.getByText('Disk')
+    const diskFormLabel = diskLabel.closest('.MuiFormControlLabel-root') as HTMLElement
+    const diskCheckbox = diskFormLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(diskCheckbox.checked).toBe(true)
+
+    const usbLabel = screen.getByText('USB')
+    const usbFormLabel = usbLabel.closest('.MuiFormControlLabel-root') as HTMLElement
+    const usbCheckbox = usbFormLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(usbCheckbox.checked).toBe(false)
+
+    // Toggle USB on
+    fireEvent.click(usbCheckbox)
+    expect(setEditOptionValue).toHaveBeenCalled()
+    const calledWith = setEditOptionValue.mock.calls[0][0] as string
+    expect(calledWith).toContain('usb')
+  })
+
+  // 8. editOptionDialog - vga
+  it('editOptionDialog vga: VGA select renders with options; changing type fires setEditOptionValue', () => {
+    const setEditOptionValue = vi.fn()
+    const props = makeProps({
+      editOptionDialog: {
+        key: 'vga',
+        label: 'Display',
+        value: 'std',
+        type: 'vga',
+        options: [
+          { value: 'std', label: 'Standard (std)' },
+          { value: 'vmware', label: 'VMware (vmware)' },
+          { value: 'none', label: 'None' },
+        ],
+      },
+      editOptionValue: 'std',
+      setEditOptionValue,
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    // The VGA select: first combobox in the dialog is the VGA type selector
+    const comboboxes = screen.getAllByRole('combobox')
+    // The VGA type combobox should be present
+    expect(comboboxes.length).toBeGreaterThanOrEqual(1)
+    // Open first combobox (VGA type selector)
+    fireEvent.mouseDown(comboboxes[0])
+
+    const noneOption = screen.getByRole('option', { name: 'None' })
+    fireEvent.click(noneOption)
+    // 'none' is not in MEMORY_CAPABLE, so buildValue('none', undefined, '') = 'none'
+    expect(setEditOptionValue).toHaveBeenCalledWith('none')
+  })
+
+  // 9. createBackupDialog
+  it('createBackupDialog: shows Backup title when open', () => {
+    const props = makeProps({ createBackupDialogOpen: true })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    const backupTexts = screen.getAllByText('Backup')
+    expect(backupTexts.length).toBeGreaterThanOrEqual(1)
+  })
+
+  // 10. deleteVmDialog
+  it('deleteVmDialog: shows Delete VM title when open', () => {
+    const props = makeProps({ deleteVmDialogOpen: true })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Delete VM')).toBeInTheDocument()
+  })
+
+  // 11. convertTemplateDialog
+  it('convertTemplateDialog: shows Convert to Template title when open', () => {
+    const props = makeProps({ convertTemplateDialogOpen: true })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Convert to Template')).toBeInTheDocument()
+  })
+
+  // 12. unlockErrorDialog
+  it('unlockErrorDialog: shows error text when open', () => {
+    const props = makeProps({
+      unlockErrorDialog: { open: true, error: 'VM is locked' },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Cannot unlock VM')).toBeInTheDocument()
+    expect(screen.getByText('VM is locked')).toBeInTheDocument()
+  })
+
+  // 13. bulkActionDialog - start-all
+  it('bulkActionDialog start-all: shows Start all VMs title when open', () => {
+    const props = makeProps({
+      bulkActionDialog: { open: true, action: 'start-all', node: null, targetNode: '' },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Start all VMs')).toBeInTheDocument()
+  })
+
+  // 14. upgradeDialogOpen
+  it('upgradeDialog: shows Enterprise Plan Required title when open', () => {
+    const props = makeProps({ upgradeDialogOpen: true })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Enterprise Plan Required')).toBeInTheDocument()
+    expect(screen.getByText('Upgrade Plan')).toBeInTheDocument()
+  })
+
+  // 15. confirmAction
+  it('confirmAction dialog: shows title and message; OK button fires onConfirm', () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    const props = makeProps({
+      confirmAction: {
+        action: 'info',
+        title: 'Test Title',
+        message: 'Test message',
+        onConfirm,
+      },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument()
+    expect(screen.getByText('Test message')).toBeInTheDocument()
+
+    // For 'info' action the button label is "OK"
+    const okBtn = screen.getByRole('button', { name: 'OK' })
+    fireEvent.click(okBtn)
+    expect(onConfirm).toHaveBeenCalled()
+  })
+
+  // 16. deleteHaGroupDialog
+  it('deleteHaGroupDialog: shows HA group name when open', () => {
+    const props = makeProps({
+      deleteHaGroupDialog: { group: 'ha-group-1' },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Delete HA group')).toBeInTheDocument()
+    expect(screen.getByText('ha-group-1')).toBeInTheDocument()
+  })
+
+  // 17. deleteHaRuleDialog
+  // en.json: drs.deleteAffinityRule = "Delete affinity rule"
+  it('deleteHaRuleDialog: shows HA rule name when open', () => {
+    const props = makeProps({
+      deleteHaRuleDialog: { rule: 'affinity-rule-1' },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    expect(screen.getByText('Delete affinity rule')).toBeInTheDocument()
+    expect(screen.getByText('affinity-rule-1')).toBeInTheDocument()
+  })
+
+  // 18. createVmDialogOpen (embedded static dialog)
+  it('createVmDialog: dialog mounts when createVmDialogOpen is true', async () => {
+    const props = makeProps({
+      createVmDialogOpen: true,
+      effectiveCreateDefaults: { connId: CONN_ID },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+
+  // 19. createLxcDialogOpen (embedded static dialog)
+  it('createLxcDialog: dialog mounts when createLxcDialogOpen is true', async () => {
+    const props = makeProps({
+      createLxcDialogOpen: true,
+      effectiveCreateDefaults: { connId: CONN_ID },
+    })
+    renderWithProviders(<InventoryDialogs {...props} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -29,6 +29,7 @@ import {
   screen,
   waitFor,
   fireEvent,
+  within,
 } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
@@ -515,9 +516,10 @@ describe('InventoryDialogs', () => {
 
     // The VGA select: first combobox in the dialog is the VGA type selector
     const comboboxes = screen.getAllByRole('combobox')
-    // The VGA type combobox should be present
-    expect(comboboxes.length).toBeGreaterThanOrEqual(1)
-    // Open first combobox (VGA type selector)
+    // With value='std' (a MEMORY_CAPABLE type), both the VGA-type Select ([0])
+    // and the clipboard Select ([1]) render, so we expect at least 2 comboboxes.
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2)
+    // Open first combobox (VGA type selector); [1] is the clipboard Select
     fireEvent.mouseDown(comboboxes[0])
 
     const noneOption = screen.getByRole('option', { name: 'None' })
@@ -531,8 +533,14 @@ describe('InventoryDialogs', () => {
     const props = makeProps({ createBackupDialogOpen: true })
     renderWithProviders(<InventoryDialogs {...props} />)
 
-    const backupTexts = screen.getAllByText('Backup')
-    expect(backupTexts.length).toBeGreaterThanOrEqual(1)
+    const dialog = screen.getByRole('dialog')
+    // The backup dialog heading ("Backup") is an <h2> scoped to this dialog.
+    // Asserting via getByRole('heading') confirms the backup dialog opened, not
+    // just that the word "Backup" appeared somewhere on the page.
+    expect(within(dialog).getByRole('heading', { name: /^backup$/i })).toBeInTheDocument()
+    // The "Note (optional)" textarea is unique to the backup dialog; its <label>
+    // is linked via for/id so getByRole resolves it as a named textbox.
+    expect(within(dialog).getByRole('textbox', { name: 'Note (optional)' })).toBeInTheDocument()
   })
 
   // 10. deleteVmDialog

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -179,7 +179,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/settings/DiagnosticModal.tsx,\
   frontend/src/components/templates/DeployWizard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx,\
   frontend/src/app/api/v1/inventory/route.ts,\
   frontend/src/app/api/v1/inventory/stream/route.ts,\
   frontend/src/components/TasksFooter.tsx,\


### PR DESCRIPTION
Third batch of component tests through the jsdom Vitest lane, continuing the dialog coverage from batch 2 (#461). Reuses the dialog + MSW + frozen-fixture pattern.

## What this adds

| Component | Lines | Tests | Per-file line coverage | Coverage exclusion |
|-----------|-------|-------|------------------------|--------------------|
| `CreateVmDialog.tsx` | 2460 | 29 | 58% | removed |
| `InventoryDialogs.tsx` | 4160 | 19 | 13% | kept (see below) |

- `CreateVmDialog` is the create-VM dialog, a near-twin of `CreateLxcDialog` (covered in batch 2). The test mocks `useRBAC`/`useTenant`, seeds the on-open fetch cascade with MSW (connections, nodes, next id, vdcs, pools, storage, network choices, plus the ISO-content fetch that fires when an ISO storage auto-selects), and exercises open/close, data load, tabs, VM ID validation, the OS preset selection, firmware hints, and the full create POST (success and server-error paths). Its `sonar.coverage.exclusions` entry is removed.
- `InventoryDialogs` is a large prop-driven dialog dispatcher. A `makeProps()` factory over its full props lets each test drive one dialog. The tests cover the edit-option dialog (all five input types: text, boolean, select, hotplug, vga), the node action confirmation, and the prop-gated rendering of the other dialogs. Its coverage caps around 13% because the lazy `dynamic(ssr:false)` child modals render nothing under jsdom and the ESXi / bulk-migration blocks are driven by internal state rather than props, so they are not reachable from a component test. That is below the bar to count the file toward overall coverage, so its exclusion is intentionally kept. The 19 tests still stand as regression coverage of the edit-option and node-action logic.

Fixture: `pveProvisioning.ts` gains two new exports (`vmStorage`, `vdcs`); existing exports are untouched so the batch-2 dialog test is unaffected.

## Notes

- Test and fixture code only. No production source changed. `sonar.cpd.exclusions` is untouched; only the `CreateVmDialog` coverage exclusion was removed.
- Full suite green: 1872 tests (node + jsdom lanes).
- Ratchet floor stays at 11; it will be bumped at a milestone in a dedicated commit.
