### PR TITLE
fix(compliance): sanitize error before logging in framework report route

### DIFF
--- a/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.ts
+++ b/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.ts
@@ -20,6 +20,7 @@ import { computeNodeBreakdown } from '@/lib/compliance/nodeBreakdown'
 import { frameworkReportHtml } from '@/lib/compliance/report/frameworkReportHtml'
 import { sanitizeFilename } from '@/lib/compliance/report/escapeHtml'
 import { renderPdf } from '@/lib/reporting/weasyprintClient'
+import { safeLog } from '@/lib/log/sanitize'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -174,7 +175,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ frameworkId: st
       },
     })
   } catch (e: any) {
-    console.error('[compliance/frameworks/report] Error:', e?.message)
+    console.error('[compliance/frameworks/report] Error:', safeLog(e?.message))
     return NextResponse.json({ error: e?.message || 'Internal server error' }, { status: 500 })
   }
 }


### PR DESCRIPTION
## What

Resolves two CodeQL code-scanning alerts on the compliance framework report route (`/api/v1/compliance/frameworks/[frameworkId]/report`).

### Alert #793 — `js/log-injection` (medium) — fixed in this PR

The caught error message was passed straight into `console.error`, so a user-derived error string could inject CR/LF and forge log entries. It is now wrapped in the repo's canonical sanitizer `safeLog()` (`@/lib/log/sanitize`), which strips CR/LF/control characters.

```diff
- console.error('[compliance/frameworks/report] Error:', e?.message)
+ console.error('[compliance/frameworks/report] Error:', safeLog(e?.message))
```

### Alert #792 — `js/user-controlled-bypass` (high) — dismissed as false positive

The flagged condition is the presence check `if (!connectionId)`. It is **not** a security decision: all authorization guards run unconditionally *after* it and cannot be bypassed via `connectionId` (`requireEnterprise()`, framework-id allow-list, `verifyConnectionOwnership(connectionId)`, `checkPermission` RBAC). The CodeQL data flow is a single node with no tainted value reaching a sensitive sink. Dismissed in the Security tab with that justification.

## Impact

No functional change. The error-path HTTP response is unchanged; only the formatting of the logged error string differs.

## Testing

Logging-only change, nothing to validate in the UI. The compliance report PDF renders identically.
