### PR TITLE
feat(users): grant Community-created users full super-admin (#512)

### DIFF
--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -480,6 +480,14 @@ return
           )
         })()}
 
+        {!showRbac && !isSelf && (
+          <Alert severity='info' icon={<i className='ri-information-line' />} sx={{ mb: 2 }}>
+            <Typography variant='caption'>
+              {t ? t('usersPage.communityAdminNotice') : 'In Community edition, every user has full administrator access. Scoped, role-based permissions require the Enterprise edition.'}
+            </Typography>
+          </Alert>
+        )}
+
         {isEdit && !isSelf && (
           <FormControlLabel
             control={

--- a/frontend/src/app/api/v1/users/route.test.ts
+++ b/frontend/src/app/api/v1/users/route.test.ts
@@ -1,0 +1,120 @@
+/**
+ * POST /api/v1/users — Community auto super-admin grant (issue #512).
+ *
+ * Community edition has no RBAC role-management UI, so a user created there
+ * would otherwise have zero permissions and see nothing. On Community every
+ * new user is granted role_super_admin (mirroring the setup account);
+ * Enterprise leaves the grant out and assigns scoped roles via the RBAC
+ * picker instead. Detection uses getServerLicense() (fail-closed to
+ * Community), the same signal that drives RBAC picker visibility in the UI.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { callRoute } from "@/__tests__/setup/route-test"
+
+const checkPermissionMock = vi.fn()
+const getCurrentTenantIdMock = vi.fn()
+const getServerLicenseMock = vi.fn()
+const hashPasswordMock = vi.fn(async () => "hashed")
+const auditMock = vi.fn(async () => {})
+
+const userFindUniqueMock = vi.fn()
+const userCreateMock = vi.fn((args: any) => ({ __op: "user.create", args }))
+const userTenantCreateMock = vi.fn((args: any) => ({ __op: "userTenant.create", args }))
+const rbacUserRoleCreateMock = vi.fn((args: any) => ({ __op: "rbacUserRole.create", args }))
+const tenantFindManyMock = vi.fn()
+const transactionMock = vi.fn(async (ops: any[]) => ops)
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn(async () => ({ user: { id: "admin" } })) }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/auth/password", () => ({ hashPassword: hashPasswordMock }))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    user: { findUnique: userFindUniqueMock, create: userCreateMock },
+    userTenant: { create: userTenantCreateMock },
+    rbacUserRole: { create: rbacUserRoleCreateMock },
+    tenant: { findMany: tenantFindManyMock },
+    $transaction: transactionMock,
+  },
+}))
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_USERS: "admin.users" },
+  isUserSuperAdmin: vi.fn(),
+  PROTECTED_ROLE_IDS: ["role_super_admin", "role_provider_admin"],
+}))
+vi.mock("@/lib/tenant", () => ({
+  DEFAULT_TENANT_ID: "default",
+  getCurrentTenantId: getCurrentTenantIdMock,
+}))
+vi.mock("@/lib/auth/requireEnterprise", () => ({ getServerLicense: getServerLicenseMock }))
+
+async function importPOST() {
+  const mod = await import("./route")
+  return mod.POST
+}
+
+describe("POST /api/v1/users — Community auto super-admin (issue #512)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermissionMock.mockResolvedValue(null) // permission granted
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    userFindUniqueMock.mockResolvedValue(null) // email is free
+  })
+
+  it("Community: grants role_super_admin to the new user and flags the audit", async () => {
+    getServerLicenseMock.mockResolvedValue({
+      enterprise: false,
+      edition: "community",
+      licensed: false,
+      features: [],
+    })
+    const POST = await importPOST()
+    const res = await callRoute(POST as any, {
+      body: { email: "u@example.com", password: "longenoughpw", name: "U" },
+    })
+
+    expect(res.status).toBe(200)
+    // Legacy role field mirrors the setup super-admin account.
+    expect(userCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ role: "super_admin" }) }),
+    )
+    // A real RBAC grant is created inside the same transaction.
+    expect(rbacUserRoleCreateMock).toHaveBeenCalledTimes(1)
+    const grantArg = rbacUserRoleCreateMock.mock.calls[0][0]
+    expect(grantArg.data).toMatchObject({
+      roleId: "role_super_admin",
+      scopeType: "global",
+      scopeTarget: null,
+      tenantId: "default",
+    })
+    // The grant is tied to the exact user that was created.
+    expect(grantArg.data.userId).toBe(userCreateMock.mock.calls[0][0].data.id)
+    expect(transactionMock).toHaveBeenCalledTimes(1)
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ superAdminGranted: true }) }),
+    )
+  })
+
+  it("Enterprise: does NOT auto-grant; the user role stays 'user'", async () => {
+    getServerLicenseMock.mockResolvedValue({
+      enterprise: true,
+      edition: "enterprise",
+      licensed: true,
+      features: ["rbac"],
+    })
+    const POST = await importPOST()
+    const res = await callRoute(POST as any, {
+      body: { email: "e@example.com", password: "longenoughpw" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(userCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ role: "user" }) }),
+    )
+    expect(rbacUserRoleCreateMock).not.toHaveBeenCalled()
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ superAdminGranted: false }) }),
+    )
+  })
+})

--- a/frontend/src/app/api/v1/users/route.ts
+++ b/frontend/src/app/api/v1/users/route.ts
@@ -10,6 +10,7 @@ import { hashPassword } from "@/lib/auth/password"
 import { authOptions } from "@/lib/auth/config"
 import { checkPermission, PERMISSIONS, isUserSuperAdmin, PROTECTED_ROLE_IDS } from "@/lib/rbac"
 import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
+import { getServerLicense } from "@/lib/auth/requireEnterprise"
 
 export const runtime = "nodejs"
 
@@ -214,6 +215,17 @@ export async function POST(req: Request) {
       initialTenantIds = [callerTenantId]
     }
 
+    // Community edition has no RBAC role-management UI (that is Enterprise
+    // only), so a user created here would otherwise receive zero grants and
+    // see nothing after logging in (issue #512). On Community we therefore
+    // grant every new user full super-admin access, mirroring the initial
+    // setup account, so additional users can actually manage the platform.
+    // Enterprise leaves the grant out: scoped roles are assigned separately
+    // through the RBAC picker. A fail-closed license (orchestrator
+    // unreachable) is treated as Community, consistent with the rest of the app.
+    const license = await getServerLicense()
+    const grantSuperAdmin = !license.enterprise
+
     await prisma.$transaction([
       prisma.user.create({
         data: {
@@ -221,7 +233,7 @@ export async function POST(req: Request) {
           email: normalisedEmail,
           password: hashedPassword,
           name: name || null,
-          role: "user",
+          role: grantSuperAdmin ? "super_admin" : "user",
           authProvider: "credentials",
           enabled: true,
           createdAt: now,
@@ -238,6 +250,21 @@ export async function POST(req: Request) {
           },
         })
       ),
+      ...(grantSuperAdmin
+        ? [
+            prisma.rbacUserRole.create({
+              data: {
+                id: nanoid(),
+                userId: id,
+                roleId: "role_super_admin",
+                scopeType: "global",
+                scopeTarget: null,
+                tenantId: DEFAULT_TENANT_ID,
+                grantedAt: now,
+              },
+            }),
+          ]
+        : []),
     ])
 
     // Audit
@@ -248,7 +275,7 @@ export async function POST(req: Request) {
       resourceType: "user",
       resourceId: id,
       resourceName: normalisedEmail,
-      details: { name: name || null },
+      details: { name: name || null, superAdminGranted: grantSuperAdmin },
       status: "success",
     })
 

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5171,6 +5171,7 @@
     "rolesDefinePermissions": "Roles define user Berechtigungen",
     "roleDefinesPermissions": "The role defines user Berechtigungen",
     "protectedRolesNote": "Super Admin und Provider Admin werden unter Sicherheit › RBAC › Zuweisungen verwaltet.",
+    "communityAdminNotice": "In der Community Edition hat jeder Benutzer vollen Administratorzugriff. Rollenbasierte, eingeschränkte Berechtigungen erfordern die Enterprise Edition.",
     "newPassword": "Neues Passwort (leer lassen, um das aktuelle beizubehalten)",
     "minChars": "minimal 8 characters",
     "accountActive": "Konto aktiv",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5235,6 +5235,7 @@
     "rolesDefinePermissions": "Roles define user permissions",
     "roleDefinesPermissions": "The role defines user permissions",
     "protectedRolesNote": "Super Admin and Provider Admin are managed in Security › RBAC › Assignments.",
+    "communityAdminNotice": "In Community edition, every user has full administrator access. Scoped, role-based permissions require the Enterprise edition.",
     "newPassword": "New password (leave empty to keep current)",
     "minChars": "Minimum 8 characters",
     "accountActive": "Account active",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5235,6 +5235,7 @@
     "rolesDefinePermissions": "Les rôles définissent les permissions de l'utilisateur",
     "roleDefinesPermissions": "Le rôle définit les permissions de l'utilisateur",
     "protectedRolesNote": "Super Admin et Provider Admin se gèrent dans Sécurité › RBAC › Assignations.",
+    "communityAdminNotice": "En édition Community, chaque utilisateur dispose d'un accès administrateur complet. Les permissions scopées basées sur les rôles nécessitent l'édition Enterprise.",
     "newPassword": "Nouveau mot de passe (laisser vide pour ne pas changer)",
     "minChars": "Minimum 8 caractères",
     "accountActive": "Compte actif",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5177,6 +5177,7 @@
     "rolesDefinePermissions": "角色定义用户权限",
     "roleDefinesPermissions": "角色定义用户权限",
     "protectedRolesNote": "超级管理员和提供商管理员在 安全 › RBAC › 分配 中管理。",
+    "communityAdminNotice": "在社区版中，每个用户都拥有完整的管理员权限。基于角色的精细化权限需要企业版。",
     "newPassword": "新密码（留空保持不变）",
     "minChars": "至少 8 个字符",
     "accountActive": "账户已激活",


### PR DESCRIPTION
## Summary

On Community edition there is no RBAC role-management UI (that is an Enterprise feature), so a user created via Settings > Security > Users received no role grant and could access nothing: blank dashboard, empty inventory, widgets showing zeros instead of real data. Reported in discussion #512.

Since Community has no concept of scoped roles, this grants every user created on Community full super-admin access (the same access as the initial setup account), so additional users can actually manage and share the platform. Enterprise is unchanged: scoped roles continue to be assigned via the RBAC picker.

## Changes

- `api/v1/users` POST: when the server license is non-Enterprise, add a `role_super_admin` grant (global scope, default tenant) inside the same transaction, and set the legacy role field. The gate uses the same license signal that drives RBAC picker visibility in the UI, so the backend grant and the UI never disagree (both degrade to Community together if the license backend is unreachable).
- Community-only notice in the user dialog explaining that every user has full administrator access and that scoped roles require Enterprise (en/fr/de/zh-CN).
- Route test covering both the Community grant and the Enterprise no-grant paths.

## Testing

- `vitest run src/app/api/v1/users/route.test.ts` passes (2 tests).
- Browser-validated on Community: a newly created user logs in and sees the full dashboard with real data and inventory, instead of the previous empty/zeroed dashboard. The Community notice appears in the user dialog.

Resolves the problem reported in discussion #512.
