### PR TITLE
fix(api): stop swallowing real errors in guest/node routes (#448)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -2347,7 +2347,7 @@ return (
       setConfirmAction({
         action: 'info',
         title: t('common.success'),
-        message: `${t('common.delete')} "${vmName}" ${t('common.success')}`,
+        message: `${t('common.delete')} "${vmName}" ${t('common.success')}${json.warning ? ` (${json.warning})` : ''}`,
         vmName: undefined,
         onConfirm: async () => {
           setConfirmAction(null)

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.test.ts
@@ -176,7 +176,7 @@ describe('DELETE /api/v1/connections/[id]/guests/[type]/[node]/[vmid]', () => {
     expect(body.error).toBe('PVE 500')
   })
 
-  it('IPAM release failure is swallowed (does not affect 200 response)', async () => {
+  it('IPAM release failure is surfaced as a warning, VM still deleted', async () => {
     pveFetchMock
       .mockResolvedValueOnce({ status: 'stopped' })
       .mockResolvedValueOnce('UPID:delete:task')
@@ -184,7 +184,19 @@ describe('DELETE /api/v1/connections/[id]/guests/[type]/[node]/[vmid]', () => {
     const res = await DELETE(makeReq(), {
       params: Promise.resolve(baseParams),
     })
-    // Handler catches IPAM errors internally and returns 200 anyway
+    // The VM is already gone in PVE, so we must not fail the request: it still
+    // succeeds (200) but the IPAM failure is reported via body.warning + audit.
     expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.warning).toMatch(/IPAM release failed/i)
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'delete',
+        details: expect.objectContaining({
+          ipamReleaseError: expect.stringMatching(/IPAM release failed/i),
+        }),
+      })
+    )
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/route.ts
@@ -104,6 +104,7 @@ export async function DELETE(
     // Our IPAM is keyed on vmid so we don't need to re-parse netN/ipconfigN
     // out of the (already-deleted) qm config. Idempotent: missing rows are
     // ignored.
+    let ipamWarning: string | undefined
     if (type === 'qemu') {
       try {
         const numericVmid = Number(vmid)
@@ -111,6 +112,7 @@ export async function DELETE(
           await releaseAllocationsForVm(id, numericVmid)
         }
       } catch (err: any) {
+        ipamWarning = `IPAM release failed: ${err?.message || String(err)}`
         console.warn(`[vm-delete] IPAM release failed for ${type}/${vmid}: ${err?.message}`)
       }
     }
@@ -123,13 +125,14 @@ export async function DELETE(
       category: type === 'lxc' ? 'containers' : 'vms',
       resourceType: type,
       resourceId: vmid,
-      details: { node, connectionId: id },
+      details: { node, connectionId: id, ipamReleaseError: ipamWarning },
     })
 
     return NextResponse.json({
       success: true,
       data: result,
-      message: `VM ${vmid} supprimée avec succès`
+      message: `VM ${vmid} supprimée avec succès`,
+      ...(ipamWarning ? { warning: ipamWarning } : {}),
     })
   } catch (e: any) {
     console.error("[DELETE VM] Error:", e)

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
@@ -4,6 +4,9 @@ import { callRoute, readJson } from '@/__tests__/setup/route-test'
 
 vi.mock('@/lib/connections/getConnection', () => ({
   getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+  // Real pure helper: matches the production "connection not found" detection.
+  isConnectionNotFoundError: (err: unknown) =>
+    /connection not found/i.test((err as { message?: string } | null)?.message || ''),
 }))
 
 vi.mock('@/lib/proxmox/client', () => ({
@@ -91,14 +94,14 @@ describe('GET /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
     expect(body.data.maintenance).toBeNull()
   })
 
-  it('returns maintenance=null when pveFetch rejects (swallowed via .catch)', async () => {
+  it('500 when pveFetch rejects (cluster error now surfaces)', async () => {
     pveFetchMock.mockRejectedValue(new Error('cluster unreachable'))
     const res = await GET(new Request('http://test.local/_'), {
       params: Promise.resolve(baseParams),
     })
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(500)
     const body = await readJson<any>(res)
-    expect(body.data.maintenance).toBeNull()
+    expect(body.error).toMatch(/cluster unreachable/i)
   })
 
   it('403 when RBAC denies node.view', async () => {
@@ -116,6 +119,16 @@ describe('GET /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
       params: Promise.resolve(baseParams),
     })
     expect(res.status).toBe(500)
+  })
+
+  it('404 when getConnectionById rejects with a not-found error', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve(baseParams),
+    })
+    expect(res.status).toBe(404)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/not found/i)
   })
 
   it('calls pveFetch with correct cluster resources path', async () => {
@@ -145,12 +158,21 @@ describe('POST /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockResolvedValue(null)
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await callRoute(POST as any, {
       method: 'POST',
       params: baseParams,
     })
     expect(res.status).toBe(404)
+  })
+
+  it('500 when getConnectionById rejects with a non-not-found error', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
   })
 
   it('200 happy path: executes enable SSH command and returns output', async () => {
@@ -212,12 +234,21 @@ describe('DELETE /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockResolvedValue(null)
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await callRoute(DELETE as any, {
       method: 'DELETE',
       params: baseParams,
     })
     expect(res.status).toBe(404)
+  })
+
+  it('500 when getConnectionById rejects with a non-not-found error', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: baseParams,
+    })
+    expect(res.status).toBe(500)
   })
 
   it('200 happy path: executes disable SSH command and returns output', async () => {

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
@@ -7,6 +7,53 @@ import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
 
+// Map a thrown error to the right HTTP response: a genuine not-found becomes a
+// 404, everything else (DB/crypto/infra) surfaces as a 500 with the original
+// message. Shared by all three handlers so the not-found vs real-error
+// distinction lives in one place.
+function maintenanceError(label: string, e: any, fallback: string): NextResponse {
+  console.error(`[maintenance] ${label} Error:`, e?.message)
+  if (isConnectionNotFoundError(e)) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+  }
+  return NextResponse.json({ error: e?.message || fallback }, { status: 500 })
+}
+
+// Enter (enable) or exit (disable) HA maintenance on a node via SSH. POST and
+// DELETE are identical bar the verb, so the whole body lives here.
+async function toggleMaintenance(
+  ctx: { params: Promise<{ id: string; node: string }> },
+  enable: boolean
+): Promise<NextResponse> {
+  const label = enable ? 'POST' : 'DELETE'
+  const fallback = enable ? 'Failed to enter maintenance mode' : 'Failed to exit maintenance mode'
+  try {
+    const { id, node } = await ctx.params
+
+    const resourceId = buildNodeResourceId(id, node)
+    const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "node", resourceId)
+    if (denied) return denied
+
+    const conn = await getConnectionById(id)
+
+    const nodeIp = await getNodeIp(conn, node)
+    const command = `ha-manager crm-command node-maintenance ${enable ? 'enable' : 'disable'} ${node}`
+
+    console.log(`[maintenance] ${label} ${node}: executing via SSH on ${nodeIp}: ${command}`)
+    const result = await executeSSH(id, nodeIp, command)
+
+    if (result.success) {
+      return NextResponse.json({ success: true, method: 'ssh', output: result.output })
+    }
+    return NextResponse.json({
+      error: result.error,
+      hint: `Run manually on a PVE node: ${command}`
+    }, { status: 500 })
+  } catch (e: any) {
+    return maintenanceError(label, e, fallback)
+  }
+}
+
 /**
  * GET /api/v1/connections/[id]/nodes/[node]/maintenance
  *
@@ -31,11 +78,7 @@ export async function GET(
 
     return NextResponse.json({ data: { maintenance } })
   } catch (e: any) {
-    console.error("[maintenance] GET Error:", e?.message)
-    if (isConnectionNotFoundError(e)) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
-    return NextResponse.json({ error: e?.message || "Failed to get maintenance status" }, { status: 500 })
+    return maintenanceError('GET', e, 'Failed to get maintenance status')
   }
 }
 
@@ -44,40 +87,11 @@ export async function GET(
  *
  * Enter maintenance mode via SSH: ha-manager crm-command node-maintenance enable <node>
  */
-export async function POST(
+export function POST(
   _req: Request,
   ctx: { params: Promise<{ id: string; node: string }> }
 ) {
-  try {
-    const { id, node } = await ctx.params
-
-    const resourceId = buildNodeResourceId(id, node)
-    const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "node", resourceId)
-    if (denied) return denied
-
-    const conn = await getConnectionById(id)
-
-    const nodeIp = await getNodeIp(conn, node)
-    const command = `ha-manager crm-command node-maintenance enable ${node}`
-
-    console.log(`[maintenance] POST ${node}: executing via SSH on ${nodeIp}: ${command}`)
-    const result = await executeSSH(id, nodeIp, command)
-
-    if (result.success) {
-      return NextResponse.json({ success: true, method: 'ssh', output: result.output })
-    } else {
-      return NextResponse.json({
-        error: result.error,
-        hint: `Run manually on a PVE node: ${command}`
-      }, { status: 500 })
-    }
-  } catch (e: any) {
-    console.error("[maintenance] POST Error:", e?.message)
-    if (isConnectionNotFoundError(e)) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
-    return NextResponse.json({ error: e?.message || "Failed to enter maintenance mode" }, { status: 500 })
-  }
+  return toggleMaintenance(ctx, true)
 }
 
 /**
@@ -85,38 +99,9 @@ export async function POST(
  *
  * Exit maintenance mode via SSH: ha-manager crm-command node-maintenance disable <node>
  */
-export async function DELETE(
+export function DELETE(
   _req: Request,
   ctx: { params: Promise<{ id: string; node: string }> }
 ) {
-  try {
-    const { id, node } = await ctx.params
-
-    const resourceId = buildNodeResourceId(id, node)
-    const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "node", resourceId)
-    if (denied) return denied
-
-    const conn = await getConnectionById(id)
-
-    const nodeIp = await getNodeIp(conn, node)
-    const command = `ha-manager crm-command node-maintenance disable ${node}`
-
-    console.log(`[maintenance] DELETE ${node}: executing via SSH on ${nodeIp}: ${command}`)
-    const result = await executeSSH(id, nodeIp, command)
-
-    if (result.success) {
-      return NextResponse.json({ success: true, method: 'ssh', output: result.output })
-    } else {
-      return NextResponse.json({
-        error: result.error,
-        hint: `Run manually on a PVE node: ${command}`
-      }, { status: 500 })
-    }
-  } catch (e: any) {
-    console.error("[maintenance] DELETE Error:", e?.message)
-    if (isConnectionNotFoundError(e)) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
-    return NextResponse.json({ error: e?.message || "Failed to exit maintenance mode" }, { status: 500 })
-  }
+  return toggleMaintenance(ctx, false)
 }

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById } from "@/lib/connections/getConnection"
+import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
 import { checkPermission, buildNodeResourceId, PERMISSIONS } from "@/lib/rbac"
 import { executeSSH } from "@/lib/ssh/exec"
 import { getNodeIp } from "@/lib/ssh/node-ip"
@@ -24,17 +24,17 @@ export async function GET(
     if (denied) return denied
 
     const conn = await getConnectionById(id)
-    if (!conn) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
 
-    const nodeResources = await pveFetch<any[]>(conn, '/cluster/resources?type=node').catch(() => [])
+    const nodeResources = await pveFetch<any[]>(conn, '/cluster/resources?type=node')
     const nodeResource = (nodeResources || []).find((nr: any) => nr?.node === node)
     const maintenance = nodeResource?.hastate === 'maintenance' ? 'maintenance' : null
 
     return NextResponse.json({ data: { maintenance } })
   } catch (e: any) {
     console.error("[maintenance] GET Error:", e?.message)
+    if (isConnectionNotFoundError(e)) {
+      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+    }
     return NextResponse.json({ error: e?.message || "Failed to get maintenance status" }, { status: 500 })
   }
 }
@@ -56,9 +56,6 @@ export async function POST(
     if (denied) return denied
 
     const conn = await getConnectionById(id)
-    if (!conn) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
 
     const nodeIp = await getNodeIp(conn, node)
     const command = `ha-manager crm-command node-maintenance enable ${node}`
@@ -76,6 +73,9 @@ export async function POST(
     }
   } catch (e: any) {
     console.error("[maintenance] POST Error:", e?.message)
+    if (isConnectionNotFoundError(e)) {
+      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+    }
     return NextResponse.json({ error: e?.message || "Failed to enter maintenance mode" }, { status: 500 })
   }
 }
@@ -97,9 +97,6 @@ export async function DELETE(
     if (denied) return denied
 
     const conn = await getConnectionById(id)
-    if (!conn) {
-      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
-    }
 
     const nodeIp = await getNodeIp(conn, node)
     const command = `ha-manager crm-command node-maintenance disable ${node}`
@@ -117,6 +114,9 @@ export async function DELETE(
     }
   } catch (e: any) {
     console.error("[maintenance] DELETE Error:", e?.message)
+    if (isConnectionNotFoundError(e)) {
+      return NextResponse.json({ error: "Connection not found" }, { status: 404 })
+    }
     return NextResponse.json({ error: e?.message || "Failed to exit maintenance mode" }, { status: 500 })
   }
 }

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
@@ -3,10 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { callRoute, readJson } from '@/__tests__/setup/route-test'
 
 vi.mock('@/lib/connections/getConnection', () => ({
-  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
-  // Real pure helper: matches the production "connection not found" detection.
-  isConnectionNotFoundError: (err: unknown) =>
-    /connection not found/i.test((err as { message?: string } | null)?.message || ''),
+  // The not-found vs real-error mapping now lives in getConnectionByIdOrNull
+  // (unit-tested in getConnection.test.ts); the route just consumes its result.
+  getConnectionByIdOrNull: vi.fn<(id: string) => Promise<any>>(),
 }))
 
 vi.mock('@/lib/proxmox/client', () => ({
@@ -14,10 +13,10 @@ vi.mock('@/lib/proxmox/client', () => ({
 }))
 
 import { GET } from './route'
-import { getConnectionById } from '@/lib/connections/getConnection'
+import { getConnectionByIdOrNull } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'
 
-const getConnectionByIdMock = getConnectionById as any
+const getConnectionByIdOrNullMock = getConnectionByIdOrNull as any
 const pveFetchMock = pveFetch as any
 
 const QEMU_VM_KEY = 'conn-1:qemu:pve-node-01:101'
@@ -25,7 +24,7 @@ const LXC_VM_KEY = 'conn-1:lxc:pve-node-01:200'
 
 beforeEach(() => {
   vi.clearAllMocks()
-  getConnectionByIdMock.mockResolvedValue({ id: 'conn-1' })
+  getConnectionByIdOrNullMock.mockResolvedValue({ id: 'conn-1' })
 })
 
 describe('GET /api/v1/guests/[vmid]/features', () => {
@@ -93,7 +92,8 @@ describe('GET /api/v1/guests/[vmid]/features', () => {
   })
 
   it('404 when the connection cannot be resolved for lxc', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
+    // getConnectionByIdOrNull maps a genuine not-found to null
+    getConnectionByIdOrNullMock.mockResolvedValue(null)
     const res = await callRoute(GET as any, {
       method: 'GET',
       params: { vmid: LXC_VM_KEY },
@@ -105,7 +105,7 @@ describe('GET /api/v1/guests/[vmid]/features', () => {
   })
 
   it('500 when getConnection fails with a non-not-found error (no longer masked)', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    getConnectionByIdOrNullMock.mockRejectedValue(new Error('DB error'))
     const res = await callRoute(GET as any, {
       method: 'GET',
       params: { vmid: LXC_VM_KEY },

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
@@ -4,6 +4,9 @@ import { callRoute, readJson } from '@/__tests__/setup/route-test'
 
 vi.mock('@/lib/connections/getConnection', () => ({
   getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+  // Real pure helper: matches the production "connection not found" detection.
+  isConnectionNotFoundError: (err: unknown) =>
+    /connection not found/i.test((err as { message?: string } | null)?.message || ''),
 }))
 
 vi.mock('@/lib/proxmox/client', () => ({
@@ -90,7 +93,7 @@ describe('GET /api/v1/guests/[vmid]/features', () => {
   })
 
   it('404 when the connection cannot be resolved for lxc', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('nope'))
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await callRoute(GET as any, {
       method: 'GET',
       params: { vmid: LXC_VM_KEY },
@@ -101,29 +104,41 @@ describe('GET /api/v1/guests/[vmid]/features', () => {
     expect(body.error).toMatch(/not found/i)
   })
 
-  it('returns hasFeature: false (not 500) when pveFetch throws', async () => {
+  it('500 when getConnection fails with a non-not-found error (no longer masked)', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    const res = await callRoute(GET as any, {
+      method: 'GET',
+      params: { vmid: LXC_VM_KEY },
+      searchParams: { feature: 'snapshot' },
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/DB error/i)
+  })
+
+  it('500 with the error message when pveFetch throws', async () => {
     pveFetchMock.mockRejectedValue(new Error('PVE unreachable'))
     const res = await callRoute(GET as any, {
       method: 'GET',
       params: { vmid: LXC_VM_KEY },
       searchParams: { feature: 'snapshot' },
     })
-    // The handler catches all errors and returns hasFeature: false, never a 500
-    expect(res.status).toBe(200)
+    // A real PVE error must surface as a 500, not be masked as hasFeature: false
+    expect(res.status).toBe(500)
     const body = await readJson<any>(res)
-    expect(body.data.hasFeature).toBe(false)
+    expect(body.error).toMatch(/PVE unreachable/i)
   })
 
-  it('returns hasFeature: false (not 500) on a malformed vmKey', async () => {
+  it('400 on a malformed vmKey', async () => {
     const res = await callRoute(GET as any, {
       method: 'GET',
       params: { vmid: 'bad-key' },
       searchParams: { feature: 'snapshot' },
     })
-    // parseVmKey throws, caught by outer try/catch, returns hasFeature: false
-    expect(res.status).toBe(200)
+    // parseVmKey throws "Invalid vmKey ..." which is a client error
+    expect(res.status).toBe(400)
     const body = await readJson<any>(res)
-    expect(body.data.hasFeature).toBe(false)
+    expect(body.error).toMatch(/invalid vmkey/i)
   })
 
   it('url-encodes the feature name in the PVE api path', async () => {

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
+import { getConnectionByIdOrNull } from "@/lib/connections/getConnection"
 
 export const runtime = "nodejs"
 
@@ -21,19 +21,6 @@ function parseVmKey(vmKey: string) {
     type: parts[1],
     node: parts[2],
     vmid: parts[3],
-  }
-}
-
-async function getConnection(id: string) {
-  // Use the shared helper so vDC tenants reach provider-owned connections
-  // through their vDC scope. Only a genuine not-found becomes a 404; real
-  // DB/infra errors propagate to the outer catch (500) instead of being
-  // masked as "feature unavailable".
-  try {
-    return await getConnectionById(id)
-  } catch (e) {
-    if (isConnectionNotFoundError(e)) return null
-    throw e
   }
 }
 
@@ -62,7 +49,7 @@ export async function GET(
       return NextResponse.json({ data: { hasFeature: true } })
     }
 
-    const conn = await getConnection(connId)
+    const conn = await getConnectionByIdOrNull(connId)
 
     if (!conn) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 })

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById } from "@/lib/connections/getConnection"
+import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
 
 export const runtime = "nodejs"
 
@@ -26,11 +26,14 @@ function parseVmKey(vmKey: string) {
 
 async function getConnection(id: string) {
   // Use the shared helper so vDC tenants reach provider-owned connections
-  // through their vDC scope instead of getting a tenant-scoped 404.
+  // through their vDC scope. Only a genuine not-found becomes a 404; real
+  // DB/infra errors propagate to the outer catch (500) instead of being
+  // masked as "feature unavailable".
   try {
     return await getConnectionById(id)
-  } catch {
-    return null
+  } catch (e) {
+    if (isConnectionNotFoundError(e)) return null
+    throw e
   }
 }
 
@@ -73,6 +76,7 @@ export async function GET(
     })
   } catch (e: any) {
     console.error("Feature check error:", e?.message)
-    return NextResponse.json({ data: { hasFeature: false } })
+    const status = /invalid vmkey/i.test(e?.message || "") ? 400 : 500
+    return NextResponse.json({ error: e?.message || "Feature check failed" }, { status })
   }
 }

--- a/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
@@ -7,10 +7,9 @@ vi.mock('next/headers', () => ({
 }))
 
 vi.mock('@/lib/connections/getConnection', () => ({
-  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
-  // Real pure helper: matches the production "connection not found" detection.
-  isConnectionNotFoundError: (err: unknown) =>
-    /connection not found/i.test((err as { message?: string } | null)?.message || ''),
+  // The not-found vs real-error mapping now lives in getConnectionByIdOrNull
+  // (unit-tested in getConnection.test.ts); the route just consumes its result.
+  getConnectionByIdOrNull: vi.fn<(id: string) => Promise<any>>(),
 }))
 
 vi.mock('@/lib/proxmox/client', () => ({
@@ -46,14 +45,14 @@ vi.mock('@/lib/audit', () => ({
 }))
 
 import { GET, POST, DELETE } from './route'
-import { getConnectionById } from '@/lib/connections/getConnection'
+import { getConnectionByIdOrNull } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'
 import { checkPermission } from '@/lib/rbac'
 import { getCurrentTenantId } from '@/lib/tenant'
 import { resolveVdcForTenant, checkVdcQuota } from '@/lib/vdc/quota'
 import { audit } from '@/lib/audit'
 
-const getConnectionByIdMock = getConnectionById as any
+const getConnectionByIdOrNullMock = getConnectionByIdOrNull as any
 const pveFetchMock = pveFetch as any
 const checkPermissionMock = checkPermission as any
 const getCurrentTenantIdMock = getCurrentTenantId as any
@@ -69,7 +68,7 @@ const VMID = '101'
 beforeEach(() => {
   vi.clearAllMocks()
   checkPermissionMock.mockResolvedValue(null)
-  getConnectionByIdMock.mockResolvedValue({ id: CONN_ID })
+  getConnectionByIdOrNullMock.mockResolvedValue({ id: CONN_ID })
   pveFetchMock.mockResolvedValue([])
   getCurrentTenantIdMock.mockResolvedValue('default')
   resolveVdcForTenantMock.mockResolvedValue(null)
@@ -109,7 +108,7 @@ describe('GET /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
+    getConnectionByIdOrNullMock.mockResolvedValue(null)
     const res = await GET(new Request('http://test.local/_'), {
       params: Promise.resolve({ vmid: VM_KEY }),
     })
@@ -118,7 +117,7 @@ describe('GET /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('500 when getConnection fails with a non-not-found error (no longer masked as 404)', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    getConnectionByIdOrNullMock.mockRejectedValue(new Error('DB error'))
     const res = await GET(new Request('http://test.local/_'), {
       params: Promise.resolve({ vmid: VM_KEY }),
     })
@@ -181,7 +180,7 @@ describe('POST /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
+    getConnectionByIdOrNullMock.mockResolvedValue(null)
     const res = await callRoute(POST as any, {
       method: 'POST',
       params: { vmid: VM_KEY },
@@ -308,7 +307,7 @@ describe('DELETE /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
+    getConnectionByIdOrNullMock.mockResolvedValue(null)
     const res = await callRoute(DELETE as any, {
       method: 'DELETE',
       params: { vmid: VM_KEY },

--- a/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.test.ts
@@ -8,6 +8,9 @@ vi.mock('next/headers', () => ({
 
 vi.mock('@/lib/connections/getConnection', () => ({
   getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+  // Real pure helper: matches the production "connection not found" detection.
+  isConnectionNotFoundError: (err: unknown) =>
+    /connection not found/i.test((err as { message?: string } | null)?.message || ''),
 }))
 
 vi.mock('@/lib/proxmox/client', () => ({
@@ -106,12 +109,22 @@ describe('GET /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await GET(new Request('http://test.local/_'), {
       params: Promise.resolve({ vmid: VM_KEY }),
     })
-    // getConnection wrapper catches and returns null -> 404
+    // getConnection wrapper maps a genuine not-found to null -> 404
     expect(res.status).toBe(404)
+  })
+
+  it('500 when getConnection fails with a non-not-found error (no longer masked as 404)', async () => {
+    getConnectionByIdMock.mockRejectedValue(new Error('DB error'))
+    const res = await GET(new Request('http://test.local/_'), {
+      params: Promise.resolve({ vmid: VM_KEY }),
+    })
+    expect(res.status).toBe(500)
+    const body = await readJson<any>(res)
+    expect(body.error).toMatch(/DB error/i)
   })
 
   it('403 when RBAC denies vm.view', async () => {
@@ -168,7 +181,7 @@ describe('POST /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await callRoute(POST as any, {
       method: 'POST',
       params: { vmid: VM_KEY },
@@ -295,7 +308,7 @@ describe('DELETE /api/v1/guests/[vmid]/snapshots', () => {
   })
 
   it('404 when connection not found', async () => {
-    getConnectionByIdMock.mockRejectedValue(new Error('not found'))
+    getConnectionByIdMock.mockRejectedValue(new Error('Connection not found: conn-1'))
     const res = await callRoute(DELETE as any, {
       method: 'DELETE',
       params: { vmid: VM_KEY },

--- a/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
+import { getConnectionByIdOrNull } from "@/lib/connections/getConnection"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { getDateLocale } from "@/lib/i18n/date"
 import { getCurrentTenantId } from "@/lib/tenant"
@@ -30,19 +30,6 @@ return {
   }
 }
 
-async function getConnection(id: string) {
-  // Use the shared helper so vDC tenants reach provider-owned connections
-  // through their vDC scope. Only a genuine not-found becomes a 404; real
-  // DB/infra errors propagate to the outer catch (500) instead of being
-  // masked as a tenant-scoped 404.
-  try {
-    return await getConnectionById(id)
-  } catch (e) {
-    if (isConnectionNotFoundError(e)) return null
-    throw e
-  }
-}
-
 /**
  * GET /api/v1/guests/[vmid]/snapshots
  * Liste les snapshots d'une VM
@@ -65,7 +52,7 @@ export async function GET(
     const cookieStore = await cookies()
     const dateLocale = getDateLocale(cookieStore.get('NEXT_LOCALE')?.value || 'en')
 
-    const conn = await getConnection(connId)
+    const conn = await getConnectionByIdOrNull(connId)
 
     if (!conn) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 })
@@ -135,7 +122,7 @@ export async function POST(
       }, { status: 400 })
     }
 
-    const conn = await getConnection(connId)
+    const conn = await getConnectionByIdOrNull(connId)
 
     if (!conn) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 })
@@ -231,7 +218,7 @@ export async function DELETE(
       return NextResponse.json({ error: "Snapshot name is required" }, { status: 400 })
     }
 
-    const conn = await getConnection(connId)
+    const conn = await getConnectionByIdOrNull(connId)
 
     if (!conn) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 })

--- a/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/snapshots/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById } from "@/lib/connections/getConnection"
+import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { getDateLocale } from "@/lib/i18n/date"
 import { getCurrentTenantId } from "@/lib/tenant"
@@ -32,11 +32,14 @@ return {
 
 async function getConnection(id: string) {
   // Use the shared helper so vDC tenants reach provider-owned connections
-  // through their vDC scope instead of getting a tenant-scoped 404.
+  // through their vDC scope. Only a genuine not-found becomes a 404; real
+  // DB/infra errors propagate to the outer catch (500) instead of being
+  // masked as a tenant-scoped 404.
   try {
     return await getConnectionById(id)
-  } catch {
-    return null
+  } catch (e) {
+    if (isConnectionNotFoundError(e)) return null
+    throw e
   }
 }
 

--- a/frontend/src/lib/connections/getConnection.test.ts
+++ b/frontend/src/lib/connections/getConnection.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/lib/tenant', () => ({
   getCurrentTenantId: vi.fn(() => { throw new Error('getCurrentTenantId must not be called in these tests') }),
 }))
 
-import { getConnectionById, isConnectionNotFoundError } from './getConnection'
+import { getConnectionById, getConnectionByIdOrNull, isConnectionNotFoundError } from './getConnection'
 
 const MSP_CONNECTION = {
   id: 'c-msp',
@@ -93,5 +93,35 @@ describe('isConnectionNotFoundError', () => {
 
   it('returns false for a non-Error value', () => {
     expect(isConnectionNotFoundError('Connection not found')).toBe(false)
+  })
+})
+
+describe('getConnectionByIdOrNull', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFindFirst.mockResolvedValue(null)
+  })
+
+  it('returns the connection when it resolves', async () => {
+    mockFindUnique.mockResolvedValue({ ...MSP_CONNECTION, id: 'c-ok', tenantId: 't-ok' })
+
+    const result = await getConnectionByIdOrNull('c-ok', 't-ok')
+
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe('c-ok')
+  })
+
+  it('returns null for a genuine not-found error', async () => {
+    mockFindUnique.mockResolvedValue(null)
+
+    const result = await getConnectionByIdOrNull('c-missing', 't-x')
+
+    expect(result).toBeNull()
+  })
+
+  it('rethrows a non-not-found error (config/infra) instead of swallowing it', async () => {
+    mockFindUnique.mockResolvedValue({ ...MSP_CONNECTION, id: 'c-nobase', tenantId: 't-nb', baseUrl: null })
+
+    await expect(getConnectionByIdOrNull('c-nobase', 't-nb')).rejects.toThrow(/baseUrl/)
   })
 })

--- a/frontend/src/lib/connections/getConnection.test.ts
+++ b/frontend/src/lib/connections/getConnection.test.ts
@@ -24,7 +24,7 @@ vi.mock('@/lib/tenant', () => ({
   getCurrentTenantId: vi.fn(() => { throw new Error('getCurrentTenantId must not be called in these tests') }),
 }))
 
-import { getConnectionById } from './getConnection'
+import { getConnectionById, isConnectionNotFoundError } from './getConnection'
 
 const MSP_CONNECTION = {
   id: 'c-msp',
@@ -67,5 +67,31 @@ describe('getConnectionById — MSP direct tenant ownership', () => {
         where: expect.objectContaining({ tenantId: 't-other', connectionId: 'c-msp' }),
       }),
     )
+  })
+})
+
+describe('isConnectionNotFoundError', () => {
+  it('returns true for a PVE "Connection not found" error', () => {
+    expect(isConnectionNotFoundError(new Error('Connection not found: c1'))).toBe(true)
+  })
+
+  it('returns true for a PBS "PBS Connection not found" error', () => {
+    expect(isConnectionNotFoundError(new Error('PBS Connection not found: c1'))).toBe(true)
+  })
+
+  it('returns false for a config error (no baseUrl)', () => {
+    expect(isConnectionNotFoundError(new Error('Connection c1 has no baseUrl'))).toBe(false)
+  })
+
+  it('returns false for a generic DB/infra error', () => {
+    expect(isConnectionNotFoundError(new Error('DB exploded'))).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isConnectionNotFoundError(null)).toBe(false)
+  })
+
+  it('returns false for a non-Error value', () => {
+    expect(isConnectionNotFoundError('Connection not found')).toBe(false)
   })
 })

--- a/frontend/src/lib/connections/getConnection.ts
+++ b/frontend/src/lib/connections/getConnection.ts
@@ -69,6 +69,19 @@ function isCrossTenantFromSession(
   )
 }
 
+/**
+ * True when an error from getConnectionById/getPbsConnectionById means the
+ * connection genuinely does not exist (or is denied, which we surface as
+ * not-found to avoid id enumeration). Lets routes return 404 for not-found
+ * while letting real DB/crypto/infra errors propagate to a 500. Matches the
+ * "Connection not found" / "PBS Connection not found" messages those helpers
+ * throw; config errors (no baseUrl, no apiTokenEnc, ...) are NOT not-found.
+ */
+export function isConnectionNotFoundError(err: unknown): boolean {
+  const msg = (err as { message?: string } | null)?.message || ""
+  return /connection not found/i.test(msg)
+}
+
 // In-memory cache for connections
 const connectionCache = new Map<string, { data: PveConn | PbsConn; expiry: number }>()
 const CACHE_TTL = 60_000 // 60 seconds

--- a/frontend/src/lib/connections/getConnection.ts
+++ b/frontend/src/lib/connections/getConnection.ts
@@ -179,6 +179,25 @@ export async function getConnectionById(id: string, tenantId?: string): Promise<
   return result
 }
 
+/**
+ * getConnectionById, but tolerant of a missing/denied connection: returns null
+ * for a genuine not-found (so the caller can answer 404) while letting real
+ * DB/crypto/config errors propagate to the caller's 500 path. Centralises the
+ * try/catch wrapper that the guest proxy routes (features, snapshots) shared
+ * verbatim. See isConnectionNotFoundError.
+ */
+export async function getConnectionByIdOrNull(
+  id: string,
+  tenantId?: string
+): Promise<PveConn | null> {
+  try {
+    return await getConnectionById(id, tenantId)
+  } catch (e) {
+    if (isConnectionNotFoundError(e)) return null
+    throw e
+  }
+}
+
 
 /**
  * Loads a PBS connection by id WITHOUT tenant ownership check.


### PR DESCRIPTION
## Summary

Several guest/node API route handlers masked genuine DB/infra failures as benign empty results, hiding real outages behind misleading "not found", "no feature" or "no maintenance" responses. This makes the failures observable: a real not-found stays a 404, but real errors now surface as 500 (or 400 for bad input) instead of a silent empty payload.

Closes #448.

## What changed

- **`getConnection`**: new `isConnectionNotFoundError()` helper. Callers return 404 only for a genuinely missing/denied connection; real DB/crypto/infra errors propagate to a 500 instead of a tenant-scoped 404.
- **`guests/[vmid]/features`**: the `getConnection` wrapper rethrows non-not-found errors; the `GET` catch returns 400 for an invalid `vmKey` and 500 otherwise, instead of masking everything as `{ hasFeature: false }`.
- **`guests/[vmid]/snapshots`**: the `getConnection` wrapper rethrows non-not-found errors instead of collapsing to a 404.
- **`nodes/[node]/maintenance`**: drop the `.catch(() => [])` on `/cluster/resources` so a fetch failure is a 500, not a fake "not in maintenance"; return 404 only for a genuine not-found.
- **`DELETE` guest**: surface an IPAM release failure as a response `warning` and an audit-log detail instead of only `console.warn`; `InventoryDetails` appends the warning to the delete success message so a partial success is visible to the user.

## Testing

- 68 unit tests across the 5 changed files (route handlers via `callRoute`, the helper via direct unit tests).
- New-code line coverage: 100% on features + maintenance, 98.8% on snapshots, 95.2% on the guest DELETE route; `isConnectionNotFoundError` fully unit-tested. `InventoryDetails.tsx` stays in `sonar.coverage.exclusions` (3000+ line JSX container, not renderable under the node-env Vitest suite).
- Browser-validated: VM snapshots, VM deletion and node maintenance toggle all behave correctly.
