### PR TITLE
fix(templates): allow VM names starting with a digit (#522)

### DIFF
--- a/frontend/src/lib/schemas.test.ts
+++ b/frontend/src/lib/schemas.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { deploySchema } from './schemas'
+
+// vmName follows Proxmox DNS-hostname rules (RFC 1123): a label may start
+// with a digit. Regression guard for #522 — names like "2604-kdcs-002" were
+// rejected with "Invalid VM name" because the regex forced a leading letter.
+describe('deploySchema vmName', () => {
+  const vmName = deploySchema.shape.vmName
+
+  it('accepts a name starting with a digit (#522)', () => {
+    expect(vmName.safeParse('2604-kdcs-002').success).toBe(true)
+  })
+
+  it('accepts a name starting with a letter', () => {
+    expect(vmName.safeParse('web-server-01').success).toBe(true)
+  })
+
+  it('accepts dots and underscores', () => {
+    expect(vmName.safeParse('db1.prod_east').success).toBe(true)
+  })
+
+  it('is optional', () => {
+    expect(vmName.safeParse(undefined).success).toBe(true)
+  })
+
+  it('rejects names with spaces or illegal characters', () => {
+    expect(vmName.safeParse('my vm').success).toBe(false)
+    expect(vmName.safeParse('vm@host').success).toBe(false)
+  })
+
+  it('rejects names longer than 63 characters', () => {
+    expect(vmName.safeParse('a'.repeat(64)).success).toBe(false)
+  })
+})

--- a/frontend/src/lib/schemas.ts
+++ b/frontend/src/lib/schemas.ts
@@ -323,7 +323,9 @@ export const deploySchema = z.object({
   // the resolved image is an install-media ISO (image.format === 'iso').
   isoStorage: z.string().optional(),
   vmid: z.number().int().min(100).max(999999999),
-  vmName: z.string().max(63).regex(/^[a-zA-Z][a-zA-Z0-9._-]*$/, 'Invalid VM name').optional(),
+  // Proxmox VM names follow DNS-hostname rules (RFC 1123): a label may start
+  // with a digit, so names like "2604-kdcs-002" are valid (see issue #522).
+  vmName: z.string().max(63).regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/, 'Invalid VM name').optional(),
   imageSlug: z.string().min(1, 'imageSlug is required'),
   blueprintId: z.string().optional(),
   hardware: z.object({


### PR DESCRIPTION
## Summary

Deploying a template VM with a name that starts with a digit (e.g. `2604-kdcs-002`) failed with "Invalid input". The `deploySchema.vmName` validation required a leading letter (`^[a-zA-Z]`), so any digit-leading name was rejected before the deploy request reached the backend.

Proxmox VM names follow DNS-hostname rules (RFC 1123), where a label may start with a digit, so the validation was too strict.

## Change

- Relax the `vmName` regex from `^[a-zA-Z][a-zA-Z0-9._-]*$` to `^[a-zA-Z0-9][a-zA-Z0-9._-]*$` (allow a leading digit; all other rules unchanged: max 63 chars, charset `a-zA-Z0-9._-`).
- Add `schemas.test.ts` covering the digit-leading regression plus guards for the existing constraints (illegal characters, length, optionality).

## Testing

- `vitest run src/lib/schemas.test.ts` — 6/6 pass (the digit-leading case fails before the fix, passes after).
- Verified in the browser: deploying an Ubuntu 22.04 template named `2604-kdcs-002` now succeeds.

Fixes #522
