### PR TITLE
fix(connections): surface per-node SSH test results on failure (#492)

### DIFF
--- a/frontend/src/components/settings/ConnectionDialog.tsx
+++ b/frontend/src/components/settings/ConnectionDialog.tsx
@@ -1139,31 +1139,32 @@ export default function ConnectionDialog({
 
                 {sshTestResult && (
                   <Box sx={{ mt: 2 }}>
-                    {sshTestResult.success ? (
-                      <Alert severity="success">
-                        <Typography variant="body2" sx={{ fontWeight: 600, mb: 1 }}>
-                          {t('settings.sshTestSuccess')}
-                        </Typography>
-                        {sshTestResult.nodes?.map(node => (
-                          <Box key={node.node} sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 1 }}>
-                            <i className={node.status === 'ok' ? "ri-check-line" : "ri-close-line"} 
-                               style={{ color: node.status === 'ok' ? '#22c55e' : '#ef4444' }} />
-                            <Typography variant="body2">
-                              {node.node} ({node.ip})
+                    <Alert severity={sshTestResult.success ? 'success' : 'error'}>
+                      <Typography variant="body2" sx={{ fontWeight: 600, mb: sshTestResult.nodes?.length ? 1 : 0 }}>
+                        {sshTestResult.success
+                          ? t('settings.sshTestSuccess')
+                          : (sshTestResult.error || t('settings.sshTestFailed'))}
+                      </Typography>
+                      {/* Always render the per-node breakdown when present, even when the
+                          overall test failed. In a cluster a single unreachable or
+                          misconfigured node fails the whole test; the user needs to see
+                          WHICH node failed and why instead of a bare "SSH test failed"
+                          (issue #492). */}
+                      {sshTestResult.nodes?.map(node => (
+                        <Box key={node.node} sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 1 }}>
+                          <i className={node.status === 'ok' ? "ri-check-line" : "ri-close-line"}
+                             style={{ color: node.status === 'ok' ? '#22c55e' : '#ef4444' }} />
+                          <Typography variant="body2">
+                            {node.node} ({node.ip})
+                          </Typography>
+                          {node.error && (
+                            <Typography variant="caption" color="error">
+                              - {node.error}
                             </Typography>
-                            {node.error && (
-                              <Typography variant="caption" color="error">
-                                - {node.error}
-                              </Typography>
-                            )}
-                          </Box>
-                        ))}
-                      </Alert>
-                    ) : (
-                      <Alert severity="error">
-                        {sshTestResult.error || t('settings.sshTestFailed')}
-                      </Alert>
-                    )}
+                          )}
+                        </Box>
+                      ))}
+                    </Alert>
                   </Box>
                 )}
               </Box>


### PR DESCRIPTION
## Problem

The SSH connection test (Settings → connection dialog) only rendered the per-node result breakdown when the overall test succeeded. On failure it showed a bare "SSH test failed" and discarded the `nodes` array returned by the API.

In a multi-node cluster the test reports success only if every node passes. A single unreachable or misconfigured node therefore fails the whole test, but the user was left with no indication of which node failed or why, even though that detail was already computed and returned.

## Fix

Collapse the success/failure rendering into a single `Alert` whose severity tracks `success`, and render the per-node ok/error breakdown (with each node's error) whenever per-node results are present, not only on success. A true top-level error (SSH disabled, decrypt failure, node-list fetch failure, timeout) still shows its message with no list.

## Notes

- No new i18n keys, no type changes; reduces rendering duplication rather than adding it.
- `ConnectionDialog.tsx` is already in `sonar.coverage.exclusions` (documented pure-JSX form), so no new-code coverage is triggered.
- A related backend change (orchestrator node-IP resolution) was shipped separately; this PR covers the user-facing display surfaced by it.

Fixes #492
