### PR TITLE
feat(rbac): scope inventory/topology tree + connections list to RBAC infra grants

### DIFF
--- a/frontend/src/@menu/menuData.js
+++ b/frontend/src/@menu/menuData.js
@@ -33,9 +33,11 @@ export const menuData = (t = (key) => key) => [
         href: '/infrastructure/topology',
         permissions: ['vm.view', 'node.view'],
         // Cluster-wide layout (nodes / shared storages / SDN graph) is a
-        // provider concern — tenants don't manage placement and it would
-        // re-leak the node names we hide elsewhere.
-        requires: { isProviderTenant: true }
+        // provider concern. Hidden for tenants (isProviderTenant) and for
+        // VM / tag / pool scoped roles (infraScope). Both would re-leak the
+        // node names we hide everywhere else in those views, even though such
+        // roles legitimately keep vm.view to see and start/stop their guests.
+        requires: { isProviderTenant: true, infraScope: true }
       },
       {
         label: t('navigation.storage'),

--- a/frontend/src/app/(dashboard)/infrastructure/topology/page.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/page.tsx
@@ -9,6 +9,8 @@ import { ReactFlowProvider } from '@xyflow/react'
 
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import { useTenant } from '@/contexts/TenantContext'
+import { useRBAC } from '@/contexts/RBACContext'
+import { hasInfraScope } from '@/lib/rbac/scopeKinds'
 
 import type { TopologyFilters, SelectedNodeInfo } from './types'
 import { useTopologyData } from './hooks/useTopologyData'
@@ -21,17 +23,22 @@ import TopologyGeoView from './components/TopologyGeoView'
 export default function TopologyPage() {
   const t = useTranslations()
   const { setPageInfo } = usePageTitle()
-  // Topology view is provider-only — also gated in the menu via
-  // requires.isProviderTenant. Redirect tenants who hit the URL directly
-  // (bookmark, copy-paste) instead of letting them load a graph that
-  // would re-leak node names hidden everywhere else in the tenant view.
+  // Topology view is provider-only and infra-scope-only. It is also gated in
+  // the menu via requires.isProviderTenant + requires.infraScope. Redirect
+  // anyone who hits the URL directly (bookmark, copy-paste) without those
+  // rights, instead of letting them load a graph that would re-leak node
+  // names hidden everywhere else: tenants, and VM / tag / pool scoped roles
+  // (which legitimately keep vm.view to see and start/stop their own guests).
   const { currentTenant, loading: tenantLoading } = useTenant()
+  const { scopeTypes, isAdmin, loading: rbacLoading } = useRBAC()
+  const isProvider = !currentTenant || currentTenant.id === 'default'
+  const allowed = isProvider && hasInfraScope(scopeTypes, isAdmin)
   const router = useRouter()
   useEffect(() => {
-    if (!tenantLoading && currentTenant && currentTenant.id !== 'default') {
+    if (!tenantLoading && !rbacLoading && !allowed) {
       router.replace('/')
     }
-  }, [tenantLoading, currentTenant, router])
+  }, [tenantLoading, rbacLoading, allowed, router])
 
   const [filters, setFilters] = useState<TopologyFilters>({
     vmThreshold: 8,
@@ -64,10 +71,10 @@ export default function TopologyPage() {
     setSelectedNode(node)
   }, [])
 
-  // Hold the render until the tenant context has loaded and the redirect
-  // above has had a chance to fire. Avoids a one-frame flash of the graph
-  // for tenants who landed via direct URL.
-  if (tenantLoading || (currentTenant && currentTenant.id !== 'default')) {
+  // Hold the render until the tenant + RBAC contexts have loaded and the
+  // redirect above has had a chance to fire. Avoids a one-frame flash of the
+  // graph for users who landed via direct URL without infra rights.
+  if (tenantLoading || rbacLoading || !allowed) {
     return null
   }
 

--- a/frontend/src/app/api/v1/connections/connectionListScope.test.ts
+++ b/frontend/src/app/api/v1/connections/connectionListScope.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../__tests__/setup/route-test"
 
-const { findManyGlobalMock, findManySessionMock, getInfraMock, checkPermissionMock } = vi.hoisted(() => ({
+const { findManyGlobalMock, findManySessionMock, getInfraMock, checkPermissionMock, getRBACContextMock, getRbacInfraScopeMock } = vi.hoisted(() => ({
   findManyGlobalMock: vi.fn(),
   findManySessionMock: vi.fn(),
   getInfraMock: vi.fn(),
   checkPermissionMock: vi.fn(),
+  getRBACContextMock: vi.fn(),
+  getRbacInfraScopeMock: vi.fn(),
 }))
 
 vi.mock("@/lib/tenant", () => ({
@@ -20,6 +22,14 @@ vi.mock("@/lib/db/prisma", () => ({ prisma: { connection: { findMany: findManyGl
 vi.mock("@/lib/rbac", () => ({
   checkPermission: () => checkPermissionMock(),
   PERMISSIONS: { CONNECTION_VIEW: "connection.view", CONNECTION_MANAGE: "connection.manage" },
+  getRBACContext: () => getRBACContextMock(),
+  getRbacInfraScope: (...a: any[]) => getRbacInfraScopeMock(...a),
+  filterVisibleConnections: (list: Array<{ id: string }>, scope: any) => {
+    if (scope === null) return list
+    return list.filter((item: { id: string }) => {
+      return scope.fullConnections?.has(item.id) || scope.nodesByConnection?.has(item.id)
+    })
+  },
 }))
 vi.mock("@/lib/crypto/secret", () => ({ encryptSecret: (s: string) => `enc:${s}` }))
 vi.mock("@/lib/schemas", () => ({ createConnectionSchema: { safeParse: (b: any) => ({ success: true, data: b }) } }))
@@ -35,6 +45,9 @@ beforeEach(() => {
   findManyGlobalMock.mockReset().mockResolvedValue([])
   findManySessionMock.mockReset().mockResolvedValue([])
   getInfraMock.mockReset()
+  // Default: no RBAC context (unauthenticated / unrestricted path)
+  getRBACContextMock.mockReset().mockResolvedValue(null)
+  getRbacInfraScopeMock.mockReset().mockResolvedValue(null)
 })
 
 describe("GET /api/v1/connections scope", () => {
@@ -64,5 +77,44 @@ describe("GET /api/v1/connections scope", () => {
     const res = await callRoute(GET, { method: "GET" })
     expect(res.status).toBe(200)
     expect(new Set(findManyGlobalMock.mock.calls[0][0].where.id.in)).toEqual(new Set(["p1", "p2", "pbs1"]))
+  })
+
+  it("provider + node/connection-scoped RBAC user: list filtered to the scoped connection only", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "user-rbac", isAdmin: false, tenantId: "tenant-x" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["connA"]),
+      nodesByConnection: new Map(),
+    })
+    const rows = [
+      { id: "connA", name: "A", type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false, hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null, fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null, sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(), hosts: [] },
+      { id: "connB", name: "B", type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false, hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null, fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null, sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(), hosts: [] },
+      { id: "connC", name: "C", type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false, hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null, fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null, sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(), hosts: [] },
+    ]
+    findManyGlobalMock.mockResolvedValue(rows)
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].id).toBe("connA")
+    // provider where clause must not have an id filter (prisma query is untouched)
+    expect(findManyGlobalMock.mock.calls[0][0].where?.id).toBeUndefined()
+  })
+
+  it("provider + admin: full list returned, getRbacInfraScope not consulted", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "admin-user", isAdmin: true, tenantId: "tenant-x" })
+    const rows = [
+      { id: "connA", name: "A", type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false, hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null, fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null, sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(), hosts: [] },
+      { id: "connB", name: "B", type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false, hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null, fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null, sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(), hosts: [] },
+    ]
+    findManyGlobalMock.mockResolvedValue(rows)
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toHaveLength(2)
+    expect(getRbacInfraScopeMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/connections/route.ts
+++ b/frontend/src/app/api/v1/connections/route.ts
@@ -6,7 +6,7 @@ import { getSessionPrisma, getCurrentTenantId, DEFAULT_TENANT_ID } from "@/lib/t
 import { prisma as globalPrisma } from "@/lib/db/prisma"
 import { getTenantInfrastructureScope } from "@/lib/tenant/infraScope"
 import { encryptSecret } from "@/lib/crypto/secret"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, PERMISSIONS, getRBACContext, getRbacInfraScope, filterVisibleConnections } from "@/lib/rbac"
 import { createConnectionSchema } from "@/lib/schemas"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -39,6 +39,13 @@ export async function GET(req: Request) {
     // msp sees the connections it directly owns (Connection.tenant_id).
     const tenantId = await getCurrentTenantId()
     const infra = await getTenantInfrastructureScope(tenantId)
+
+    // RBAC infra-scope: resolve once before the query so post-fetch filtering
+    // is O(1). Null means unrestricted (admin or global-scope grant).
+    const rbacCtx = await getRBACContext()
+    const rbacScope = rbacCtx && !rbacCtx.isAdmin
+      ? await getRbacInfraScope(rbacCtx.userId, rbacCtx.tenantId)
+      : null
 
     let prisma: typeof globalPrisma | Awaited<ReturnType<typeof getSessionPrisma>>
     if (infra.kind === "provider") {
@@ -123,8 +130,14 @@ export async function GET(req: Request) {
       },
     })
 
+    // RBAC post-query filter: applied in memory after the prisma query so the
+    // provider branch where clause is not touched (preserves existing behaviour
+    // for admin/null scope). filterVisibleConnections is a no-op when rbacScope
+    // is null (admin or unrestricted user).
+    const visibleConnections = filterVisibleConnections(connections, rbacScope)
+
     // Calculer sshConfigured en mémoire sans N+1 queries
-    const connectionsWithSSHStatus = connections.map((conn) => {
+    const connectionsWithSSHStatus = visibleConnections.map((conn) => {
       const { sshKeyEnc, sshPassEnc, ...rest } = conn
 
       return {

--- a/frontend/src/app/api/v1/inventory/events/inventoryEventsScope.test.ts
+++ b/frontend/src/app/api/v1/inventory/events/inventoryEventsScope.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { callRoute } from "../../../../../__tests__/setup/route-test"
 
 // Hoist mocks so vi.mock factories can reference them
-const { getInfraMock, subscribeMock, tenantConnectionIdsMock } = vi.hoisted(() => ({
+const { getInfraMock, subscribeMock, tenantConnectionIdsMock, getRbacInfraScopeMock, getRBACContextMock } = vi.hoisted(() => ({
   getInfraMock: vi.fn(),
   subscribeMock: vi.fn(),
   tenantConnectionIdsMock: vi.fn(),
+  getRbacInfraScopeMock: vi.fn(),
+  getRBACContextMock: vi.fn(),
 }))
 
 // Keep real maskingScope; only stub getTenantInfrastructureScope
@@ -20,10 +22,17 @@ vi.mock("@/lib/tenant", () => ({
   getTenantConnectionIds: (...a: any[]) => tenantConnectionIdsMock(...a),
 }))
 
-vi.mock("@/lib/rbac", () => ({
-  checkPermission: vi.fn().mockResolvedValue(null),
-  PERMISSIONS: { VM_VIEW: "vm.view" },
-}))
+// Use real isConnectionVisible from infraScope; mock only the DB-touching helpers
+vi.mock("@/lib/rbac", async (orig) => {
+  const real = await orig<typeof import("@/lib/rbac")>()
+  return {
+    ...real,
+    checkPermission: vi.fn().mockResolvedValue(null),
+    PERMISSIONS: { VM_VIEW: "vm.view" },
+    getRBACContext: (...a: any[]) => getRBACContextMock(...a),
+    getRbacInfraScope: (...a: any[]) => getRbacInfraScopeMock(...a),
+  }
+})
 
 vi.mock("@/lib/demo/demo-api", () => ({
   demoResponse: vi.fn().mockReturnValue(null),
@@ -78,6 +87,9 @@ const VM_EVENT = {
 beforeEach(() => {
   vi.clearAllMocks()
   tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+  // Default: admin context — no RBAC pruning.
+  getRBACContextMock.mockResolvedValue({ userId: "u1", isAdmin: true, tenantId: "t1" })
+  getRbacInfraScopeMock.mockResolvedValue(null)
   // Default: subscribe immediately calls the handler with the VM_EVENT and
   // returns a no-op unsubscribe.
   subscribeMock.mockImplementation((fn: (evs: any[]) => void) => {
@@ -163,5 +175,164 @@ describe("GET /api/v1/inventory/events scope routing", () => {
 
     expect(getInfraMock).toHaveBeenCalled()
     expect(getVdcScope).not.toHaveBeenCalled()
+  })
+
+  it("RBAC scope: vm:* event is DROPPED when connection not in user scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    // Non-admin user whose scope only covers connection c2, not c1
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["c2"]),
+      nodesByConnection: new Map(),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res, { stopAfterConnected: true })
+    expect(text).toContain("event: connected")
+    // VM_EVENT is on c1 which is not in the scope -> must be dropped
+    expect(text).not.toContain("event: vm:update")
+  })
+
+  it("RBAC scope: vm:* event PASSES when connection is in user scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    // Non-admin user whose scope covers connection c1
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["c1"]),
+      nodesByConnection: new Map(),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res)
+    expect(text).toContain("event: vm:update")
+    expect(text).toContain('"connId":"c1"')
+  })
+
+  it("RBAC scope: admin context passes all events regardless of scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    // Admin: getRbacInfraScope should not even be called; isAdmin=true => rbacScope=null
+    getRBACContextMock.mockResolvedValue({ userId: "u1", isAdmin: true, tenantId: "t1" })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res)
+    expect(text).toContain("event: vm:update")
+    // Scope lookup must not be called for admins
+    expect(getRbacInfraScopeMock).not.toHaveBeenCalled()
+  })
+
+  it("RBAC scope: node:update is DROPPED when node not in user scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    // User can see c1 but only node2, not node1
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["c1", new Set(["node2"])]]),
+    })
+
+    const NODE_EVENT = {
+      event: "node:update" as const,
+      connId: "c1",
+      node: "node1",
+      status: "online",
+    }
+    subscribeMock.mockImplementation((fn: (evs: any[]) => void) => {
+      fn([NODE_EVENT])
+      return () => {}
+    })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res, { stopAfterConnected: true })
+    expect(text).not.toContain("event: node:update")
+  })
+
+  it("RBAC node-scope: vm:update is DROPPED when node not in user scope (leak fix)", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    // User can see c1 but only node2; VM_EVENT is on node1 -> must be dropped
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["c1", new Set(["node2"])]]),
+    })
+    // VM_EVENT.node = "node1" which is NOT granted
+    subscribeMock.mockImplementation((fn: (evs: any[]) => void) => {
+      fn([VM_EVENT])
+      return () => {}
+    })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res, { stopAfterConnected: true })
+    expect(text).toContain("event: connected")
+    expect(text).not.toContain("event: vm:update")
+  })
+
+  it("RBAC node-scope: vm:update PASSES when node is in user scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    // User can see c1 node1; VM_EVENT is on node1 -> must pass
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["c1", new Set(["node1"])]]),
+    })
+    // VM_EVENT.node = "node1" which IS granted; no pool masking (kind: provider)
+    subscribeMock.mockImplementation((fn: (evs: any[]) => void) => {
+      fn([VM_EVENT])
+      return () => {}
+    })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res)
+    expect(text).toContain("event: vm:update")
+    expect(text).toContain('"connId":"c1"')
+  })
+
+  it("RBAC scope: node:update PASSES when node is in user scope", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "t1" })
+    // User can see c1 node1
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["c1", new Set(["node1"])]]),
+    })
+
+    const NODE_EVENT = {
+      event: "node:update" as const,
+      connId: "c1",
+      node: "node1",
+      status: "online",
+    }
+    subscribeMock.mockImplementation((fn: (evs: any[]) => void) => {
+      fn([NODE_EVENT])
+      return () => {}
+    })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const text = await collectSseText(res)
+    expect(text).toContain("event: node:update")
+    expect(text).toContain('"node":"node1"')
   })
 })

--- a/frontend/src/app/api/v1/inventory/events/route.ts
+++ b/frontend/src/app/api/v1/inventory/events/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server"
 import { subscribe, type InventoryEvent } from "@/lib/cache/inventoryPoller"
 import { getCurrentTenantId, getTenantConnectionIds } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, PERMISSIONS, getRBACContext, getRbacInfraScope, isConnectionVisible, type RbacInfraScope } from "@/lib/rbac"
 import { demoResponse } from "@/lib/demo/demo-api"
 
 export const runtime = "nodejs"
@@ -48,6 +48,13 @@ export async function GET(request: NextRequest) {
   const tenantId = await getCurrentTenantId()
   const vdcScope = maskingScope(await getTenantInfrastructureScope(tenantId))
 
+  // Resolve RBAC infra scope once per request; null = admin/unrestricted (no pruning).
+  // Prunes events for connections (and nodes) the user has no infra grant for.
+  const rbacCtx = await getRBACContext()
+  const rbacScope: RbacInfraScope | null = rbacCtx && !rbacCtx.isAdmin
+    ? await getRbacInfraScope(rbacCtx.userId, rbacCtx.tenantId)
+    : null
+
   const encoder = new TextEncoder()
 
   let unsubscribe: (() => void) | null = null
@@ -76,15 +83,27 @@ export async function GET(request: NextRequest) {
 
       // Subscribe to inventory changes — filter by tenant connections AND,
       // for VM events on a vDC-scoped tenant, by allowed pools.
+      // Also filter by RBAC infra scope when the user is not an admin.
       unsubscribe = subscribe((events: InventoryEvent[]) => {
         if (closed) return
         for (const ev of events) {
           if (!tenantConnIds.has(ev.connId)) continue
 
-          // node:update isn't pool-bound — pass through.
-          if (ev.event === 'node:update') {
-            send(ev.event, ev)
-            continue
+          // RBAC infra scope: drop events for connections the user cannot see.
+          if (rbacScope && !isConnectionVisible(rbacScope, ev.connId)) continue
+
+          // Generic node-level gate: applies to ALL event types that carry a node.
+          // When the user holds a node-scoped grant on this connection (i.e. the
+          // connection is NOT in fullConnections), every event whose node is not in
+          // the granted set must be dropped. Connection-level events without a node
+          // field already passed the connection gate above and are kept as-is.
+          // This subsumes the old node:update-only check and also covers vm:* events.
+          if (rbacScope && !rbacScope.fullConnections.has(ev.connId)) {
+            const evNode = (ev as { node?: string }).node
+            if (evNode !== undefined) {
+              const allowedNodes = rbacScope.nodesByConnection.get(ev.connId)
+              if (!allowedNodes || !allowedNodes.has(evNode)) continue
+            }
           }
 
           // vm:* events: enforce vDC pool boundary when scope active.

--- a/frontend/src/app/api/v1/inventory/inventoryScope.test.ts
+++ b/frontend/src/app/api/v1/inventory/inventoryScope.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Scope-routing tests for GET /api/v1/inventory.
+ *
+ * Strategy: mock @/lib/cache/inventoryCache to return a pre-built "fresh"
+ * payload (two clusters, one PBS server per cluster's connection). This avoids
+ * any PVE/PBS HTTP -- the fresh-cache path is the normal production code path,
+ * so no injectable seam is needed beyond the existing cache module.
+ *
+ * Mock @/lib/rbac for getRBACContext, getRbacInfraScope, and the helpers that
+ * the route chains. Keep real maskingScope (from @/lib/tenant/infraScope) so
+ * the vDC composition is exercised with a real function.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { NextRequest } from "next/server"
+import { readJson } from "../../../../__tests__/setup/route-test"
+
+/** Minimal callRoute for GET handlers that use request.nextUrl.searchParams. */
+async function callGet(handler: (req: NextRequest, ctx: any) => Promise<Response>) {
+  const req = new NextRequest("http://test.local/api/v1/inventory")
+  return handler(req, { params: Promise.resolve({}) })
+}
+
+// ---------------------------------------------------------------------------
+// Hoisted mock factories
+// ---------------------------------------------------------------------------
+const {
+  getInfraMock,
+  getInventoryFromCacheMock,
+  getRBACContextMock,
+  getRbacInfraScopeMock,
+  checkPermissionMock,
+  filterVmsByPermissionMock,
+} = vi.hoisted(() => ({
+  getInfraMock: vi.fn(),
+  getInventoryFromCacheMock: vi.fn(),
+  getRBACContextMock: vi.fn(),
+  getRbacInfraScopeMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  filterVmsByPermissionMock: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Keep real maskingScope; only stub getTenantInfrastructureScope
+vi.mock("@/lib/tenant/infraScope", async (orig) => ({
+  ...(await orig<typeof import("@/lib/tenant/infraScope")>()),
+  getTenantInfrastructureScope: (...a: any[]) => getInfraMock(...a),
+}))
+
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: async () => "t1",
+  getSessionPrisma: async () => ({}),
+}))
+
+// Stub the inventory cache so the route takes the "fresh" path without any
+// PVE HTTP. getInventoryFromCacheMock is configured per-test.
+vi.mock("@/lib/cache/inventoryCache", () => ({
+  getInventoryFromCache: (...a: any[]) => getInventoryFromCacheMock(...a),
+  setCachedInventory: vi.fn(),
+  getInflightFetch: vi.fn().mockReturnValue(null),
+  setInflightFetch: vi.fn(),
+}))
+
+vi.mock("@/lib/rbac", async (orig) => {
+  // Keep real applyRbacInfraFilter, isConnectionVisible, applyVdcFilter
+  // (they are pure helpers, no side-effects). Only stub the async ones.
+  const real = await orig<typeof import("@/lib/rbac")>()
+  return {
+    ...real,
+    checkPermission: (...a: any[]) => checkPermissionMock(...a),
+    getRBACContext: (...a: any[]) => getRBACContextMock(...a),
+    getRbacInfraScope: (...a: any[]) => getRbacInfraScopeMock(...a),
+    filterVmsByPermission: (...a: any[]) => filterVmsByPermissionMock(...a),
+  }
+})
+
+vi.mock("@/lib/demo/demo-api", () => ({
+  demoResponse: vi.fn().mockReturnValue(null),
+}))
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    connection: { findMany: vi.fn().mockResolvedValue([]) },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Test fixture: two PVE clusters + one PBS server
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw inventory with:
+ *   connA: nodes [n1 (online), n2 (online)], each with one guest
+ *   connB: nodes [m1 (online)], one guest
+ *   pbsConnA: PBS server whose id matches connA (same connection id)
+ */
+function makeRawInventory() {
+  return {
+    clusters: [
+      {
+        id: "connA",
+        name: "Cluster A",
+        type: "pve",
+        isCluster: true,
+        status: "online" as const,
+        nodes: [
+          {
+            node: "n1",
+            status: "online",
+            guests: [{ vmid: 101, type: "qemu", status: "running", name: "vm101", node: "n1" }],
+          },
+          {
+            node: "n2",
+            status: "online",
+            guests: [{ vmid: 102, type: "qemu", status: "stopped", name: "vm102", node: "n2" }],
+          },
+        ],
+      },
+      {
+        id: "connB",
+        name: "Cluster B",
+        type: "pve",
+        isCluster: false,
+        status: "online" as const,
+        nodes: [
+          {
+            node: "m1",
+            status: "online",
+            guests: [{ vmid: 201, type: "lxc", status: "running", name: "ct201", node: "m1" }],
+          },
+        ],
+      },
+    ],
+    pbsServers: [
+      {
+        id: "pbsConnA",
+        name: "PBS A",
+        type: "pbs" as const,
+        status: "online" as const,
+        datastores: [],
+        stats: { totalSize: 0, totalUsed: 0, datastoreCount: 2, backupCount: 5 },
+      },
+      {
+        id: "pbsConnB",
+        name: "PBS B",
+        type: "pbs" as const,
+        status: "online" as const,
+        datastores: [],
+        stats: { totalSize: 0, totalUsed: 0, datastoreCount: 1, backupCount: 3 },
+      },
+    ],
+    externalHypervisors: [],
+    storages: [],
+    stats: {
+      totalClusters: 2,
+      totalNodes: 3,
+      totalGuests: 3,
+      onlineNodes: 3,
+      runningGuests: 2,
+      totalPbsServers: 2,
+      totalDatastores: 3,
+      totalBackups: 8,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Common setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Default: permission check passes
+  checkPermissionMock.mockResolvedValue(null)
+  // Default: provider infra scope (no vDC mask)
+  getInfraMock.mockResolvedValue({ kind: "provider" })
+  // Default: fresh cache hit with the two-cluster fixture
+  getInventoryFromCacheMock.mockReturnValue({ status: "fresh", data: makeRawInventory() })
+  // Default: filterVmsByPermission passes all guests through (returns them as-is)
+  filterVmsByPermissionMock.mockImplementation((_userId: any, vms: any[]) => Promise.resolve(vms))
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/v1/inventory RBAC infra-scope pruning", () => {
+
+  it("node-scoped user: tree shows only the granted connection and the granted node", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "u1", isAdmin: false, tenantId: "default" })
+    // User has node scope on connA/n1 only
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["connA", new Set(["n1"])]]),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // Only connA should appear
+    expect(data.clusters.map((c: any) => c.id)).toEqual(["connA"])
+    // Within connA, only n1 (n2 is pruned)
+    expect(data.clusters[0].nodes.map((n: any) => n.node)).toEqual(["n1"])
+    // connB is gone -- PBS of connB also gone (if it were scoped to connA only)
+    // connA has 1 running guest on n1
+    expect(data.stats.totalNodes).toBe(1)
+    expect(data.stats.totalGuests).toBe(1)
+    expect(data.stats.runningGuests).toBe(1)
+  })
+
+  it("admin (isAdmin: true): tree unchanged and getRbacInfraScope NOT called", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "admin", isAdmin: true, tenantId: "default" })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // Both clusters present
+    expect(data.clusters.map((c: any) => c.id).sort()).toEqual(["connA", "connB"])
+    // getRbacInfraScope must never be consulted for admins
+    expect(getRbacInfraScopeMock).not.toHaveBeenCalled()
+    expect(data.stats.totalNodes).toBe(3)
+  })
+
+  it("connection-scoped user (fullConnections): whole connection visible, other connection absent", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "u2", isAdmin: false, tenantId: "default" })
+    // User has full connection scope on connB only
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["connB"]),
+      nodesByConnection: new Map<string, Set<string>>(),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // Only connB
+    expect(data.clusters.map((c: any) => c.id)).toEqual(["connB"])
+    // All of connB's nodes present (full connection grant)
+    expect(data.clusters[0].nodes.map((n: any) => n.node)).toEqual(["m1"])
+    expect(data.stats.totalNodes).toBe(1)
+  })
+
+  it("PBS servers are pruned by the same RBAC scope (node-scoped user sees no PBS)", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "u1", isAdmin: false, tenantId: "default" })
+    // Node scope on connA/n1 only -- pbsConnA and pbsConnB are different connection ids
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["connA", new Set(["n1"])]]),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // pbsConnA and pbsConnB are not in the RBAC scope (connA/n1 node scope does
+    // NOT grant a PBS connection with id "pbsConnA" -- different id)
+    expect(data.pbsServers).toHaveLength(0)
+    expect(data.stats.totalPbsServers).toBe(0)
+    expect(data.stats.totalDatastores).toBe(0)
+    expect(data.stats.totalBackups).toBe(0)
+  })
+
+  it("admin: PBS servers all present", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "admin", isAdmin: true, tenantId: "default" })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    expect(data.pbsServers).toHaveLength(2)
+    expect(data.stats.totalPbsServers).toBe(2)
+    expect(data.stats.totalDatastores).toBe(3)
+    expect(data.stats.totalBackups).toBe(8)
+  })
+
+  it("null RBAC context (unauthenticated): guest filter and node prune are skipped (provider scope)", async () => {
+    // checkPermission passes but no RBAC context
+    getRBACContextMock.mockResolvedValue(null)
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // Full tree visible (no pruning on unauthenticated)
+    expect(data.clusters).toHaveLength(2)
+    expect(getRbacInfraScopeMock).not.toHaveBeenCalled()
+  })
+
+  it("PBS: connection-scoped user retains PBS whose id is in fullConnections, excludes others", async () => {
+    getRBACContextMock.mockResolvedValue({ userId: "u3", isAdmin: false, tenantId: "default" })
+    // User has full access to connA and pbsConnA, but NOT pbsConnB
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["connA", "pbsConnA"]),
+      nodesByConnection: new Map<string, Set<string>>(),
+    })
+
+    const { GET } = await import("./route")
+    const res = await callGet(GET)
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const data = body?.data ?? body
+
+    // pbsConnA is granted, pbsConnB is not
+    expect(data.pbsServers.map((p: any) => p.id)).toEqual(["pbsConnA"])
+    expect(data.pbsServers).toHaveLength(1)
+    expect(data.stats.totalPbsServers).toBe(1)
+    // PBS A has datastoreCount=2, backupCount=5
+    expect(data.stats.totalDatastores).toBe(2)
+    expect(data.stats.totalBackups).toBe(5)
+  })
+
+  it("externalHypervisors: scoped user sees only granted connections, admin sees all", async () => {
+    // Extend the fixture with two external hypervisors
+    const rawWithExt = {
+      ...makeRawInventory(),
+      externalHypervisors: [
+        { id: "extA", name: "vCenter A", type: "vmware" },
+        { id: "extB", name: "ESXi B", type: "vmware" },
+      ],
+    }
+    getInventoryFromCacheMock.mockReturnValue({ status: "fresh", data: rawWithExt })
+
+    // First: scoped user with only extA in fullConnections
+    getRBACContextMock.mockResolvedValue({ userId: "u4", isAdmin: false, tenantId: "default" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["extA"]),
+      nodesByConnection: new Map<string, Set<string>>(),
+    })
+
+    const { GET } = await import("./route")
+    const scopedRes = await callGet(GET)
+    expect(scopedRes.status).toBe(200)
+    const scopedBody = await readJson<any>(scopedRes)
+    const scopedData = scopedBody?.data ?? scopedBody
+    expect(scopedData.externalHypervisors.map((h: any) => h.id)).toEqual(["extA"])
+
+    // Second: admin sees both
+    getRBACContextMock.mockResolvedValue({ userId: "admin", isAdmin: true, tenantId: "default" })
+    const adminRes = await callGet(GET)
+    expect(adminRes.status).toBe(200)
+    const adminBody = await readJson<any>(adminRes)
+    const adminData = adminBody?.data ?? adminBody
+    expect(adminData.externalHypervisors.map((h: any) => h.id).sort()).toEqual(["extA", "extB"])
+  })
+})

--- a/frontend/src/app/api/v1/inventory/route.ts
+++ b/frontend/src/app/api/v1/inventory/route.ts
@@ -6,7 +6,7 @@ import { demoResponse } from "@/lib/demo/demo-api"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getRBACContext, filterVmsByPermission, PERMISSIONS, checkPermission } from "@/lib/rbac"
+import { getRBACContext, filterVmsByPermission, PERMISSIONS, checkPermission, getRbacInfraScope, applyRbacInfraFilter, filterVisibleConnections } from "@/lib/rbac"
 import { resolveManagementIp } from "@/lib/proxmox/resolveManagementIp"
 import {
   getInventoryFromCache,
@@ -600,10 +600,16 @@ export async function GET(request: NextRequest) {
       raw = await blockingFetch(tenantId, infra)
     }
 
-    // 2) Deep-clone clusters pour le filtrage RBAC (ne pas muter le cache)
-    //    Also filter by vDC connection scope — only include clusters whose
-    //    connection is part of the tenant's vDC assignments.
-    const visibleRawClusters = mask ? raw.clusters.filter(c => mask.connectionIds.has(c.id)) : raw.clusters
+    // 2) Resolve RBAC context + infra scope once, before any filtering
+    const rbacCtx = await getRBACContext()
+    const rbacScope = rbacCtx && !rbacCtx.isAdmin
+      ? await getRbacInfraScope(rbacCtx.userId, rbacCtx.tenantId)
+      : null
+
+    // 3) Deep-clone clusters pour le filtrage RBAC (ne pas muter le cache).
+    //    Filter by vDC connection scope first, then by RBAC infra scope (intersection).
+    let visibleRawClusters = mask ? raw.clusters.filter(c => mask.connectionIds.has(c.id)) : raw.clusters
+    visibleRawClusters = filterVisibleConnections(visibleRawClusters, rbacScope)
 
     let clusters: ClusterData[] = visibleRawClusters.map(c => ({
       ...c,
@@ -613,11 +619,10 @@ export async function GET(request: NextRequest) {
       }))
     }))
 
-    // 3) RBAC + vDC: Filter guests by user permissions, then by vDC scope (nodes + pools)
-    const rbacCtx = await getRBACContext()
-
+    // 4) RBAC + vDC: Filter guests by user permissions, then apply both
+    //    vDC mask (nodes+pools) and RBAC infra scope (node prune), composed.
     clusters = await Promise.all(clusters.map(async cluster => {
-      // Apply RBAC first
+      // Apply RBAC guest filter first (unchanged)
       let filtered = cluster
       if (rbacCtx && !rbacCtx.isAdmin) {
         const filteredNodes = await Promise.all(
@@ -641,11 +646,15 @@ export async function GET(request: NextRequest) {
           nodes: filteredNodes,
         }
       }
-      // Then apply vDC filter (nodes + pool membership)
-      return applyVdcFilter(filtered, mask)
+      // Apply vDC filter (nodes + pool membership), then RBAC node prune (composed)
+      return applyRbacInfraFilter(applyVdcFilter(filtered, mask), rbacScope)
     }))
 
-    // 4) Recalculer les stats après filtrage RBAC
+    // 5) Prune PBS servers and external hypervisors by RBAC infra scope (.id = connection id)
+    const visiblePbs = filterVisibleConnections(raw.pbsServers, rbacScope)
+    const visibleExternalHypervisors = filterVisibleConnections(raw.externalHypervisors, rbacScope)
+
+    // 6) Recalculer les stats après filtrage RBAC
     let totalNodes = 0
     let onlineNodes = 0
     let totalGuests = 0
@@ -666,7 +675,7 @@ export async function GET(request: NextRequest) {
     let totalDatastores = 0
     let totalBackups = 0
 
-    for (const pbs of raw.pbsServers) {
+    for (const pbs of visiblePbs) {
       totalDatastores += pbs.stats.datastoreCount
       totalBackups += pbs.stats.backupCount
     }
@@ -674,8 +683,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       data: {
         clusters,
-        pbsServers: raw.pbsServers,
-        externalHypervisors: raw.externalHypervisors,
+        pbsServers: visiblePbs,
+        externalHypervisors: visibleExternalHypervisors,
         cached: cacheResult.status !== 'miss',
         stats: {
           totalClusters: clusters.length,
@@ -683,7 +692,7 @@ export async function GET(request: NextRequest) {
           totalGuests,
           onlineNodes,
           runningGuests,
-          totalPbsServers: raw.pbsServers.length,
+          totalPbsServers: visiblePbs.length,
           totalDatastores,
           totalBackups,
         }

--- a/frontend/src/app/api/v1/inventory/stream/route.ts
+++ b/frontend/src/app/api/v1/inventory/stream/route.ts
@@ -8,7 +8,7 @@ import { scopePbsDataForTenant, type PbsServerData, type PbsDatastoreData } from
 import { pveFetch } from "@/lib/proxmox/client"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { isSharedStorage } from "@/lib/proxmox/storage"
-import { getRBACContext, filterVmsByPermission, PERMISSIONS, checkPermission } from "@/lib/rbac"
+import { getRBACContext, filterVmsByPermission, PERMISSIONS, checkPermission, getRbacInfraScope, applyRbacInfraFilter, filterVisibleConnections, isConnectionVisible, type RbacInfraScope } from "@/lib/rbac"
 import { resolveManagementIp } from "@/lib/proxmox/resolveManagementIp"
 import {
   getInventoryFromCache,
@@ -506,28 +506,33 @@ async function fetchOnePbs(conn: { id: string; name: string }): Promise<PbsServe
 /* RBAC filtering for a single cluster                                 */
 /* ------------------------------------------------------------------ */
 
-async function applyRbacToCluster(cluster: ClusterData, rbacCtx: any): Promise<ClusterData> {
-  if (!rbacCtx || rbacCtx.isAdmin) return cluster
-  const filteredNodes = await Promise.all(
-    cluster.nodes.map(async node => ({
-      ...node,
-      guests: await filterVmsByPermission(
-        rbacCtx.userId,
-        node.guests.map(g => ({
-          ...g,
-          connId: cluster.id,
-          node: node.node,
-          vmid: String(g.vmid),
-        })),
-        PERMISSIONS.VM_VIEW,
-        rbacCtx.tenantId
-      )
-    }))
-  )
-  return {
-    ...cluster,
-    nodes: filteredNodes,
+async function applyRbacToCluster(
+  cluster: ClusterData,
+  rbacCtx: any,
+  rbacScope: RbacInfraScope | null,
+): Promise<ClusterData> {
+  let result = cluster
+  if (rbacCtx && !rbacCtx.isAdmin) {
+    const filteredNodes = await Promise.all(
+      cluster.nodes.map(async node => ({
+        ...node,
+        guests: await filterVmsByPermission(
+          rbacCtx.userId,
+          node.guests.map(g => ({
+            ...g,
+            connId: cluster.id,
+            node: node.node,
+            vmid: String(g.vmid),
+          })),
+          PERMISSIONS.VM_VIEW,
+          rbacCtx.tenantId
+        )
+      }))
+    )
+    result = { ...cluster, nodes: filteredNodes }
   }
+  // Apply RBAC node prune (composed with vDC mask at call site)
+  return applyRbacInfraFilter(result, rbacScope)
 }
 
 /* ------------------------------------------------------------------ */
@@ -555,6 +560,10 @@ export async function GET(request: NextRequest) {
     const cached = cacheResult.data
     const rbacCtx = await getRBACContext()
     const mask = maskingScope(await getTenantInfrastructureScope(tenantId))
+    // Resolve RBAC infra scope once; null = admin/unrestricted (no pruning)
+    const rbacScope = rbacCtx && !rbacCtx.isAdmin
+      ? await getRbacInfraScope(rbacCtx.userId, rbacCtx.tenantId)
+      : null
 
     const stream = new ReadableStream({
       async start(controller) {
@@ -563,20 +572,24 @@ export async function GET(request: NextRequest) {
         }
 
         try {
-          // Filter clusters visible to this tenant's vDC scope
-          const visibleClusters = mask ? cached.clusters.filter(c => mask.connectionIds.has(c.id)) : cached.clusters
+          // Filter clusters by vDC scope then RBAC infra scope (intersection)
+          let visibleClusters = mask ? cached.clusters.filter(c => mask.connectionIds.has(c.id)) : cached.clusters
+          visibleClusters = filterVisibleConnections(visibleClusters, rbacScope)
+
+          const visiblePbs = filterVisibleConnections(cached.pbsServers, rbacScope)
+          const visibleExt = filterVisibleConnections(cached.externalHypervisors, rbacScope)
 
           send('init', {
             totalPve: visibleClusters.length,
-            totalPbs: cached.pbsServers.length,
-            totalExt: cached.externalHypervisors.length,
+            totalPbs: visiblePbs.length,
+            totalExt: visibleExt.length,
             cached: true,
           })
 
           for (const cluster of visibleClusters) {
-            send('cluster', applyVdcFilter(await applyRbacToCluster(cluster, rbacCtx), mask))
+            send('cluster', applyVdcFilter(await applyRbacToCluster(cluster, rbacCtx, rbacScope), mask))
           }
-          for (const pbs of cached.pbsServers) {
+          for (const pbs of visiblePbs) {
             const scoped = await scopePbsDataForTenant(pbs, mask)
             if (scoped) send('pbs', scoped)
           }
@@ -587,8 +600,8 @@ export async function GET(request: NextRequest) {
               if (scoped) send('storage', scoped)
             }
           }
-          if (cached.externalHypervisors.length > 0) {
-            send('external', cached.externalHypervisors)
+          if (visibleExt.length > 0) {
+            send('external', visibleExt)
           }
           send('done', { stats: cached.stats })
         } finally {
@@ -609,6 +622,10 @@ export async function GET(request: NextRequest) {
 
   // Cache miss — stream progressively as each connection resolves
   const rbacCtx = await getRBACContext()
+  // Resolve RBAC infra scope once per request; null = admin/unrestricted (no pruning)
+  const rbacScope = rbacCtx && !rbacCtx.isAdmin
+    ? await getRbacInfraScope(rbacCtx.userId, rbacCtx.tenantId)
+    : null
   const infra = await getTenantInfrastructureScope(tenantId)
   const mask = maskingScope(infra)
   const plan = inventoryConnectionPlan(infra)
@@ -654,27 +671,39 @@ export async function GET(request: NextRequest) {
           (extUseGlobal ? globalPrisma : prisma).connection.findMany({ where: { type: { in: ['vmware', 'hyperv', 'xcpng', 'nutanix'] } }, orderBy: { createdAt: 'desc' }, select: { id: true, name: true, type: true } }),
         ])
 
-        // Determine which PVE connections are visible under this tenant's vDC scope.
+        // Determine which PVE connections are visible under vDC scope AND RBAC infra scope.
         // We fetch ALL connections (for the cache), but only stream visible ones to the client.
-        const visiblePveConnectionIds = mask
+        const vdcVisibleIds = mask
           ? new Set(pveConnections.filter(c => mask.connectionIds.has(c.id)).map(c => c.id))
           : null
 
-        const visiblePveCount = visiblePveConnectionIds
-          ? visiblePveConnectionIds.size
-          : pveConnections.length
+        // RBAC infra scope prune: build a set of RBAC-visible connection ids
+        const rbacVisiblePveIds = rbacScope
+          ? new Set(pveConnections.filter(c => isConnectionVisible(rbacScope, c.id)).map(c => c.id))
+          : null
+
+        // A PVE connection is streamed only if it passes BOTH vDC and RBAC filters
+        const isVisibleConn = (connId: string) =>
+          (!vdcVisibleIds || vdcVisibleIds.has(connId)) &&
+          (!rbacVisiblePveIds || rbacVisiblePveIds.has(connId))
+
+        const visiblePveCount = pveConnections.filter(c => isVisibleConn(c.id)).length
+
+        // RBAC prune PBS and external before counting for init
+        const visiblePbsConnections = filterVisibleConnections(pbsConnections, rbacScope)
+        const visibleExtConnections = filterVisibleConnections(externalConnections, rbacScope)
 
         // Send init event so frontend knows how many items to expect
         send('init', {
           totalPve: visiblePveCount,
-          totalPbs: pbsConnections.length,
-          totalExt: externalConnections.length,
+          totalPbs: visiblePbsConnections.length,
+          totalExt: visibleExtConnections.length,
           cached: false,
         })
 
         // Send external hypervisors immediately (no fetch needed)
-        if (externalConnections.length > 0) {
-          send('external', externalConnections)
+        if (visibleExtConnections.length > 0) {
+          send('external', visibleExtConnections)
         }
 
         // Fire all fetches concurrently — each sends its event as soon as ready
@@ -686,22 +715,22 @@ export async function GET(request: NextRequest) {
           const cluster = await fetchOneCluster(conn)
           allClusters.push(cluster)
 
-          // Only stream clusters visible to this tenant's vDC scope
-          const isVisible = !visiblePveConnectionIds || visiblePveConnectionIds.has(conn.id)
-          if (isVisible) {
-            send('cluster', applyVdcFilter(await applyRbacToCluster(cluster, rbacCtx), mask))
+          // Only stream clusters visible to both vDC and RBAC infra scope
+          if (isVisibleConn(conn.id)) {
+            send('cluster', applyVdcFilter(await applyRbacToCluster(cluster, rbacCtx, rbacScope), mask))
           }
 
           // Fetch storage data for this cluster and emit immediately (only if visible)
           const storageData = await fetchStoragesForCluster(conn, cluster)
           allStorages.push(storageData)
-          if (isVisible) {
+          if (isVisibleConn(conn.id)) {
             const scoped = scopeStorageDataForTenant(storageData, mask)
             if (scoped) send('storage', scoped)
           }
         })
 
-        const pbsPromises = pbsConnections.map(async (conn) => {
+        // Only fetch PBS servers visible under RBAC infra scope
+        const pbsPromises = visiblePbsConnections.map(async (conn) => {
           const pbs = await fetchOnePbs(conn)
           allPbsServers.push(pbs)
           const scoped = await scopePbsDataForTenant(pbs, mask)

--- a/frontend/src/components/GenerateMenu.jsx
+++ b/frontend/src/components/GenerateMenu.jsx
@@ -9,6 +9,7 @@ import { SubMenu as VerticalSubMenu, MenuItem as VerticalMenuItem, MenuSection }
 
 // RBAC Hook
 import { useRBAC } from '@/contexts/RBACContext'
+import { hasInfraScope } from '@/lib/rbac/scopeKinds'
 
 // License Hook
 import { useLicense } from '@/contexts/LicenseContext'
@@ -21,11 +22,12 @@ import { useTenant } from '@/contexts/TenantContext'
 
 // Generate a menu from the menu data array
 export const GenerateVerticalMenu = ({ menuData }) => {
-  const { hasAnyPermission, loading } = useRBAC()
+  const { hasAnyPermission, scopeTypes, isAdmin, loading } = useRBAC()
   const { hasFeature, loading: licenseLoading } = useLicense()
   const { hasVdc, loading: vdcLoading } = useMyVdcs()
   const { currentTenant, loading: tenantLoading } = useTenant()
   const isProviderTenant = currentTenant?.id === 'default'
+  const infraScoped = hasInfraScope(scopeTypes, isAdmin)
 
   // Fonction pour vérifier si un item doit être affiché (RBAC)
   const canView = (item) => {
@@ -33,6 +35,7 @@ export const GenerateVerticalMenu = ({ menuData }) => {
     if (item.requires?.hasVdc === true && !hasVdc) return false
     if (item.requires?.hasVdc === false && hasVdc) return false
     if (item.requires?.isProviderTenant === true && !isProviderTenant) return false
+    if (item.requires?.infraScope === true && !infraScoped) return false
     if (!item.permissions || item.permissions.length === 0) return true
 
     return hasAnyPermission(item.permissions)
@@ -141,17 +144,19 @@ export const GenerateVerticalMenu = ({ menuData }) => {
 
 // Generate a menu from the menu data array
 export const GenerateHorizontalMenu = ({ menuData }) => {
-  const { hasAnyPermission, loading } = useRBAC()
+  const { hasAnyPermission, scopeTypes, isAdmin, loading } = useRBAC()
   const { hasFeature, loading: licenseLoading } = useLicense()
   const { hasVdc, loading: vdcLoading } = useMyVdcs()
   const { currentTenant, loading: tenantLoading } = useTenant()
   const isProviderTenant = currentTenant?.id === 'default'
+  const infraScoped = hasInfraScope(scopeTypes, isAdmin)
 
   const canView = (item) => {
     if (loading || vdcLoading || tenantLoading) return true // Afficher pendant le chargement
     if (item.requires?.hasVdc === true && !hasVdc) return false
     if (item.requires?.hasVdc === false && hasVdc) return false
     if (item.requires?.isProviderTenant === true && !isProviderTenant) return false
+    if (item.requires?.infraScope === true && !infraScoped) return false
     if (!item.permissions || item.permissions.length === 0) return true
 
     return hasAnyPermission(item.permissions)

--- a/frontend/src/components/layout/horizontal/BurgerMenu.jsx
+++ b/frontend/src/components/layout/horizontal/BurgerMenu.jsx
@@ -8,6 +8,7 @@ import { useTheme, alpha } from '@mui/material/styles'
 
 import { menuData } from '@/@menu/menuData'
 import { useRBAC } from '@/contexts/RBACContext'
+import { hasInfraScope } from '@/lib/rbac/scopeKinds'
 import { useLicense } from '@/contexts/LicenseContext'
 import { useMyVdcs } from '@/hooks/useMyVdcs'
 import { useTenant } from '@/contexts/TenantContext'
@@ -27,11 +28,12 @@ const BurgerMenu = ({ anchorEl, open, onClose }) => {
   const pathname = usePathname()
   const t = useTranslations()
   const theme = useTheme()
-  const { hasPermission, loading: rbacLoading } = useRBAC()
+  const { hasPermission, scopeTypes, isAdmin, loading: rbacLoading } = useRBAC()
   const { hasFeature } = useLicense()
   const { hasVdc, loading: vdcLoading } = useMyVdcs()
   const { currentTenant, loading: tenantLoading } = useTenant()
   const isProviderTenant = currentTenant?.id === 'default'
+  const infraScoped = hasInfraScope(scopeTypes, isAdmin)
 
   const sections = useMemo(() => {
     const data = menuData(t)
@@ -46,6 +48,7 @@ const BurgerMenu = ({ anchorEl, open, onClose }) => {
       if (entry.requires?.hasVdc === true && !hasVdc) return false
       if (entry.requires?.hasVdc === false && hasVdc) return false
       if (entry.requires?.isProviderTenant === true && !isProviderTenant) return false
+      if (entry.requires?.infraScope === true && !infraScoped) return false
       return true
     }
 
@@ -90,7 +93,7 @@ const BurgerMenu = ({ anchorEl, open, onClose }) => {
     }
 
     return result
-  }, [t, hasPermission, hasFeature, hasVdc, isProviderTenant, rbacLoading, vdcLoading, tenantLoading])
+  }, [t, hasPermission, hasFeature, hasVdc, isProviderTenant, infraScoped, rbacLoading, vdcLoading, tenantLoading])
 
   const handleNavigate = (href, locked) => {
     if (locked) return

--- a/frontend/src/hooks/useRBACScopeProfile.ts
+++ b/frontend/src/hooks/useRBACScopeProfile.ts
@@ -2,11 +2,14 @@ import { useMemo } from 'react'
 
 import { useRBAC } from '@/contexts/RBACContext'
 import { useTenant } from '@/contexts/TenantContext'
+import { INFRA_SCOPE_TYPES } from '@/lib/rbac/scopeKinds'
 
 import type { ViewMode } from '@/app/(dashboard)/infrastructure/inventory/InventoryTree'
 
-/** Scope types that reveal infrastructure details (cluster/node names) */
-const INFRA_SCOPES = new Set(['global', 'connection', 'node'])
+/** Scope types that reveal infrastructure details (cluster/node names).
+ *  Shared with the nav/topology gate via INFRA_SCOPE_TYPES so "what counts as
+ *  infra scope" has a single source of truth. */
+const INFRA_SCOPES = new Set<string>(INFRA_SCOPE_TYPES)
 
 /** View modes that are always safe — they only show VMs the user can access */
 const ALWAYS_ALLOWED: ViewMode[] = ['vms', 'favorites', 'templates']

--- a/frontend/src/lib/rbac/index.ts
+++ b/frontend/src/lib/rbac/index.ts
@@ -15,7 +15,15 @@ import { prisma } from "@/lib/db/prisma"
 import { authOptions } from "@/lib/auth/config"
 import { resolveVmMeta } from "@/lib/cache/vmMetaCache"
 import { DEFAULT_TENANT_ID } from "@/lib/tenant"
+import {
+  deriveRbacInfraScope,
+  isConnectionVisible,
+  applyRbacInfraFilter,
+  filterVisibleConnections,
+  type RbacInfraScope,
+} from './infraScope'
 
+export { isConnectionVisible, applyRbacInfraFilter, filterVisibleConnections, type RbacInfraScope }
 
 export interface PermissionCheck {
   userId: string
@@ -649,4 +657,18 @@ export async function filterNodesByPermission<T extends { connId: string; node: 
     }
   }
   return result
+}
+
+/**
+ * Resolve the RBAC infrastructure-scope tree mask for a user. Mirrors
+ * filterVmsByPermission's grant-loading. Returns null when unrestricted
+ * (super admin / global scope) -- callers skip tree pruning then.
+ */
+export async function getRbacInfraScope(
+  userId: string,
+  tenantId?: string,
+): Promise<RbacInfraScope | null> {
+  const tid = tenantId ?? DEFAULT_TENANT_ID
+  const grants = await loadUserGrants(userId, tid)
+  return deriveRbacInfraScope(grants)
 }

--- a/frontend/src/lib/rbac/infraScope.test.ts
+++ b/frontend/src/lib/rbac/infraScope.test.ts
@@ -1,0 +1,103 @@
+// frontend/src/lib/rbac/infraScope.test.ts
+import { describe, it, expect } from 'vitest'
+import { deriveRbacInfraScope, isConnectionVisible, applyRbacInfraFilter, filterVisibleConnections } from './infraScope'
+
+describe('deriveRbacInfraScope', () => {
+  it('returns null (unrestricted) for super admins', () => {
+    expect(deriveRbacInfraScope({ superAdmin: true, byScope: [] })).toBeNull()
+  })
+
+  it('returns null when any global scope is present', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [{ scopeType: 'global', scopeTarget: null }] })
+    expect(s).toBeNull()
+  })
+
+  it('maps a node scope to nodesByConnection (only that node)', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [{ scopeType: 'node', scopeTarget: 'connA:nodeX' }] })!
+    expect(s.fullConnections.size).toBe(0)
+    expect([...s.nodesByConnection.get('connA')!]).toEqual(['nodeX'])
+  })
+
+  it('maps a connection scope to fullConnections (all nodes)', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [{ scopeType: 'connection', scopeTarget: 'connA' }] })!
+    expect(s.fullConnections.has('connA')).toBe(true)
+    expect(s.nodesByConnection.has('connA')).toBe(false)
+  })
+
+  it('derives connId+node from a vm scope target', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [{ scopeType: 'vm', scopeTarget: 'connA:nodeX:qemu:100' }] })!
+    expect([...s.nodesByConnection.get('connA')!]).toEqual(['nodeX'])
+  })
+
+  it('ignores tag/pool scopes (Decision 2: not infra)', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [
+      { scopeType: 'tag', scopeTarget: 'prod' },
+      { scopeType: 'pool', scopeTarget: 'poolA' },
+    ] })!
+    expect(s.fullConnections.size).toBe(0)
+    expect(s.nodesByConnection.size).toBe(0)
+  })
+
+  it('mixed node + tag keeps only the node-derived connection', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [
+      { scopeType: 'node', scopeTarget: 'connA:nodeX' },
+      { scopeType: 'tag', scopeTarget: 'prod' },
+    ] })!
+    expect([...s.nodesByConnection.keys()]).toEqual(['connA'])
+  })
+})
+
+describe('isConnectionVisible', () => {
+  it('true for a full connection and for a node-scoped connection, false otherwise', () => {
+    const s = { fullConnections: new Set(['connA']), nodesByConnection: new Map([['connB', new Set(['n1'])]]) }
+    expect(isConnectionVisible(s, 'connA')).toBe(true)
+    expect(isConnectionVisible(s, 'connB')).toBe(true)
+    expect(isConnectionVisible(s, 'connC')).toBe(false)
+  })
+})
+
+describe('filterVisibleConnections', () => {
+  const items = [{ id: 'connA' }, { id: 'connB' }, { id: 'connC' }]
+
+  it('returns the same list when scope is null (admin/unrestricted)', () => {
+    expect(filterVisibleConnections(items, null)).toBe(items)
+  })
+
+  it('keeps only items whose id is visible under a full-connection scope', () => {
+    const s = { fullConnections: new Set(['connA']), nodesByConnection: new Map() }
+    expect(filterVisibleConnections(items, s).map(x => x.id)).toEqual(['connA'])
+  })
+
+  it('keeps items reachable via node-scope (nodesByConnection), drops others', () => {
+    const s = { fullConnections: new Set<string>(), nodesByConnection: new Map([['connB', new Set(['n1'])]]) }
+    expect(filterVisibleConnections(items, s).map(x => x.id)).toEqual(['connB'])
+  })
+
+  it('returns empty list when scope matches nothing', () => {
+    const s = { fullConnections: new Set<string>(), nodesByConnection: new Map() }
+    expect(filterVisibleConnections(items, s)).toHaveLength(0)
+  })
+})
+
+describe('applyRbacInfraFilter', () => {
+  const cluster = { id: 'connB', nodes: [{ node: 'n1' }, { node: 'n2' }] }
+
+  it('null scope returns the cluster unchanged', () => {
+    expect(applyRbacInfraFilter(cluster, null)).toBe(cluster)
+  })
+
+  it('full connection returns all nodes', () => {
+    const s = { fullConnections: new Set(['connB']), nodesByConnection: new Map() }
+    expect(applyRbacInfraFilter(cluster, s).nodes).toHaveLength(2)
+  })
+
+  it('node-scoped connection keeps only allowed nodes', () => {
+    const s = { fullConnections: new Set<string>(), nodesByConnection: new Map([['connB', new Set(['n1'])]]) }
+    expect(applyRbacInfraFilter(cluster, s).nodes.map(n => n.node)).toEqual(['n1'])
+  })
+
+  it('non-visible connection is emptied', () => {
+    const s = { fullConnections: new Set<string>(), nodesByConnection: new Map([['connOther', new Set(['x'])]]) }
+    expect(applyRbacInfraFilter(cluster, s).nodes).toHaveLength(0)
+  })
+})

--- a/frontend/src/lib/rbac/infraScope.ts
+++ b/frontend/src/lib/rbac/infraScope.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure, dependency-free RBAC infrastructure-scope helpers for the inventory /
+ * topology TREE. Derived from a user's grants and applied at the same
+ * chokepoints as the tenant/vDC mask, COMPOSED with it (intersection).
+ *
+ * Only connection/node/vm scopes describe infrastructure the user may see in
+ * the tree. tag/pool scopes are resource-flat (Decision 2, 2026-06-30): they
+ * never widen the tree, so a tag/pool-only user gets an empty tree.
+ */
+
+export type RbacInfraScope = {
+  /** Connections granted whole (connection scope) -> ALL their nodes are visible. */
+  fullConnections: Set<string>
+  /** Per-connection node names granted (node / vm scope) -> only those nodes. */
+  nodesByConnection: Map<string, Set<string>>
+}
+
+const TREE_SCOPE_TYPES = new Set(['connection', 'node', 'vm'])
+
+/**
+ * Build the tree mask from loaded grants. Returns null when the user is
+ * unrestricted (super admin or holds a `global` scope); callers must then skip
+ * RBAC tree pruning. A non-null scope with empty sets restricts the tree to
+ * nothing (tag/pool-only or no infra grants).
+ */
+export function deriveRbacInfraScope(grants: {
+  superAdmin: boolean
+  byScope: ReadonlyArray<{ scopeType: string; scopeTarget: string | null }>
+}): RbacInfraScope | null {
+  if (grants.superAdmin) return null
+  if (grants.byScope.some(g => g.scopeType === 'global')) return null
+
+  const fullConnections = new Set<string>()
+  const nodesByConnection = new Map<string, Set<string>>()
+
+  for (const g of grants.byScope) {
+    if (!TREE_SCOPE_TYPES.has(g.scopeType) || !g.scopeTarget) continue
+    const parts = g.scopeTarget.split(':')
+    const connId = parts[0]
+    if (!connId) continue
+    if (g.scopeType === 'connection') {
+      fullConnections.add(connId)
+      continue
+    }
+    // node => connId:nodeName ; vm => connId:nodeName:type:vmid
+    const nodeName = parts[1]
+    if (!nodeName) continue
+    let set = nodesByConnection.get(connId)
+    if (!set) {
+      set = new Set<string>()
+      nodesByConnection.set(connId, set)
+    }
+    set.add(nodeName)
+  }
+
+  return { fullConnections, nodesByConnection }
+}
+
+/** Whether a whole connection should appear in the tree at all. */
+export function isConnectionVisible(scope: RbacInfraScope, connId: string): boolean {
+  return scope.fullConnections.has(connId) || scope.nodesByConnection.has(connId)
+}
+
+/**
+ * Keep only items whose id is visible in the scope. Null scope = no pruning.
+ * Covers clusters, pbsServers, and externalHypervisors (all have an `id` that
+ * maps to the connection id).
+ */
+export function filterVisibleConnections<T extends { id: string }>(
+  list: T[],
+  scope: RbacInfraScope | null,
+): T[] {
+  if (scope === null) return list
+  return list.filter(item => isConnectionVisible(scope, item.id))
+}
+
+/**
+ * Prune a cluster's NODES by the RBAC scope. Guests are left untouched; the
+ * caller already filtered them via filterVmsByPermission. A full-connection
+ * grant keeps every node; a node grant keeps only listed nodes; a non-visible
+ * connection is emptied (callers drop it at the connection step).
+ */
+export function applyRbacInfraFilter<C extends { id: string; nodes: Array<{ node: string }> }>(
+  cluster: C,
+  scope: RbacInfraScope | null,
+): C {
+  if (scope === null) return cluster
+  const connId = cluster.id
+  if (scope.fullConnections.has(connId)) return cluster
+  const allowed = scope.nodesByConnection.get(connId)
+  if (!allowed) return { ...cluster, nodes: [] }
+  return { ...cluster, nodes: cluster.nodes.filter(n => allowed.has(n.node)) }
+}

--- a/frontend/src/lib/rbac/scopeKinds.test.ts
+++ b/frontend/src/lib/rbac/scopeKinds.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+
+import { INFRA_SCOPE_TYPES, hasInfraScope } from './scopeKinds'
+
+describe('INFRA_SCOPE_TYPES', () => {
+  it('is exactly the infrastructure-level scope kinds', () => {
+    expect([...INFRA_SCOPE_TYPES].sort()).toEqual(['connection', 'global', 'node'])
+  })
+})
+
+describe('hasInfraScope', () => {
+  it('grants admins infra scope regardless of their scope types', () => {
+    expect(hasInfraScope([], true)).toBe(true)
+    expect(hasInfraScope(undefined, true)).toBe(true)
+    expect(hasInfraScope(['vm'], true)).toBe(true)
+  })
+
+  it('treats a global scope as infra scope', () => {
+    expect(hasInfraScope(['global'], false)).toBe(true)
+  })
+
+  it('treats a connection scope as infra scope', () => {
+    expect(hasInfraScope(['connection'], false)).toBe(true)
+  })
+
+  it('treats a node scope as infra scope', () => {
+    expect(hasInfraScope(['node'], false)).toBe(true)
+  })
+
+  it('returns true when any role carries an infra scope', () => {
+    expect(hasInfraScope(['vm', 'tag', 'node'], false)).toBe(true)
+  })
+
+  it('returns false for VM-only scope (the restricted-customer case)', () => {
+    expect(hasInfraScope(['vm'], false)).toBe(false)
+  })
+
+  it('returns false for tag-only or pool-only scopes', () => {
+    expect(hasInfraScope(['tag'], false)).toBe(false)
+    expect(hasInfraScope(['pool'], false)).toBe(false)
+    expect(hasInfraScope(['tag', 'pool'], false)).toBe(false)
+  })
+
+  it('returns false when the user has no scopes at all', () => {
+    expect(hasInfraScope([], false)).toBe(false)
+    expect(hasInfraScope(undefined, false)).toBe(false)
+    expect(hasInfraScope(null, false)).toBe(false)
+  })
+})

--- a/frontend/src/lib/rbac/scopeKinds.ts
+++ b/frontend/src/lib/rbac/scopeKinds.ts
@@ -1,0 +1,31 @@
+/**
+ * Client-safe helpers describing what a user's RBAC scope kinds reveal.
+ *
+ * Kept dependency-free (no prisma / server imports) so it can be used from
+ * client components — the nav menu and the topology page both gate on it.
+ */
+
+/**
+ * Scope kinds that grant an infrastructure-level view: the user can see
+ * cluster / node topology. A role scoped to one of these (or `global`) is a
+ * provider-side scope. VM / tag / pool scopes are resource-flat: they reveal
+ * individual guests but never the underlying cluster/node layout.
+ */
+export const INFRA_SCOPE_TYPES = ['global', 'connection', 'node'] as const
+
+/**
+ * True when the user may see infrastructure topology, i.e. they are an admin
+ * or hold at least one infra-level scope. VM / tag / pool only scopes return
+ * false — those users get a flat resource view with no cluster/node topology,
+ * so topology-revealing surfaces (the Topology page, inventory tree/hosts)
+ * stay hidden for them.
+ */
+export function hasInfraScope(
+  scopeTypes: readonly string[] | null | undefined,
+  isAdmin: boolean,
+): boolean {
+  if (isAdmin) return true
+  if (!scopeTypes) return false
+
+  return scopeTypes.some(s => (INFRA_SCOPE_TYPES as readonly string[]).includes(s))
+}


### PR DESCRIPTION
## Summary

Restrict connection/node/vm-scoped RBAC users to only the connections and nodes their scope grants, across the inventory tree, the topology page, the live inventory stream and events, and the connections list. Previously such a user saw the entire fleet topology (all connections, nodes and PBS servers) while only their VMs were filtered.

## Background

On the provider tenant, RBAC role scopes only ever filtered guests (VMs). Connections, nodes, PBS and external hypervisors were returned in full to any authenticated user, so a user scoped to a single node still saw the whole tree and every other connection. Only tenant isolation (vDC / MSP) hid connections. This change applies RBAC role-scope filtering at the same chokepoints, composed with the existing tenant/vDC mask.

## What changed

- New pure module `lib/rbac/infraScope.ts`: an `RbacInfraScope` mask derived from a user's grants (`deriveRbacInfraScope`), plus `isConnectionVisible`, `filterVisibleConnections` and `applyRbacInfraFilter`. Only connection/node/vm scopes describe infrastructure; tag/pool scopes are resource-flat and never widen the tree. Super admin or a global scope returns null (unrestricted). Nodes are pruned without touching guests.
- `lib/rbac/index.ts`: `getRbacInfraScope` wrapper over `loadUserGrants`.
- Inventory route, stream and events: prune clusters, nodes, PBS and external hypervisors by the RBAC scope, composed with the existing tenant/vDC mask. Inventory events are gated by connection AND node membership.
- Connections list: filter rows post-query by the RBAC scope (the provider query is unchanged; admins are unaffected).
- Hide the Topology nav item and page for vm/tag/pool-only roles (roles with no infrastructure scope).

## Safety and behavior

- Admins and global-scoped users: no change.
- Filtering runs per request on cloned data, so the shared inventory cache is never mutated and cannot leak one user's filtered view to another.
- Composes with (does not replace) the existing tenant/vDC isolation.
- Enterprise-only surface.

## Tests

50 tests across 5 new or extended Vitest files: `infraScope` unit tests, inventory route scope, inventory events scope, connections list scope, and the topology scope-kinds tests. Manually validated in the browser with a node-scoped user (sees only the granted connection and node, all other connections/nodes/PBS hidden) and with an admin (full tree unchanged).

## Deferred to a follow-up

RBAC scoping of the secondary aggregate reads is intentionally out of scope here: changes / changes-recent / top-level events, the dashboard KPIs, and the orchestrator alerts routes. The dashboard needs care so capacity KPIs are not under-counted, and the alerts routes should extend the existing alert-visibility helper rather than add a parallel filter. These will be handled separately.
