### PR TITLE
fix(security): drop unused npm from the runtime image to clear bundled undici CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -100,13 +100,15 @@ WORKDIR /app
 # root, before the USER switch further down.
 RUN apk upgrade --no-cache libssl3 libcrypto3
 
-# Patch npm to a version whose bundled dependencies clear the latest
-# CVE round (tar < 7.5.16 / CVE-2026-53655 PAX header smuggling, plus the
-# bundled undici advisories CVE-2026-12151 et al.). Pinning the version
-# keeps the build reproducible; bump this line when a newer bundle
-# becomes available. The npm cache is wiped afterwards so the layer does
-# not grow.
-RUN npm install -g npm@11.17.0 && npm cache clean --force
+# Remove npm/npx from the runtime image. The app never invokes them at
+# run time (docker-entrypoint.sh runs the Prisma CLI via `node
+# node_modules/prisma/build/index.js` directly, and start.js spawns no
+# npm), so the global npm under /usr/local/lib only contributes its
+# bundled dependencies (undici, tar, ...) to the Trivy attack surface
+# without being reachable. Dropping it clears those findings at the
+# source instead of chasing each npm bundle bump, and trims the image.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+    /usr/local/bin/npm /usr/local/bin/npx
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

Follow-up to #469. After that merge, the main-branch Trivy rescan cleared the dompurify/form-data/tar findings but **4 `undici` advisories remained** (incl. CVE-2026-12151, high) under npm's bundled modules — bumping the npm pin to 11.17.0 fixed its bundled `tar` but npm still ships a vulnerable `undici`.

The runtime image never invokes `npm`/`npx`:
- `docker-entrypoint.sh` runs the Prisma CLI via `node node_modules/prisma/build/index.js migrate deploy` (and `node prisma/seed.js`) directly — the comment there notes `.bin` symlinks are not preserved, which is exactly why it uses `node`.
- `start.js` / `ws-proxy.js` spawn no npm; no `src` runtime path spawns npm.

So the global npm under `/usr/local/lib/node_modules/npm` only contributed its bundled deps to the Trivy attack surface without being reachable. This PR removes npm/npx from the runner stage, clearing the `undici` (and bundled `tar`) findings **at the source** rather than chasing each upstream npm bundle, and trimming the image.

## Change

Replaces the `RUN npm install -g npm@11.17.0` line (runner stage) with removal of `/usr/local/lib/node_modules/npm` and the `npm`/`npx` bins. `node` itself is untouched.

## Verification

- Confirmed no runtime npm/npx usage (entrypoint, start.js, ws-proxy.js, `src`).
- The **Trivy — Frontend Image** check builds the image and must report the 4 `undici` findings cleared.
- Container boot path is unaffected (Prisma + server run via `node`).

## Related

- CodeQL `js/log-injection` on `features/route.ts` (#764) was dismissed as a false positive: the value is sanitized at runtime by `safeLog()`, which CodeQL cannot model as a barrier — consistent with the prior dismissal on the same file and the repo-wide pattern.
