### PR TITLE
feat(migration): list SDN VNets in the migration network selector

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -772,13 +772,27 @@ export default function InventoryDetails({
         setMigTargetStorage(localLvm ? 'local-lvm' : storages[0].storage)
       }
     }).catch(() => {})
-    // Also fetch network bridges
-    fetch(`/api/v1/connections/${migTargetConn}/nodes/${fetchNode}/network`).then(r => r.json()).then(d => {
-      const bridges = (d.data || d || []).filter((iface: any) => iface.type === 'bridge' || iface.type === 'OVSBridge')
-      setMigBridges(bridges)
-      if (bridges.length > 0) {
+    // Fetch classic Linux/OVS bridges (node-scoped) AND SDN VNets (cluster-scoped),
+    // merged into one selector list. A migrated NIC accepts a VNet name in its
+    // bridge= slot exactly like a vmbr, so nodes that use SDN are no longer stuck
+    // with an empty/limited dropdown.
+    Promise.all([
+      fetch(`/api/v1/connections/${migTargetConn}/nodes/${fetchNode}/network`).then(r => r.json()).catch(() => null),
+      fetch(`/api/v1/connections/${migTargetConn}/sdn/vnets`).then(r => r.json()).catch(() => null),
+    ]).then(([net, sdn]) => {
+      const bridges = ((net?.data || net || []) as any[]).filter((iface: any) => iface.type === 'bridge' || iface.type === 'OVSBridge')
+      const vnets = ((sdn?.data?.vnets || []) as any[])
+        .filter((v: any) => typeof v.vnet === 'string' && v.vnet.length > 0)
+        .map((v: any) => ({
+          iface: v.vnet,
+          type: 'vnet',
+          comments: v.alias && v.alias !== v.vnet ? `VNet · ${v.alias}` : `VNet${v.zone ? ' · ' + v.zone : ''}`,
+        }))
+      const merged = [...bridges, ...vnets]
+      setMigBridges(merged)
+      if (merged.length > 0) {
         const vmbr0 = bridges.find((b: any) => b.iface === 'vmbr0')
-        setMigNetworkBridge(vmbr0 ? 'vmbr0' : bridges[0].iface)
+        setMigNetworkBridge(vmbr0 ? 'vmbr0' : merged[0].iface)
       }
     }).catch(() => {})
   }, [migTargetConn, migTargetNode, migNodeOptions.length])


### PR DESCRIPTION
## What

The migration dialog's target-network dropdown only listed classic Linux/OVS bridges (`vmbr...`). On nodes whose guest networks are SDN VNets, the list was empty or limited, so a VM could not be placed directly onto a VNet during migration.

This fetches `/cluster/sdn/vnets` alongside the node bridges and merges them into the selector. A migrated NIC accepts a VNet name in its `bridge=` slot exactly like a vmbr. VNets are labelled `VNet · <alias>` (or `VNet · <zone>`) so they are distinct from classic bridges. Non-SDN clusters are unaffected (the fetch tolerates an empty or failed result).

Fixes #501.

## Scope

Frontend-only, single file (`InventoryDetails.tsx`, already in `sonar.coverage.exclusions`).

## Validation

- Code-reviewed; the merge logic plus the existing dropdown rendering (which already shows the `comments` label) cover VNet items.
- Before merge: a quick no-regression browser check (classic bridges still listed, dropdown not broken). The VNet listing itself should be validated on a cluster that has SDN VNets defined.
