### PR TITLE
fix(migration): allocate a free NBD device for warm migration (#521)

### DIFF
--- a/frontend/src/lib/migration/warm/vddk-reader.test.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.test.ts
@@ -16,14 +16,23 @@ const OPTS: VddkOpts = {
 }
 
 describe("pure builders", () => {
-  it("frees a stale device, then connects the unix socket to a kernel nbd device", () => {
-    const c = buildNbdConnectCmd("/tmp/v.sock", "/dev/nbd3")
-    expect(c).toContain("nbd-client -unix /tmp/v.sock /dev/nbd3")
-    // Defensively detach /dev/nbd3 first: a device left allocated by a previous
-    // failed/aborted attempt otherwise blocks the attach with "Failed to setup
-    // device" on every retry (#503). The detach must precede the attach.
-    expect(c).toContain("nbd-client -d /dev/nbd3")
-    expect(c.indexOf("nbd-client -d /dev/nbd3")).toBeLessThan(c.indexOf("nbd-client -unix"))
+  it("attaches the socket to the first FREE nbd device and echoes the choice", () => {
+    const c = buildNbdConnectCmd("/tmp/v.sock")
+    // Iterate the kernel NBD devices and skip any whose client is live (its pid
+    // file is non-empty) — a device left allocated by a previous failed/aborted
+    // attempt keeps its pid file, so it is skipped instead of blocking the retry
+    // with "nbd0 already in use" (#521).
+    expect(c).toContain("for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15")
+    expect(c).toContain("[ -s /sys/block/nbd$i/pid ] && continue")
+    // Attach to the candidate device and, on success, report which one we took.
+    expect(c).toContain("nbd-client -unix /tmp/v.sock /dev/nbd$i")
+    expect(c).toContain('echo "NBD_DEV=$ATTACHED"')
+    // No fixed per-disk device is hardcoded any more (that was the collision cause).
+    expect(c).not.toContain("/dev/nbd3")
+    // Never detach inside the allocation loop: on a lost race the candidate is
+    // owned by another concurrent migration, and `nbd-client -d` would disconnect
+    // its live reader. A failed attach must simply fall through to the next device.
+    expect(c).not.toContain("nbd-client -d")
   })
   it("tears down device, nbdkit, socket, password file", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw" })
@@ -39,22 +48,32 @@ describe("pure builders", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw", logFile: "/tmp/v.log" })
     expect(c).toContain("/tmp/v.log")
   })
+  it("omits the device detach when no device was allocated (attach failed before a device was chosen)", () => {
+    const c = buildReaderTeardownCmd({ nbdDev: "", sock: "/tmp/v.sock", pwFile: "/tmp/pw" })
+    // With no owned device there is nothing to detach; a bare `nbd-client -d`
+    // would error and, worse, could target an unintended device.
+    expect(c).not.toContain("nbd-client -d")
+    // nbdkit and temp files are still cleaned up.
+    expect(c).toContain('pkill -f "[n]bdkit.*/tmp/v.sock"')
+    expect(c).toContain("rm -f /tmp/v.sock /tmp/pw")
+  })
 })
 
 describe("startVddkReader", () => {
   beforeEach(() => mockSSH.mockReset())
 
-  it("writes the password file, launches nbdkit, waits for the socket, attaches the device", async () => {
-    // call 0: pw-write + launch ; call 1: socket missing ; call 2: socket EXISTS ; call 3: nbd-client connect
+  it("writes the password file, launches nbdkit, waits for the socket, attaches a free device", async () => {
+    // call 0: pw-write + launch ; call 1: socket missing ; call 2: socket EXISTS ; call 3: nbd-client attach (reports the chosen device)
     mockSSH
       .mockResolvedValueOnce({ success: true, output: "12345" })
       .mockResolvedValueOnce({ success: true, output: "" })
       .mockResolvedValueOnce({ success: true, output: "EXISTS" })
-      .mockResolvedValueOnce({ success: true, output: "" })
+      .mockResolvedValueOnce({ success: true, output: "NBD_DEV=/dev/nbd0" })
 
-    const handle = await startVddkReader("conn", "10.99.99.201", OPTS, "s3cr3t", "/dev/nbd3", { intervalMs: 0, maxAttempts: 5 })
+    const handle = await startVddkReader("conn", "10.99.99.201", OPTS, "s3cr3t", { intervalMs: 0, maxAttempts: 5 })
 
-    expect(handle.nbdDev).toBe("/dev/nbd3")
+    // The device is whatever the node reported free, not a caller-chosen index.
+    expect(handle.nbdDev).toBe("/dev/nbd0")
     expect(handle.sock).toBe("/tmp/v.sock")
     expect(handle.pwFile).toBe("/tmp/pw")
     // The launch call writes the password (no trailing newline) and backgrounds nbdkit to a log file.
@@ -62,9 +81,20 @@ describe("startVddkReader", () => {
     expect(launchCmd).toContain("printf '%s'")
     expect(launchCmd).toContain("nohup nbdkit -r -U '/tmp/v.sock' vddk")
     expect(launchCmd).not.toContain("\ns3cr3t\n") // password not heredoc'd raw
-    // The device-attach call uses the connect builder.
+    // The device-attach call uses the free-device connect builder.
     const connectCmd = mockSSH.mock.calls[3][2] as string
-    expect(connectCmd).toContain("nbd-client -unix /tmp/v.sock /dev/nbd3")
+    expect(connectCmd).toContain("nbd-client -unix /tmp/v.sock /dev/nbd$i")
+  })
+
+  it("returns the actual device the node picked (not a fixed index)", async () => {
+    mockSSH.mockImplementation(async (...args: unknown[]) => {
+      const cmd = String(args[2] ?? "")
+      if (cmd.includes("test -S")) return { success: true, output: "EXISTS" }
+      if (cmd.includes("nbd-client -unix")) return { success: true, output: "NBD_DEV=/dev/nbd7" }
+      return { success: true, output: "12345" }
+    })
+    const handle = await startVddkReader("conn", "10.99.99.201", OPTS, "pw", { intervalMs: 0, maxAttempts: 3 })
+    expect(handle.nbdDev).toBe("/dev/nbd7")
   })
 
   it("throws with the nbdkit log when the socket never appears", async () => {
@@ -77,20 +107,22 @@ describe("startVddkReader", () => {
     })
 
     await expect(
-      startVddkReader("conn", "10.99.99.201", OPTS, "pw", "/dev/nbd3", { intervalMs: 0, maxAttempts: 3 }),
+      startVddkReader("conn", "10.99.99.201", OPTS, "pw", { intervalMs: 0, maxAttempts: 3 }),
     ).rejects.toThrow(/bad thumbprint|nbdkit/i)
   })
 
-  it("throws when nbd-client fails to attach the device", async () => {
+  it("throws when no free device could be attached", async () => {
+    // Every candidate was busy (or lost to a race): the command exits non-zero
+    // with NBD_ALLOC_FAILED and no NBD_DEV line, so no device is returned.
     mockSSH.mockImplementation(async (...args: unknown[]) => {
       const cmd = String(args[2] ?? "")
       if (cmd.includes("test -S")) return { success: true, output: "EXISTS" }
-      if (cmd.includes("nbd-client -unix")) return { success: false, output: "", error: "Device or resource busy" }
+      if (cmd.includes("nbd-client -unix")) return { success: false, output: "NBD_ALLOC_FAILED: nbd0 already in use", error: "" }
       return { success: true, output: "" }
     })
     await expect(
-      startVddkReader("conn", "10.99.99.201", OPTS, "pw", "/dev/nbd3", { intervalMs: 0, maxAttempts: 3 }),
-    ).rejects.toThrow(/busy|nbd-client/i)
+      startVddkReader("conn", "10.99.99.201", OPTS, "pw", { intervalMs: 0, maxAttempts: 3 }),
+    ).rejects.toThrow(/free NBD device|already in use/i)
   })
 })
 

--- a/frontend/src/lib/migration/warm/vddk-reader.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.ts
@@ -11,19 +11,41 @@ export interface VddkReaderHandle {
 }
 
 /**
- * Attach an nbdkit unix socket to a kernel NBD device. `modprobe nbd` is a
- * no-op when the module is already loaded; `max_part=0` keeps the kernel from
- * scanning the source disk's partition table (we read it as a flat image).
- * The `nbd-client -d` before the attach defensively frees the device: a
- * /dev/nbdN left allocated by a previous failed or aborted attempt (whose
- * teardown never ran) otherwise blocks every retry with "Failed to setup
- * device, check dmesg" (#503). It is a no-op (suppressed) when the device is
- * already free, so it is safe in the normal case.
- * sock/nbdDev are system-generated paths (no spaces/metacharacters), so they
- * are interpolated unescaped to match the validated spike command.
+ * Attach a running nbdkit unix socket to the first FREE kernel NBD device and
+ * echo the device it chose as `NBD_DEV=/dev/nbdN` (or `NBD_ALLOC_FAILED: …` and
+ * a non-zero exit when none could be attached).
+ *
+ * `modprobe nbd` is a no-op when the module is already loaded; `max_part=0`
+ * keeps the kernel from scanning the source disk's partition table (we read it
+ * as a flat image).
+ *
+ * We iterate /dev/nbd0../dev/nbd15 and skip any device whose kernel client is
+ * live (`/sys/block/nbdN/pid` non-empty), then attach to the first free one.
+ * This deliberately replaces the old fixed per-disk device (#521): a /dev/nbdN
+ * left allocated by a previous failed/aborted attempt (or by an unrelated NBD
+ * user) keeps its pid file, so it is skipped instead of blocking every retry
+ * with "nbd0 already in use". This also sidesteps a *wedged* device whose pid
+ * file points at a now-dead process (`nbd-client -d` cannot reclaim it and
+ * `rmmod nbd` refuses while it is held) — it stays non-empty, so we skip it and
+ * use the next free device instead of failing (#521 field case).
+ * We NEVER `nbd-client -d` a device we did not attach: if a candidate we saw
+ * free was grabbed by a concurrent migration between the pid check and our
+ * attach, our `nbd-client -unix` simply fails (the device is in use) and we move
+ * on to the next candidate — detaching it here would disconnect the other job's
+ * live reader and corrupt its copy. So no node-wide lock is needed.
+ * `sock` is a system-generated path (no spaces/metacharacters), so it is
+ * interpolated unescaped to match the validated spike command.
  */
-export function buildNbdConnectCmd(sock: string, nbdDev: string): string {
-  return `modprobe nbd max_part=0 2>/dev/null; nbd-client -d ${nbdDev} 2>/dev/null; nbd-client -unix ${sock} ${nbdDev} 2>&1`
+export function buildNbdConnectCmd(sock: string): string {
+  return [
+    "modprobe nbd max_part=0 2>/dev/null",
+    "ATTACHED=",
+    "for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do",
+    "  [ -s /sys/block/nbd$i/pid ] && continue",
+    `  if err=$(nbd-client -unix ${sock} /dev/nbd$i 2>&1); then ATTACHED=/dev/nbd$i; echo "NBD_DEV=$ATTACHED"; break; fi`,
+    "done",
+    '[ -n "$ATTACHED" ] || { echo "NBD_ALLOC_FAILED: ${err}"; exit 1; }',
+  ].join("\n")
 }
 
 /**
@@ -34,6 +56,10 @@ export function buildNbdConnectCmd(sock: string, nbdDev: string): string {
  */
 export function buildReaderTeardownCmd(h: VddkReaderHandle): string {
   const files = [h.sock, h.pwFile, h.logFile].filter(Boolean).join(" ")
+  // Only detach a device we actually own. When attach failed before any device
+  // was chosen (h.nbdDev === ""), a bare `nbd-client -d` would error and could
+  // target an unintended device — so skip it entirely in that case.
+  const detach = h.nbdDev ? `nbd-client -d ${h.nbdDev} 2>/dev/null; ` : ""
   // The pkill pattern is "[n]bdkit" (a one-character class), not "nbdkit":
   // pkill -f matches against each process's FULL command line, and this teardown
   // command's own shell carries the pattern string in its argv (and the sock path
@@ -41,17 +67,18 @@ export function buildReaderTeardownCmd(h: VddkReaderHandle): string {
   // the teardown shell itself (exit 143, and the rm cleanup never runs, leaking the
   // temp files). "[n]bdkit" still matches the real `nbdkit …` process but no longer
   // matches this shell's own "[n]bdkit" literal.
-  return `nbd-client -d ${h.nbdDev} 2>/dev/null; pkill -f "[n]bdkit.*${h.sock}" 2>/dev/null; rm -f ${files}`
+  return `${detach}pkill -f "[n]bdkit.*${h.sock}" 2>/dev/null; rm -f ${files}`
 }
 
 export interface PollOpts { intervalMs?: number; maxAttempts?: number }
 
 /**
- * Start an nbdkit-vddk reader on the PVE node and attach it to `nbdDev`:
+ * Start an nbdkit-vddk reader on the PVE node and attach it to a free NBD device:
  *   1. write the ESXi password to opts.passwordFile (0600, no trailing newline)
  *      and launch `buildNbdkitVddkCmd(opts)` backgrounded with output to a log,
  *   2. poll until the unix socket appears (VDDK login can take a few seconds),
- *   3. attach the socket to the kernel NBD device.
+ *   3. attach the socket to the first free kernel NBD device and record which
+ *      one was chosen in the returned handle.
  * On socket timeout the nbdkit log is read back so the caller sees the real
  * VDDK failure (bad thumbprint, snapshot gone, …) rather than a bare timeout.
  */
@@ -60,7 +87,6 @@ export async function startVddkReader(
   nodeIp: string,
   opts: VddkOpts,
   esxiPassword: string,
-  nbdDev: string,
   poll: PollOpts = {},
 ): Promise<VddkReaderHandle> {
   const intervalMs = poll.intervalMs ?? 1000
@@ -89,19 +115,25 @@ export async function startVddkReader(
   }
   if (!ready) {
     const log = await executeSSH(connectionId, nodeIp, `cat ${shellEscape(logFile)} 2>/dev/null | tail -n 20`)
-    await stopVddkReader(connectionId, nodeIp, { nbdDev, sock: opts.sock, pwFile: opts.passwordFile, logFile }).catch(() => {})
+    // No device was attached (we never reached the attach step), so pass nbdDev:""
+    // — teardown must not `nbd-client -d` a device this reader never owned.
+    await stopVddkReader(connectionId, nodeIp, { nbdDev: "", sock: opts.sock, pwFile: opts.passwordFile, logFile }).catch(() => {})
     throw new Error(`nbdkit-vddk socket never appeared. nbdkit log: ${log.output?.trim() || "(empty)"}`)
   }
 
-  // Attach the socket to the kernel device.
-  const connect = await executeSSH(connectionId, nodeIp, buildNbdConnectCmd(opts.sock, nbdDev))
-  if (!connect.success) {
+  // Attach the socket to the first free kernel NBD device; the command echoes
+  // the device it chose as "NBD_DEV=/dev/nbdN".
+  const connect = await executeSSH(connectionId, nodeIp, buildNbdConnectCmd(opts.sock))
+  const nbdDev = (connect.output ?? "")
+    .split("\n").map(l => l.trim())
+    .find(l => l.startsWith("NBD_DEV="))?.slice("NBD_DEV=".length).trim() ?? ""
+  if (!connect.success || !nbdDev) {
     // The VDDK failure detail lands in the nbdkit log (and the nbd-client output
-    // via 2>&1), not in the orchestrator's generic exit message — read both
-    // before teardown removes the log.
+    // via the command's NBD_ALLOC_FAILED echo), not in the orchestrator's generic
+    // exit message — read both before teardown removes the log.
     const log = await executeSSH(connectionId, nodeIp, `cat ${shellEscape(logFile)} 2>/dev/null | tail -n 40`)
     await stopVddkReader(connectionId, nodeIp, { nbdDev, sock: opts.sock, pwFile: opts.passwordFile, logFile }).catch(() => {})
-    throw new Error(`nbd-client failed to attach ${nbdDev}: ${(connect.output || connect.error || "").trim()} | nbdkit log: ${log.output?.trim() || "(empty)"}`)
+    throw new Error(`nbd-client failed to attach a free NBD device: ${(connect.output || connect.error || "").trim()} | nbdkit log: ${log.output?.trim() || "(empty)"}`)
   }
 
   return { nbdDev, sock: opts.sock, pwFile: opts.passwordFile, logFile }

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -327,9 +327,8 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       if (extents.length === 0) return 0
       const sock = `/tmp/proxcenter-vddk-${jobId}-${disk.deviceKey}.sock`
       const pwFile = `/tmp/proxcenter-vddk-${jobId}-${disk.deviceKey}.pw`
-      const nbdDev = `/dev/nbd${diskIndex}`
       const opts: VddkOpts = { sock, libdir, server: esxiHost, user: username, passwordFile: pwFile, thumbprint, moref: config.sourceVmId, diskPath: disk.fileName, snapshot: snapMor }
-      const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password, nbdDev)
+      const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password)
       activeReaders.push(reader)
       try {
         await applyExtents(reader.nbdDev, targetDev.get(disk.deviceKey)!, extents, disk.capacityBytes, "block apply failed", diskIndex)
@@ -425,9 +424,8 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
           const disk = vmConfig.disks[i]
           const sock = `/tmp/proxcenter-vddk-${jobId}-${disk.deviceKey}.sock`
           const pwFile = `/tmp/proxcenter-vddk-${jobId}-${disk.deviceKey}.pw`
-          const nbdDev = `/dev/nbd${i}`
           const opts: VddkOpts = { sock, libdir, server: esxiHost, user: username, passwordFile: pwFile, thumbprint, moref: config.sourceVmId, diskPath: disk.fileName, snapshot: snapMor }
-          const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password, nbdDev)
+          const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password)
           activeReaders.push(reader)
           try {
             const dev = targetDev.get(disk.deviceKey)!
@@ -460,7 +458,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       const pwFile = `/tmp/proxcenter-vddk-${jobId}-vrfy-${disk.deviceKey}.pw`
       try {
         const reader = await startVddkReader(config.targetConnectionId, nodeIp,
-          { sock, libdir, server: esxiHost, user: username, passwordFile: pwFile, thumbprint, moref: config.sourceVmId, diskPath: disk.fileName }, password, `/dev/nbd${i}`)
+          { sock, libdir, server: esxiHost, user: username, passwordFile: pwFile, thumbprint, moref: config.sourceVmId, diskPath: disk.fileName }, password)
         try {
           const [src, dst] = await Promise.all([
             scanBlockChecksums(config.targetConnectionId, nodeIp, reader.nbdDev, 256 * 1024 * 1024, 1),


### PR DESCRIPTION
## Problem (#521)

VMware warm migration (CBT/VDDK) could fail on retry with:

```
✗ Warm migration failed: nbd-client failed to attach /dev/nbd0: ... Error: Failed to setup device, check dmesg
```

with `nbd: nbd0 already in use` in the node's dmesg. Once a previous attempt left `/dev/nbd0` allocated (for example a wedged device: a stale `/sys/block/nbd0/pid` whose backing process is dead, which `nbd-client -d` cannot reclaim and while it is held `rmmod nbd` refuses), every subsequent migration was stuck because the device could not be reattached.

## Root cause

The warm pipeline attached each disk to a hard-coded `/dev/nbd${diskIndex}` and, before attaching, ran an asynchronous `nbd-client -d` immediately followed by the reattach. Two problems:

1. The kernel had not finished releasing the device by the time the reattach ran, so a device left over from a prior failure kept blocking the same fixed index.
2. Because the device was fixed and detached defensively, two migrations to the same node could collide on `nbd0`, and the defensive `-d` could disconnect a device owned by another in-flight migration.

## Fix

`buildNbdConnectCmd` now allocates a device dynamically:

- Scan `/dev/nbd0..15` and skip any device whose kernel client is live (non-empty `/sys/block/nbdN/pid`). This naturally skips a wedged device (stale pid) instead of failing on it.
- Attach the first free device and report it as `NBD_DEV=/dev/nbdN`; `startVddkReader` parses that and records it in the handle. Callers already consumed `reader.nbdDev` downstream, so no caller logic changed beyond dropping the now-unused device argument.
- Never `nbd-client -d` a device we did not attach. If a candidate we saw free is grabbed by a concurrent migration between the pid check and our attach, our attach simply fails and we fall through to the next device. This removes the collision and the risk of disconnecting another job's live reader, without needing a node-wide lock.

The command stays within the same shell command families already used by the cold-migration path, so no orchestrator-side change is required.

## Testing

- `vddk-reader` unit tests updated and extended (free-device selection, device parsing, teardown guard when no device was allocated, the lost-race no-detach invariant): 9/9 pass.
- Full warm-migration test module: 72/72 pass.
- Generated node-side command verified as valid POSIX shell (`sh -n`).
- Type check clean on the touched files.

## Notes

- Frontend-only. No backend or orchestrator change.
- `warm-pipeline.ts` is in `sonar.coverage.exclusions`; the covered logic lives in `vddk-reader.ts` and is exercised by the tests.
- Field limitation: a device that gets wedged still requires a reboot to reclaim the slot itself, but it no longer blocks migrations (it is skipped and a free device is used).

Refs #521 (kept open until confirmed by the reporter on a released build)
