### PR TITLE
fix(migration): free a stale /dev/nbdN before attaching in warm migration

### DIFF
--- a/frontend/src/lib/migration/warm/vddk-reader.test.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.test.ts
@@ -16,8 +16,14 @@ const OPTS: VddkOpts = {
 }
 
 describe("pure builders", () => {
-  it("connects the unix socket to a kernel nbd device", () => {
-    expect(buildNbdConnectCmd("/tmp/v.sock", "/dev/nbd3")).toContain("nbd-client -unix /tmp/v.sock /dev/nbd3")
+  it("frees a stale device, then connects the unix socket to a kernel nbd device", () => {
+    const c = buildNbdConnectCmd("/tmp/v.sock", "/dev/nbd3")
+    expect(c).toContain("nbd-client -unix /tmp/v.sock /dev/nbd3")
+    // Defensively detach /dev/nbd3 first: a device left allocated by a previous
+    // failed/aborted attempt otherwise blocks the attach with "Failed to setup
+    // device" on every retry (#503). The detach must precede the attach.
+    expect(c).toContain("nbd-client -d /dev/nbd3")
+    expect(c.indexOf("nbd-client -d /dev/nbd3")).toBeLessThan(c.indexOf("nbd-client -unix"))
   })
   it("tears down device, nbdkit, socket, password file", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw" })

--- a/frontend/src/lib/migration/warm/vddk-reader.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.ts
@@ -14,11 +14,16 @@ export interface VddkReaderHandle {
  * Attach an nbdkit unix socket to a kernel NBD device. `modprobe nbd` is a
  * no-op when the module is already loaded; `max_part=0` keeps the kernel from
  * scanning the source disk's partition table (we read it as a flat image).
+ * The `nbd-client -d` before the attach defensively frees the device: a
+ * /dev/nbdN left allocated by a previous failed or aborted attempt (whose
+ * teardown never ran) otherwise blocks every retry with "Failed to setup
+ * device, check dmesg" (#503). It is a no-op (suppressed) when the device is
+ * already free, so it is safe in the normal case.
  * sock/nbdDev are system-generated paths (no spaces/metacharacters), so they
  * are interpolated unescaped to match the validated spike command.
  */
 export function buildNbdConnectCmd(sock: string, nbdDev: string): string {
-  return `modprobe nbd max_part=0 2>/dev/null; nbd-client -unix ${sock} ${nbdDev} 2>&1`
+  return `modprobe nbd max_part=0 2>/dev/null; nbd-client -d ${nbdDev} 2>/dev/null; nbd-client -unix ${sock} ${nbdDev} 2>&1`
 }
 
 /**


### PR DESCRIPTION
## What

A warm (CBT) migration could fail at the NBD attach step with `Failed to setup device, check dmesg` when `/dev/nbdN` was still allocated by a previous failed or aborted attempt (its teardown never ran). Every subsequent retry then failed until the device was freed by hand (`nbd-client -d /dev/nbdN`).

This prepends a best-effort `nbd-client -d <dev>` before the attach. It is suppressed and a no-op when the device is already free, so it is safe in the normal path.

Fixes #503.

## Scope

Frontend-only. No backend change required.

## Tests

`vddk-reader.test.ts`: asserts the connect command detaches the device before it attaches (ordering enforced). Full warm migration suite green (63 tests).
