### PR TITLE
fix(inventory,theme): persist panel width and make theme status chips readable (#538)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/page.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/page.tsx
@@ -72,8 +72,13 @@ export default function InventoryPage() {
 
   // Favoris (derived from SWR above)
   
-  // État pour collapse la tree
-  const [isTreeCollapsed, setIsTreeCollapsed] = useState(false)
+  // État pour collapse la tree (persisté — #538)
+  const [isTreeCollapsed, setIsTreeCollapsed] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('pxc-inventory-tree-collapsed') === 'true'
+    }
+    return false
+  })
 
   // Show VM ID in tree
   const [showVmId, setShowVmId] = useState(() => {
@@ -386,8 +391,16 @@ return () => setPageInfo('', '', '')
     }
   }, [favorites, mutateFavorites])
 
-  // Largeur du panneau gauche (resizable)
-  const [leftWidth, setLeftWidth] = useState(DEFAULT_LEFT_WIDTH)
+  // Largeur du panneau gauche (resizable, persistée — #538)
+  const [leftWidth, setLeftWidth] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const saved = Number(localStorage.getItem('pxc-inventory-tree-width'))
+      if (Number.isFinite(saved) && saved > 0) {
+        return Math.min(MAX_LEFT_WIDTH, Math.max(MIN_LEFT_WIDTH, saved))
+      }
+    }
+    return DEFAULT_LEFT_WIDTH
+  })
   const [isResizing, setIsResizing] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
 
@@ -444,6 +457,19 @@ return () => setPageInfo('', '', '')
       document.removeEventListener('mouseup', handleMouseUp)
     }
   }, [isResizing])
+
+  // Persiste la largeur du panneau pour la conserver après navigation/reload (#538).
+  // Écrit une fois par redimensionnement (au relâchement), pas à chaque mousemove.
+  useEffect(() => {
+    if (isResizing || typeof window === 'undefined') return
+    localStorage.setItem('pxc-inventory-tree-width', String(leftWidth))
+  }, [isResizing, leftWidth])
+
+  // Persiste l'état replié du panneau (#538).
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    localStorage.setItem('pxc-inventory-tree-collapsed', String(isTreeCollapsed))
+  }, [isTreeCollapsed])
 
   // Charger les IP, Snapshots et Uptime pour toutes les VMs
   const loadIpSnap = useCallback(async () => {

--- a/frontend/src/components/theme/index.jsx
+++ b/frontend/src/components/theme/index.jsx
@@ -1115,10 +1115,11 @@ const getGlobalThemeStyles = (globalTheme, mode, customBorderRadius, blurIntensi
         accentText: '--nord-bg-primary',
         hover: '--nord-bg-tertiary'
       }),
-      '.MuiChip-colorSuccess': { color: 'var(--nord-success) !important', border: '1px solid var(--nord-success) !important' },
-      '.MuiChip-colorError': { color: 'var(--nord-error) !important', border: '1px solid var(--nord-error) !important' },
-      '.MuiChip-colorWarning': { color: 'var(--nord-warning) !important', border: '1px solid var(--nord-warning) !important' },
-      '.MuiChip-colorInfo': { color: 'var(--nord-info) !important', border: '1px solid var(--nord-info) !important' }
+      // #538 : badges pleins (couleurs sémantiques par défaut), lisibles en clair comme en sombre
+      '.MuiChip-colorSuccess': { backgroundColor: 'var(--mui-palette-success-main) !important', color: 'var(--mui-palette-success-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorError': { backgroundColor: 'var(--mui-palette-error-main) !important', color: 'var(--mui-palette-error-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorWarning': { backgroundColor: 'var(--mui-palette-warning-main) !important', color: 'var(--mui-palette-warning-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorInfo': { backgroundColor: 'var(--mui-palette-info-main) !important', color: 'var(--mui-palette-info-contrastText) !important', border: 'none !important' }
     }),
 
     // Dracula Theme
@@ -1173,10 +1174,11 @@ const getGlobalThemeStyles = (globalTheme, mode, customBorderRadius, blurIntensi
         accentText: '--dracula-bg',
         hover: '--dracula-hover'
       }),
-      '.MuiChip-colorSuccess': { color: 'var(--dracula-green) !important', border: '1px solid var(--dracula-green) !important' },
-      '.MuiChip-colorError': { color: 'var(--dracula-red) !important', border: '1px solid var(--dracula-red) !important' },
-      '.MuiChip-colorWarning': { color: 'var(--dracula-orange) !important', border: '1px solid var(--dracula-orange) !important' },
-      '.MuiChip-colorInfo': { color: 'var(--dracula-cyan) !important', border: '1px solid var(--dracula-cyan) !important' }
+      // #538 : badges pleins (couleurs sémantiques par défaut), lisibles en clair comme en sombre
+      '.MuiChip-colorSuccess': { backgroundColor: 'var(--mui-palette-success-main) !important', color: 'var(--mui-palette-success-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorError': { backgroundColor: 'var(--mui-palette-error-main) !important', color: 'var(--mui-palette-error-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorWarning': { backgroundColor: 'var(--mui-palette-warning-main) !important', color: 'var(--mui-palette-warning-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorInfo': { backgroundColor: 'var(--mui-palette-info-main) !important', color: 'var(--mui-palette-info-contrastText) !important', border: 'none !important' }
     }),
 
     // One Dark Theme (Atom/VS Code)
@@ -1231,10 +1233,11 @@ const getGlobalThemeStyles = (globalTheme, mode, customBorderRadius, blurIntensi
         accentText: '--onedark-bg',
         hover: '--onedark-hover'
       }),
-      '.MuiChip-colorSuccess': { color: 'var(--onedark-green) !important', border: '1px solid var(--onedark-green) !important' },
-      '.MuiChip-colorError': { color: 'var(--onedark-red) !important', border: '1px solid var(--onedark-red) !important' },
-      '.MuiChip-colorWarning': { color: 'var(--onedark-yellow) !important', border: '1px solid var(--onedark-yellow) !important' },
-      '.MuiChip-colorInfo': { color: 'var(--onedark-cyan) !important', border: '1px solid var(--onedark-cyan) !important' }
+      // #538 : badges pleins (couleurs sémantiques par défaut), lisibles en clair comme en sombre
+      '.MuiChip-colorSuccess': { backgroundColor: 'var(--mui-palette-success-main) !important', color: 'var(--mui-palette-success-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorError': { backgroundColor: 'var(--mui-palette-error-main) !important', color: 'var(--mui-palette-error-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorWarning': { backgroundColor: 'var(--mui-palette-warning-main) !important', color: 'var(--mui-palette-warning-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorInfo': { backgroundColor: 'var(--mui-palette-info-main) !important', color: 'var(--mui-palette-info-contrastText) !important', border: 'none !important' }
     }),
 
     // Glassmorphism Theme - special glass effects on sidebar too
@@ -1396,10 +1399,11 @@ const getGlobalThemeStyles = (globalTheme, mode, customBorderRadius, blurIntensi
         accentHover: '--corp-accent-hover',
         hover: '--corp-hover'
       }),
-      '.MuiChip-colorSuccess': { color: 'var(--corp-success) !important' },
-      '.MuiChip-colorError': { color: 'var(--corp-error) !important' },
-      '.MuiChip-colorWarning': { color: 'var(--corp-warning) !important' },
-      '.MuiChip-colorInfo': { color: 'var(--corp-info) !important' },
+      // #538 : badges pleins (couleurs sémantiques par défaut), lisibles en clair comme en sombre
+      '.MuiChip-colorSuccess': { backgroundColor: 'var(--mui-palette-success-main) !important', color: 'var(--mui-palette-success-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorError': { backgroundColor: 'var(--mui-palette-error-main) !important', color: 'var(--mui-palette-error-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorWarning': { backgroundColor: 'var(--mui-palette-warning-main) !important', color: 'var(--mui-palette-warning-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorInfo': { backgroundColor: 'var(--mui-palette-info-main) !important', color: 'var(--mui-palette-info-contrastText) !important', border: 'none !important' },
       '.MuiButton-containedPrimary': {
         backgroundColor: 'var(--corp-accent) !important',
         color: '#ffffff !important',
@@ -1460,10 +1464,11 @@ const getGlobalThemeStyles = (globalTheme, mode, customBorderRadius, blurIntensi
         accentHover: '--round-accent-hover',
         hover: '--round-hover'
       }),
-      '.MuiChip-colorSuccess': { color: 'var(--round-success) !important' },
-      '.MuiChip-colorError': { color: 'var(--round-error) !important' },
-      '.MuiChip-colorWarning': { color: 'var(--round-warning) !important' },
-      '.MuiChip-colorInfo': { color: 'var(--round-info) !important' },
+      // #538 : badges pleins (couleurs sémantiques par défaut), lisibles en clair comme en sombre
+      '.MuiChip-colorSuccess': { backgroundColor: 'var(--mui-palette-success-main) !important', color: 'var(--mui-palette-success-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorError': { backgroundColor: 'var(--mui-palette-error-main) !important', color: 'var(--mui-palette-error-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorWarning': { backgroundColor: 'var(--mui-palette-warning-main) !important', color: 'var(--mui-palette-warning-contrastText) !important', border: 'none !important' },
+      '.MuiChip-colorInfo': { backgroundColor: 'var(--mui-palette-info-main) !important', color: 'var(--mui-palette-info-contrastText) !important', border: 'none !important' },
       '.MuiButton-containedPrimary': {
         backgroundColor: 'var(--round-accent) !important',
         color: 'var(--round-bg) !important',


### PR DESCRIPTION
## What

Two small UI enhancements requested in discussion #538.

### 1. Inventory tree panel width now persists

The left tree panel in the Inventory view could be dragged wider to reveal long VM names, but the width was ephemeral React state and reset to the default (340px) on every remount (navigation away/back or reload). Users had to re-drag it every time.

The panel width and its collapsed state now persist to `localStorage` (`pxc-inventory-tree-width`, `pxc-inventory-tree-collapsed`), reusing the same lazy-init pattern already used for `showVmId` in the same file. The width is written once per resize (on release), clamped to the existing 200-500px bounds.

### 2. Status chips readable in more themes

In the Corporate, Rounded, Nord, Dracula and One Dark themes, filled status chips (success/error/warning/info) rendered same-color text on a same-color background, so labels like "UP", "OK" or "online" were barely legible. The per-theme overrides set only the chip label `color` and left the default filled background in place.

These chips now render as solid filled badges using the default semantic palette (`--mui-palette-<sev>-main` background + `contrastText` label), matching the rest of the app and readable in both light and dark mode. Applied to all four semantic colors across the five affected themes. Themes that were already correct (Terminal, Cyberpunk, High Contrast) are untouched.

## Testing

- Inventory: widen/collapse the tree panel, then navigate away and back and reload. Width and collapsed state are preserved.
- Appearance settings: switch to Corporate, Rounded, Nord, One Dark and Dracula, in both light and dark mode, and confirm status chips are solid and legible.

## Notes

- No unit tests added: both touched files are already excluded from analysis/coverage (`**/*.jsx` and `**/page.tsx` in the Sonar config), and the changes are localStorage side-effects in a client page plus CSS-in-JS strings, with no pure-logic surface worth extracting solely to test.

Requested in discussion #538: https://github.com/adminsyspro/proxcenter-ui/discussions/538
