### PR TITLE
fix(auth): create the membership on tenant switch so super-admins can switch

### DIFF
--- a/frontend/src/app/api/v1/auth/switch-tenant/route.test.ts
+++ b/frontend/src/app/api/v1/auth/switch-tenant/route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute } from '../../../../../__tests__/setup/route-test'
+
+const {
+  sessionMock,
+  accessMock,
+  findUniqueMock,
+  txMock,
+  updateManyMock,
+  upsertMock,
+  auditMock,
+} = vi.hoisted(() => ({
+  sessionMock: vi.fn(),
+  accessMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+  txMock: vi.fn(),
+  updateManyMock: vi.fn(),
+  upsertMock: vi.fn(),
+  auditMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: () => sessionMock() }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/tenant', () => ({ userHasAccessToTenant: (...a: any[]) => accessMock(...a) }))
+vi.mock('@/lib/audit', () => ({ audit: (...a: any[]) => auditMock(...a) }))
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    tenant: { findUnique: (...a: any[]) => findUniqueMock(...a) },
+    userTenant: {
+      updateMany: (...a: any[]) => updateManyMock(...a),
+      upsert: (...a: any[]) => upsertMock(...a),
+    },
+    $transaction: (...a: any[]) => txMock(...a),
+  },
+}))
+vi.mock('@/lib/cache/inventoryCache', () => ({ invalidateInventoryCache: vi.fn() }))
+vi.mock('@/lib/cache/nodeIpCache', () => ({ invalidateNodeIpCache: vi.fn() }))
+vi.mock('@/lib/connections/getConnection', () => ({ invalidateConnectionCache: vi.fn() }))
+
+beforeEach(() => {
+  sessionMock.mockReset().mockResolvedValue({ user: { id: 'u1', email: 'admin@x' } })
+  accessMock.mockReset().mockResolvedValue(true)
+  findUniqueMock.mockReset().mockResolvedValue({ id: 'tenant-aid', name: 'AID', enabled: true })
+  updateManyMock.mockReset().mockReturnValue({ op: 'updateMany' })
+  upsertMock.mockReset().mockReturnValue({ op: 'upsert' })
+  txMock.mockReset().mockResolvedValue([])
+  auditMock.mockReset().mockResolvedValue(undefined)
+})
+
+describe('POST /api/v1/auth/switch-tenant', () => {
+  it('creates the membership when a super-admin switches to a tenant they do not yet belong to', async () => {
+    // A super-admin sees every tenant in the switcher but only has a
+    // user_tenants row for tenants created while already super-admin. Setting
+    // the new default must upsert (not updateMany) so the switch isn't a
+    // silent no-op when the row is missing.
+    const { POST } = await import('./route')
+    const res = await callRoute(POST, { body: { tenantId: 'tenant-aid' } })
+
+    expect(res.status).toBe(200)
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_tenantId: { userId: 'u1', tenantId: 'tenant-aid' } },
+        update: { isDefault: true },
+        create: expect.objectContaining({ userId: 'u1', tenantId: 'tenant-aid', isDefault: true }),
+      }),
+    )
+  })
+
+  it('clears the previous default before setting the new one', async () => {
+    const { POST } = await import('./route')
+    await callRoute(POST, { body: { tenantId: 'tenant-aid' } })
+
+    expect(updateManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'u1' }, data: { isDefault: false } }),
+    )
+  })
+
+  it('rejects a tenant the user cannot access with 403 and writes nothing', async () => {
+    accessMock.mockResolvedValue(false)
+    const { POST } = await import('./route')
+    const res = await callRoute(POST, { body: { tenantId: 'tenant-x' } })
+
+    expect(res.status).toBe(403)
+    expect(txMock).not.toHaveBeenCalled()
+    expect(upsertMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/auth/switch-tenant/route.ts
+++ b/frontend/src/app/api/v1/auth/switch-tenant/route.ts
@@ -43,14 +43,23 @@ export async function POST(req: NextRequest) {
   // Update the user's default tenant: clear any other default, mark this one.
   // Wrapped in a transaction so a partial failure can't leave a user with
   // zero or two default memberships.
+  //
+  // The target membership is upserted, not just updated: a super-admin sees
+  // every tenant in the switcher (cross-tenant access by design) but only has
+  // a user_tenants row for tenants created while they were already super-admin
+  // (createTenant auto-attaches them). Without the create branch, switching to
+  // a tenant the user has no row for updated zero rows, left no default, and
+  // silently fell back to `default`. userHasAccessToTenant already authorised
+  // the target above, so creating the row here is safe.
   await prisma.$transaction([
     prisma.userTenant.updateMany({
       where: { userId: session.user.id },
       data: { isDefault: false },
     }),
-    prisma.userTenant.updateMany({
-      where: { userId: session.user.id, tenantId },
-      data: { isDefault: true },
+    prisma.userTenant.upsert({
+      where: { userId_tenantId: { userId: session.user.id, tenantId } },
+      update: { isDefault: true },
+      create: { userId: session.user.id, tenantId, isDefault: true, joinedAt: new Date() },
     }),
   ])
 


### PR DESCRIPTION
## Problem

A super-admin sees every tenant in the tenant switcher (cross-tenant access by design: `getUserTenants` returns all enabled tenants), but they only get a `user_tenants` membership row for tenants created while they were already a super-admin (`createTenant` auto-attaches them).

`POST /api/v1/auth/switch-tenant` set the new default tenant with an `updateMany` keyed on an existing membership row:

```
updateMany({ where: { userId } }, { isDefault: false })            // clears the old default
updateMany({ where: { userId, tenantId } }, { isDefault: true })   // 0 rows when no membership exists
```

For a super-admin without a membership row for the target tenant, the second `updateMany` matched zero rows: no default was set, and on the next session refresh the JWT fell back to the provider tenant (`default`). The switch silently did nothing.

This affected a customer whose super-admin account was granted the role after the tenants already existed: it could pick the other tenants in the switcher but always landed back on the provider tenant.

## Fix

Upsert the target membership instead of updating it. Access is already authorised by `userHasAccessToTenant` above (super-admins are cross-tenant by design and are pinned to every tenant elsewhere in the codebase), so creating the row is correct. It also self-heals existing super-admins on their first switch, so no data migration is needed.

## Tests

Adds the first tests for this route (it had none):

- creates the membership when a super-admin switches to a tenant they do not yet belong to (the fix)
- clears the previous default before setting the new one (regression guard)
- rejects a tenant the user cannot access with 403 and writes nothing (regression guard)

Validated in the browser: a super-admin member of `default` only switched to another tenant, a `user_tenants` row was created with `is_default = true`, and the session stayed on the selected tenant instead of snapping back to the provider tenant.
