### PR TITLE
chore(release): v1.4.4 notes, What's New entry and dialog scroll fix

### DIFF
--- a/RELEASE_NOTES_v1.4.4.md
+++ b/RELEASE_NOTES_v1.4.4.md
@@ -1,0 +1,30 @@
+# ProxCenter v1.4.4
+
+**Maintenance release: stability and security hardening, shared migration tasks, plus MSP per-tenant dashboards.**
+
+## MSP & dashboards
+- **Header tenant switcher.** Switch the active tenant from the navbar; dashboards are scoped to the selected tenant, so the provider can review each tenant's view without leaving the dashboard.
+
+## Migration
+- **Shared migration tasks.** In-flight migrations now appear in the footer for every user, so the whole team sees what is running, with a link to the warm-migration setup docs.
+- **Correct stream exit code.** A failed block-device transfer is now reported as a failure instead of being masked as success.
+- **Bounded thick-target zero-fill.** Warm migration to a thick target bounds the zero-fill so it can no longer exit on a false ENOSPC on the destination volume.
+
+## Backups
+- **Real gateway errors.** The Backups tab now surfaces the underlying gateway error instead of failing with "Unexpected token '<'" when a reverse proxy returns an HTML error page.
+
+## RBAC & access
+- **OIDC role re-sync on login.** OIDC users re-sync their role from IdP group membership on every login, so group changes take effect immediately.
+- **Resource-scoped performance graphs.** RRD performance graphs are scoped to the individual resource rather than the whole connection, closing an RBAC scope leak.
+
+## Reliability
+- **Stable performance chart axes.** RRD charts show dates on the axes for multi-day timeframes, not just times.
+- **Stable inventory NETWORK section.** The NETWORK section stays in place when a connection briefly blips instead of collapsing.
+- **Real errors surfaced.** Guest and node API routes no longer swallow underlying errors, so failures are reported instead of showing empty data.
+- **Faster console previews.** VM console screenshots are served as JPEG instead of raw PPM, for lighter and faster previews.
+- **Writable cache for the runtime user.** The container creates a writable .next/cache for the non-root runtime user, fixing a startup EACCES behind some deployments.
+- **Safer DR config writes.** Replication writes the DR config with cp -f on pmxcfs, avoiding a transient failure window during the write.
+
+## Security
+- **Reduced image surface.** The unused npm binary is removed from the runtime image, clearing the bundled undici advisories.
+- **Patched CVEs.** Dependency CVEs are patched (including OpenSSL on the orchestrator image), a feature-route error log is sanitized, and front-end dependencies are refreshed (postcss, tailwindcss, @novnc/novnc, next-intl, nanoid, ws).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxcenter",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "license": "Commercial",
   "private": true,
   "scripts": {

--- a/frontend/src/components/dialogs/WhatsNewDialog.tsx
+++ b/frontend/src/components/dialogs/WhatsNewDialog.tsx
@@ -109,7 +109,7 @@ export default function WhatsNewDialog({ open, onClose }: WhatsNewDialogProps) {
         </IconButton>
       </DialogTitle>
 
-      <DialogContent dividers sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1 }}>
+      <DialogContent dividers sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 1, minHeight: 0, overflowY: 'auto' }}>
         {entries.map((entry, idx) => {
           const isExpanded = expandedVersion === entry.version
           const isLatest = idx === 0
@@ -122,6 +122,7 @@ export default function WhatsNewDialog({ open, onClose }: WhatsNewDialogProps) {
               disableGutters
               elevation={0}
               sx={{
+                flexShrink: 0,
                 border: '1px solid',
                 borderColor: isExpanded
                   ? alpha(theme.palette.primary.main, 0.3)

--- a/frontend/src/data/changelog.json
+++ b/frontend/src/data/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "1.4.4",
+    "title": "Stability, security & shared migration tasks",
+    "items": [
+      { "type": "new", "text": "Header tenant switcher with per-tenant dashboards for MSP: switch the active tenant from the navbar and see dashboards scoped to that tenant" },
+      { "type": "new", "text": "Shared migration tasks in the footer, visible across users so the whole team sees in-flight migrations, with a warm-setup docs link" },
+      { "type": "improved", "text": "VM console screenshots are served as JPEG instead of raw PPM, for lighter and faster previews" },
+      { "type": "fix", "text": "RRD performance charts show dates on the axes for multi-day timeframes, not just times" },
+      { "type": "fix", "text": "The Backups tab surfaces the real gateway error instead of failing with \"Unexpected token '<'\" when a proxy returns an HTML error page" },
+      { "type": "fix", "text": "A failed migration block-device transfer is reported as a failure instead of being masked as success" },
+      { "type": "fix", "text": "Warm migration to a thick target bounds the zero-fill so it can no longer exit on a false ENOSPC" },
+      { "type": "fix", "text": "Guest and node API routes no longer swallow real errors, so failures surface instead of empty data" },
+      { "type": "fix", "text": "OIDC users re-sync their role from IdP group membership on every login, so group changes take effect immediately" },
+      { "type": "fix", "text": "RRD performance graphs are scoped to the resource rather than the whole connection, closing an RBAC scope leak" },
+      { "type": "fix", "text": "The inventory NETWORK section stays stable when a connection briefly blips instead of collapsing" },
+      { "type": "fix", "text": "Replication writes the DR config with cp -f on pmxcfs, avoiding a transient failure window" },
+      { "type": "fix", "text": "Security: removed the unused npm from the runtime image, patched dependency CVEs (undici, OpenSSL on the orchestrator) and refreshed front-end dependencies" }
+    ]
+  },
+  {
     "version": "1.4.3",
     "title": "MSP mode, multi-license stacking & connection diagnostics",
     "items": [


### PR DESCRIPTION
## Release prep for v1.4.4

This is the release-prep PR for **v1.4.4**, a maintenance release: stability and security hardening, shared migration tasks, plus the MSP per-tenant dashboard switcher. All functional changes already landed on `main` since v1.4.3; this PR only adds the release notes, the What's New entry, the version bump, and one What's New dialog fix.

### Changes
- **Release notes**: `RELEASE_NOTES_v1.4.4.md`.
- **What's New**: new `1.4.4` entry in `changelog.json` (title "Stability, security & shared migration tasks").
- **Version bump**: frontend `1.4.3` to `1.4.4`.
- **Fix (What's New dialog)**: a long release list was clipped with no scrollbar. Root cause: the global dialog theme override sets `overflow: hidden` on the dialog Paper, and the dialog content was a flex column whose children could shrink, so the expanded accordion was compressed and its inner list clipped instead of the content scrolling. Fix: the content area is now a proper scroll container (`minHeight: 0`, `overflowY: auto`) and the version accordions no longer shrink (`flexShrink: 0`). No global theme change.

### Verification
- What's New dialog validated in the browser: the version list scrolls and the expanded entry shows all items, in light and dark themes.
- `WhatsNewDialog` has an existing render test; the change is style-only.

### Follow-up (not in this PR)
- Tag both repositories `v1.4.4` and promote the `latest` image after merge.
