### PR TITLE
fix(migration): report block-device stream exit code correctly

### DIFF
--- a/frontend/src/lib/migration/pipe-exit.test.ts
+++ b/frontend/src/lib/migration/pipe-exit.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
+
+describe("pipe-exit snippet builders", () => {
+  it("captures the whole PIPESTATUS array in one command", () => {
+    // The fix hinges on snapshotting the array atomically. A per-element
+    // read (`X=${PIPESTATUS[0]}`) resets PIPESTATUS and loses dd's code.
+    expect(capturePipelineStatus()).toBe('__PS=("${PIPESTATUS[@]}")')
+  })
+
+  it("reads exit codes from the snapshot, not live PIPESTATUS", () => {
+    const snippet = writePipelineExit("/tmp/x.exit")
+    expect(snippet).toContain("${__PS[0]}")
+    expect(snippet).toContain("${__PS[1]")
+    expect(snippet).not.toContain("PIPESTATUS")
+  })
+
+  it("prefers the producer's code, falling back to dd's", () => {
+    const snippet = writePipelineExit("/tmp/x.exit")
+    // producer (stage 0) non-zero -> report it; else dd (stage 1)
+    expect(snippet).toContain('if [ "${__PS[0]}" -ne 0 ]')
+    expect(snippet).toContain('echo "${__PS[0]}" > "/tmp/x.exit"')
+    expect(snippet).toContain('echo "${__PS[1]:-1}" > "/tmp/x.exit"')
+  })
+})
+
+/**
+ * Behavioural test: run the generated snippet through a real bash and assert
+ * the recorded exit code. `( exit A ) | ( cat >/dev/null; exit B )` yields a
+ * pipeline whose PIPESTATUS is (A, B) without needing curl/dd. This is the
+ * regression that bit issue: a successful transfer (0,0) was reported as 1.
+ */
+function runPipeline(producerCode: number, ddCode: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "pipe-exit-"))
+  const exitFile = join(dir, "ctrl.pid.exit")
+  try {
+    const script = [
+      `( exit ${producerCode} ) | ( cat >/dev/null; exit ${ddCode} )`,
+      capturePipelineStatus(),
+      // an intervening command (mirrors cleanupCmd in the SSH path) that
+      // would clobber live PIPESTATUS — the snapshot must survive it
+      `true`,
+      writePipelineExit(exitFile),
+    ].join("\n")
+    execFileSync("bash", ["-c", script])
+    return readFileSync(exitFile, "utf8").trim()
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe("pipe-exit recorded code (real bash)", () => {
+  it("records 0 when curl AND dd both succeed (the false-failure regression)", () => {
+    expect(runPipeline(0, 0)).toBe("0")
+  })
+
+  it("records the producer's code when curl/ssh fails", () => {
+    expect(runPipeline(18, 0)).toBe("18") // curl 18 = partial transfer
+  })
+
+  it("records dd's code when the producer succeeds but dd fails", () => {
+    expect(runPipeline(0, 1)).toBe("1") // dd 1 = write error (e.g. ENOSPC)
+  })
+
+  it("prefers the producer's code when both fail", () => {
+    expect(runPipeline(56, 1)).toBe("56") // curl 56 = recv error
+  })
+})

--- a/frontend/src/lib/migration/pipe-exit.ts
+++ b/frontend/src/lib/migration/pipe-exit.ts
@@ -1,0 +1,48 @@
+/**
+ * Exit-code capture for two-stage `producer | dd` streaming pipelines.
+ *
+ * Migration disks are streamed to block devices with a shell pipeline such
+ * as `curl ... | dd of=/dev/zvol/...` (HTTPS transfer) or
+ * `ssh ... dd | dd of=/dev/zvol/...` (SSH transfer). We need the exit code
+ * of BOTH stages: the producer (curl/ssh) tells us about upstream failures
+ * (HTTP/TLS/RST, NFC lease expiry) and dd tells us about the local write
+ * (ENOSPC, I/O error).
+ *
+ * The naive way to read them is fatally wrong:
+ *
+ *     curl ... | dd ...
+ *     CURL_EXIT=${PIPESTATUS[0]}   # ok, reads curl's code
+ *     DD_EXIT=${PIPESTATUS[1]}     # BUG: always empty
+ *
+ * `PIPESTATUS` reflects only the most-recently-executed pipeline, and a bare
+ * assignment like `CURL_EXIT=${PIPESTATUS[0]}` is itself a command that
+ * RESETS `PIPESTATUS` to `(0)`. By the time `${PIPESTATUS[1]}` is read it is
+ * unset → `DD_EXIT` is empty. The JS poller then sees a blank exit file and
+ * defaults it to a bogus "exit code 1", so a fully successful transfer (full
+ * disk copied, `records in == records out`) is reported as a failure.
+ *
+ * The fix is to snapshot the whole array in ONE command immediately after the
+ * pipeline, then read from the snapshot. The producer's code wins when
+ * non-zero (it is the upstream cause); otherwise dd's code is reported.
+ */
+
+/**
+ * Snapshot the exit codes of the immediately-preceding pipeline.
+ *
+ * MUST be emitted as the very next command after the `producer | dd`
+ * pipeline, before any other command (including cleanup), or `PIPESTATUS`
+ * will already have been clobbered.
+ */
+export function capturePipelineStatus(): string {
+  return `__PS=("\${PIPESTATUS[@]}")`
+}
+
+/**
+ * Write the effective exit code of the captured pipeline to `exitFile`.
+ * Pair with {@link capturePipelineStatus}, which must run right after the
+ * pipeline. Safe to emit after intervening commands (e.g. cleanup) because it
+ * reads the `__PS` snapshot rather than the live `PIPESTATUS`.
+ */
+export function writePipelineExit(exitFile: string): string {
+  return `if [ "\${__PS[0]}" -ne 0 ]; then echo "\${__PS[0]}" > "${exitFile}"; else echo "\${__PS[1]:-1}" > "${exitFile}"; fi`
+}

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -27,6 +27,7 @@ import type { SoapSession, EsxiVmConfig, EsxiDiskInfo, NfcLeaseDeviceUrl } from 
 import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
+import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
 
@@ -520,7 +521,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       // Build streaming script: curl pipes directly to dd on block device
       // status=progress makes dd write periodic progress to stderr
       await executeSSH(config.targetConnectionId, nodeIp,
-        `cat > "${dlScript}" << 'DLEOF'\ncurl -sk --fail -b '${safeCookie}' '${vmdkUrl}' 2>"${stderrFile}" | dd of="${devicePath}" bs=4M status=progress 2>"${progressFile}"\nCURL_EXIT=\${PIPESTATUS[0]}\nDD_EXIT=\${PIPESTATUS[1]}\nif [ \$CURL_EXIT -ne 0 ]; then echo \$CURL_EXIT > "${pidFile}.exit"; else echo \$DD_EXIT > "${pidFile}.exit"; fi\nDLEOF`
+        `cat > "${dlScript}" << 'DLEOF'\ncurl -sk --fail -b '${safeCookie}' '${vmdkUrl}' 2>"${stderrFile}" | dd of="${devicePath}" bs=4M status=progress 2>"${progressFile}"\n${capturePipelineStatus()}\n${writePipelineExit(pidFile + ".exit")}\nDLEOF`
       )
 
       const startDl = await executeSSH(config.targetConnectionId, nodeIp,
@@ -716,7 +717,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       const sshCmd = `${sshPrefix} -p ${esxiSshPort} ${esxiSshUser}@${esxiHost} "dd if='${downloadPath}' bs=4M" | dd of="${devicePath}" bs=4M status=progress 2>"${progressFile}"`
 
       await executeSSH(config.targetConnectionId, nodeIp,
-        `cat > "${dlScript}" << 'DLEOF'\n${setupCmd}\n${sshCmd}\nSSH_EXIT=\${PIPESTATUS[0]}\nDD_EXIT=\${PIPESTATUS[1]}\n${cleanupCmd}\nif [ \$SSH_EXIT -ne 0 ]; then echo \$SSH_EXIT > "${pidFile}.exit"; else echo \$DD_EXIT > "${pidFile}.exit"; fi\nDLEOF`
+        `cat > "${dlScript}" << 'DLEOF'\n${setupCmd}\n${sshCmd}\n${capturePipelineStatus()}\n${cleanupCmd}\n${writePipelineExit(pidFile + ".exit")}\nDLEOF`
       )
 
       const startDl = await executeSSH(config.targetConnectionId, nodeIp,


### PR DESCRIPTION
## Problem

Migrations to **block storage** (ZFS / LVM-thin / Ceph) over the HTTPS (and SSH) transfer mode failed with `Streaming failed: curl/dd exit code 1` **after the whole disk had already been copied**. A user reported it on a 96 GiB Windows 11 disk:

```
[Disk 1/1] Streaming "Hard disk 1" to block device (96.0 GB)...
✗ Migration failed: Streaming failed: curl/dd exit code 1
  (dd: 0+6384993 records in 0+6384993 records out
   103079215104 bytes (103 GB, 96 GiB) copied, 937.141 s, 110 MB/s)
```

`103079215104 bytes` is exactly 96 GiB, and `records in == records out`, so dd wrote every block it read. The transfer had actually succeeded; the failure was a false negative.

## Root cause

The streaming script captured the pipeline exit codes with two sequential assignments:

```bash
curl ... | dd of=/dev/zvol/...
CURL_EXIT=${PIPESTATUS[0]}
DD_EXIT=${PIPESTATUS[1]}
```

`PIPESTATUS` only reflects the most recently executed pipeline, and a bare `CURL_EXIT=${PIPESTATUS[0]}` assignment is itself a command that resets `PIPESTATUS` to `(0)`. By the time `${PIPESTATUS[1]}` is read it is unset, so `DD_EXIT` is empty. When curl succeeds the `else` branch writes an empty value to the exit file, and the JS poller defaults a blank exit file to `1`.

File-based storage (dir / NFS / CIFS) was unaffected because it downloads with a single-command `curl -o file` reporting `echo $?`.

## Fix

Snapshot the whole array in one command, then read both codes from the snapshot. The producer code (curl/ssh) wins when non-zero (it is the upstream cause), otherwise dd's code is reported:

```bash
curl ... | dd ...
__PS=("${PIPESTATUS[@]}")
if [ "${__PS[0]}" -ne 0 ]; then echo "${__PS[0]}" > "...exit"; else echo "${__PS[1]:-1}" > "...exit"; fi
```

The shell builders are extracted to `pipe-exit.ts` and shared by both affected paths (`streamDiskToBlock` and `streamDiskViaSshToBlock`). It also fails safe: if dd's code is somehow missing, it defaults to a failure rather than a false success.

## Tests

- Unit tests on the snippet builders.
- Real-bash behavioural tests proving `(0,0) -> 0`, `(curl 18) -> 18`, `(dd 1) -> 1`, `(56,1) -> 56`. The old pattern produced an empty value (the false failure); the new one records `0`.
- Full migration suite: 78/78 green.

## Risk

Reporting-only change. The `curl|dd` data path is byte-for-byte identical, so there is no impact on the transfer itself, only on how its result is reported.
