### PR TITLE
fix(migration): preserve source NIC MAC in warm and direct-ESXi migrations

### DIFF
--- a/frontend/src/lib/migration/configMapper.test.ts
+++ b/frontend/src/lib/migration/configMapper.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest"
+import { mapEsxiToPveConfig } from "./configMapper"
+import type { EsxiVmConfig } from "@/lib/vmware/soap"
+
+function makeConfig(overrides: Partial<EsxiVmConfig> = {}): EsxiVmConfig {
+  return {
+    name: "test-vm",
+    guestOS: "Ubuntu Linux (64-bit)",
+    guestId: "ubuntu64Guest",
+    numCPU: 2,
+    numCoresPerSocket: 1,
+    sockets: 2,
+    memoryMB: 2048,
+    firmware: "bios",
+    uuid: "564d-uuid",
+    vmxVersion: "vmx-19",
+    vmPathName: "[ds] test-vm/test-vm.vmx",
+    powerState: "poweredOn",
+    committed: 0,
+    disks: [],
+    nics: [{ label: "Network adapter 1", type: "Vmxnet3", macAddress: "00:50:56:aa:bb:cc", network: "VM Network" }],
+    snapshotCount: 0,
+    ...overrides,
+  }
+}
+
+describe("mapEsxiToPveConfig — NIC MAC preservation", () => {
+  it("preserves the source NIC MAC on net0", () => {
+    const p = mapEsxiToPveConfig(makeConfig(), 100, "local-lvm", "vmbr0")
+    expect(p.net0).toContain(",macaddr=00:50:56:aa:bb:cc")
+  })
+
+  it("omits macaddr when the source NIC has no MAC", () => {
+    const p = mapEsxiToPveConfig(
+      makeConfig({ nics: [{ label: "nic1", type: "Vmxnet3", macAddress: "", network: "VM Network" }] }),
+      100, "local-lvm", "vmbr0",
+    )
+    expect(p.net0).not.toContain("macaddr=")
+  })
+
+  it("omits macaddr when the source MAC is malformed", () => {
+    const p = mapEsxiToPveConfig(
+      makeConfig({ nics: [{ label: "nic1", type: "Vmxnet3", macAddress: "not-a-mac", network: "VM Network" }] }),
+      100, "local-lvm", "vmbr0",
+    )
+    expect(p.net0).not.toContain("macaddr=")
+  })
+
+  it("keeps both the preserved MAC and the VLAN tag", () => {
+    const p = mapEsxiToPveConfig(makeConfig(), 100, "local-lvm", "vmbr0", 42)
+    expect(p.net0).toContain(",macaddr=00:50:56:aa:bb:cc")
+    expect(p.net0).toContain(",tag=42")
+  })
+
+  it("preserves the MAC for a Windows guest (e1000 model)", () => {
+    const p = mapEsxiToPveConfig(
+      makeConfig({ guestId: "windows2019srv_64Guest", guestOS: "Microsoft Windows Server 2019 (64-bit)" }),
+      100, "local-lvm", "vmbr0",
+    )
+    expect(p.net0).toMatch(/^e1000,bridge=vmbr0,macaddr=00:50:56:aa:bb:cc$/)
+  })
+})
+
+describe("mapEsxiToPveConfig — baseline behavior (unchanged)", () => {
+  it("uses virtio-scsi-single + virtio NIC for Linux", () => {
+    const p = mapEsxiToPveConfig(makeConfig(), 100, "local-lvm", "vmbr0")
+    expect(p.scsihw).toBe("virtio-scsi-single")
+    expect(p.net0.startsWith("virtio,")).toBe(true)
+  })
+
+  it("uses lsi + e1000 NIC for Windows (no injected drivers)", () => {
+    const p = mapEsxiToPveConfig(
+      makeConfig({ guestId: "windows9Server64Guest", guestOS: "Microsoft Windows Server 2022 (64-bit)" }),
+      100, "local-lvm", "vmbr0",
+    )
+    expect(p.scsihw).toBe("lsi")
+    expect(p.net0.startsWith("e1000,")).toBe(true)
+  })
+})

--- a/frontend/src/lib/migration/configMapper.ts
+++ b/frontend/src/lib/migration/configMapper.ts
@@ -80,6 +80,18 @@ export function mapEsxiToPveConfig(
       ? `,tag=${vlanTag}`
       : ""
 
+  // Preserve the source NIC's MAC so the guest keeps its network identity.
+  // Without this Proxmox assigns a fresh MAC, the guest (notably Windows) sees
+  // a brand new adapter and its IP is stranded on the old "ghost" NIC. The
+  // cold/virt-v2v path already does this (see v2vConfigMapper). Only set a
+  // well-formed unicast MAC; the target boots after the source is powered off
+  // (warm cutover / direct-ESXi power-off), so there is no MAC collision.
+  const sourceMac = esxiConfig.nics[0]?.macAddress
+  const macSuffix =
+    sourceMac && /^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(sourceMac)
+      ? `,macaddr=${sourceMac}`
+      : ""
+
   const params: PveVmCreateParams = {
     vmid: targetVmid,
     name: esxiConfig.name.replace(/[^a-zA-Z0-9-]/g, "-").replace(/^-+|-+$/g, '').substring(0, 63) || 'vm',
@@ -93,7 +105,7 @@ export function mapEsxiToPveConfig(
     machine: "q35",
     boot: "order=scsi0",
     agent: "1",
-    net0: `${nicModel},bridge=${networkBridge}${tagSuffix}`,
+    net0: `${nicModel},bridge=${networkBridge}${macSuffix}${tagSuffix}`,
   }
 
   if (isEfi) {


### PR DESCRIPTION
## What

Warm and direct-ESXi migrations let Proxmox assign a fresh MAC to the migrated VM's NIC. The guest (notably Windows) then sees a brand new network adapter and its previous IP configuration is stranded on the now-absent "ghost" adapter, forcing the operator to remove the old NIC and re-IP inside the guest.

This carries the source NIC's MAC over onto the target `net0`, but only when it is a well-formed unicast MAC. It matches the cold/virt-v2v path, which already preserves the MAC.

Fixes #500.

## Why it is safe

- Purely additive to the `net0` string. No change to the function signature or the returned object shape, so the callers (`runWarmMigration`, `runMigrationPipeline`) are unaffected.
- No MAC collision: in both pipelines the source is powered off before the target boots (warm cutover with confirmed power-off, direct-ESXi power-off), so the source and target never run with the same MAC at the same time.

## Tests

New `configMapper.test.ts`: MAC preserved (Linux and Windows), omitted when absent or malformed, coexists with the VLAN tag, plus baseline `scsihw` / NIC model. Full migration suite green (88 tests).

## Validation

Validated end to end on a lab node: a warm migration produced a `net0` whose MAC was in VMware's OUI (`00:50:56:xx`), confirming the source MAC was preserved (Proxmox auto-generated MACs use a different OUI).
