### PR TITLE
test(components): component-lane batch 4 (DiagnosticModal, WhatsNewDialog, CloneVmDialog, RestoreVmDialog)

### DIFF
--- a/frontend/src/__tests__/fixtures/diagnostics.ts
+++ b/frontend/src/__tests__/fixtures/diagnostics.ts
@@ -1,0 +1,56 @@
+// Static fixture for DiagnosticModal tests.
+// Shape mirrors DiagResult / DiagCheck as defined in DiagnosticModal.tsx.
+
+export interface DiagCheck {
+  id: string
+  category:
+    | 'network'
+    | 'auth'
+    | 'version'
+    | 'cluster'
+    | 'storage'
+    | 'ssh'
+    | 'datastore'
+  label: string
+  status: 'ok' | 'warn' | 'error' | 'skip'
+  message: string
+  detail?: string
+  durationMs: number
+}
+
+export interface DiagResult {
+  connectionId: string
+  type: string
+  checks: DiagCheck[]
+  summary: { ok: number; warn: number; error: number; skip: number }
+  ranAt: string
+  durationMs: number
+}
+
+// Two categories (network + auth), one ok check and one warn check.
+export const diagResultFixture: DiagResult = {
+  connectionId: 'conn-1',
+  type: 'pve',
+  checks: [
+    {
+      id: 'network-ping',
+      category: 'network',
+      label: 'Host reachable',
+      status: 'ok',
+      message: 'TCP connect succeeded',
+      durationMs: 42,
+    },
+    {
+      id: 'auth-token',
+      category: 'auth',
+      label: 'API token valid',
+      status: 'warn',
+      message: 'Token expires soon',
+      detail: 'Expires in 3 days',
+      durationMs: 88,
+    },
+  ],
+  summary: { ok: 1, warn: 1, error: 0, skip: 0 },
+  ranAt: '2026-06-20T00:00:00.000Z',
+  durationMs: 130,
+}

--- a/frontend/src/__tests__/fixtures/pveProvisioning.ts
+++ b/frontend/src/__tests__/fixtures/pveProvisioning.ts
@@ -92,3 +92,29 @@ export const vmStorage = [
  * means vdcQuota stays null and all quota checks pass unconditionally.
  */
 export const vdcs: unknown[] = []
+
+// ------------------------------------------------------------------ //
+// RestoreVmDialog additions (EXTEND-only -- do NOT mutate exports above)
+// ------------------------------------------------------------------ //
+
+/**
+ * resources: a minimal slice of the /api/v1/connections/:id/resources
+ * response used by RestoreVmDialog to populate usedVmIds. Each entry
+ * must carry a numeric vmid field. We seed one VM (100) as already existing
+ * so the dialog auto-enables the "Unique MACs" toggle for VMID 100.
+ */
+export const resources = [
+  { vmid: 100, name: 'test-vm', status: 'running', type: 'qemu', node: 'pve1' },
+]
+
+/**
+ * backupRef: a minimal BackupRef using the volid path so the dialog does not
+ * fall through to the "Backup reference incomplete" error branch. The volid
+ * is a valid PVE backup volume reference that the backend accepts directly
+ * without PBS coordinate resolution.
+ */
+export const backupRef = {
+  volid: 'local:backup/vzdump-qemu-100-2025_01_15-10_00_00.vma.zst',
+  vmid: 100,
+  backupTime: 1736935200,
+}

--- a/frontend/src/components/backup/RestoreVmDialog.test.tsx
+++ b/frontend/src/components/backup/RestoreVmDialog.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * Component tests for RestoreVmDialog.tsx
+ *
+ * Strategy: render the dialog with open={true}, pass connectionId+node as
+ * props so the pickers are locked and we only need to seed the endpoints
+ * that actually fire. MSW is wired globally with onUnhandledRequest:'error'
+ * so every on-open endpoint must be seeded in beforeEach.
+ *
+ * Gotchas carried over from the CreateLxc/CreateVm templates:
+ *   - Dialog renders in a MUI portal: use screen.* (not container.*)
+ *   - MUI Select combobox aria-labelledby not resolved by jsdom: use index
+ *     access + length guard, not getByRole('combobox', {name:...}) or
+ *     getByLabelText for Select elements.
+ *   - Select via fireEvent.mouseDown then getByRole('option')
+ *   - Await fetched content with findBy*
+ *   - "Restore VM" text appears in BOTH the title div AND the submit button;
+ *     use getAllByText or scope to a specific element role when asserting presence.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import {
+  connections,
+  nodes,
+  storage,
+  vdcs,
+  resources,
+  backupRef,
+} from '@/__tests__/fixtures/pveProvisioning'
+
+import RestoreVmDialog from './RestoreVmDialog'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+// Provider path: currentTenant=null means isVdcTenant=false, full surface shown.
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ currentTenant: null, loading: false }),
+}))
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = connections[0].id  // 'conn-1'
+const NODE_NAME = nodes[0].node    // 'pve1'
+const SOURCE_VMID = 100
+const UPID = 'UPID:pve1:00001234:5678ABCD:restore:100:root@pam:'
+
+// ------------------------------------------------------------------ //
+// MSW handler factory
+// Seeds ALL endpoints the dialog fires on open when connectionId+node are locked.
+//
+// With both props locked:
+//   - callerLocksConn=true => connections list fetch is skipped
+//   - callerLocksNode=true => nodes list fetch is skipped
+//   - isVdcTenant=false    => vdcs fetch is skipped (guard: if (!open || !isVdcTenant) return)
+//   - storages + resources always fire when connectionId+node are known
+//   - nextid only fires during tenant restoreAsNew submit (not seeded per-test here)
+//
+// We seed connections, nodes, and vdcs anyway for safety so that if the
+// component renders in a path that fires them we don't get an unhandled-
+// request error that masks the real failure.
+// ------------------------------------------------------------------ //
+
+function seedBaseHandlers() {
+  server.use(
+    // 1. vdcs -- provider path: empty list
+    http.get('*/api/v1/vdcs', () =>
+      HttpResponse.json({ data: vdcs }),
+    ),
+
+    // 2. connections (type=pve) -- seeded even when locked (harmless)
+    http.get('*/api/v1/connections', ({ request }) => {
+      const url = new URL(request.url)
+      if (url.searchParams.get('type') === 'pve') {
+        return HttpResponse.json({ data: connections })
+      }
+      return HttpResponse.json({ data: [] })
+    }),
+
+    // 3. nodes for the connection (seeded even when locked, harmless)
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodes }),
+    ),
+
+    // 4. storages for the node -- content param added by component (images or rootdir)
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storages`, () =>
+      HttpResponse.json({ data: storage }),
+    ),
+
+    // 5. resources -- used to build the set of existing VMIDs
+    http.get(`*/api/v1/connections/${CONN_ID}/resources`, () =>
+      HttpResponse.json({ data: resources }),
+    ),
+
+    // 6. cluster/nextid -- only called in tenant restoreAsNew submit path
+    http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+      HttpResponse.json({ data: 101 }),
+    ),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// Helpers
+// ------------------------------------------------------------------ //
+
+type DialogProps = Parameters<typeof RestoreVmDialog>[0]
+
+function makeProps(overrides: Partial<DialogProps> = {}): DialogProps {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onStarted: vi.fn(),
+    connectionId: CONN_ID,
+    node: NODE_NAME,
+    type: 'qemu',
+    backup: backupRef,
+    sourceVmid: SOURCE_VMID,
+    ...overrides,
+  }
+}
+
+/**
+ * Wait for the dialog data loads to complete.
+ *
+ * In the provider (non-vdcTenant) path the VMID TextField is always rendered
+ * with label "VMID" (common.vmId). MUI TextField emits a proper `for`
+ * attribute so getByLabelText works here. Once we can find the VMID input
+ * we know the component has mounted and set its initial state.
+ */
+async function waitForDataLoad() {
+  await screen.findByLabelText('VMID')
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Dialog open / closed visibility
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - open/closed state', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('does not render dialog content when open=false', () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ open: false })} />)
+    // Dialog title div is gone; note the submit button shares the same text
+    // so we scope to the dialog role which should not exist.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog when open=true (qemu type)', async () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ type: 'qemu' })} />)
+    // The dialog element itself must be present
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // Title text is inside a heading; "Restore VM" appears in h2 (title) + button.
+    // Assert the heading contains it.
+    const heading = screen.getByRole('heading')
+    expect(heading).toHaveTextContent('Restore VM')
+  })
+
+  it('renders Cancel and the submit button when open=true', async () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps()} />)
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    // Submit button: text is "Restore VM" (inventory.pbsRestoreVm). There is
+    // also a heading with that text so we target the button role specifically.
+    const submitBtn = screen.getAllByRole('button').find(
+      (b) => b.textContent?.trim() === 'Restore VM',
+    )
+    expect(submitBtn).not.toBeUndefined()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Data load -- storages populate, VMID pre-filled
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - data load on open', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('pre-fills the VMID field with sourceVmid after open', async () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ sourceVmid: 100 })} />)
+    await waitForDataLoad()
+
+    // MUI TextField for VMID has a proper `for` attribute so getByLabelText works.
+    const vmidInput = screen.getByLabelText('VMID') as HTMLInputElement
+    expect(vmidInput.value).toBe('100')
+  })
+
+  it('opens the Target Storage select and shows a seeded storage option', async () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // Storage Select is rendered as a combobox. jsdom does not resolve
+    // aria-labelledby so we use index access. In the provider path with
+    // connectionId+node locked, the comboboxes are: [storage].
+    // (connection + node pickers are hidden when callerLocksConn/Node=true)
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(1)
+
+    // The storage select is the last (and only) combobox in this configuration.
+    fireEvent.mouseDown(comboboxes[comboboxes.length - 1])
+
+    // 'local' is the first storage entry in the fixture.
+    const localOption = await screen.findByRole('option', { name: /^local$/ })
+    expect(localOption).toBeInTheDocument()
+  })
+
+  it('shows the backup summary info alert with source VMID', async () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ sourceVmid: 100 })} />)
+    // The info Alert always renders: "VM 100 · <datetime>"
+    // We can assert "VM 100" is in the document right away (no fetch needed).
+    expect(screen.getByText(/VM 100/)).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. type branch: qemu vs lxc
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - type branch', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('shows "Restore VM" in the heading for type=qemu', () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ type: 'qemu' })} />)
+    const heading = screen.getByRole('heading')
+    expect(heading).toHaveTextContent('Restore VM')
+    expect(heading).not.toHaveTextContent('Restore CT')
+  })
+
+  it('shows "Restore CT" in the heading for type=lxc', () => {
+    renderWithProviders(<RestoreVmDialog {...makeProps({ type: 'lxc' })} />)
+    const heading = screen.getByRole('heading')
+    expect(heading).toHaveTextContent('Restore CT')
+    expect(heading).not.toHaveTextContent('Restore VM')
+  })
+
+  it('renders the Live restore toggle for type=qemu but not for type=lxc', async () => {
+    // qemu path -- Live restore switch is type-guarded in JSX
+    const { unmount } = renderWithProviders(<RestoreVmDialog {...makeProps({ type: 'qemu' })} />)
+    await waitForDataLoad()
+    expect(screen.getByText('Live restore')).toBeInTheDocument()
+    unmount()
+    cleanup()
+
+    // Re-seed for the second render.
+    seedBaseHandlers()
+
+    // lxc path -- Live restore switch must be absent
+    renderWithProviders(<RestoreVmDialog {...makeProps({ type: 'lxc' })} />)
+    await waitForDataLoad()
+    expect(screen.queryByText('Live restore')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Restore success: POST fires, onStarted(upid) + onClose called
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - restore success', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('fires the restore POST and calls onStarted(upid) + onClose on success', async () => {
+    const onClose = vi.fn()
+    const onStarted = vi.fn()
+
+    // Seed the restore POST to return a UPID string under `data`.
+    // Component line ~372: if (typeof j?.data === 'string') onStarted?.(j.data)
+    server.use(
+      http.post(
+        `*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/restore`,
+        async () => HttpResponse.json({ data: UPID }),
+      ),
+    )
+
+    renderWithProviders(
+      <RestoreVmDialog {...makeProps({ onClose, onStarted })} />,
+    )
+
+    // Wait for the VMID field to confirm the dialog is ready.
+    await waitForDataLoad()
+
+    // canSubmit = !submitting && !!connectionId && !!node && vmidValid.
+    // sourceVmid=100, which is a valid VMID (100..999999999).
+    // The submit button text is "Restore VM" (shared with heading); target by role.
+    const submitBtn = screen.getAllByRole('button').find(
+      (b) => b.textContent?.trim() === 'Restore VM',
+    )
+    expect(submitBtn).not.toBeUndefined()
+    expect(submitBtn).not.toBeDisabled()
+
+    fireEvent.click(submitBtn!)
+
+    await waitFor(() => {
+      expect(onStarted).toHaveBeenCalledWith(UPID)
+    })
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Restore error: 500 POST => error shown, no onClose/onStarted
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - restore error', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('shows the server error text and does not call onClose/onStarted on 500', async () => {
+    const onClose = vi.fn()
+    const onStarted = vi.fn()
+
+    // Seed the restore POST to fail with a 500 + error message.
+    server.use(
+      http.post(
+        `*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/restore`,
+        async () => HttpResponse.json({ error: 'no space left' }, { status: 500 }),
+      ),
+    )
+
+    renderWithProviders(
+      <RestoreVmDialog {...makeProps({ onClose, onStarted })} />,
+    )
+
+    await waitForDataLoad()
+
+    const submitBtn = screen.getAllByRole('button').find(
+      (b) => b.textContent?.trim() === 'Restore VM',
+    )
+    expect(submitBtn).not.toBeUndefined()
+    expect(submitBtn).not.toBeDisabled()
+
+    fireEvent.click(submitBtn!)
+
+    // Error message from the server response appears in the MUI Alert.
+    await waitFor(() => {
+      expect(screen.getByText(/no space left/i)).toBeInTheDocument()
+    })
+
+    // onClose and onStarted must NOT have been called.
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onStarted).not.toHaveBeenCalled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. Cancel button calls onClose
+// ------------------------------------------------------------------ //
+
+describe('RestoreVmDialog - Cancel button', () => {
+  beforeEach(() => {
+    seedBaseHandlers()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<RestoreVmDialog {...makeProps({ onClose })} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
+++ b/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
@@ -85,13 +85,12 @@ describe('WhatsNewDialog component', () => {
   })
 
   it('hides dialog from accessibility tree after transition to open=false', () => {
-    // Render open first, then rerender closed. MUI keeps the Dialog subtree in
-    // the DOM during the exit transition under jsdom (no CSS animations) but
-    // marks the outer MuiModal-root with aria-hidden="true", which removes
-    // the whole dialog from the accessibility tree.
-    // Strategy: locate the portal container via the live [role="dialog"] before
-    // rerender, then re-query from that same container after rerender to pick
-    // up the updated aria-hidden attribute on the (possibly replaced) modal root.
+    // NOTE: WhatsNewDialog keeps its subtree mounted even when rendered with
+    // open=false from the start (it uses MUI keepMounted or an equivalent
+    // pattern). The fresh-render content-absence strategy therefore does not
+    // apply here. Closure is verified via the aria-hidden="true" attribute that
+    // MUI places on the MuiModal-root, which removes the whole dialog from the
+    // accessibility tree while leaving the DOM nodes present.
     const { rerender } = renderWithProviders(<WhatsNewDialog open={true} onClose={vi.fn()} />)
     // When open, the accessible dialog is present.
     const dialogEl = screen.getByRole('dialog')
@@ -102,7 +101,7 @@ describe('WhatsNewDialog component', () => {
     expect(modalRoot).not.toBeNull()
     const portalContainer = modalRoot.parentElement as Element
     expect(portalContainer).not.toBeNull()
-    // The wrapper for THIS open dialog must not be aria-hidden.
+    // The wrapper for this open dialog must not be aria-hidden.
     expect(modalRoot.getAttribute('aria-hidden')).toBeNull()
 
     rerender(<WhatsNewDialog open={false} onClose={vi.fn()} />)

--- a/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
+++ b/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import WhatsNewDialog, { useWhatsNew } from './WhatsNewDialog'
+import changelog from '@/data/changelog.json'
+
+const STORAGE_KEY = 'proxcenter_whats_new_seen'
+
+// Cast to get typed access; the real data shape is version/title/items.
+const latestVersion = (changelog as { version: string }[])[0].version
+
+// ---------------------------------------------------------------------------
+// localStorage isolation: clear before each test, restore after.
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+// ---------------------------------------------------------------------------
+// useWhatsNew hook
+// ---------------------------------------------------------------------------
+describe('useWhatsNew hook', () => {
+  it('reports hasUnseen=true and open=false when localStorage is empty', () => {
+    // No previous value in localStorage => latest version not seen yet.
+    const { result } = renderHook(() => useWhatsNew())
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.hasUnseen).toBe(true)
+  })
+
+  it('opens the dialog when handleOpen is called', () => {
+    const { result } = renderHook(() => useWhatsNew())
+
+    act(() => {
+      result.current.handleOpen()
+    })
+
+    expect(result.current.open).toBe(true)
+  })
+
+  it('closes the dialog, marks seen in localStorage, and clears hasUnseen on handleClose', () => {
+    const { result } = renderHook(() => useWhatsNew())
+
+    // Open first so there is something to close.
+    act(() => {
+      result.current.handleOpen()
+    })
+    expect(result.current.open).toBe(true)
+
+    act(() => {
+      result.current.handleClose()
+    })
+
+    expect(result.current.open).toBe(false)
+    expect(result.current.hasUnseen).toBe(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(latestVersion)
+  })
+
+  it('reports hasUnseen=false when localStorage already holds the latest version', () => {
+    // Simulate a returning user who has already seen this version.
+    localStorage.setItem(STORAGE_KEY, latestVersion)
+
+    const { result } = renderHook(() => useWhatsNew())
+
+    expect(result.current.hasUnseen).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WhatsNewDialog component
+// ---------------------------------------------------------------------------
+describe('WhatsNewDialog component', () => {
+  it('renders the dialog title and latest version chip when open=true', () => {
+    renderWithProviders(<WhatsNewDialog open={true} onClose={vi.fn()} />)
+
+    // The dialog title key renders to "What's New" via real en.json messages.
+    expect(screen.getByText("What's New")).toBeInTheDocument()
+
+    // The latest changelog version chip must be visible.
+    expect(screen.getByText(latestVersion)).toBeInTheDocument()
+  })
+
+  it('marks the modal root aria-hidden after transition to open=false', () => {
+    // Render open first, then rerender closed. MUI keeps the Dialog subtree in
+    // the DOM during the exit transition but marks the outer modal root with
+    // aria-hidden="true" so AT ignores it. In jsdom (no CSS animations) the
+    // node stays mounted; assert the aria attribute, not DOM removal.
+    const { rerender } = renderWithProviders(<WhatsNewDialog open={true} onClose={vi.fn()} />)
+    // When open, the accessible dialog is present.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    rerender(<WhatsNewDialog open={false} onClose={vi.fn()} />)
+    // After closing, the outer MUI Modal wrapper gains aria-hidden="true".
+    const modalRoot = document.querySelector('.MuiModal-root')
+    expect(modalRoot).not.toBeNull()
+    expect(modalRoot!.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('calls onClose when the close IconButton is clicked', async () => {
+    const onClose = vi.fn()
+    renderWithProviders(<WhatsNewDialog open={true} onClose={onClose} />)
+
+    // There are two close triggers: the IconButton (ri-close-line) and the
+    // "Close" button in DialogActions. Click the first button that is
+    // accessible via its role - the IconButton sibling to the title.
+    // userEvent.click on ANY close trigger should fire onClose.
+    const buttons = screen.getAllByRole('button')
+    // The IconButton with the X icon is the first button (before "Close").
+    await userEvent.click(buttons[0])
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the "Close" action button is clicked', async () => {
+    const onClose = vi.fn()
+    renderWithProviders(<WhatsNewDialog open={true} onClose={onClose} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows at least the first changelog entry title in the expanded accordion', () => {
+    renderWithProviders(<WhatsNewDialog open={true} onClose={vi.fn()} />)
+
+    // The first entry is expanded by default; its title must be visible.
+    // Use getAllByText and assert at least one match is in the document,
+    // since jsdom may duplicate portal nodes across renders in the same suite.
+    const firstTitle = (changelog as { version: string; title: string }[])[0].title
+    const matches = screen.getAllByText(firstTitle)
+    expect(matches.length).toBeGreaterThan(0)
+    expect(matches[0]).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
+++ b/frontend/src/components/dialogs/WhatsNewDialog.test.tsx
@@ -84,20 +84,33 @@ describe('WhatsNewDialog component', () => {
     expect(screen.getByText(latestVersion)).toBeInTheDocument()
   })
 
-  it('marks the modal root aria-hidden after transition to open=false', () => {
+  it('hides dialog from accessibility tree after transition to open=false', () => {
     // Render open first, then rerender closed. MUI keeps the Dialog subtree in
-    // the DOM during the exit transition but marks the outer modal root with
-    // aria-hidden="true" so AT ignores it. In jsdom (no CSS animations) the
-    // node stays mounted; assert the aria attribute, not DOM removal.
+    // the DOM during the exit transition under jsdom (no CSS animations) but
+    // marks the outer MuiModal-root with aria-hidden="true", which removes
+    // the whole dialog from the accessibility tree.
+    // Strategy: locate the portal container via the live [role="dialog"] before
+    // rerender, then re-query from that same container after rerender to pick
+    // up the updated aria-hidden attribute on the (possibly replaced) modal root.
     const { rerender } = renderWithProviders(<WhatsNewDialog open={true} onClose={vi.fn()} />)
     // When open, the accessible dialog is present.
-    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    const dialogEl = screen.getByRole('dialog')
+    expect(dialogEl).toBeInTheDocument()
+    // Find the portal container: the body-level div that MUI injects to host
+    // the dialog portal. This parent is stable across rerenders.
+    const modalRoot = dialogEl.closest('.MuiModal-root') as Element
+    expect(modalRoot).not.toBeNull()
+    const portalContainer = modalRoot.parentElement as Element
+    expect(portalContainer).not.toBeNull()
+    // The wrapper for THIS open dialog must not be aria-hidden.
+    expect(modalRoot.getAttribute('aria-hidden')).toBeNull()
 
     rerender(<WhatsNewDialog open={false} onClose={vi.fn()} />)
-    // After closing, the outer MUI Modal wrapper gains aria-hidden="true".
-    const modalRoot = document.querySelector('.MuiModal-root')
-    expect(modalRoot).not.toBeNull()
-    expect(modalRoot!.getAttribute('aria-hidden')).toBe('true')
+    // After closing, MUI marks the modal root aria-hidden="true". Re-query
+    // from the stable portal container to get the current (possibly new) node.
+    const modalRootAfter = portalContainer.querySelector('.MuiModal-root') as Element
+    expect(modalRootAfter).not.toBeNull()
+    expect(modalRootAfter.getAttribute('aria-hidden')).toBe('true')
   })
 
   it('calls onClose when the close IconButton is clicked', async () => {
@@ -132,7 +145,6 @@ describe('WhatsNewDialog component', () => {
     // since jsdom may duplicate portal nodes across renders in the same suite.
     const firstTitle = (changelog as { version: string; title: string }[])[0].title
     const matches = screen.getAllByText(firstTitle)
-    expect(matches.length).toBeGreaterThan(0)
-    expect(matches[0]).toBeInTheDocument()
+    expect(matches.length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/frontend/src/components/hardware/CloneVmDialog.test.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.test.tsx
@@ -1,0 +1,503 @@
+/**
+ * Component tests for CloneVmDialog.tsx
+ *
+ * Strategy: render the dialog with open={true}, seed every MSW endpoint the
+ * dialog calls on open (nodes, pools, storages, snapshots, nextid), await
+ * data load, then assert visible output and representative interactions.
+ * Context hooks that depend on live providers are mocked at module level.
+ *
+ * Provider view (isFullClusterView=true, our default mock):
+ *   isProviderTenant=true => full grid form (node/storage/VMID/pool).
+ *   The VMID field starts empty; user fills it manually (dice or type).
+ *   The /cluster/nextid effect fires ONLY for tenant (isProviderTenant=false),
+ *   so it is seeded for completeness but does not prefill the field here.
+ *
+ * Not covered here:
+ *   - Clone-from-snapshot Select (snapshot endpoint returns empty list so the
+ *     picker stays hidden; the rendering branch is still executed for coverage)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { nodes, pools } from '@/__tests__/fixtures/pveProvisioning'
+import { CloneVmDialog } from './CloneVmDialog'
+
+// ------------------------------------------------------------------ //
+// Context mocks
+// ------------------------------------------------------------------ //
+
+vi.mock('@/contexts/TenantContext', () => ({
+  useTenant: () => ({ currentTenant: null, loading: false, isFullClusterView: true }),
+}))
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = 'conn-1'
+const NODE_NAME = 'pve1'
+const NEXT_VMID = 101
+const VM_ID = '100'
+const VM_NAME = 'web'
+const VM_TYPE = 'qemu'
+
+// Encode the vmKey the component constructs: connId:vmType:currentNode:vmid
+const VM_KEY = encodeURIComponent(`${CONN_ID}:${VM_TYPE}:${NODE_NAME}:${VM_ID}`)
+
+// Storage fixtures: the component filters by content.includes('images') or
+// specific types. 'local' has 'images' so it passes the filter.
+const cloneStorage = [
+  {
+    storage: 'local',
+    content: 'rootdir,images,vztmpl',
+    type: 'dir',
+    avail: 50 * 1024 * 1024 * 1024,
+    total: 100 * 1024 * 1024 * 1024,
+  },
+  {
+    storage: 'local-zfs',
+    content: 'images',
+    type: 'zfspool',
+    avail: 200 * 1024 * 1024 * 1024,
+    total: 400 * 1024 * 1024 * 1024,
+  },
+]
+
+// ------------------------------------------------------------------ //
+// MSW handler factory
+// Seeds ALL 5 endpoints the dialog fires on open.
+// ------------------------------------------------------------------ //
+
+function seedAllHandlers() {
+  server.use(
+    // 1. Nodes for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodes }),
+    ),
+
+    // 2. Pools for the connection
+    http.get(`*/api/v1/connections/${CONN_ID}/pools`, () =>
+      HttpResponse.json({ data: pools }),
+    ),
+
+    // 3. Storages for the target node
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storages`, () =>
+      HttpResponse.json({ data: cloneStorage }),
+    ),
+
+    // 4. Snapshots for the source VM (empty list => snapshot picker stays hidden)
+    http.get(`*/api/v1/guests/${VM_KEY}/snapshots`, () =>
+      HttpResponse.json({ data: { snapshots: [] } }),
+    ),
+
+    // 5. Cluster next available VMID (fetched by tenant path only; seeded for
+    //    completeness so MSW does not raise an unhandled-request error)
+    http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+      HttpResponse.json({ data: NEXT_VMID }),
+    ),
+  )
+}
+
+// ------------------------------------------------------------------ //
+// Default props factory
+// ------------------------------------------------------------------ //
+
+function makeProps(overrides: Partial<{
+  open: boolean
+  onClose: ReturnType<typeof vi.fn>
+  onClone: ReturnType<typeof vi.fn>
+  connId: string
+  currentNode: string
+  vmName: string
+  vmid: string
+  vmType: string
+  nextVmid: number
+  pools: string[]
+  existingVmids: number[]
+}> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onClone: vi.fn().mockResolvedValue(undefined),
+    connId: CONN_ID,
+    currentNode: NODE_NAME,
+    vmName: VM_NAME,
+    vmid: VM_ID,
+    vmType: VM_TYPE,
+    nextVmid: NEXT_VMID,
+    pools: [],
+    existingVmids: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Wait for the nodes fetch to complete so the Target node combobox shows pve1.
+ *
+ * In provider view (isProviderTenant=true) the component loads nodes on open
+ * and populates the Target node Select. We wait until the first combobox (the
+ * Target node Select) shows the seeded node name (pve1).
+ *
+ * MUI Select aria-labelledby name computation does not resolve under jsdom,
+ * so getByRole('combobox', {name: ...}) does not work here; use index access.
+ */
+async function waitForDataLoad() {
+  await waitFor(() => {
+    const comboboxes = screen.getAllByRole('combobox')
+    // In provider view there are at least: Target node (0), Target Storage (1),
+    // Format (2), Resource Pool (3) comboboxes.
+    expect(comboboxes.length).toBeGreaterThanOrEqual(1)
+    // comboboxes[0] is the Target node select; after load it shows 'pve1'.
+    expect(comboboxes[0].textContent).toContain(NODE_NAME)
+  })
+}
+
+/**
+ * Set the VM ID spinbutton to a given value.
+ * The VM ID TextField is type="number" so its ARIA role is "spinbutton".
+ * There is only one spinbutton in the provider form.
+ */
+function setVmid(value: string) {
+  const inputs = screen.getAllByRole('spinbutton')
+  expect(inputs.length).toBeGreaterThanOrEqual(1)
+  fireEvent.change(inputs[0], { target: { value } })
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Dialog open / closed state
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - open/closed state', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('renders the dialog title when open=true', () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    // Translation: hardware.cloneTitle => "Clone VM {vmName} ({vmid})"
+    expect(screen.getByText(`Clone VM ${VM_NAME} (${VM_ID})`)).toBeInTheDocument()
+  })
+
+  it('renders Cancel and Clone buttons when open=true', () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^clone$/i })).toBeInTheDocument()
+  })
+
+  it('does not render dialog content when open=false', () => {
+    renderWithProviders(<CloneVmDialog {...makeProps({ open: false })} />)
+    expect(screen.queryByText(`Clone VM ${VM_NAME} (${VM_ID})`)).not.toBeInTheDocument()
+  })
+
+  it('Clone button is disabled initially because VMID is empty', () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    // The VMID starts as '' in provider view (not prefilled); button must be disabled
+    const cloneBtn = screen.getByRole('button', { name: /^clone$/i })
+    expect(cloneBtn).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Data load on open -- nodes load and appear in Target node Select
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - data loads on open', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('shows the seeded target node in the Target node Select after load', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // comboboxes[0] is the Target node select; after nodes load it contains NODE_NAME
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes[0].textContent).toContain(NODE_NAME)
+  })
+
+  it('opens Target node Select and shows seeded node as option', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const comboboxes = screen.getAllByRole('combobox')
+    expect(comboboxes.length).toBeGreaterThanOrEqual(1)
+    fireEvent.mouseDown(comboboxes[0])
+
+    const option = await screen.findByRole('option', { name: /pve1/ })
+    expect(option).toBeInTheDocument()
+  })
+
+  it('opens Resource Pool Select and shows seeded pools as options', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // comboboxes order in provider form (4 selects visible):
+    //   0: Target node, 1: Target Storage, 2: Format, 3: Resource Pool
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(4)
+    })
+
+    const comboboxes = screen.getAllByRole('combobox')
+    // Resource Pool is the 4th combobox (index 3)
+    fireEvent.mouseDown(comboboxes[3])
+
+    const poolDev = await screen.findByRole('option', { name: /pool-dev/ })
+    expect(poolDev).toBeInTheDocument()
+  })
+
+  it('opens Target Storage Select and shows seeded storages as options', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(2)
+    })
+
+    const comboboxes = screen.getAllByRole('combobox')
+    // comboboxes[1] is the Target Storage select
+    fireEvent.mouseDown(comboboxes[1])
+
+    // "Same as source" is the sentinel option always at the top of the storage list
+    const sameAsSource = await screen.findByRole('option', { name: /same as source/i })
+    expect(sameAsSource).toBeInTheDocument()
+
+    // The storage options from the seeded MSW response appear after the sentinel.
+    // MUI renders each MenuItem text; the storage name 'local' appears inside an option.
+    const options = screen.getAllByRole('option')
+    const optionTexts = options.map((o) => o.textContent)
+    expect(optionTexts.some((t) => t?.includes('local'))).toBe(true)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. VMID validation
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - VMID validation', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('shows an error and blocks Clone when VMID is in existingVmids', async () => {
+    renderWithProviders(
+      <CloneVmDialog {...makeProps({ existingVmids: [200] })} />,
+    )
+    await waitForDataLoad()
+
+    // Enter a VMID that collides with existingVmids
+    setVmid('200')
+
+    await waitFor(() => {
+      expect(screen.getByText(/VM ID 200 already in use/i)).toBeInTheDocument()
+    })
+
+    // Clone button must be disabled when vmidError is set
+    const cloneBtn = screen.getByRole('button', { name: /^clone$/i })
+    expect(cloneBtn).toBeDisabled()
+  })
+
+  it('Clone button is enabled when VMID is free', async () => {
+    renderWithProviders(
+      <CloneVmDialog {...makeProps({ existingVmids: [999] })} />,
+    )
+    await waitForDataLoad()
+
+    // Set a valid VMID not in existingVmids
+    setVmid('200')
+
+    await waitFor(() => {
+      const cloneBtn = screen.getByRole('button', { name: /^clone$/i })
+      expect(cloneBtn).not.toBeDisabled()
+    })
+  })
+
+  it('changing VMID to a value below 100 shows minimum error', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    setVmid('50')
+
+    await waitFor(() => {
+      expect(screen.getByText(/VM ID must be >= 100/i)).toBeInTheDocument()
+    })
+
+    // Clone button must be disabled when vmidError is set
+    expect(screen.getByRole('button', { name: /^clone$/i })).toBeDisabled()
+  })
+
+  it('entering a valid free VMID shows no error', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    setVmid('150')
+
+    await waitFor(() => {
+      const cloneBtn = screen.getByRole('button', { name: /^clone$/i })
+      expect(cloneBtn).not.toBeDisabled()
+    })
+
+    expect(screen.queryByText(/VM ID must be/i)).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Full Clone toggle (provider-only)
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - Full Clone toggle', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('Full Clone checkbox is checked by default', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // The "Full Clone" label walks to the nearest MuiFormControlLabel root
+    const label = screen.getByText('Full Clone')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(formControlLabel).not.toBeNull()
+    const checkbox = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox).not.toBeNull()
+    expect(checkbox.checked).toBe(true)
+  })
+
+  it('unchecking Full Clone toggles to linked clone description', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    const label = screen.getByText('Full Clone')
+    const formControlLabel = label.closest('.MuiFormControlLabel-root') as HTMLElement
+    const checkbox = formControlLabel.querySelector('input[type="checkbox"]') as HTMLInputElement
+
+    // Default: full clone description visible
+    expect(screen.getByText(/Creates a complete and independent copy/i)).toBeInTheDocument()
+
+    // Uncheck -- should show the linked clone description text
+    fireEvent.click(checkbox)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Linked Clone:/i)).toBeInTheDocument()
+    })
+    expect(checkbox.checked).toBe(false)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Clone success path
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - Clone success', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('calls onClone with expected params and then calls onClose on success', async () => {
+    const onClone = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <CloneVmDialog {...makeProps({ onClone, onClose })} />,
+    )
+    await waitForDataLoad()
+
+    // Set a valid VMID to enable the Clone button
+    setVmid('150')
+
+    // Set a name to verify it flows through to onClone
+    const nameInput = screen.getByLabelText('Name') as HTMLInputElement
+    fireEvent.change(nameInput, { target: { value: 'web-clone' } })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^clone$/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^clone$/i }))
+
+    await waitFor(() => {
+      expect(onClone).toHaveBeenCalledTimes(1)
+    })
+
+    // Verify the key params passed to onClone
+    const cloneArgs = onClone.mock.calls[0][0]
+    expect(cloneArgs.targetNode).toBe(NODE_NAME)
+    expect(cloneArgs.newVmid).toBe(150)
+    expect(cloneArgs.name).toBe('web-clone')
+    expect(cloneArgs.full).toBe(true)
+
+    // onClose must fire after onClone resolves
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. Clone error path
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - Clone error', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('shows error message and does NOT call onClose when onClone rejects', async () => {
+    const onClone = vi.fn().mockRejectedValue(new Error('boom'))
+    const onClose = vi.fn()
+
+    renderWithProviders(
+      <CloneVmDialog {...makeProps({ onClone, onClose })} />,
+    )
+    await waitForDataLoad()
+
+    // Set a valid VMID to enable the Clone button
+    setVmid('150')
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^clone$/i })).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^clone$/i }))
+
+    await waitFor(() => {
+      expect(onClone).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('boom')).toBeInTheDocument()
+    })
+
+    // onClose must NOT have been called after an error
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 7. Cancel button
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - Cancel button', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<CloneVmDialog {...makeProps({ onClose })} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/settings/DiagnosticModal.test.tsx
+++ b/frontend/src/components/settings/DiagnosticModal.test.tsx
@@ -278,17 +278,9 @@ describe('DiagnosticModal - close button', () => {
     const onClose = vi.fn()
     renderWithProviders(<DiagnosticModal {...makeProps({ onClose })} />)
 
-    // The IconButton in DialogTitle has no accessible label; it is the only
-    // button that is not "Re-run" or "Close".
+    // The close IconButton in DialogTitle wraps an icon with no visible text;
+    // it is the only button with empty text content.
     const allButtons = screen.getAllByRole('button')
-    const xBtn = allButtons.find(
-      b => b.getAttribute('aria-label') === null &&
-           b.textContent?.trim() === '' ||
-      (!b.textContent?.match(/re-run|close/i) && b !== allButtons[allButtons.length - 1])
-    )
-    // We use the simpler approach: the close IconButton wraps an <i> with no text;
-    // click every button that is neither Re-run nor Close and assert onClose fired.
-    // More precise: find by querying buttons and picking the one with no text.
     const iconBtns = allButtons.filter(b => !b.textContent?.trim())
     // There is exactly one icon-only button: the X in the title.
     expect(iconBtns).toHaveLength(1)

--- a/frontend/src/components/settings/DiagnosticModal.test.tsx
+++ b/frontend/src/components/settings/DiagnosticModal.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Component tests for DiagnosticModal.tsx
+ *
+ * Strategy: render the dialog, seed the single MSW endpoint it fires on open
+ * (GET /api/v1/connections/:id/diagnostics), await data, then assert visible
+ * output and interactions.
+ *
+ * No context mocks needed: the component only calls useTranslations, which the
+ * renderWithProviders harness satisfies via the real en.json.
+ *
+ * Dialog renders into a MUI portal; use screen.* (not within(container)).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { diagResultFixture } from '@/__tests__/fixtures/diagnostics'
+
+import DiagnosticModal from './DiagnosticModal'
+
+// ------------------------------------------------------------------ //
+// Constants
+// ------------------------------------------------------------------ //
+
+const CONN_ID = 'conn-1'
+const CONN_NAME = 'pve-cluster-test'
+
+// ------------------------------------------------------------------ //
+// Helper: default props
+// ------------------------------------------------------------------ //
+
+function makeProps(
+  overrides: Partial<Parameters<typeof DiagnosticModal>[0]> = {},
+) {
+  return {
+    open: true,
+    connectionId: CONN_ID,
+    connectionName: CONN_NAME,
+    onClose: vi.fn(),
+    ...overrides,
+  }
+}
+
+// ------------------------------------------------------------------ //
+// MSW handler factory
+// Seeds the diagnostics endpoint for the happy path.
+// ------------------------------------------------------------------ //
+
+function seedDiagnosticsOk() {
+  server.use(
+    http.get(`*/api/v1/connections/${CONN_ID}/diagnostics`, () =>
+      HttpResponse.json(diagResultFixture),
+    ),
+  )
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Closed state
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - closed state', () => {
+  it('does not render dialog content when open=false', () => {
+    renderWithProviders(
+      <DiagnosticModal {...makeProps({ open: false, connectionId: CONN_ID })} />,
+    )
+    // The dialog title only appears when the Dialog is open.
+    expect(screen.queryByText('Connection diagnostics')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Happy path: title + connectionName + fetch-driven check data
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - success path', () => {
+  beforeEach(() => {
+    seedDiagnosticsOk()
+  })
+
+  it('shows the dialog title and connectionName when open=true', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    // Title comes from t('title') = "Connection diagnostics".
+    expect(screen.getByText('Connection diagnostics')).toBeInTheDocument()
+    // connectionName caption is rendered below the title.
+    expect(screen.getByText(CONN_NAME)).toBeInTheDocument()
+  })
+
+  it('renders check labels from the fixture after fetch resolves', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    // "Host reachable" is the ok-check label from the fixture, not static text.
+    expect(await screen.findByText('Host reachable')).toBeInTheDocument()
+    // "API token valid" is the warn-check label from the fixture.
+    expect(screen.getByText('API token valid')).toBeInTheDocument()
+  })
+
+  it('renders the category headers from the fixture (network + auth)', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('Host reachable')
+    // Category headers are rendered as overline Typography with the raw category string.
+    expect(screen.getByText('network')).toBeInTheDocument()
+    expect(screen.getByText('auth')).toBeInTheDocument()
+  })
+
+  it('renders check messages from the fixture', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('Host reachable')
+    expect(screen.getByText('TCP connect succeeded')).toBeInTheDocument()
+    expect(screen.getByText('Token expires soon')).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Status rendering: ok chip + warn chip both surface from fixture
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - summary chips', () => {
+  beforeEach(() => {
+    seedDiagnosticsOk()
+  })
+
+  it('renders the ok summary chip with count from fixture (1 OK)', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('Host reachable')
+    // t('summaryOk', { count: 1 }) = "1 OK"
+    expect(screen.getByText('1 OK')).toBeInTheDocument()
+  })
+
+  it('renders the warn summary chip with count from fixture (1 warning)', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('Host reachable')
+    // t('summaryWarn', { count: 1 }) = "1 warning"
+    expect(screen.getByText('1 warning')).toBeInTheDocument()
+  })
+
+  it('does NOT render error or skip chips when fixture has none', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('Host reachable')
+    // fixture.summary.error=0 and fixture.summary.skip=0
+    expect(screen.queryByText(/\d+ error/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/\d+ skipped/)).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Detail expand/collapse for warn check
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - detail expansion', () => {
+  beforeEach(() => {
+    seedDiagnosticsOk()
+  })
+
+  it('shows "Show detail" button for a check that has a detail field', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('API token valid')
+    // The warn check has detail="Expires in 3 days"; the component renders a toggle button.
+    expect(screen.getByRole('button', { name: /show detail/i })).toBeInTheDocument()
+  })
+
+  it('clicking Show detail reveals the detail text, clicking Hide detail collapses it', async () => {
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText('API token valid')
+
+    const showBtn = screen.getByRole('button', { name: /show detail/i })
+    fireEvent.click(showBtn)
+
+    // After expanding, the detail text from the fixture is visible.
+    expect(await screen.findByText('Expires in 3 days')).toBeInTheDocument()
+    // Button label has changed to "Hide detail".
+    expect(screen.getByRole('button', { name: /hide detail/i })).toBeInTheDocument()
+
+    // Collapse it again.
+    fireEvent.click(screen.getByRole('button', { name: /hide detail/i }))
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /hide detail/i })).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /show detail/i })).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 5. Error path: 500 response renders the error alert
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - error path', () => {
+  it('renders the error alert when the endpoint returns 500', async () => {
+    server.use(
+      http.get(`*/api/v1/connections/${CONN_ID}/diagnostics`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    )
+
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+
+    // t('unavailable') = "Diagnostics unavailable"; the component appends ": {msg}".
+    expect(
+      await screen.findByText(/Diagnostics unavailable/),
+    ).toBeInTheDocument()
+    // The error message from the JSON body must also appear.
+    expect(screen.getByText(/boom/)).toBeInTheDocument()
+  })
+
+  it('does not render check data on error', async () => {
+    server.use(
+      http.get(`*/api/v1/connections/${CONN_ID}/diagnostics`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    )
+
+    renderWithProviders(<DiagnosticModal {...makeProps()} />)
+    await screen.findByText(/Diagnostics unavailable/)
+
+    // No check labels from the fixture should appear.
+    expect(screen.queryByText('Host reachable')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 6. null connectionId: fetch does NOT fire, modal renders clean
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - null connectionId', () => {
+  // No MSW handler seeded. If a request fires, MSW will error (onUnhandledRequest:'error').
+
+  it('renders the dialog title without firing diagnostics when connectionId=null', () => {
+    renderWithProviders(
+      <DiagnosticModal
+        {...makeProps({ connectionId: null })}
+      />,
+    )
+    // Dialog is open: title is visible.
+    expect(screen.getByText('Connection diagnostics')).toBeInTheDocument()
+    // No check data from fixture should ever appear (no fetch ran).
+    expect(screen.queryByText('Host reachable')).not.toBeInTheDocument()
+  })
+
+  it('Re-run button is disabled when connectionId=null', () => {
+    renderWithProviders(
+      <DiagnosticModal {...makeProps({ connectionId: null })} />,
+    )
+    const rerunBtn = screen.getByRole('button', { name: /re-run/i })
+    expect(rerunBtn).toBeDisabled()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 7. Close button
+// ------------------------------------------------------------------ //
+
+describe('DiagnosticModal - close button', () => {
+  beforeEach(() => {
+    seedDiagnosticsOk()
+  })
+
+  it('calls onClose when the Close button in DialogActions is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<DiagnosticModal {...makeProps({ onClose })} />)
+
+    // t('close') = "Close" -- the contained button in DialogActions.
+    const closeBtn = screen.getByRole('button', { name: 'Close' })
+    fireEvent.click(closeBtn)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the X icon button in the title is clicked', () => {
+    const onClose = vi.fn()
+    renderWithProviders(<DiagnosticModal {...makeProps({ onClose })} />)
+
+    // The IconButton in DialogTitle has no accessible label; it is the only
+    // button that is not "Re-run" or "Close".
+    const allButtons = screen.getAllByRole('button')
+    const xBtn = allButtons.find(
+      b => b.getAttribute('aria-label') === null &&
+           b.textContent?.trim() === '' ||
+      (!b.textContent?.match(/re-run|close/i) && b !== allButtons[allButtons.length - 1])
+    )
+    // We use the simpler approach: the close IconButton wraps an <i> with no text;
+    // click every button that is neither Re-run nor Close and assert onClose fired.
+    // More precise: find by querying buttons and picking the one with no text.
+    const iconBtns = allButtons.filter(b => !b.textContent?.trim())
+    // There is exactly one icon-only button: the X in the title.
+    expect(iconBtns).toHaveLength(1)
+    fireEvent.click(iconBtns[0])
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -106,10 +106,8 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 # - inventory/components/CephTopology.tsx: the Ceph CRUSH topology view. Pure
 #   presentational JSX (tree rows, details panel, pools table); its only logic
 #   (buildCrushTopology/capacityColor) lives in cephTopology.ts and is unit-tested.
-# - components/hardware/CloneVmDialog.tsx: the clone-VM dialog is a pure-JSX MUI
-#   form (node/storage/pool selectors, clone-from-snapshot picker). Its side
-#   effects only fetch lists to populate dropdowns; the clone itself is driven by
-#   the measured clone route (connections/**/clone) and the useVmActions handlers.
+# - components/hardware/CloneVmDialog.tsx: removed from exclusions (jsdom component
+#   test added, 81.8% line coverage).
 # - settings/TenantsTab.tsx, templates/DeployWizard.tsx,
 #   inventory/NetworkDashboard.tsx, inventory/CreateVmDialog.tsx, inventory/CreateLxcDialog.tsx:
 #   pure-JSX MUI containers (the MSP tenant provisioning panel, the deploy wizard,
@@ -174,7 +172,6 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\
-  frontend/src/components/hardware/CloneVmDialog.tsx,\
   frontend/src/components/settings/TenantsTab.tsx,\
   frontend/src/components/templates/DeployWizard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -110,14 +110,15 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   form (node/storage/pool selectors, clone-from-snapshot picker). Its side
 #   effects only fetch lists to populate dropdowns; the clone itself is driven by
 #   the measured clone route (connections/**/clone) and the useVmActions handlers.
-# - settings/TenantsTab.tsx, settings/DiagnosticModal.tsx, templates/DeployWizard.tsx,
+# - settings/TenantsTab.tsx, templates/DeployWizard.tsx,
 #   inventory/NetworkDashboard.tsx, inventory/CreateVmDialog.tsx, inventory/CreateLxcDialog.tsx:
-#   pure-JSX MUI containers (the MSP tenant provisioning panel, the connection-diagnostics
-#   result modal, the deploy wizard, the network dashboard and the create VM/LXC forms).
+#   pure-JSX MUI containers (the MSP tenant provisioning panel, the deploy wizard,
+#   the network dashboard and the create VM/LXC forms).
 #   Their side effects only fetch lists to populate the UI; the logic they drive lives in
-#   measured code (MSP scoping in lib/tenant/infraScope.ts, diagnostics in
-#   lib/diagnostics/connectionDiagnostics.ts, and the create/deploy API routes). The
-#   node-env Vitest suite cannot render them.
+#   measured code (MSP scoping in lib/tenant/infraScope.ts, and the create/deploy API routes).
+#   The node-env Vitest suite cannot render them.
+# - settings/DiagnosticModal.tsx: removed from exclusions (jsdom component test added,
+#   81% line coverage).
 # - app/api/v1/inventory/route.ts and app/api/v1/inventory/stream/route.ts: the two
 #   inventory assembly endpoints walk a live PVE+PBS cluster (every node, storage and PBS
 #   datastore) and stream the tree, so they cannot run under Vitest without a real cluster.
@@ -176,7 +177,6 @@ sonar.coverage.exclusions=\
   frontend/src/components/hardware/CloneVmDialog.tsx,\
   frontend/src/components/dialogs/WhatsNewDialog.tsx,\
   frontend/src/components/settings/TenantsTab.tsx,\
-  frontend/src/components/settings/DiagnosticModal.tsx,\
   frontend/src/components/templates/DeployWizard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx,\
   frontend/src/app/api/v1/inventory/route.ts,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -158,7 +158,6 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/PbsServerPanel.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx,\
-  frontend/src/components/backup/RestoreVmDialog.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ReportConnectionSelect.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ScheduleManager.tsx,\
   frontend/src/app/(dashboard)/operations/reports/components/ScheduleDialog.tsx,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -175,7 +175,6 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/EntityTagManager.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts,\
   frontend/src/components/hardware/CloneVmDialog.tsx,\
-  frontend/src/components/dialogs/WhatsNewDialog.tsx,\
   frontend/src/components/settings/TenantsTab.tsx,\
   frontend/src/components/templates/DeployWizard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx,\


### PR DESCRIPTION
Fourth batch of component tests through the jsdom Vitest lane, covering four mid-size dialogs. Reuses the dialog + MSW + frozen-fixture pattern from batches 2 and 3.

## What this adds

| Component | Lines | Tests | Per-file line coverage |
|-----------|-------|-------|------------------------|
| `WhatsNewDialog.tsx` | 224 | 9 | 97% |
| `DiagnosticModal.tsx` | 439 | 16 | 81% |
| `CloneVmDialog.tsx` | 631 | 17 | 82% |
| `RestoreVmDialog.tsx` | 562 | 12 | 60% |

All four `sonar.coverage.exclusions` entries are removed (per-file coverage well above the project overall in each case).

- `WhatsNewDialog` exports both a `useWhatsNew()` localStorage hook and the dialog; the hook (unseen-version detection, mark-seen, open/close) is covered via `renderHook`, the dialog via render.
- `DiagnosticModal` auto-runs a diagnostics fetch on open; the test seeds it with MSW and covers the categorized results, the ok/warn statuses, the detail expand/collapse, the error path, and the no-fetch (null connection) branch.
- `CloneVmDialog` and `RestoreVmDialog` are controlled dialogs with a cascade of fetches on open. The tests seed those with MSW from frozen fixtures and exercise data load, VMID validation, the type branch, and the full action paths: the clone calls its `onClone` callback (success and reject) and the restore fires its POST and asserts `onStarted(upid)` plus the server-error branch.

Fixtures: `pveProvisioning.ts` gains `resources` and `backupRef` (additive, existing exports untouched so sibling tests are unaffected); a new `diagnostics.ts` fixture.

## Notes

- Test, fixture, and sonar-config code only. No production source changed. `sonar.cpd.exclusions` is untouched.
- Full suite green: 1926 tests (node + jsdom lanes).
- Ratchet floor stays at 11; a bump to lock in the accumulated gains will follow in a dedicated commit.
