### PR TITLE
fix(migration): drop misleading "vSAN datastore detected" log on the vCenter NFC path

### DIFF
--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -457,7 +457,7 @@ async function runVcenterNfcExport(
    */
   snapshotMor: string | null = null,
 ): Promise<string[]> {
-  await appendLog(jobId, "vSAN datastore detected, switching to NFC transport (HttpNfcLease)", "info")
+  await appendLog(jobId, "Opening NFC export lease via vCenter (HttpNfcLease)...", "info")
 
   // Make sure the staging directory exists on the PVE node.
   await executeSSH(config.targetConnectionId, nodeIp, `mkdir -p ${shellEscape(outputDir)}`)


### PR DESCRIPTION
## What

The vCenter NFC export path logged `vSAN datastore detected, switching to NFC transport (HttpNfcLease)` unconditionally, even when the source datastore was not vSAN. This path now routes every vCenter source regardless of datastore type (NFC is faster than virt-v2v's vpx download everywhere), so the "vSAN" wording is a stale leftover that misled operators (it appeared for ordinary VMFS/NFS datastores too).

Reword the line to describe the actual step. The accurate transport announcement (`Using NFC transport (vCenter canonical API)`) already logs at the caller.

Fixes #504.

## Scope

Frontend-only, single log string. `v2v-pipeline.ts` is in `sonar.coverage.exclusions`; no test references the string.
