### PR TITLE
fix(migration): chunk warm delta-apply to stay under the SSH arg-size limit

### DIFF
--- a/frontend/src/lib/migration/warm/block-applier.test.ts
+++ b/frontend/src/lib/migration/warm/block-applier.test.ts
@@ -1,34 +1,69 @@
 import { describe, it, expect } from "vitest"
-import { buildApplyScript } from "./block-applier"
+import { buildApplyScripts, MAX_APPLY_CMD_BYTES } from "./block-applier"
 
 const MiB = 1024 * 1024
 
-describe("buildApplyScript", () => {
+// Count `dd if=` occurrences across every chunk.
+function ddCount(scripts: string[]): number {
+  return scripts.reduce((n, s) => n + (s.match(/dd if=/g) || []).length, 0)
+}
+
+describe("buildApplyScripts", () => {
   it("normalizes extents and emits one byte-accurate dd per merged extent", () => {
-    const s = buildApplyScript("/dev/nbd3", "/dev/dm-9",
+    const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9",
       [{ offset: 1 * MiB, length: 4096 }, { offset: 1 * MiB + 4096, length: 4096 }], 1024 ** 3)
-    // the two 4k extents fall in the same 1 MiB alignment block -> one dd
-    expect((s.match(/dd if=/g) || []).length).toBe(1)
-    expect(s).toContain("seek=1048576")
-    expect(s.split("\n")[0]).toBe("set -e")
+    // the two 4k extents fall in the same 1 MiB alignment block -> one dd, one chunk
+    expect(scripts).toHaveLength(1)
+    expect(ddCount(scripts)).toBe(1)
+    expect(scripts[0]).toContain("seek=1048576")
+    expect(scripts[0].split("\n")[0]).toBe("set -e")
   })
 
   it("emits a separate dd per disjoint extent", () => {
-    const s = buildApplyScript("/dev/nbd3", "/dev/dm-9",
+    const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9",
       [{ offset: 0, length: 4096 }, { offset: 100 * MiB, length: 4096 }], 1024 ** 3)
-    expect((s.match(/dd if=/g) || []).length).toBe(2)
+    expect(scripts).toHaveLength(1)
+    expect(ddCount(scripts)).toBe(2)
   })
 
-  it("emits no dd for an empty change set (just the guard header)", () => {
-    const s = buildApplyScript("/dev/nbd3", "/dev/dm-9", [], 1024 ** 3)
-    expect(s).toBe("set -e")
+  it("emits no command for an empty change set", () => {
+    expect(buildApplyScripts("/dev/nbd3", "/dev/dm-9", [], 1024 ** 3)).toEqual([])
   })
 
   it("clamps an aligned tail to the disk length so no dd writes past EOF", () => {
     // disk = 1.5 MiB; the extent's 1 MiB-aligned end (2 MiB) is clamped to 1.5 MiB.
     const diskLen = 1.5 * MiB
-    const s = buildApplyScript("/dev/nbd3", "/dev/dm-9", [{ offset: 1 * MiB, length: 256 * 1024 }], diskLen)
-    expect(s).toContain("count=524288") // 0.5 MiB, clamped
-    expect(s).not.toContain("count=1048576") // would have overrun EOF
+    const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9", [{ offset: 1 * MiB, length: 256 * 1024 }], diskLen)
+    expect(scripts[0]).toContain("count=524288") // 0.5 MiB, clamped
+    expect(scripts[0]).not.toContain("count=1048576") // would have overrun EOF
+  })
+
+  describe("command-size chunking (#445 EOF: a single 158 KB command exceeds the 128 KiB arg limit)", () => {
+    // 2000 disjoint 1 MiB-aligned extents -> ~330 KB of dd lines, well past one command.
+    const many = Array.from({ length: 2000 }, (_, i) => ({ offset: i * 2 * MiB, length: 4096 }))
+    const diskLen = 8 * 1024 ** 3
+
+    it("splits a large change set into multiple commands", () => {
+      const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9", many, diskLen)
+      expect(scripts.length).toBeGreaterThan(1)
+    })
+
+    it("keeps every command under the per-command byte budget", () => {
+      const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9", many, diskLen)
+      for (const s of scripts) expect(s.length).toBeLessThanOrEqual(MAX_APPLY_CMD_BYTES)
+      // and the budget itself must stay safely under Linux MAX_ARG_STRLEN (128 KiB),
+      // leaving headroom for the sudo `sh -c '...'` wrapper + single-quote escaping.
+      expect(MAX_APPLY_CMD_BYTES).toBeLessThan(128 * 1024)
+    })
+
+    it("guards every command and loses no block, preserving order", () => {
+      const scripts = buildApplyScripts("/dev/nbd3", "/dev/dm-9", many, diskLen)
+      for (const s of scripts) expect(s.split("\n")[0]).toBe("set -e")
+      expect(ddCount(scripts)).toBe(2000) // every extent applied exactly once
+      // seek offsets must be globally ascending across chunk boundaries (no reorder/dup)
+      const seeks = scripts.flatMap(s => [...s.matchAll(/seek=(\d+)/g)].map(m => Number(m[1])))
+      expect(seeks).toHaveLength(2000)
+      for (let i = 1; i < seeks.length; i++) expect(seeks[i]).toBeGreaterThan(seeks[i - 1])
+    })
   })
 })

--- a/frontend/src/lib/migration/warm/block-applier.ts
+++ b/frontend/src/lib/migration/warm/block-applier.ts
@@ -2,22 +2,57 @@ import { normalizeExtents, type Extent } from "./extents"
 import { buildDeltaApplyCmd } from "./dd"
 
 /**
- * Build a shell script that applies every changed extent from the NBD device
+ * Max bytes for one delta-apply command. Linux caps a *single* execve argument
+ * at MAX_ARG_STRLEN (PAGE_SIZE * 32 = 128 KiB), independent of the much larger
+ * total ARG_MAX. The apply script is sent as one `sudo sh -c '<script>'`
+ * argument over SSH, and single-quote escaping inflates it further, so we keep
+ * each command well under 128 KiB. Batching every dd into one command broke
+ * disk 0 of a busy 1.43 TB VM (707 dd lines = 158 KB > 128 KiB): the remote exec
+ * was rejected before any dd ran and the SSH channel closed without a reply,
+ * surfacing as an opaque "command failed: EOF" (adminsyspro/proxcenter-ui#445).
+ */
+export const MAX_APPLY_CMD_BYTES = 96 * 1024
+
+const HEADER = "set -e"
+
+/**
+ * Build the shell command(s) that apply every changed extent from the NBD device
  * (the snapshot's logical view, served by nbdkit-vddk) to the raw Proxmox block
  * target. Extents are aligned to `alignment` and clamped to `diskLength` first
  * (so direct-I/O writes land on aligned boundaries and no tail runs past EOF),
- * then merged, so adjacent CBT extents collapse into a single dd. `set -e`
- * aborts on the first dd failure rather than silently leaving a partial copy.
+ * then merged, so adjacent CBT extents collapse into a single dd.
+ *
+ * The dd lines are packed into one or more commands, each kept under
+ * MAX_APPLY_CMD_BYTES so a large change set never produces an oversized command
+ * (see that constant). Every command is prefixed with `set -e` so a dd failure
+ * aborts that command immediately; the caller runs the commands in order and
+ * stops on the first failure, preserving the original abort-on-first-error
+ * semantics across the split. An empty change set yields no commands.
  */
-export function buildApplyScript(
+export function buildApplyScripts(
   nbdDev: string,
   targetDev: string,
   extents: Extent[],
   diskLength: number,
   alignment = 1024 * 1024,
-): string {
+): string[] {
   const norm = normalizeExtents(extents, alignment, diskLength)
-  const lines = ["set -e"]
-  for (const e of norm) lines.push(buildDeltaApplyCmd(nbdDev, targetDev, e))
-  return lines.join("\n")
+  const scripts: string[] = []
+  let lines = [HEADER]
+  let size = HEADER.length
+  for (const e of norm) {
+    const line = buildDeltaApplyCmd(nbdDev, targetDev, e)
+    // +1 for the newline that join() inserts before this line. Flush the current
+    // command before it would cross the budget, but never emit a header-only
+    // command (lines.length > 1 guarantees at least one dd is already buffered).
+    if (lines.length > 1 && size + 1 + line.length > MAX_APPLY_CMD_BYTES) {
+      scripts.push(lines.join("\n"))
+      lines = [HEADER]
+      size = HEADER.length
+    }
+    lines.push(line)
+    size += 1 + line.length
+  }
+  if (lines.length > 1) scripts.push(lines.join("\n"))
+  return scripts
 }

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -20,7 +20,7 @@ import { decideNextPass, type PassStat, type ConvergenceConfig, type Convergence
 import { initDiskState, recordPass, type DiskWarmState } from "./state"
 import { startVddkReader, stopVddkReader, type VddkReaderHandle } from "./vddk-reader"
 import type { VddkOpts } from "./vddk-cmd"
-import { buildApplyScript } from "./block-applier"
+import { buildApplyScripts } from "./block-applier"
 import { detectChangedExtentsByChecksum, scanBlockChecksums } from "./checksum-detector"
 import { checkVddkPreflight } from "./vddk-preflight"
 import { parseSha1Thumbprint } from "./thumbprint"
@@ -286,6 +286,20 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       await appendLog(jobId, `Disk ${i}: target ${alloc.volumeId} → ${dev} (${(disk.capacityBytes / 1073741824).toFixed(1)} GB)`)
     }
 
+    // Apply a disk's changed extents to its target. buildApplyScripts splits the
+    // dd batch into one or more commands, each bounded so no single command
+    // exceeds the OS argument-length limit (see MAX_APPLY_CMD_BYTES) — a large
+    // change set in one command was rejected at exec and surfaced as an opaque
+    // "EOF" (#445). We run the commands in order and stop on the first failure,
+    // so the original abort-on-first-error (`set -e`) semantics hold across the
+    // split. `label` distinguishes the delta/full path from the checksum path.
+    async function applyExtents(nbdDev: string, dev: string, extents: Extent[], capacityBytes: number, label: string, diskIndex: number): Promise<void> {
+      for (const script of buildApplyScripts(nbdDev, dev, extents, capacityBytes)) {
+        const res = await executeSSH(config.targetConnectionId, nodeIp, script, APPLY_TIMEOUT_MS)
+        if (!res.success) throw new Error(`${label} on disk ${diskIndex}: ${res.error || res.output}`)
+      }
+    }
+
     // Read one disk of a snapshot through VDDK and apply its extents to the target.
     async function readAndApply(disk: EsxiDiskInfo, diskIndex: number, snapMor: string, extents: Extent[]): Promise<number> {
       const bytes = extents.reduce((s, e) => s + e.length, 0)
@@ -297,9 +311,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password, nbdDev)
       activeReaders.push(reader)
       try {
-        const script = buildApplyScript(reader.nbdDev, targetDev.get(disk.deviceKey)!, extents, disk.capacityBytes)
-        const res = await executeSSH(config.targetConnectionId, nodeIp, script, APPLY_TIMEOUT_MS)
-        if (!res.success) throw new Error(`block apply failed on disk ${diskIndex}: ${res.error || res.output}`)
+        await applyExtents(reader.nbdDev, targetDev.get(disk.deviceKey)!, extents, disk.capacityBytes, "block apply failed", diskIndex)
         return bytes
       } finally {
         await stopVddkReader(config.targetConnectionId, nodeIp, reader).catch(() => {})
@@ -399,9 +411,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
           try {
             const dev = targetDev.get(disk.deviceKey)!
             const extents = await detectChangedExtentsByChecksum(config.targetConnectionId, nodeIp, reader.nbdDev, dev, 256 * 1024 * 1024, disk.capacityBytes)
-            const script = buildApplyScript(reader.nbdDev, dev, extents, disk.capacityBytes)
-            const res = await executeSSH(config.targetConnectionId, nodeIp, script, APPLY_TIMEOUT_MS)
-            if (!res.success) throw new Error(`checksum apply failed on disk ${i}: ${res.error || res.output}`)
+            await applyExtents(reader.nbdDev, dev, extents, disk.capacityBytes, "checksum apply failed", i)
           } finally {
             await stopVddkReader(config.targetConnectionId, nodeIp, reader).catch(() => {})
             const idx = activeReaders.indexOf(reader)


### PR DESCRIPTION
## Problem

A warm migration of a busy multi-disk VM (discussion #445) got past the v1.4.4 thick zero-fill fix and copied all 1.43 TB, then failed at the first delta pass with:

`block apply failed on disk 0: command failed: EOF`

### Root cause

The delta pass batched **every** changed block of a disk into a single SSH command. For the OS disk (the most write churn during the multi-hour copy, ~707 `dd` lines) that command grew to ~158 KB.

Linux caps a **single** `execve` argument at `MAX_ARG_STRLEN` (`PAGE_SIZE * 32` = 128 KiB), independent of the much larger total `ARG_MAX`. At ~158 KB the command is sent as one `sudo sh -c '...'` argument, so the remote exec is rejected before any `dd` runs and the SSH channel closes before the exec reply. The SSH client then surfaces a bare `io.EOF` with empty output, which is why the log showed an opaque `command failed: EOF` and no `dd` error.

This is not a network/firewall issue: the failure is deterministic at dispatch, hits only the busiest disk, is applied first, and the reporter's node diagnostics (sshd logs, OOM, fail2ban) were all clean.

## Fix

- `buildApplyScript` becomes `buildApplyScripts`, returning the `dd` lines packed into one or more commands, each kept under `MAX_APPLY_CMD_BYTES` (96 KiB). 96 KiB leaves ~26 KB of headroom under the 128 KiB limit even after the `sudo sh -c` wrapper and single-quote escaping (largest wrapped command was ~106 KB in a 2000-extent simulation).
- A shared `applyExtents` helper in `warm-pipeline.ts` runs the commands in order and stops on the first failure, so the original `set -e` abort-on-first-error behaviour holds across the split. Both apply paths (CBT delta / full copy and the checksum fallback) use it.

No orchestrator change is required: each chunk still matches the existing SSH allowlist command shape, so it is brokered exactly as before.

## Tests

- New chunking tests in `block-applier.test.ts`: a large change set splits into multiple commands, every command stays under the byte budget (and under 128 KiB), and no block is lost or reordered across chunk boundaries.
- Full warm-migration suite green (63 tests).

Refs #445
