### PR TITLE
fix(backups): surface gateway errors instead of "Unexpected token '<'"

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
@@ -36,6 +36,13 @@ import { useTranslations, useLocale } from 'next-intl'
 import { formatBytes } from '@/utils/format'
 import { getDateLocale } from '@/lib/i18n/date'
 import { runBackupJobNow } from '@/lib/backups/runBackupJob'
+import {
+  loadBackupJobs,
+  loadBackupVms,
+  saveBackupJob,
+  deleteBackupJob,
+  toggleBackupJob,
+} from '@/lib/backups/backupJobsApi'
 
 interface BackupJob {
   id: string
@@ -171,24 +178,24 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
     setError(null)
 
     try {
-      const res = await fetch(`/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs`)
-      const json = await res.json()
+      const result = await loadBackupJobs(connectionId)
 
-      if (json.error) {
-        setError(json.error)
-        onError?.(json.error)
+      if (!result.ok) {
+        const msg = result.error || t('inventory.failedToLoadBackupJobs')
+        setError(msg)
+        onError?.(msg)
       } else {
         // Les jobs sont déjà parsés par l'API (selectionMode, vmids, excludedVmids)
         // On s'assure juste que les vmids sont des nombres pour le formulaire
-        const parsedJobs = (json.data?.jobs || []).map((job: any) => ({
+        const parsedJobs = ((result.data?.jobs as any[]) || []).map((job: any) => ({
           ...job,
           vmids: (job.vmids || []).map((v: any) => Number(v)).filter((v: number) => !Number.isNaN(v)),
           excludedVmids: (job.excludedVmids || []).map((v: any) => Number(v)).filter((v: number) => !Number.isNaN(v))
         }))
 
         setJobs(parsedJobs)
-        setStorages(json.data?.storages || [])
-        setNodes(json.data?.nodes || [])
+        setStorages((result.data?.storages as any[]) || [])
+        setNodes((result.data?.nodes as any[]) || [])
       }
     } catch (e: any) {
       const msg = e?.message || t('inventory.failedToLoadBackupJobs')
@@ -204,11 +211,10 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
     if (!connectionId) return
 
     try {
-      const res = await fetch(`/api/v1/connections/${encodeURIComponent(connectionId)}/resources?type=vm`)
-      const json = await res.json()
+      const result = await loadBackupVms(connectionId)
 
-      if (!json.error) {
-        const allVms = (json.data || []).filter((r: any) => r.type === 'qemu' || r.type === 'lxc')
+      if (result.ok) {
+        const allVms = ((result.data as any[]) || []).filter((r: any) => r.type === 'qemu' || r.type === 'lxc')
         setVms(allVms.map((vm: any) => ({
           vmid: vm.vmid,
           name: vm.name,
@@ -317,20 +323,15 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
     setError(null)
 
     try {
-      const url = dialogMode === 'create'
-        ? `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs`
-        : `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(editingJob?.id || '')}`
+      const result = await saveBackupJob(
+        connectionId,
+        dialogMode === 'create' ? 'create' : 'edit',
+        editingJob?.id || '',
+        formData
+      )
 
-      const res = await fetch(url, {
-        method: dialogMode === 'create' ? 'POST' : 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(formData)
-      })
-
-      const json = await res.json()
-
-      if (json.error) {
-        setError(json.error)
+      if (!result.ok) {
+        setError(result.error || t('inventory.failedToSaveBackupJob'))
       } else {
         setDialogOpen(false)
         loadJobs()
@@ -349,15 +350,10 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
     setDeleting(true)
 
     try {
-      const res = await fetch(
-        `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(jobToDelete.id)}`,
-        { method: 'DELETE' }
-      )
+      const result = await deleteBackupJob(connectionId, jobToDelete.id)
 
-      const json = await res.json()
-
-      if (json.error) {
-        setError(json.error)
+      if (!result.ok) {
+        setError(result.error || t('inventory.failedToDeleteBackupJob'))
       } else {
         setDeleteDialogOpen(false)
         setJobToDelete(null)
@@ -373,18 +369,9 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
   // Toggle enabled
   const handleToggleEnabled = async (job: BackupJob) => {
     try {
-      const res = await fetch(
-        `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(job.id)}`,
-        {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ enabled: !job.enabled })
-        }
-      )
+      const result = await toggleBackupJob(connectionId, job.id, !job.enabled)
 
-      const json = await res.json()
-
-      if (!json.error) {
+      if (result.ok) {
         loadJobs()
       }
     } catch (e) {

--- a/frontend/src/lib/api/fetchJsonSafe.test.ts
+++ b/frontend/src/lib/api/fetchJsonSafe.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { fetchJsonSafe } from './fetchJsonSafe'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('fetchJsonSafe', () => {
+  it('passes the url and init straight through to the fetch impl', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: 1 }))
+
+    await fetchJsonSafe('/api/x', { method: 'POST' }, fetchImpl as unknown as typeof fetch)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl.mock.calls[0]).toEqual(['/api/x', { method: 'POST' }])
+  })
+
+  it('returns ok with the data payload on success', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: { jobs: [1, 2] } }))
+
+    const result = await fetchJsonSafe('/api/x', undefined, fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: true, data: { jobs: [1, 2] } })
+  })
+
+  it('returns ok with undefined data on an empty 2xx body', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('', { status: 200 }))
+
+    const result = await fetchJsonSafe('/api/x', undefined, fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: true, data: undefined })
+  })
+
+  it('surfaces a JSON error field from the backend', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ error: 'No node available' }, 400))
+
+    const result = await fetchJsonSafe('/api/x', undefined, fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: false, error: 'No node available' })
+  })
+
+  it('falls back to the status when a non-ok response carries no error field', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({}, 500))
+
+    const result = await fetchJsonSafe('/api/x', undefined, fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: false, error: 'HTTP 500' })
+  })
+
+  it('does not leak "Unexpected token \'<\'" on an nginx HTML gateway page', async () => {
+    // The exact regression from discussion #396: a reverse proxy returns its
+    // own 504 page (a bare `<html><head>...`, no <!DOCTYPE) and the old code
+    // did `await res.json()`, throwing `Unexpected token '<', "<html> <h"...`.
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(
+        '<html>\r\n<head><title>504 Gateway Time-out</title></head>\r\n<body>...</body>\r\n</html>',
+        { status: 504, headers: { 'content-type': 'text/html' } },
+      ),
+    )
+
+    const result = await fetchJsonSafe('/api/x', undefined, fetchImpl as unknown as typeof fetch)
+
+    expect(result).toEqual({ ok: false, error: 'HTTP 504' })
+  })
+})

--- a/frontend/src/lib/api/fetchJsonSafe.ts
+++ b/frontend/src/lib/api/fetchJsonSafe.ts
@@ -1,0 +1,50 @@
+/**
+ * Fetch a JSON endpoint without ever letting `JSON.parse` leak its cryptic
+ * `Unexpected token '<', "<html> <h"... is not valid JSON` message to the UI.
+ *
+ * A reverse proxy (nginx, Traefik, ...) sitting in front of ProxCenter returns
+ * its OWN HTML error page on a gateway failure: a 502 Bad Gateway or a 504
+ * Gateway Timeout body starts with a bare `<html><head>`, not with JSON. Code
+ * that does `await res.json()` unconditionally then throws a `SyntaxError`
+ * whose message ("Unexpected token '<'") ends up verbatim in an error banner.
+ * That happened on the cluster Backups tab (discussion #396), where loading
+ * backup jobs fans out into several sequential Proxmox calls and can outrun the
+ * proxy's `proxy_read_timeout`.
+ *
+ * This helper reads the body as text first, parses it defensively, and returns
+ * a flat result so callers can surface a clean `HTTP <status>` instead. It is
+ * the same defensive shape used by {@link runBackupJobNow} (the #398 fix),
+ * generalised so every fetch in the backup panel can share it.
+ */
+export interface JsonResult<T = unknown> {
+  ok: boolean
+  error?: string
+  data?: T
+}
+
+export async function fetchJsonSafe<T = unknown>(
+  url: string,
+  init?: RequestInit,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult<T>> {
+  const res = await fetchImpl(url, init)
+
+  const text = await res.text()
+  let body: { error?: string; data?: T } | undefined
+
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // Non-JSON body (an HTML error page from a reverse proxy, a 404/502/504).
+      // Surface the status instead of the raw "Unexpected token '<'" parse error.
+      return { ok: false, error: `HTTP ${res.status}` }
+    }
+  }
+
+  if (!res.ok || body?.error) {
+    return { ok: false, error: body?.error || `HTTP ${res.status}` }
+  }
+
+  return { ok: true, data: body?.data }
+}

--- a/frontend/src/lib/backups/backupJobsApi.test.ts
+++ b/frontend/src/lib/backups/backupJobsApi.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import {
+  loadBackupJobs,
+  loadBackupVms,
+  saveBackupJob,
+  deleteBackupJob,
+  toggleBackupJob,
+} from './backupJobsApi'
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function htmlGateway(status = 504) {
+  // A reverse-proxy error page (no <!DOCTYPE), the discussion #396 case.
+  return new Response('<html> <head><title>err</title></head></html>', {
+    status,
+    headers: { 'content-type': 'text/html' },
+  })
+}
+
+describe('backupJobsApi', () => {
+  describe('loadBackupJobs', () => {
+    it('GETs the connection backup-jobs endpoint and returns the payload', async () => {
+      const payload = { jobs: [{ id: 'b1' }], storages: [], nodes: [] }
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: payload }))
+
+      const result = await loadBackupJobs('conn 1', fetchImpl as unknown as typeof fetch)
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        '/api/v1/connections/conn%201/backup-jobs',
+        undefined,
+      )
+      expect(result).toEqual({ ok: true, data: payload })
+    })
+
+    it('returns a clean HTTP error on an nginx gateway HTML page', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(htmlGateway(504))
+
+      const result = await loadBackupJobs('c', fetchImpl as unknown as typeof fetch)
+
+      expect(result).toEqual({ ok: false, error: 'HTTP 504' })
+    })
+  })
+
+  describe('loadBackupVms', () => {
+    it('GETs the resources endpoint filtered to VMs', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: [] }))
+
+      await loadBackupVms('c', fetchImpl as unknown as typeof fetch)
+
+      expect(fetchImpl).toHaveBeenCalledWith(
+        '/api/v1/connections/c/resources?type=vm',
+        undefined,
+      )
+    })
+  })
+
+  describe('saveBackupJob', () => {
+    it('POSTs to the collection in create mode', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: { id: 'new' } }))
+
+      await saveBackupJob('c', 'create', '', { schedule: '0 2' }, fetchImpl as unknown as typeof fetch)
+
+      const [url, init] = fetchImpl.mock.calls[0]
+      expect(url).toBe('/api/v1/connections/c/backup-jobs')
+      expect(init.method).toBe('POST')
+      expect(JSON.parse(init.body)).toEqual({ schedule: '0 2' })
+    })
+
+    it('PUTs to the per-job URL in edit mode', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: {} }))
+
+      await saveBackupJob('c', 'edit', 'job 9', { enabled: true }, fetchImpl as unknown as typeof fetch)
+
+      const [url, init] = fetchImpl.mock.calls[0]
+      expect(url).toBe('/api/v1/connections/c/backup-jobs/job%209')
+      expect(init.method).toBe('PUT')
+    })
+
+    it('surfaces a backend error field', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ error: 'bad cron' }, 400))
+
+      const result = await saveBackupJob('c', 'create', '', {}, fetchImpl as unknown as typeof fetch)
+
+      expect(result).toEqual({ ok: false, error: 'bad cron' })
+    })
+  })
+
+  describe('deleteBackupJob', () => {
+    it('DELETEs the per-job URL', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: {} }))
+
+      await deleteBackupJob('c', 'job 9', fetchImpl as unknown as typeof fetch)
+
+      const [url, init] = fetchImpl.mock.calls[0]
+      expect(url).toBe('/api/v1/connections/c/backup-jobs/job%209')
+      expect(init.method).toBe('DELETE')
+    })
+  })
+
+  describe('toggleBackupJob', () => {
+    it('PUTs the enabled flag', async () => {
+      const fetchImpl = vi.fn().mockResolvedValue(jsonResponse({ data: {} }))
+
+      await toggleBackupJob('c', 'b1', false, fetchImpl as unknown as typeof fetch)
+
+      const [url, init] = fetchImpl.mock.calls[0]
+      expect(url).toBe('/api/v1/connections/c/backup-jobs/b1')
+      expect(init.method).toBe('PUT')
+      expect(JSON.parse(init.body)).toEqual({ enabled: false })
+    })
+  })
+})

--- a/frontend/src/lib/backups/backupJobsApi.ts
+++ b/frontend/src/lib/backups/backupJobsApi.ts
@@ -1,0 +1,89 @@
+/**
+ * Client-side calls for the cluster Backups tab (BackupJobsPanel).
+ *
+ * Every call goes through {@link fetchJsonSafe} so a gateway error from a
+ * reverse proxy (an HTML 502/504 page) surfaces as a clean `HTTP <status>`
+ * instead of the cryptic `Unexpected token '<'` JSON-parse exception that was
+ * reported on discussion #396. Each function takes an injectable `fetchImpl`
+ * so it can be unit-tested without a DOM.
+ */
+import { fetchJsonSafe, type JsonResult } from "@/lib/api/fetchJsonSafe"
+
+const base = (connectionId: string) =>
+  `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs`
+
+const jobUrl = (connectionId: string, jobId: string) =>
+  `${base(connectionId)}/${encodeURIComponent(jobId)}`
+
+export interface BackupJobsPayload {
+  jobs?: unknown[]
+  storages?: unknown[]
+  nodes?: unknown[]
+}
+
+/** Load the backup jobs, storages and nodes for a connection. */
+export function loadBackupJobs(
+  connectionId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult<BackupJobsPayload>> {
+  return fetchJsonSafe<BackupJobsPayload>(base(connectionId), undefined, fetchImpl)
+}
+
+/** Load the VMs/LXCs of a connection (used to populate the job's selection). */
+export function loadBackupVms(
+  connectionId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult<unknown[]>> {
+  return fetchJsonSafe<unknown[]>(
+    `/api/v1/connections/${encodeURIComponent(connectionId)}/resources?type=vm`,
+    undefined,
+    fetchImpl,
+  )
+}
+
+/** Create (POST) or update (PUT) a backup job. */
+export function saveBackupJob(
+  connectionId: string,
+  mode: "create" | "edit",
+  jobId: string,
+  payload: unknown,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult> {
+  const url = mode === "create" ? base(connectionId) : jobUrl(connectionId, jobId)
+  return fetchJsonSafe(
+    url,
+    {
+      method: mode === "create" ? "POST" : "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+    fetchImpl,
+  )
+}
+
+/** Delete a backup job. */
+export function deleteBackupJob(
+  connectionId: string,
+  jobId: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult> {
+  return fetchJsonSafe(jobUrl(connectionId, jobId), { method: "DELETE" }, fetchImpl)
+}
+
+/** Enable/disable a backup job. */
+export function toggleBackupJob(
+  connectionId: string,
+  jobId: string,
+  enabled: boolean,
+  fetchImpl: typeof fetch = fetch,
+): Promise<JsonResult> {
+  return fetchJsonSafe(
+    jobUrl(connectionId, jobId),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled }),
+    },
+    fetchImpl,
+  )
+}

--- a/frontend/src/lib/backups/runBackupJob.ts
+++ b/frontend/src/lib/backups/runBackupJob.ts
@@ -9,15 +9,14 @@
  * `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
  * (issue #397, discussion #396).
  *
- * This helper (a) uses the correct URL and (b) reads the body defensively so
- * any future non-JSON response (an HTML error page from a reverse proxy, a
- * 404/502/504) surfaces a clean HTTP error instead of a JSON-parse exception.
+ * The defensive body parsing now lives in {@link fetchJsonSafe}, shared with
+ * the rest of the backup panel so any non-JSON response (an HTML error page
+ * from a reverse proxy, a 404/502/504) surfaces a clean HTTP error instead of
+ * a JSON-parse exception.
  */
-export interface RunBackupJobResult {
-  ok: boolean
-  error?: string
-  data?: unknown
-}
+import { fetchJsonSafe, type JsonResult } from "@/lib/api/fetchJsonSafe"
+
+export type RunBackupJobResult = JsonResult
 
 export async function runBackupJobNow(
   connectionId: string,
@@ -25,24 +24,5 @@ export async function runBackupJobNow(
   fetchImpl: typeof fetch = fetch,
 ): Promise<RunBackupJobResult> {
   const url = `/api/v1/connections/${encodeURIComponent(connectionId)}/backup-jobs/${encodeURIComponent(jobId)}?action=run`
-  const res = await fetchImpl(url, { method: 'POST' })
-
-  const text = await res.text()
-  let body: { error?: string; data?: unknown } | undefined
-
-  if (text) {
-    try {
-      body = JSON.parse(text)
-    } catch {
-      // Non-JSON body (HTML error page, wrong path). Don't let JSON.parse
-      // leak its cryptic "Unexpected token '<'" message to the user.
-      return { ok: false, error: `HTTP ${res.status}` }
-    }
-  }
-
-  if (!res.ok || body?.error) {
-    return { ok: false, error: body?.error || `HTTP ${res.status}` }
-  }
-
-  return { ok: true, data: body?.data }
+  return fetchJsonSafe(url, { method: "POST" }, fetchImpl)
 }


### PR DESCRIPTION
## What

The cluster **Backups** tab parsed every fetch response with `res.json()` without checking `res.ok` or the content type. When a reverse proxy in front of ProxCenter returns its own HTML error page (a 502/504 gateway page that starts with a bare `<html>`, not `<!DOCTYPE`), `JSON.parse` threw `Unexpected token '<', "<html> <h"... is not valid JSON` straight into the error banner.

Reported in discussion #396. This is distinct from #398, which fixed a genuinely missing endpoint that returned the Next.js `<!DOCTYPE` page; here the request never reaches the app, the proxy answers with its own error page first (typically a 504 when loading backup jobs outruns `proxy_read_timeout`).

## Change

- New `fetchJsonSafe` helper: reads the body as text, parses defensively, and returns a flat `{ ok, error?, data? }`. A non-JSON or non-ok response surfaces a clean `HTTP <status>` instead of a parse exception.
- New `backupJobsApi` module routing the five backup-job calls (load jobs, load VMs, save, delete, toggle) through the helper.
- `runBackupJobNow` (the #398 fix) now delegates to the shared helper, removing the duplicated parse block.
- `BackupJobsPanel` calls the lib functions; the success path is unchanged.

## Tests

- `fetchJsonSafe.test.ts`: success, empty body, backend error field, non-ok fallback, and the exact nginx 504 HTML page from the report.
- `backupJobsApi.test.ts`: URL/method/body per call plus gateway-error surfacing.
- Existing `runBackupJob.test.ts` stays green (behavior preserved).

## Note

This does not make a misconfigured proxy succeed; it turns the opaque parse error into a status that points at the real cause (for a 504, raise `proxy_read_timeout` on the reverse proxy).
