### PR TITLE
chore(coverage): raise ratchet floor 11 -> 12

### DIFF
--- a/frontend/.coverage-floor.json
+++ b/frontend/.coverage-floor.json
@@ -1,4 +1,4 @@
 {
   "comment": "Overall SonarCloud line coverage must never drop below `floor`. Bump only in a dedicated reviewed commit when a milestone is reached (see spec section 8).",
-  "floor": 11.0
+  "floor": 12.0
 }


### PR DESCRIPTION
## Summary

Raise the overall-coverage ratchet floor from **11 → 12** to lock in the gain from the recent component-lane test batches and the #448 route work.

The ratchet (`scripts/coverage-ratchet.mjs`) fails the main build if SonarCloud's overall `coverage` measure drops below the committed floor; it protects the overall number on main from silent drift. Per-PR coverage stays governed by the new-code Quality Gate (≥80%), which is unaffected by this change.

## Scope

One-line change to `frontend/.coverage-floor.json`. No code or test changes.
