### PR TITLE
fix(inventory): show host bridges & VLANs in Network view on VM-less clusters (#490)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -2439,7 +2439,7 @@ return vm?.isCluster ?? false
             connectionNames={Object.fromEntries(clusterStorages.map(cs => [cs.connId, cs.connName]))}
           />
         </Box>
-      ) : selection?.type === 'net-conn' || selection?.type === 'net-node' || selection?.type === 'net-vlan' ? (
+      ) : selection?.type === 'net-conn' || selection?.type === 'net-node' || selection?.type === 'net-vlan' || selection?.type === 'net-bridge' ? (
         <NetworkDetailPanel selection={selection} onSelect={onSelect} />
       ) : selection?.type === 'tvnet' ? (
         <Box sx={{ p: 2.5, height: '100%', overflow: 'auto' }}>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -4,7 +4,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { isSharedStorage } from '@/lib/proxmox/storage'
-import { fetchConnectionsNetworks } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { bridgeLabel } from '@/lib/proxmox/hostVlanMap'
 
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
 import { 
@@ -79,7 +80,13 @@ export type InventorySelection =
   | { type: 'ext'; id: string } // id = connectionId (external hypervisor host)
   | { type: 'extvm'; id: string } // id = connectionId:vmid (external hypervisor VM)
   | { type: 'storage-root'; id: 'storage-root' }
+  | { type: 'storage-cluster'; id: string }
+  | { type: 'storage-node'; id: string }
   | { type: 'network-root'; id: 'network-root' }
+  | { type: 'net-conn'; id: string }
+  | { type: 'net-node'; id: string }
+  | { type: 'net-vlan'; id: string }
+  | { type: 'net-bridge'; id: string } // host bridge: id = `connId:node:iface:tag`
   /** Tenant-only: SDN VNet selected from the Network tree.
    *  id = `tvnet:<vdcId>:<displayName>` */
   | { type: 'tvnet'; id: string }
@@ -419,6 +426,11 @@ function selectionFromItemId(itemId: string): InventorySelection | null {
 
   if (type === 'net-conn' || type === 'net-node' || type === 'net-vlan' || type === 'storage-cluster' || type === 'storage-node') {
     return { type: type as any, id } as InventorySelection
+  }
+
+  if (type === 'net-bridge') {
+    // net-bridge:<connId>:<node>:<iface>:<tag> — return a real net-bridge selection
+    return { type: 'net-bridge' as 'net-bridge', id }
   }
 
   if (type === 'tvnet') {
@@ -2336,6 +2348,8 @@ return favorites.has(vmKey)
   type NetIface = { id: string; model: string; bridge: string; macaddr?: string; tag?: number; firewall?: boolean; rate?: number }
   type VmNetData = { vmid: string; name: string; node: string; type: string; status: string; connId?: string; nets: NetIface[] }
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
+  const [networkBridges, setNetworkBridges] = useState<HostBridgeItem[]>([])
+  const [networkVnetAliases, setNetworkVnetAliases] = useState<Record<string, Record<string, string>>>({})
   const [networkLoading, setNetworkLoading] = useState(false)
   const [networkFailedConnIds, setNetworkFailedConnIds] = useState<string[]>([])
   const networkFetchedRef = useRef(false)
@@ -2367,7 +2381,7 @@ return favorites.has(vmKey)
       return next
     })
   }, [])
-  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[] } | null>(null)
+  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[]; bridges: HostBridgeItem[]; vnetAliasesByConn: Record<string, Record<string, string>> } | null>(null)
 
   // Fetch the tenant's VNets (display + subnet info) — only meaningful for
   // non-provider tenants. Provider keeps the legacy bridge/VLAN walk.
@@ -2411,16 +2425,20 @@ return favorites.has(vmKey)
     const cacheKey = connIds.sort((a, b) => a.localeCompare(b)).join(',')
     if (networkCacheRef.current?.connIds === cacheKey) {
       setNetworkData(networkCacheRef.current.data)
+      setNetworkBridges(networkCacheRef.current.bridges)
+      setNetworkVnetAliases(networkCacheRef.current.vnetAliasesByConn)
       return
     }
     setNetworkLoading(true)
-    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, failedConnIds }) => {
+    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, bridges, vnetAliasesByConn, failedConnIds }) => {
       setNetworkData(data)
+      setNetworkBridges(bridges)
+      setNetworkVnetAliases(vnetAliasesByConn)
       setNetworkLoading(false)
       setNetworkFailedConnIds(failedConnIds)
       // Only cache when all connections succeeded so re-opening retries any partial failure
       if (failedConnIds.length === 0) {
-        networkCacheRef.current = { connIds: cacheKey, data }
+        networkCacheRef.current = { connIds: cacheKey, data, bridges, vnetAliasesByConn }
       } else {
         // Allow the next expand to re-fetch
         networkFetchedRef.current = false
@@ -2462,49 +2480,77 @@ return favorites.has(vmKey)
     }
   }, [isHydrated, expandedNetSections, clusters.length, isFullClusterView, fetchTenantVnets])
 
-  // Build network tree: Connection → Node → VLAN → VMs
+  // Build network tree: Connection → Node → [bridges] + VLAN buckets (VMs only)
   const networkTree = useMemo(() => {
-    if (!networkData.length) return []
+    if (!networkData.length && !networkBridges.length) return []
 
-    // Group by connId → node → vlan tag
-    const connMap = new Map<string, Map<string, Map<number | 'untagged', { vm: VmNetData; netId: string; bridge: string }[]>>>()
+    type BucketEntry = { vm: VmNetData; netId: string; bridge: string }
+    type Bucket = { tag: number | 'untagged'; entries: BucketEntry[] }
+
+    // Group VMs by connId → node → vlan tag (no bridges in buckets)
+    const vmConnMap = new Map<string, Map<string, Map<number | 'untagged', Bucket>>>()
+
+    const ensureVmBucket = (cid: string, node: string, tag: number | 'untagged'): Bucket => {
+      if (!vmConnMap.has(cid)) vmConnMap.set(cid, new Map())
+      const nodeMap = vmConnMap.get(cid)!
+      if (!nodeMap.has(node)) nodeMap.set(node, new Map())
+      const vlanMap = nodeMap.get(node)!
+      if (!vlanMap.has(tag)) vlanMap.set(tag, { tag, entries: [] })
+      return vlanMap.get(tag)!
+    }
 
     for (const vm of networkData) {
       const cid = vm.connId || 'unknown'
-      if (!connMap.has(cid)) connMap.set(cid, new Map())
-      const nodeMap = connMap.get(cid)!
-      if (!nodeMap.has(vm.node)) nodeMap.set(vm.node, new Map())
-      const vlanMap = nodeMap.get(vm.node)!
-
       for (const net of vm.nets) {
         const tag = net.tag ?? 'untagged'
-        if (!vlanMap.has(tag)) vlanMap.set(tag, [])
-        vlanMap.get(tag)!.push({ vm, netId: net.id, bridge: net.bridge })
+        const bucket = ensureVmBucket(cid, vm.node, tag)
+        bucket.entries.push({ vm, netId: net.id, bridge: net.bridge })
       }
     }
 
-    return Array.from(connMap.entries()).map(([connId, nodeMap]) => {
+    // Group host bridges by connId → node
+    const bridgeNodeMap = new Map<string, Map<string, HostBridgeItem[]>>()
+    for (const b of networkBridges) {
+      const cid = b.connId || 'unknown'
+      if (!bridgeNodeMap.has(cid)) bridgeNodeMap.set(cid, new Map())
+      const nodeMap = bridgeNodeMap.get(cid)!
+      if (!nodeMap.has(b.node)) nodeMap.set(b.node, [])
+      nodeMap.get(b.node)!.push(b)
+    }
+
+    // Union of all connIds from VMs and bridges
+    const allConnIds = new Set([...vmConnMap.keys(), ...bridgeNodeMap.keys()])
+
+    return Array.from(allConnIds).map(connId => {
       const connName = clusters.find(c => c.connId === connId)?.name || connId
-      const nodes = Array.from(nodeMap.entries())
-        .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([node, vlanMap]) => {
-          const vlans = Array.from(vlanMap.entries())
+      // Union of nodes from VM map and bridge map
+      const vmNodeMap = vmConnMap.get(connId) ?? new Map<string, Map<number | 'untagged', Bucket>>()
+      const bridgesByNode = bridgeNodeMap.get(connId) ?? new Map<string, HostBridgeItem[]>()
+      const allNodes = new Set([...vmNodeMap.keys(), ...bridgesByNode.keys()])
+
+      const nodes = Array.from(allNodes)
+        .sort((a, b) => a.localeCompare(b))
+        .map(node => {
+          const vlanMap = vmNodeMap.get(node) ?? new Map<number | 'untagged', Bucket>()
+          const nodeBridges = (bridgesByNode.get(node) ?? []).slice().sort((a, b) => a.iface.localeCompare(b.iface))
+          const vlans = Array.from(vlanMap.values())
             .sort((a, b) => {
-              if (a[0] === 'untagged') return 1
-              if (b[0] === 'untagged') return -1
-              return (a[0] as number) - (b[0] as number)
+              if (a.tag === 'untagged') return 1
+              if (b.tag === 'untagged') return -1
+              return (a.tag as number) - (b.tag as number)
             })
-            .map(([tag, entries]) => ({
-              tag,
-              entries: entries.sort((a, b) => a.vm.name.localeCompare(b.vm.name)),
+            .map((bucket) => ({
+              ...bucket,
+              entries: bucket.entries.sort((a, b) => a.vm.name.localeCompare(b.vm.name)),
             }))
           const taggedVlans = vlans.filter(v => v.tag !== 'untagged').length
           const totalVms = vlans.reduce((sum, v) => sum + v.entries.length, 0)
-          return { node, vlans, totalVlans: taggedVlans, totalVms }
+          const totalBridges = nodeBridges.length
+          return { node, bridges: nodeBridges, vlans, totalVlans: taggedVlans, totalVms, totalBridges }
         })
       return { connId, connName, nodes }
-    })
-  }, [networkData, clusters])
+    }).sort((a, b) => a.connName.localeCompare(b.connName))
+  }, [networkData, networkBridges, clusters])
 
   // Expand all network tree items helper
   const expandNetworkOnLoadRef = useRef(false)
@@ -3936,8 +3982,13 @@ return (
                     </Box>
                   }
                 >
-                  {nodes.map(({ node, vlans, totalVlans, totalVms }) => {
+                  {nodes.map(({ node, bridges: nodeBridges, vlans, totalVlans, totalVms, totalBridges }) => {
                     const nodeStatus = clusters.find(c => c.connId === cId)?.nodes.find(n => n.node === node)?.status
+                    const nodeCountLabel = [
+                      totalBridges > 0 ? `${totalBridges} bridge${totalBridges > 1 ? 's' : ''}` : '',
+                      totalVlans > 0 ? `${totalVlans} VLAN${totalVlans > 1 ? 's' : ''}` : '',
+                      totalVms > 0 ? `${totalVms} VM${totalVms > 1 ? 's' : ''}` : '',
+                    ].filter(Boolean).join(', ')
                     return (
                     <TreeItem
                       key={`net-node:${cId}:${node}`}
@@ -3946,12 +3997,24 @@ return (
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
                           <NodeIcon status={nodeStatus || 'online'} size={16} />
                           <span style={{ fontSize: 13 }}>{node}</span>
-                          <span style={{ opacity: 0.4, fontSize: 11 }}>
-                            ({totalVlans > 0 ? `${totalVlans} VLAN${totalVlans > 1 ? 's' : ''}, ` : ''}{totalVms} VM{totalVms > 1 ? 's' : ''})
-                          </span>
+                          {nodeCountLabel && (
+                            <span style={{ opacity: 0.4, fontSize: 11 }}>({nodeCountLabel})</span>
+                          )}
                         </Box>
                       }
                     >
+                      {nodeBridges.map((b) => (
+                        <TreeItem
+                          key={`net-bridge:${cId}:${node}:${b.iface}:${b.tag ?? 'untagged'}`}
+                          itemId={`net-bridge:${cId}:${node}:${b.iface}:${b.tag ?? 'untagged'}`}
+                          label={
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                              <i className="ri-share-line" style={{ fontSize: 14, opacity: 0.5 }} />
+                              <span style={{ fontSize: 13 }}>{bridgeLabel(networkVnetAliases[cId], b.iface)}</span>
+                            </Box>
+                          }
+                        />
+                      ))}
                       {vlans.map(({ tag, entries }) => (
                         <TreeItem
                           key={`net-vlan:${cId}:${node}:${tag}`}
@@ -3978,11 +4041,11 @@ return (
                                     <Typography variant="body2" sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                                       {vm.name}
                                     </Typography>
-                                    <span style={{ opacity: 0.3, fontFamily: 'monospace', fontSize: 10 }}>
+                                    <span style={{ opacity: 0.4, fontSize: 11 }}>
                                       {vm.vmid}
                                     </span>
                                     <span style={{ opacity: 0.4, fontSize: 10 }}>
-                                      {bridge}
+                                      {bridgeLabel(networkVnetAliases[cId], bridge)}
                                     </span>
                                   </Box>
                                 }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import { bridgeLabel } from '@/lib/proxmox/hostVlanMap'
 import {
   Box,
   Card,
@@ -23,7 +24,7 @@ import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 import VnetsSection from './VnetsSection'
 import { useTenant } from '@/contexts/TenantContext'
-import { fetchConnectionsNetworks } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem } from '@/lib/proxmox/fetchConnectionsNetworks'
 
 type VmNetData = {
   vmid: string
@@ -157,7 +158,7 @@ type VlanEntry = {
   vms: Array<{ vmid: string; name: string; node: string; status: string; bridge: string }>
 }
 
-function VlanVmsList({ vlans }: { vlans: VlanEntry[] }) {
+function VlanVmsList({ vlans, aliases }: { vlans: VlanEntry[]; aliases?: Record<string, string> }) {
   const theme = useTheme()
   const [expanded, setExpanded] = useState<Set<number>>(new Set())
 
@@ -198,7 +199,7 @@ function VlanVmsList({ vlans }: { vlans: VlanEntry[] }) {
                     sx={{ height: 22, fontSize: 11, fontWeight: 700, fontFamily: 'JetBrains Mono, monospace', bgcolor: alpha(theme.palette.primary.main, 0.1), color: theme.palette.primary.main }}
                   />
                   <Typography variant="caption" sx={{ opacity: 0.5 }}>
-                    {v.bridges.join(', ')}
+                    {v.bridges.map(br => bridgeLabel(aliases, br)).join(', ')}
                   </Typography>
                   <Box sx={{ flex: 1 }} />
                   <Chip
@@ -234,7 +235,7 @@ function VlanVmsList({ vlans }: { vlans: VlanEntry[] }) {
                                 <span>{vm.node}</span>
                               </Stack>
                             </TableCell>
-                            <TableCell sx={{ py: 0.5, fontSize: 12, fontFamily: 'JetBrains Mono, monospace', opacity: 0.7 }}>{vm.bridge}</TableCell>
+                            <TableCell sx={{ py: 0.5, fontSize: 12, opacity: 0.7 }}>{bridgeLabel(aliases, vm.bridge)}</TableCell>
                             <TableCell sx={{ py: 0.5 }}>
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
                                 <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: vm.status === 'running' ? '#4caf50' : '#9e9e9e' }} />
@@ -276,6 +277,8 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   const isProviderTenant = currentTenant?.id === 'default' || !currentTenant
   const [loading, setLoading] = useState(false)
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
+  const [hostBridges, setHostBridges] = useState<HostBridgeItem[]>([])
+  const [vnetAliasesByConn, setVnetAliasesByConn] = useState<Record<string, Record<string, string>>>({})
   // VNet KPIs are computed from the same data VnetsSection fetches; pulling
   // it up here lets the donut row and the list stay in sync without a
   // duplicate burst of requests. Only fetched on the tenant view.
@@ -289,9 +292,11 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     const ids = connIdsKey.split(',')
     let alive = true
     setLoading(true)
-    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data }) => {
+    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data, bridges, vnetAliasesByConn }) => {
       if (!alive) return
       setNetworkData(data)
+      setHostBridges(bridges)
+      setVnetAliasesByConn(vnetAliasesByConn)
     }).finally(() => {
       if (!alive) return
       setLoading(false)
@@ -350,6 +355,31 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     const vlanMap = new Map<number, { vlan: number; vmCount: number; bridges: Set<string>; vms: Array<{ vmid: string; name: string; node: string; status: string; bridge: string }> }>()
     let totalVmsWithNetwork = 0
 
+    // Seed bridgeMap and vlanMap from host bridges so bridges/VLANs appear
+    // even when no VMs are attached. The VM loop below increments vmCount on
+    // top of these seeded entries (0 → N). Only populated for provider scope
+    // (tenant view receives bridges: []).
+    for (const b of hostBridges) {
+      const key = `${b.connId}:${b.node}:${b.iface}`
+      if (!bridgeMap.has(key)) {
+        bridgeMap.set(key, {
+          bridge: b.iface,
+          node: b.node,
+          connName: connectionNames[b.connId] || b.connId,
+          type: b.type === 'OVSBridge' ? 'ovs_bridge' : 'bridge',
+          vmCount: 0,
+        })
+      }
+      if (b.tag != null) {
+        const existing = vlanMap.get(b.tag)
+        if (existing) {
+          existing.bridges.add(b.iface)
+        } else {
+          vlanMap.set(b.tag, { vlan: b.tag, vmCount: 0, bridges: new Set([b.iface]), vms: [] })
+        }
+      }
+    }
+
     for (const vm of networkData) {
       if (vm.nets.length > 0) totalVmsWithNetwork++
       for (const net of vm.nets) {
@@ -392,12 +422,18 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
       vlanBreakdown: [...vlanMap.values()].map(v => ({ ...v, bridges: [...v.bridges] })).sort((a, b) => b.vmCount - a.vmCount),
       bridgeBreakdown: [...bridgeMap.values()],
     }
-  }, [networkData, connectionNames])
+  }, [networkData, connectionNames, hostBridges])
+
+  // Flat map of vnet id → alias across all connections (vnet ids are globally unique within a cluster)
+  const flatAliases = useMemo(
+    () => Object.assign({}, ...Object.values(vnetAliasesByConn)) as Record<string, string>,
+    [vnetAliasesByConn],
+  )
 
   // Only block the dashboard with a spinner on the initial load — after
   // that, background refetches keep the existing KPIs / tables visible
   // so the page doesn't flicker on every inventory poll.
-  if (loading && networkData.length === 0) {
+  if (loading && networkData.length === 0 && hostBridges.length === 0) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
         <CircularProgress />
@@ -511,7 +547,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
 
       {/* VMs by VLAN */}
       {summary.vlanBreakdown.length > 0 && (
-        <VlanVmsList vlans={summary.vlanBreakdown} />
+        <VlanVmsList vlans={summary.vlanBreakdown} aliases={flatAliases} />
       )}
 
       {/* Bridge Table — provider/MSP only. vDC tenants don't see / can't act
@@ -553,7 +589,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
                           <TableCell sx={{ py: 1 }}>
                             <Stack direction="row" alignItems="center" spacing={1}>
                               <i className="ri-share-line" style={{ fontSize: 14, color: theme.palette.primary.main, opacity: 0.7 }} />
-                              <Typography variant="body2" fontWeight={600} sx={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{bridge.bridge}</Typography>
+                              <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{bridgeLabel(flatAliases, bridge.bridge)}</Typography>
                             </Stack>
                           </TableCell>
                           <TableCell sx={{ py: 1 }}>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
@@ -22,7 +22,8 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import type { InventorySelection } from '../types'
-import { foldEffectiveVlanTags } from '@/lib/proxmox/hostVlanMap'
+import { bridgeLabel, foldEffectiveVlanTags, type HostBridge } from '@/lib/proxmox/hostVlanMap'
+import { StatusIcon } from '../InventoryTree'
 
 type NetIface = { id: string; model: string; bridge: string; macaddr?: string; tag?: number; firewall?: boolean; rate?: number }
 type VmNet = { vmid: string; name: string; node: string; type: string; status: string; connId?: string; nets: NetIface[] }
@@ -34,6 +35,8 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   const t = useTranslations()
   const theme = useTheme()
   const [netData, setNetData] = React.useState<VmNet[]>([])
+  const [hostBridges, setHostBridges] = React.useState<HostBridge[]>([])
+  const [vnetAliases, setVnetAliases] = React.useState<Record<string, string>>({})
   const [loading, setLoading] = React.useState(true)
 
   // Parse selection id
@@ -41,6 +44,8 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   const connId = parts[0]
   const nodeName = selection.type === 'net-node' || selection.type === 'net-vlan' ? parts[1] : undefined
   const vlanTag = selection.type === 'net-vlan' ? parts[2] : undefined
+  const bridgeNode = selection.type === 'net-bridge' ? parts[1] : undefined
+  const bridgeIface = selection.type === 'net-bridge' ? parts[2] : undefined
 
   React.useEffect(() => {
     if (!connId) return
@@ -49,8 +54,13 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       .then(r => r.json())
       // Fold each guest's server-computed host VLAN into `tag` so guests on a
       // bondX.N bridge with no per-NIC tag group under their real VLAN (see helper).
-      .then(json => setNetData((json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) }))))
-      .catch(() => setNetData([]))
+      .then(json => {
+        setNetData((json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) })))
+        // raw HostBridge[] (no connId — this panel is scoped to a single connection)
+        setHostBridges(json.bridges || [])
+        setVnetAliases(json.vnetAliases || {})
+      })
+      .catch(() => { setNetData([]); setHostBridges([]); setVnetAliases({}) })
       .finally(() => setLoading(false))
   }, [connId])
 
@@ -77,6 +87,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   // --- NET-CONN: Cluster-level network overview ---
   if (selection.type === 'net-conn') {
     const nodeMap = new Map<string, { vlans: Set<string | number>; bridges: Set<string>; vms: Set<string> }>()
+    // Seed nodeMap from host bridges so VM-less nodes appear in the table.
+    for (const b of hostBridges) {
+      if (!nodeMap.has(b.node)) nodeMap.set(b.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
+      const nd = nodeMap.get(b.node)!
+      nd.bridges.add(b.iface)
+    }
     for (const vm of netData) {
       if (!nodeMap.has(vm.node)) nodeMap.set(vm.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
       const nd = nodeMap.get(vm.node)!
@@ -87,8 +103,17 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       }
     }
     const nodes = Array.from(nodeMap.entries()).sort((a, b) => a[0].localeCompare(b[0]))
-    const totalVlans = new Set(netData.flatMap(vm => vm.nets.map(n => n.tag ?? 'untagged'))).size
-    const totalBridges = new Set(netData.flatMap(vm => vm.nets.map(n => n.bridge))).size
+    // VLANs are VM-derived only; bridges include host bridges so VM-less nodes
+    // still report a bridge count.
+    const allVlans = new Set<string | number>(
+      netData.flatMap(vm => vm.nets.map(n => n.tag ?? 'untagged'))
+    )
+    const allBridges = new Set<string>([
+      ...netData.flatMap(vm => vm.nets.map(n => n.bridge)),
+      ...hostBridges.map(b => b.iface),
+    ])
+    const totalVlans = allVlans.size
+    const totalBridges = allBridges.size
     const totalVms = new Set(netData.map(vm => vm.vmid)).size
 
     return (
@@ -177,6 +202,8 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   // --- NET-NODE: Node-level network view ---
   if (selection.type === 'net-node' && nodeName) {
     const nodeVms = netData.filter(vm => vm.node === nodeName)
+    const nodeHostBridges = hostBridges.filter(b => b.node === nodeName).slice().sort((a, b) => a.iface.localeCompare(b.iface))
+    // Build vlanMap from VMs only (no host bridge seeding)
     const vlanMap = new Map<string | number, { bridges: Set<string>; vms: VmNet[] }>()
     for (const vm of nodeVms) {
       for (const net of vm.nets) {
@@ -192,7 +219,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       if (b[0] === 'untagged') return -1
       return Number(a[0]) - Number(b[0])
     })
-    const totalBridges = new Set(nodeVms.flatMap(vm => vm.nets.map(n => n.bridge))).size
+    const totalBridges = nodeHostBridges.length
 
     return (
       <Box sx={{ p: 2.5 }}>
@@ -228,6 +255,54 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
           ))}
         </Box>
 
+        {/* Host Bridges section */}
+        {nodeHostBridges.length > 0 && (
+          <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+              <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className="ri-share-line" style={{ fontSize: 18, opacity: 0.7 }} />
+                  Bridges
+                </Typography>
+              </Box>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Bridge</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Type</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>IP / CIDR</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {nodeHostBridges.map((b) => (
+                      <TableRow
+                        key={b.iface}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => onSelect?.({ type: 'net-bridge', id: `${connId}:${nodeName}:${b.iface}:${b.tag ?? 'untagged'}` })}
+                      >
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                            <i className="ri-share-line" style={{ fontSize: 14, opacity: 0.6 }} />
+                            <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{bridgeLabel(vnetAliases, b.iface)}</Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{b.type}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{b.cidr || '—'}</Typography>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </CardContent>
+          </Card>
+        )}
+
         {/* VLANs list */}
         <Stack spacing={1.5}>
           {vlans.map(([tag, data]) => (
@@ -246,15 +321,15 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
                   <Box sx={{ flex: 1 }} />
                   <Chip size="small" label={`${data.vms.length} VM${data.vms.length > 1 ? 's' : ''}`} sx={{ fontSize: 11, height: 22 }} />
                   {Array.from(data.bridges).map(br => (
-                    <Chip key={br} size="small" variant="outlined" label={br} sx={{ fontSize: 11, height: 22, fontFamily: 'JetBrains Mono, monospace' }} />
+                    <Chip key={br} size="small" variant="outlined" label={bridgeLabel(vnetAliases, br)} sx={{ fontSize: 11, height: 22 }} />
                   ))}
                 </Box>
                 <Box>
                   {data.vms.slice(0, 5).map(vm => (
                     <Box key={vm.vmid} sx={{ px: 2, py: 0.5, display: 'flex', alignItems: 'center', gap: 1, '&:hover': { bgcolor: 'action.hover' } }}>
-                      <Box sx={{ width: 6, height: 6, borderRadius: '50%', bgcolor: vm.status === 'running' ? 'success.main' : 'text.disabled', flexShrink: 0 }} />
+                      <StatusIcon status={vm.status} type="vm" vmType={vm.type} size={16} />
                       <Typography variant="body2" sx={{ fontSize: 12 }}>{vm.name}</Typography>
-                      <Typography variant="caption" sx={{ opacity: 0.4, fontFamily: 'JetBrains Mono, monospace', fontSize: 10 }}>{vm.vmid}</Typography>
+                      <Typography variant="caption" sx={{ opacity: 0.4, fontSize: 10 }}>{vm.vmid}</Typography>
                     </Box>
                   ))}
                   {data.vms.length > 5 && (
@@ -284,6 +359,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
         }
       }
     }
+    // Bridges used by the VMs in this VLAN only (no host-bridge seeding)
     const bridges = [...new Set(vlanVms.map(v => v.net.bridge))]
 
     return (
@@ -337,9 +413,9 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
 
         {/* Bridges */}
         {bridges.length > 0 && (
-          <Box sx={{ display: 'flex', gap: 1, mb: 2 }}>
+          <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
             {bridges.map(br => (
-              <Chip key={br} variant="outlined" label={br} sx={{ fontFamily: 'JetBrains Mono, monospace', fontWeight: 600 }} />
+              <Chip key={br} variant="outlined" label={bridgeLabel(vnetAliases, br)} sx={{ fontWeight: 600 }} />
             ))}
           </Box>
         )}
@@ -379,25 +455,27 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
                       }}
                     >
                       <TableCell>
-                        <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: vm.status === 'running' ? 'success.main' : 'text.disabled' }} />
+                        <StatusIcon status={vm.status} type="vm" vmType={vm.type} size={16} />
                       </TableCell>
                       <TableCell>
-                        <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{vm.name}</Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                          <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{vm.name}</Typography>
+                        </Box>
                       </TableCell>
                       <TableCell>
-                        <Typography variant="body2" sx={{ fontSize: 12, fontFamily: 'JetBrains Mono, monospace', opacity: 0.6 }}>{vm.vmid}</Typography>
+                        <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.6 }}>{vm.vmid}</Typography>
                       </TableCell>
                       <TableCell>
-                        <Typography variant="body2" sx={{ fontSize: 12, fontFamily: 'JetBrains Mono, monospace' }}>{net.id}</Typography>
+                        <Typography variant="body2" sx={{ fontSize: 12 }}>{net.id}</Typography>
                       </TableCell>
                       <TableCell>
-                        <Chip size="small" label={net.bridge} variant="outlined" sx={{ fontSize: 11, height: 22, fontFamily: 'JetBrains Mono, monospace' }} />
+                        <Chip size="small" label={bridgeLabel(vnetAliases, net.bridge)} variant="outlined" sx={{ fontSize: 11, height: 22 }} />
                       </TableCell>
                       <TableCell>
                         <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.6 }}>{net.model}</Typography>
                       </TableCell>
                       <TableCell>
-                        <Typography variant="body2" sx={{ fontSize: 11, fontFamily: 'JetBrains Mono, monospace', opacity: 0.6 }}>{net.macaddr || '—'}</Typography>
+                        <Typography variant="body2" sx={{ fontSize: 11, opacity: 0.6 }}>{net.macaddr || '—'}</Typography>
                       </TableCell>
                       <TableCell>
                         {net.firewall ? (
@@ -411,6 +489,164 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
                 </TableBody>
               </Table>
             </TableContainer>
+          </CardContent>
+        </Card>
+      </Box>
+    )
+  }
+
+  // --- NET-BRIDGE: Host bridge detail view ---
+  if (selection.type === 'net-bridge' && bridgeNode && bridgeIface) {
+    const bridge = hostBridges.find(b => b.node === bridgeNode && b.iface === bridgeIface)
+    // Find VMs attached to this bridge on this node
+    const bridgeVms: { vm: VmNet; net: NetIface }[] = []
+    for (const vm of netData) {
+      if (vm.node !== bridgeNode) continue
+      for (const net of vm.nets) {
+        if (net.bridge === bridgeIface) {
+          bridgeVms.push({ vm, net })
+        }
+      }
+    }
+
+    return (
+      <Box sx={{ p: 2.5 }}>
+        {/* Breadcrumb header */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+          <Chip size="small" label="NETWORK" icon={<i className="ri-global-line" style={{ fontSize: 14, marginLeft: 8 }} />} />
+          <Typography
+            variant="body2"
+            sx={{ opacity: 0.5, cursor: 'pointer', '&:hover': { opacity: 0.8 } }}
+            onClick={() => onSelect?.({ type: 'net-conn', id: connId })}
+          >
+            {connName}
+          </Typography>
+          <i className="ri-arrow-right-s-line" style={{ opacity: 0.3 }} />
+          <Typography
+            variant="body2"
+            sx={{ opacity: 0.5, cursor: 'pointer', '&:hover': { opacity: 0.8 }, display: 'flex', alignItems: 'center', gap: 0.5 }}
+            onClick={() => onSelect?.({ type: 'net-node', id: `${connId}:${bridgeNode}` })}
+          >
+            <img src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={14} height={14} />
+            {bridgeNode}
+          </Typography>
+          <i className="ri-arrow-right-s-line" style={{ opacity: 0.3 }} />
+          <Typography variant="h6" fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <i className="ri-share-line" style={{ fontSize: 18, opacity: 0.7 }} />
+            {bridgeLabel(vnetAliases, bridgeIface)}
+          </Typography>
+        </Box>
+
+        {/* Details card */}
+        <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+          <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+              <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className="ri-share-line" style={{ fontSize: 18, opacity: 0.7 }} />
+                Bridge Details
+              </Typography>
+            </Box>
+            {!bridge ? (
+              <Box sx={{ px: 2, py: 2 }}>
+                <Typography variant="body2" sx={{ opacity: 0.5 }}>Bridge details unavailable.</Typography>
+              </Box>
+            ) : (
+              <Table size="small">
+                <TableBody>
+                  {[
+                    { label: 'Type', value: bridge.type },
+                    { label: 'VLAN', value: bridge.tag != null ? `VLAN ${bridge.tag}` : 'Untagged' },
+                    { label: 'IP / CIDR', value: bridge.cidr || '—' },
+                    { label: 'Ports / Uplinks', value: bridge.ports || '—' },
+                    { label: 'VLAN-aware', value: bridge.vlanAware ? 'Yes' : 'No' },
+                    { label: 'Active', value: bridge.active ? 'Yes' : 'No' },
+                    { label: 'Autostart', value: bridge.autostart ? 'Yes' : 'No' },
+                    ...(bridgeLabel(vnetAliases, bridgeIface!) !== bridgeIface
+                      ? [{ label: 'VNet ID', value: bridgeIface! }]
+                      : []),
+                  ].map(({ label, value }) => (
+                    <TableRow key={label}>
+                      <TableCell sx={{ fontWeight: 600, fontSize: 12, width: 160, opacity: 0.6, borderBottom: 'none', py: 0.75 }}>{label}</TableCell>
+                      <TableCell sx={{ fontSize: 12, borderBottom: 'none', py: 0.75 }}>{value}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Attached VMs table */}
+        <Card variant="outlined" sx={{ borderRadius: 2 }}>
+          <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+              <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className="ri-computer-line" style={{ fontSize: 18, opacity: 0.7 }} />{' '}
+                Virtual Machines
+              </Typography>
+            </Box>
+            {bridgeVms.length === 0 ? (
+              <Box sx={{ px: 2, py: 2 }}>
+                <Typography variant="body2" sx={{ opacity: 0.5 }}>No VMs attached to this bridge.</Typography>
+              </Box>
+            ) : (
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Status</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VM</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VMID</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Interface</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Model</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>MAC</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Firewall</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {bridgeVms.map(({ vm, net }, idx) => (
+                      <TableRow
+                        key={`${vm.vmid}-${net.id}-${idx}`}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => {
+                          const vmKey = `${vm.connId || connId}:${vm.node}:${vm.type}:${vm.vmid}`
+                          onSelect?.({ type: 'vm', id: vmKey })
+                        }}
+                      >
+                        <TableCell>
+                          <StatusIcon status={vm.status} type="vm" vmType={vm.type} size={16} />
+                        </TableCell>
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                            <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{vm.name}</Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.6 }}>{vm.vmid}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12 }}>{net.id}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.6 }}>{net.model}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 11, opacity: 0.6 }}>{net.macaddr || '—'}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          {net.firewall ? (
+                            <i className="ri-shield-check-fill" style={{ fontSize: 14, color: theme.palette.success.main }} />
+                          ) : (
+                            <i className="ri-shield-line" style={{ fontSize: 14, opacity: 0.2 }} />
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            )}
           </CardContent>
         </Card>
       </Box>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
@@ -703,6 +703,22 @@ describe('fetchDetails — cluster allVms isCluster', () => {
 })
 
 /* ------------------------------------------------------------------ */
+/* fetchDetails — section/network selections have no generic details   */
+/* ------------------------------------------------------------------ */
+
+describe('fetchDetails — section selections return null (no generic CPU/RAM panel)', () => {
+  // net-bridge is a host-bridge selection (#490); like the other net-*/section
+  // types it must NOT fall through to the generic 'UNKNOWN' details payload.
+  it.each([
+    'root', 'storage-root', 'network-root', 'backup-root', 'migration-root',
+    'net-conn', 'net-node', 'net-vlan', 'net-bridge', 'tvnet',
+    'storage-cluster', 'storage-node',
+  ])('returns null for %s', async (type) => {
+    expect(await fetchDetails({ type, id: 'x' } as any)).toBeNull()
+  })
+})
+
+/* ------------------------------------------------------------------ */
 /* RRD time-axis formatting (issue #474)                              */
 /* ------------------------------------------------------------------ */
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -562,7 +562,7 @@ export async function fetchRrdBatch(
 
 export async function fetchDetails(sel: InventorySelection): Promise<DetailsPayload | null> {
   // Root / section selections don't have details — skip fetching
-  if (sel.type === 'root' || sel.type === 'storage-root' || sel.type === 'network-root' || sel.type === 'backup-root' || sel.type === 'migration-root' || sel.type === 'net-conn' || sel.type === 'net-node' || sel.type === 'net-vlan' || sel.type === 'tvnet' || sel.type === 'storage-cluster' || sel.type === 'storage-node') return null
+  if (sel.type === 'root' || sel.type === 'storage-root' || sel.type === 'network-root' || sel.type === 'backup-root' || sel.type === 'migration-root' || sel.type === 'net-conn' || sel.type === 'net-node' || sel.type === 'net-vlan' || sel.type === 'net-bridge' || sel.type === 'tvnet' || sel.type === 'storage-cluster' || sel.type === 'storage-node') return null
 
   const lastUpdated = new Date().toLocaleString()
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/types.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/types.ts
@@ -19,6 +19,7 @@ export type InventorySelection =
   | { type: 'net-conn'; id: string }
   | { type: 'net-node'; id: string }
   | { type: 'net-vlan'; id: string }
+  | { type: 'net-bridge'; id: string } // host bridge: id = `connId:node:iface:tag`
   /** Tenant-only: a single SDN VNet selected from the Network tree.
    *  ID format: `tvnet:<vdcId>:<displayName>`. */
   | { type: 'tvnet'; id: string }

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
@@ -52,7 +52,9 @@ const CONFIGS: Record<string, any> = {
 function wireProxmox() {
   pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
     if (path === '/cluster/resources?type=vm') return RESOURCES
+    if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
     if (path === '/nodes/pve1/network') return HOST_NETWORK
+    if (path === '/cluster/sdn/vnets') return []
     if (path in CONFIGS) return CONFIGS[path]
     throw new Error(`unexpected pveFetch path: ${path}`)
   })
@@ -105,6 +107,7 @@ describe('GET /api/v1/connections/[id]/networks — effectiveTag', () => {
   it('still succeeds when a node network fetch fails (no effectiveTag enrichment)', async () => {
     pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
       if (path === '/cluster/resources?type=vm') return RESOURCES
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
       if (path === '/nodes/pve1/network') throw new Error('network unreachable')
       if (path in CONFIGS) return CONFIGS[path]
       throw new Error(`unexpected pveFetch path: ${path}`)
@@ -152,5 +155,128 @@ describe('parseNetString', () => {
     expect(iface.bridge).toBe('vmbr1')
     expect(iface.tag).toBeUndefined()
     expect(iface.firewall).toBeUndefined()
+  })
+})
+
+describe('GET /api/v1/connections/[id]/networks — host bridges', () => {
+  const NODE_NETWORK = [
+    { iface: 'bond0', type: 'bond' },
+    { iface: 'bond0.10', type: 'vlan' },
+    { iface: 'vmbr0V10', type: 'bridge', bridge_ports: 'bond0.10', bridge_vlan_aware: 1 },
+    { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+  ]
+
+  it('returns bridges populated from cluster nodes when VM list is empty (provider scope)', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }, { node: 'pve2' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/nodes/pve2/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+
+    expect(body.data).toEqual([])
+    expect(Array.isArray(body.bridges)).toBe(true)
+    expect(body.bridges.length).toBeGreaterThan(0)
+
+    const bridge = body.bridges.find((b: any) => b.iface === 'vmbr0V10' && b.node === 'pve1')
+    expect(bridge).toBeDefined()
+    expect(bridge.type).toBe('bridge')
+    expect(bridge.tag).toBe(10)
+  })
+
+  it('returns bridges with entries for each node in the cluster', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }, { node: 'pve2' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/nodes/pve2/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    const nodes = [...new Set(body.bridges.map((b: any) => b.node))]
+    expect(nodes).toContain('pve1')
+    expect(nodes).toContain('pve2')
+  })
+
+  it('returns bridges: [] for tenant (vDC) scope even when host networks exist', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    // Truthy vdcScope = iaas tenant (vdcScope returned from getVdcScope is truthy)
+    getVdcScopeMock.mockResolvedValue({
+      connectionIds: new Set(['c1']),
+      poolsByConnection: new Map([['c1', new Set(['pool1'])]]),
+      vdcIds: new Set(),
+      vdcNames: new Set(),
+    })
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.bridges).toEqual([])
+    expect(pveFetchMock).not.toHaveBeenCalledWith(expect.anything(), '/cluster/resources?type=node')
+  })
+})
+
+describe('GET /api/v1/connections/[id]/networks — vnetAliases', () => {
+  const NODE_NETWORK = [
+    { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+  ]
+
+  it('populates vnetAliases from /cluster/sdn/vnets for provider scope', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return [
+        { vnet: 'v42fc503', alias: 'Production LAN', zone: 'zone1' },
+        { vnet: 'v99aa001', alias: 'v99aa001', zone: 'zone1' },   // alias === vnet → omit
+        { vnet: 'v11bb002', alias: '', zone: 'zone1' },            // blank alias → omit
+        { vnet: 'v22cc003', zone: 'zone1' },                       // no alias → omit
+        { vnet: 'v33dd004', alias: 'Dev Network', zone: 'zone1' },
+      ]
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+
+    expect(body.vnetAliases).toEqual({
+      v42fc503: 'Production LAN',
+      v33dd004: 'Dev Network',
+    })
+  })
+
+  it('returns vnetAliases: {} for tenant (vDC) scope and does not call /cluster/sdn/vnets', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue({
+      connectionIds: new Set(['c1']),
+      poolsByConnection: new Map([['c1', new Set(['pool1'])]]),
+      vdcIds: new Set(),
+      vdcNames: new Set(),
+    })
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+
+    expect(body.vnetAliases).toEqual({})
+    expect(pveFetchMock).not.toHaveBeenCalledWith(expect.anything(), '/cluster/sdn/vnets')
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.ts
@@ -5,7 +5,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
-import { buildBridgeVlanMap, resolveEffectiveTag } from "@/lib/proxmox/hostVlanMap"
+import { buildBridgeVlanMap, extractHostBridges, resolveEffectiveTag, type HostBridge } from "@/lib/proxmox/hostVlanMap"
 
 export const runtime = "nodejs"
 
@@ -96,7 +96,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
     // Get all VMs/CTs from cluster resources
     const allResources = await pveFetch<any[]>(conn, "/cluster/resources?type=vm")
     if (!allResources || !Array.isArray(allResources)) {
-      return NextResponse.json({ data: [] })
+      return NextResponse.json({ data: [], bridges: [], vnetAliases: {} })
     }
 
     // Restrict to the tenant's vDC pool(s) on this connection. Without this,
@@ -115,25 +115,80 @@ export async function GET(_req: Request, ctx: RouteContext) {
         : []
     }
 
+    const isProviderScope = !vdcScope
+
+    // For provider scope, fetch SDN VNet aliases so the UI can display friendly
+    // names instead of raw VNet ids (e.g. "v42fc503"). Fault-tolerant: if SDN is
+    // unavailable the map stays empty and raw ids are shown.
+    let vnetAliases: Record<string, string> = {}
+    if (isProviderScope) {
+      try {
+        const vnets = await pveFetch<any[]>(conn, "/cluster/sdn/vnets")
+        if (Array.isArray(vnets)) {
+          for (const v of vnets) {
+            if (
+              v &&
+              typeof v.vnet === "string" &&
+              typeof v.alias === "string" &&
+              v.alias.length > 0 &&
+              v.alias !== v.vnet
+            ) {
+              vnetAliases[v.vnet] = v.alias
+            }
+          }
+        }
+      } catch { /* SDN unavailable — fall back to raw bridge names */ }
+    }
+
+    // For provider scope, enumerate ALL cluster nodes so host bridges are surfaced
+    // even when no VMs exist on them. For tenant scope, only visit nodes that
+    // actually host the tenant's VMs (avoids extra PVE calls outside the pool).
+    let nodeNames: string[]
+    if (isProviderScope) {
+      try {
+        const clusterNodes = await pveFetch<any[]>(conn, "/cluster/resources?type=node")
+        nodeNames = Array.isArray(clusterNodes)
+          ? clusterNodes
+              .map((n: any) => n?.node)
+              .filter((n: any): n is string => typeof n === "string" && n.length > 0)
+          : []
+      } catch {
+        nodeNames = []
+      }
+    } else {
+      nodeNames = [...new Set(
+        resources.map((vm: any) => vm?.node).filter((n: any): n is string => typeof n === "string" && n.length > 0)
+      )]
+    }
+
     // Build a per-node `bridge -> VLAN` map from each node's host networking.
     // This lets us resolve the effective VLAN of guests on the traditional
     // layout (a `bondX.N` sub-interface feeding a dedicated bridge), which carry
     // no per-NIC tag and would otherwise all show up as Untagged (discussion #389).
-    const nodeNames = [...new Set(
-      resources.map((vm: any) => vm?.node).filter((n: any): n is string => typeof n === "string" && n.length > 0)
-    )]
     const bridgeVlanByNode = new Map<string, Map<string, number>>()
+    const hostBridgesIfacesByNode = new Map<string, any[]>()
     await Promise.all(
       nodeNames.map(async (node) => {
         try {
           const ifaces = await pveFetch<any[]>(conn, `/nodes/${encodeURIComponent(node)}/network`)
-          bridgeVlanByNode.set(node, buildBridgeVlanMap(Array.isArray(ifaces) ? ifaces : []))
+          const ifaceArr = Array.isArray(ifaces) ? ifaces : []
+          bridgeVlanByNode.set(node, buildBridgeVlanMap(ifaceArr))
+          if (isProviderScope) hostBridgesIfacesByNode.set(node, ifaceArr)
         } catch {
           // Host network unavailable for this node — guests fall back to NIC tags only.
           bridgeVlanByNode.set(node, new Map())
         }
       })
     )
+
+    // Collect host bridges for provider scope
+    const hostBridges: HostBridge[] = []
+    if (isProviderScope) {
+      for (const [node, ifaces] of hostBridgesIfacesByNode) {
+        const map = bridgeVlanByNode.get(node) ?? new Map<string, number>()
+        hostBridges.push(...extractHostBridges(node, ifaces, map))
+      }
+    }
 
     // Batch fetch configs with concurrency limit
     const CONCURRENCY = 15
@@ -187,7 +242,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
       }
     }
 
-    return NextResponse.json({ data: results })
+    return NextResponse.json({ data: results, bridges: isProviderScope ? hostBridges : [], vnetAliases })
   } catch (e: any) {
     console.error("[networks] Error:", e)
     return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
@@ -133,4 +133,134 @@ describe('fetchConnectionsNetworks', () => {
     expect(result.failedConnIds).toEqual([])
     expect(fetchImpl).not.toHaveBeenCalled()
   })
+
+  it('threads bridges from route response, tagging each with connId', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: {
+        data: [],
+        bridges: [
+          { node: 'pve1', iface: 'vmbr0', type: 'bridge' },
+          { node: 'pve1', iface: 'vmbr1', type: 'bridge', tag: 10 },
+        ],
+      } as any,
+      conn2: {
+        data: [],
+        bridges: [
+          { node: 'pve2', iface: 'vmbr0', type: 'OVSBridge' },
+        ],
+      } as any,
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1', 'conn2'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.bridges).toHaveLength(3)
+    expect(result.bridges.every((b) => typeof b.connId === 'string')).toBe(true)
+    const conn1Bridges = result.bridges.filter((b) => b.connId === 'conn1')
+    expect(conn1Bridges).toHaveLength(2)
+    const conn2Bridges = result.bridges.filter((b) => b.connId === 'conn2')
+    expect(conn2Bridges).toHaveLength(1)
+    expect(conn2Bridges[0].node).toBe('pve2')
+  })
+
+  it('contributes no bridges from a failed connection', async () => {
+    const fetchImpl = makeFailFetch('bad-conn', {
+      'good-conn': {
+        data: [],
+        bridges: [{ node: 'pve1', iface: 'vmbr0', type: 'bridge' }],
+      } as any,
+    })
+
+    const result = await fetchConnectionsNetworks(['good-conn', 'bad-conn'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.failedConnIds).toEqual(['bad-conn'])
+    expect(result.bridges).toHaveLength(1)
+    expect(result.bridges[0].connId).toBe('good-conn')
+  })
+
+  it('returns bridges: [] when the route response has no bridges field (backward compat)', async () => {
+    // Old route response without bridges
+    const fetchImpl = makeOkFetch({
+      conn1: { data: [] },
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.bridges).toEqual([])
+  })
+
+  it('collects vnetAliases per connection into vnetAliasesByConn', async () => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      const match = /\/connections\/([^/]+)\/networks/.exec(url)
+      const connId = match ? decodeURIComponent(match[1]) : '__unknown__'
+      const bodies: Record<string, any> = {
+        conn1: { data: [], bridges: [], vnetAliases: { v42fc503: 'Production LAN' } },
+        conn2: { data: [], bridges: [], vnetAliases: { vaaaabbb: 'Dev Network' } },
+      }
+      const body = bodies[connId]
+      if (!body) throw new Error(`Unexpected connId: ${connId}`)
+      return new Response(JSON.stringify(body), { status: 200 })
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1', 'conn2'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.vnetAliasesByConn).toEqual({
+      conn1: { v42fc503: 'Production LAN' },
+      conn2: { vaaaabbb: 'Dev Network' },
+    })
+  })
+
+  it('sets vnetAliasesByConn[connId] to {} when route response omits vnetAliases (backward compat)', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: { data: [] },
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.vnetAliasesByConn).toEqual({ conn1: {} })
+  })
+
+  it('returns vnetAliasesByConn: {} immediately for empty connIds input', async () => {
+    const result = await fetchConnectionsNetworks([], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: vi.fn() as any,
+    })
+
+    expect(result.vnetAliasesByConn).toEqual({})
+  })
+
+  it('does not include failed connections in vnetAliasesByConn', async () => {
+    const fetchImpl = makeFailFetch('bad-conn', {
+      'good-conn': { data: [] },
+    })
+
+    const result = await fetchConnectionsNetworks(['good-conn', 'bad-conn'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(Object.keys(result.vnetAliasesByConn)).toEqual(['good-conn'])
+    expect(result.failedConnIds).toContain('bad-conn')
+  })
 })

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
@@ -1,4 +1,4 @@
-import { foldEffectiveVlanTags } from './hostVlanMap'
+import { foldEffectiveVlanTags, type HostBridge } from './hostVlanMap'
 
 export type VmNetItem = {
   vmid: string
@@ -10,6 +10,8 @@ export type VmNetItem = {
   nets: any[]
 }
 
+export type HostBridgeItem = HostBridge & { connId: string }
+
 const DEFAULT_RETRIES = 2
 const DEFAULT_RETRY_DELAY_MS = 300
 
@@ -18,7 +20,7 @@ async function fetchWithRetry(
   retries: number,
   retryDelayMs: number,
   fetchImpl: typeof fetch,
-): Promise<{ ok: true; items: VmNetItem[] } | { ok: false }> {
+): Promise<{ ok: true; items: VmNetItem[]; bridges: HostBridgeItem[]; vnetAliases: Record<string, string> } | { ok: false }> {
   let attempt = 0
   while (attempt <= retries) {
     try {
@@ -32,7 +34,12 @@ async function fetchWithRetry(
         connId,
         nets: foldEffectiveVlanTags(vm.nets),
       }))
-      return { ok: true, items }
+      const bridges: HostBridgeItem[] = (json.bridges ?? []).map((b: HostBridge) => ({
+        ...b,
+        connId,
+      }))
+      const vnetAliases: Record<string, string> = json.vnetAliases ?? {}
+      return { ok: true, items, bridges, vnetAliases }
     } catch {
       if (attempt < retries) {
         if (retryDelayMs > 0) {
@@ -49,14 +56,15 @@ async function fetchWithRetry(
 
 /**
  * Fetch VM network data from multiple connections concurrently with per-connection
- * retry logic. Returns flat data plus the list of connection IDs that failed after
- * all retries. Never rejects — partial failure is surfaced via failedConnIds.
+ * retry logic. Returns flat data, flat host bridges (tagged with connId), plus the
+ * list of connection IDs that failed after all retries. Never rejects — partial
+ * failure is surfaced via failedConnIds.
  */
 export async function fetchConnectionsNetworks(
   connIds: string[],
   opts?: { retries?: number; retryDelayMs?: number; fetchImpl?: typeof fetch },
-): Promise<{ data: VmNetItem[]; failedConnIds: string[] }> {
-  if (connIds.length === 0) return { data: [], failedConnIds: [] }
+): Promise<{ data: VmNetItem[]; bridges: HostBridgeItem[]; vnetAliasesByConn: Record<string, Record<string, string>>; failedConnIds: string[] }> {
+  if (connIds.length === 0) return { data: [], bridges: [], vnetAliasesByConn: {}, failedConnIds: [] }
 
   const retries = opts?.retries ?? DEFAULT_RETRIES
   const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
@@ -67,16 +75,20 @@ export async function fetchConnectionsNetworks(
   )
 
   const data: VmNetItem[] = []
+  const bridges: HostBridgeItem[] = []
+  const vnetAliasesByConn: Record<string, Record<string, string>> = {}
   const failedConnIds: string[] = []
 
   for (let i = 0; i < results.length; i++) {
     const result = results[i]
     if (result.ok) {
       data.push(...result.items)
+      bridges.push(...result.bridges)
+      vnetAliasesByConn[connIds[i]] = result.vnetAliases
     } else {
       failedConnIds.push(connIds[i])
     }
   }
 
-  return { data, failedConnIds }
+  return { data, bridges, vnetAliasesByConn, failedConnIds }
 }

--- a/frontend/src/lib/proxmox/hostVlanMap.test.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.test.ts
@@ -5,6 +5,8 @@ import {
   buildBridgeVlanMap,
   resolveEffectiveTag,
   foldEffectiveVlanTags,
+  extractHostBridges,
+  bridgeLabel,
   type HostNetIface,
 } from './hostVlanMap'
 
@@ -160,5 +162,143 @@ describe('foldEffectiveVlanTags', () => {
 
   it('is null-safe', () => {
     expect(foldEffectiveVlanTags(undefined)).toEqual([])
+  })
+})
+
+describe('extractHostBridges', () => {
+  const IFACES: HostNetIface[] = [
+    { iface: 'bond0', type: 'bond' },
+    { iface: 'bond0.10', type: 'vlan' },
+    { iface: 'vmbr0V10', type: 'bridge', bridge_ports: 'bond0.10', bridge_vlan_aware: 1 },
+    { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+    { iface: 'ovs0', type: 'OVSBridge', ovs_ports: 'bond0.20' },
+  ]
+  const VLAN_MAP = buildBridgeVlanMap(IFACES)
+
+  it('includes bridge and OVSBridge interfaces, excludes non-bridge types', () => {
+    const result = extractHostBridges('pve1', IFACES, VLAN_MAP)
+    const ifaces = result.map((b) => b.iface)
+    expect(ifaces).toContain('vmbr0V10')
+    expect(ifaces).toContain('vmbr0')
+    expect(ifaces).toContain('ovs0')
+    expect(ifaces).not.toContain('bond0')
+    expect(ifaces).not.toContain('bond0.10')
+  })
+
+  it('stamps the correct node on every entry', () => {
+    const result = extractHostBridges('mynode', IFACES, VLAN_MAP)
+    expect(result.every((b) => b.node === 'mynode')).toBe(true)
+  })
+
+  it('maps bridge type correctly', () => {
+    const result = extractHostBridges('pve1', IFACES, VLAN_MAP)
+    const bridge = result.find((b) => b.iface === 'vmbr0')
+    const ovs = result.find((b) => b.iface === 'ovs0')
+    expect(bridge?.type).toBe('bridge')
+    expect(ovs?.type).toBe('OVSBridge')
+  })
+
+  it('attaches the VLAN tag from the bridgeVlanMap', () => {
+    const result = extractHostBridges('pve1', IFACES, VLAN_MAP)
+    const tagged = result.find((b) => b.iface === 'vmbr0V10')
+    expect(tagged?.tag).toBe(10)
+  })
+
+  it('leaves tag undefined for a bridge not in the vlan map', () => {
+    const result = extractHostBridges('pve1', IFACES, VLAN_MAP)
+    const untagged = result.find((b) => b.iface === 'vmbr0')
+    expect(untagged?.tag).toBeUndefined()
+  })
+
+  it('sets vlanAware from bridge_vlan_aware truthy field', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+      { iface: 'vmbr1', type: 'bridge', bridge_ports: 'bond1', bridge_vlan_aware: 0 },
+      { iface: 'vmbr2', type: 'bridge', bridge_ports: 'bond2' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.find((b) => b.iface === 'vmbr0')?.vlanAware).toBe(true)
+    expect(result.find((b) => b.iface === 'vmbr1')?.vlanAware).toBe(false)
+    expect(result.find((b) => b.iface === 'vmbr2')?.vlanAware).toBe(false)
+  })
+
+  it('omits ports field when bridge_ports is empty or absent', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: '' },
+      { iface: 'vmbr1', type: 'bridge' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.find((b) => b.iface === 'vmbr0')?.ports).toBeUndefined()
+    expect(result.find((b) => b.iface === 'vmbr1')?.ports).toBeUndefined()
+  })
+
+  it('sets ports from bridge_ports (trimmed) when present', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: '  bond0  ' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.find((b) => b.iface === 'vmbr0')?.ports).toBe('bond0')
+  })
+
+  it('prefers bridge_ports over ovs_ports for port field', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'ovsBr', type: 'OVSBridge', ovs_ports: 'bond0.20' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.find((b) => b.iface === 'ovsBr')?.ports).toBe('bond0.20')
+  })
+
+  it('sets cidr when the iface carries a cidr field', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', cidr: '192.168.1.1/24' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.find((b) => b.iface === 'vmbr0')?.cidr).toBe('192.168.1.1/24')
+  })
+
+  it('sorts results by iface name', () => {
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr2', type: 'bridge' },
+      { iface: 'vmbr0', type: 'bridge' },
+      { iface: 'vmbr1', type: 'bridge' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.map((b) => b.iface)).toEqual(['vmbr0', 'vmbr1', 'vmbr2'])
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(extractHostBridges('pve1', [], new Map())).toEqual([])
+  })
+
+  it('is null-safe for non-array input', () => {
+    expect(extractHostBridges('pve1', undefined as unknown as HostNetIface[], new Map())).toEqual([])
+  })
+
+  it('skips entries without a string iface field', () => {
+    const ifaces: HostNetIface[] = [
+      null as unknown as HostNetIface,
+      { iface: 'vmbr0', type: 'bridge' },
+      { iface: 42 as unknown as string, type: 'bridge' },
+    ]
+    const result = extractHostBridges('pve1', ifaces, new Map())
+    expect(result.map((b) => b.iface)).toEqual(['vmbr0'])
+  })
+})
+
+describe('bridgeLabel', () => {
+  it('returns the alias when present and non-empty', () => {
+    expect(bridgeLabel({ v42fc503: 'Production LAN' }, 'v42fc503')).toBe('Production LAN')
+  })
+
+  it('returns the bridge name unchanged when no alias is present', () => {
+    expect(bridgeLabel({ v42fc503: 'Production LAN' }, 'vmbr0')).toBe('vmbr0')
+  })
+
+  it('returns the bridge name when the alias map is undefined', () => {
+    expect(bridgeLabel(undefined, 'vmbr0')).toBe('vmbr0')
+  })
+
+  it('returns the bridge name when the alias is an empty string', () => {
+    expect(bridgeLabel({ v42fc503: '' }, 'v42fc503')).toBe('v42fc503')
   })
 })

--- a/frontend/src/lib/proxmox/hostVlanMap.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.ts
@@ -22,6 +22,8 @@ export type HostNetIface = {
   'vlan-id'?: number | string
   vlan_id?: number | string
   bridge_vlan_aware?: number | boolean
+  active?: number | boolean
+  autostart?: number | boolean
   [key: string]: unknown
 }
 
@@ -105,6 +107,14 @@ export function resolveEffectiveTag(
   return undefined
 }
 
+/** Resolve a bridge name to its friendly label: the SDN VNet alias when the
+ *  bridge is a VNet, otherwise the bridge name unchanged. Null-safe. */
+export function bridgeLabel(aliases: Record<string, string> | undefined, bridge: string): string {
+  if (!bridge) return bridge
+  const a = aliases?.[bridge]
+  return a && a.length > 0 ? a : bridge
+}
+
 /**
  * Client-side boundary helper: fold each net's server-computed `effectiveTag`
  * into `tag` so the inventory VLAN grouping (tree, dashboard, detail panel)
@@ -116,4 +126,63 @@ export function foldEffectiveVlanTags<T extends { tag?: number; effectiveTag?: n
   nets: T[] | undefined,
 ): T[] {
   return (nets ?? []).map((n) => ({ ...n, tag: n.effectiveTag ?? n.tag }))
+}
+
+/**
+ * A host-level bridge interface as reported by `/nodes/{node}/network`, enriched
+ * with a derived VLAN tag from the node's bridge-to-VLAN map.
+ */
+export type HostBridge = {
+  node: string
+  iface: string
+  type: 'bridge' | 'OVSBridge'
+  active?: boolean
+  autostart?: boolean
+  vlanAware?: boolean
+  ports?: string
+  cidr?: string
+  tag?: number
+}
+
+/**
+ * Extract all host bridge interfaces from a node's network config, enriched
+ * with a VLAN tag derived from the node's bridge-to-VLAN map.
+ *
+ * Includes only entries where `type === 'bridge'` or `type === 'OVSBridge'`.
+ * Results are sorted by interface name. Array- and null-safe.
+ */
+export function extractHostBridges(
+  node: string,
+  ifaces: HostNetIface[],
+  bridgeVlanMap: Map<string, number>,
+): HostBridge[] {
+  if (!Array.isArray(ifaces)) return []
+
+  const bridges: HostBridge[] = []
+  for (const iface of ifaces) {
+    if (!iface || typeof iface.iface !== 'string') continue
+    if (iface.type !== 'bridge' && iface.type !== 'OVSBridge') continue
+
+    const rawPorts = String(iface.bridge_ports ?? iface.ovs_ports ?? '').trim()
+    const ports = rawPorts || undefined
+
+    const bridge: HostBridge = {
+      node,
+      iface: iface.iface,
+      type: iface.type as 'bridge' | 'OVSBridge',
+      active: Boolean(iface.active),
+      autostart: Boolean(iface.autostart),
+      vlanAware: Boolean(iface.bridge_vlan_aware),
+      ...(ports !== undefined ? { ports } : {}),
+      ...(typeof iface.cidr === 'string' ? { cidr: iface.cidr } : {}),
+    }
+
+    const tag = bridgeVlanMap.get(iface.iface)
+    if (tag !== undefined) bridge.tag = tag
+
+    bridges.push(bridge)
+  }
+
+  bridges.sort((a, b) => a.iface.localeCompare(b.iface))
+  return bridges
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -132,6 +132,11 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   testable logic they drive — the tenant-scoped read API and the task merge —
 #   lives in app/api/v1/tasks/shared/** and lib/tasks/{sharedTask,mergeSharedTasks}.ts
 #   and stays measured and covered.
+# - inventory/components/NetworkDetailPanel.tsx: pure JSX inventory detail panel;
+#   logic is render-time grouping from API responses and React state wiring that
+#   the node-env Vitest suite cannot render. The data it consumes (host bridge
+#   enumeration, VLAN derivation) lives in lib/proxmox/hostVlanMap.ts and the
+#   route handler, both of which stay measured and covered.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -184,7 +189,8 @@ sonar.coverage.exclusions=\
   frontend/src/app/(dashboard)/infrastructure/inventory/BackupDashboard.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/RrdCharts.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageDetailPanel.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageIntermediatePanel.tsx
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageIntermediatePanel.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them
@@ -217,7 +223,8 @@ sonar.cpd.exclusions=frontend/src/lib/templates/cloudImages.ts,\
   frontend/src/app/(dashboard)/infrastructure/inventory/RootInventoryView.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/RrdCharts.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageDetailPanel.tsx,\
-  frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageIntermediatePanel.tsx
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/StorageIntermediatePanel.tsx,\
+  frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
 
 # Per-rule false-positive suppressions, scoped to specific files. SonarCloud
 # evaluates each `e<n>` block as (ruleKey, resourceKey) and silences the


### PR DESCRIPTION
## Problem

Fixes #490. On a cluster with no VMs, the Inventory → Network view rendered empty (no bridges / VLANs), even though the bridges exist on every node and are visible in the per-host **System → Network** tab.

**Root cause:** the aggregated Network view was built entirely from guest (VM/CT) NIC configs. `/connections/[id]/networks` listed VMs and parsed their `netN` config; with no VMs there was nothing to show. Host networking was only used to enrich guest VLAN tags, never surfaced on its own.

## Changes

- **API**: `/connections/[id]/networks` now also enumerates host bridges per node and returns an SDN VNet `id → alias` map. Both are **provider / full-cluster scope only**; vDC tenants receive empty values and keep their existing pool-filtered, VM-derived data unchanged (no physical-topology leak). New pure helpers `extractHostBridges` / `bridgeLabel` in `hostVlanMap.ts`.
- **Views** (`NetworkDashboard`, `InventoryTree`, `NetworkDetailPanel`): render host bridges so bridges/VLANs appear even with zero VMs.
- **Node-level bridges**: bridges are listed once per node (not forced into VLAN buckets), so a VLAN-aware/trunk bridge no longer shows up incorrectly under "Untagged". VLAN buckets now contain only VMs.
- **Clickable bridges**: selecting a bridge opens a detail panel (type, VLAN, IP/CIDR, ports, vlan-aware, active/autostart, attached VMs).
- **VNet names**: SDN VNet bridge ids resolve to their friendly alias across the views (the raw id is still surfaced in the bridge detail).
- **VM rows** show the VM icon + status indicator; removed leftover monospace from network cells per the UI convention.

## Scope / safety

vDC tenant behavior is unchanged: host bridges and VNet aliases are gated to provider/full-cluster scope, and the per-tenant pool filtering is untouched.

## Testing

- New unit tests for the host-bridge helper, the SDN alias helper, the route (provider populates bridges/aliases; tenant returns empty and never calls the node/SDN endpoints), and the fetch aggregation.
- Full suite green (2015 tests). `tsc --noEmit` clean on the changed files.
- Pure-JSX panels (`NetworkDetailPanel`, etc.) added to Sonar coverage/CPD exclusions consistent with the sibling detail panels.
- Validated in the browser on a 4-node VM-less cluster: nodes and their bridges now appear, bridge detail and VNet names render correctly.
