### PR TITLE
chore(release): v1.4.5

### DIFF
--- a/RELEASE_NOTES_v1.4.5.md
+++ b/RELEASE_NOTES_v1.4.5.md
@@ -1,0 +1,38 @@
+# ProxCenter v1.4.5
+
+**Maintenance release: security compliance frameworks, a fix for the v1.4.4 OIDC role demotion, plus a batch of migration, inventory and DRS improvements.**
+
+## Compliance (Enterprise)
+- **Security compliance frameworks.** A new Frameworks tab in Compliance assesses a connection against NIST 800-53 r5, NIST 800-171 r2, CMMC Level 2 and ISO/IEC 27001:2022, reusing the existing hardening checks through a check-to-control crosswalk. Each framework shows a score donut and a satisfied / partial / failed breakdown, with a per-node result table, and exports a styled PDF report (cover, per-control table, provenance and source link) rendered by the WeasyPrint sidecar.
+
+## RBAC & access
+- **OIDC role preserved on login (v1.4.4 regression fix).** v1.4.4 re-derived every OIDC user's role from IdP groups on each login and demoted anyone with no group match to viewer, which could lock out admins whose role was assigned manually. The re-sync is now authoritative only when a group-to-role mapping is configured and the IdP actually sent a groups array; otherwise the existing assignment is preserved, mirroring the LDAP path. First login still seeds the configured default role.
+- **Correct OIDC account handling.** OIDC accounts now show an OIDC auth method instead of being labelled "Local", and setting a local password is blocked on OIDC and LDAP accounts on every surface (user edit dialog, profile, and the API), so an SSO account cannot gain a credentials login path that bypasses SSO and MFA. The profile shows "OIDC / SSO" as the login method with a provider-aware notice.
+
+## Migration
+- **SDN VNets in the network selector.** The migration target-network dropdown now lists SDN VNets alongside classic Linux and OVS bridges, so nodes whose guest networks are VNets no longer get an empty list. VNets are labelled to distinguish them from bridges, and non-SDN clusters are unaffected.
+- **Source MAC preserved.** Warm and direct-ESXi migrations now carry over the source NIC's MAC address (matching the cold / virt-v2v path), so the migrated guest keeps its network identity instead of booting with a fresh adapter and a stranded IP. The target boots only after the source is powered off, so there is no MAC collision.
+- **Warm migration reliability.** A stale /dev/nbdN device is now released before attaching, and the warm delta-apply is chunked to stay under the SSH argument-size limit, so large or busy disks no longer fail late in the transfer.
+- **Cleaner vCenter logs.** The misleading "vSAN datastore detected" line is no longer logged on the vCenter NFC path.
+- **Running LXC migration fixed.** Migrating a running container now uses restart mode (restart=1) instead of online=1, which Proxmox rejects for containers, so an online CT migration no longer fails outright.
+
+## Inventory
+- **Open in Proxmox.** A button next to the cluster or node name opens the native Proxmox web interface in a new tab. Clusters and standalone hosts open the connection origin; a cluster member node deep-links to its own management IP, falling back to the connection origin when the node IP is unknown or the connection sits behind a reverse proxy.
+- **Network view on VM-less clusters.** The Inventory Network view now enumerates host bridges and VLANs per node, so a cluster with no VMs is no longer empty. Bridges are listed once at the node level and open a detail panel (type, VLAN, IP/CIDR, ports, vlan-aware, active/autostart, attached VMs); SDN VNet ids resolve to their friendly alias. Provider / full-cluster scope only; vDC tenants keep their pool-filtered, VM-derived data.
+- **Per-tenant tree state.** The inventory tree expand/collapse state is scoped per tenant, so switching tenant no longer carries over the previous tenant's expansion.
+- **Clearer VM delete dialog.** The VM delete confirmation dialog spells out exactly what will be removed.
+- **No clipped "100%".** The percent chart Y-axis is widened so the "100%" label is no longer clipped.
+
+## DRS & maintenance
+- **Balance Types is now honored.** The DRS load balancer respects the VM / CT Balance Types selection, which was previously a dead knob: candidates are filtered by guest type for both reactive balancing and homogenization, the setting is persisted and validated (an empty or non vm/ct value is rejected), and a guest-type gate is applied at execution time so a stale recommendation cannot move a guest of an excluded type.
+- **Simpler node maintenance.** Entering node maintenance now just triggers Proxmox node-maintenance (HA guests are evacuated and spread by Proxmox), with a note that non-HA guests must be migrated or shut down manually. The forced single-target migration and the client-side storage scan are gone; the SSH-required notice and a disabled confirm button show only when SSH is disabled.
+- **DRS settings cleanup.** The settings panel drops the balancing-method and balancing-mode selectors (knobs the engine never read, which also silences a backend warning), guards the Balance Types selection at a minimum of one, puts the three resource-weight sliders on one row, and adds cluster, node and guest icons with status across the exclusions and balance-types controls.
+
+## Connections
+- **Per-node SSH test results on failure.** The cluster SSH test now shows the per-node ok / error breakdown on failure too, so one unreachable or misconfigured node no longer hides behind a bare "SSH test failed". The orchestrator resolves each node's own management IP for the test rather than reusing the connection endpoint.
+
+## Reliability
+- **No stale task re-alerts.** Old completed tasks are no longer surfaced as new alerts about a week after they ran, when the event poller's dedup window outlived Proxmox task retention.
+
+## Security
+- **Patched orchestrator CVEs.** The Go orchestrator's dependencies are bumped (golang.org/x/crypto, x/net, x/sys) to clear the SSH, HTML and IDNA advisories.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxcenter",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "license": "Commercial",
   "private": true,
   "scripts": {

--- a/frontend/src/data/changelog.json
+++ b/frontend/src/data/changelog.json
@@ -1,5 +1,30 @@
 [
   {
+    "version": "1.4.5",
+    "title": "Compliance frameworks, DRS load balancing & OIDC role fix",
+    "items": [
+      { "type": "new", "text": "Security compliance frameworks (Enterprise): assess a connection against NIST 800-53, NIST 800-171, CMMC Level 2 and ISO/IEC 27001 from a new Frameworks tab, with a score donut, satisfied / partial / failed breakdown, per-node results and a styled PDF report" },
+      { "type": "new", "text": "Open in Proxmox: a button next to the cluster or node name opens the native Proxmox web interface in a new tab, deep-linking a member node to its own management IP" },
+      { "type": "new", "text": "The migration target-network selector now lists SDN VNets alongside classic bridges, so nodes whose guest networks are VNets no longer get an empty list" },
+      { "type": "improved", "text": "Inventory Network view shows host bridges and VLANs per node, so clusters with no VMs are no longer empty; bridges open a detail panel and SDN VNet ids resolve to their friendly alias" },
+      { "type": "improved", "text": "Node maintenance is simpler: entering maintenance triggers Proxmox node-maintenance (HA guests evacuated by Proxmox) with a note that non-HA guests must be migrated or shut down manually" },
+      { "type": "improved", "text": "DRS now honors the Balance Types setting (previously a dead knob): load-balancing candidates are filtered by guest type for both reactive balancing and homogenization, with a guest-type gate applied at execution time" },
+      { "type": "improved", "text": "DRS settings cleanup: removed the dead balancing-method and balancing-mode knobs, guarded balance-types at a minimum of one, one-row resource weights, and status icons on exclusions and balance-types" },
+      { "type": "improved", "text": "The inventory tree expand/collapse state is now scoped per tenant, so switching tenant no longer carries over the previous expansion" },
+      { "type": "improved", "text": "The cluster SSH test shows the per-node ok / error breakdown on failure too, not just on success" },
+      { "type": "improved", "text": "The VM delete confirmation dialog spells out exactly what will be removed" },
+      { "type": "fix", "text": "OIDC role preserved on login: v1.4.4 demoted OIDC users with no IdP group match to viewer on every sign-in (locking out manually assigned admins); the re-sync is now authoritative only when a group-to-role mapping is configured and groups are sent" },
+      { "type": "fix", "text": "OIDC accounts are labelled correctly and can no longer be given a local password, closing a credentials login path that would bypass SSO and MFA" },
+      { "type": "fix", "text": "Warm and direct-ESXi migrations preserve the source NIC MAC, so the migrated guest keeps its network identity instead of stranding its IP on a ghost adapter" },
+      { "type": "fix", "text": "Warm migration reliability: a stale /dev/nbdN device is released before attaching and the delta-apply is chunked under the SSH argument-size limit" },
+      { "type": "fix", "text": "Migrating a running LXC container now uses restart mode instead of online=1 (which Proxmox rejects for containers), so an online CT migration no longer fails outright" },
+      { "type": "fix", "text": "Dropped the misleading \"vSAN datastore detected\" log line on the vCenter migration path" },
+      { "type": "fix", "text": "The percent chart Y-axis is widened so the \"100%\" label is no longer clipped" },
+      { "type": "fix", "text": "Old completed tasks are no longer re-alerted as new events about a week after they ran" },
+      { "type": "fix", "text": "Security: patched Go orchestrator CVEs by bumping golang.org/x/crypto, x/net and x/sys (SSH, HTML and IDNA advisories)" }
+    ]
+  },
+  {
     "version": "1.4.4",
     "title": "Stability, security & shared migration tasks",
     "items": [


### PR DESCRIPTION
## ProxCenter v1.4.5 — release notes & What's New

Release PR for v1.4.5: adds `RELEASE_NOTES_v1.4.5.md`, the v1.4.5 What's New entry (`frontend/src/data/changelog.json`), and bumps `frontend/package.json` to 1.4.5.

Merging this and tagging `v1.4.5` triggers the Docker build. The orchestrator is tagged at the same version.

### Highlights
- **Compliance frameworks (Enterprise):** assess a connection against NIST 800-53, NIST 800-171, CMMC Level 2 and ISO/IEC 27001, with a score donut, per-node breakdown and a styled PDF report.
- **DRS load balancing:** the Balance Types setting is now honored (previously a dead knob); load-balancing candidates are filtered by guest type, with a guest-type gate applied at execution time. Node maintenance and the DRS settings panel are simplified.
- **OIDC role fix (v1.4.4 regression):** the manually-assigned role is preserved on login unless a group-to-role mapping is configured and the IdP sends groups; OIDC accounts are labelled correctly and can no longer be given a local password that bypasses SSO/MFA.
- **Migration:** SDN VNets in the network selector, source NIC MAC preserved (warm and direct-ESXi), warm-migration reliability fixes, and a running-LXC migration fix.
- **Inventory:** open the native Proxmox UI from cluster/node headers, host bridges and VLANs on VM-less clusters, per-tenant tree state, and a clearer VM delete dialog.
- **Security:** orchestrator dependency CVEs patched.

Full list in `RELEASE_NOTES_v1.4.5.md`.
