### PR TITLE
Security: WeasyPrint sidecar exposes internal error details to clients

### DIFF
--- a/weasyprint/server.py
+++ b/weasyprint/server.py
@@ -40,9 +40,9 @@ def render() -> Response:
         # base_url=None disables remote resource fetching by default; the Go
         # caller embeds CSS / images inline in the report templates.
         pdf_bytes = HTML(string=html).write_pdf()
-    except Exception as exc:  # noqa: BLE001 — surface the rendering failure verbatim.
+    except Exception as exc:  # noqa: BLE001 — log full details, return generic message.
         log.exception("PDF rendering failed")
-        return jsonify(error=str(exc)), 500
+        return jsonify(error="PDF rendering failed"), 500
 
     return Response(pdf_bytes, mimetype="application/pdf")
 


### PR DESCRIPTION
## Problem

The /render endpoint returns the raw exception message to clients via `str(exc)`. This can leak internal information such as file paths, WeasyPrint version details, or rendering engine internals that could aid attackers in fingerprinting or further exploitation.

**Severity**: `medium`
**File**: `weasyprint/server.py`

## Solution

Replace the verbose error response with a generic message while logging the full exception internally:


## Changes

- `weasyprint/server.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
