### PR TITLE
fix(backups): run scheduled job on the guest's real node, not nodes[0] (#537)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/BackupJobsPanel.tsx
@@ -117,6 +117,7 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
   const [vms, setVms] = useState<any[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [runInfo, setRunInfo] = useState<string | null>(null)
 
   // Dialog
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -381,14 +382,26 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
 
   // Run now
   const handleRunNow = async (job: BackupJob) => {
+    setError(null)
+    setRunInfo(null)
     try {
       const result = await runBackupJobNow(connectionId, job.id)
 
       if (!result.ok) {
         setError(result.error || t('inventory.failedToRunBackupJob'))
-      } else {
-        loadJobs()
+        return
       }
+
+      const data = result.data as
+        | { tasks?: unknown[]; errors?: Array<{ node: string; error: string }> }
+        | undefined
+      const started = data?.tasks?.length ?? 0
+      setRunInfo(t('inventory.backupJobStarted', { count: started }))
+      // A run can start on some nodes and fail on others — surface both.
+      if (data?.errors?.length) {
+        setError(data.errors.map((e) => `${e.node}: ${e.error}`).join('; '))
+      }
+      loadJobs()
     } catch (e: any) {
       setError(e?.message || t('inventory.failedToRunBackupJob'))
     }
@@ -571,6 +584,13 @@ export default function BackupJobsPanel({ connectionId, onError }: BackupJobsPan
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
           {error}
+        </Alert>
+      )}
+
+      {/* Run confirmation */}
+      {runInfo && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setRunInfo(null)}>
+          {runInfo}
         </Alert>
       )}
 

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
+const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
+const getAllowedJobPoolsMock = vi.fn<(...args: any[]) => Promise<any>>()
+const maskingScopeMock = vi.fn<(...args: any[]) => any>()
+
+vi.mock('@/lib/proxmox/client', () => ({ pveFetch: pveFetchMock }))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: {
+    BACKUP_JOB_RUN: 'backup_job.run',
+    BACKUP_JOB_VIEW: 'backup_job.view',
+    BACKUP_JOB_EDIT: 'backup_job.edit',
+    BACKUP_JOB_DELETE: 'backup_job.delete',
+  },
+}))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'default' }))
+vi.mock('@/lib/tenant/infraScope', () => ({
+  getTenantInfrastructureScope: async () => null,
+  maskingScope: maskingScopeMock,
+}))
+vi.mock('@/lib/vdc/backupJobs', () => ({
+  getAllowedJobPools: getAllowedJobPoolsMock,
+  isJobOwnedByTenantPools: () => true,
+  validateTenantJobBody: () => null,
+  validateTenantJobInfra: () => null,
+}))
+
+// Cluster: VM 105 lives on pve-r730-01; nodes[0] is the alphabetically-first
+// pve-r240 (the node the old code wrongly picked).
+const NODES = [
+  { node: 'pve-r240', status: 'online' },
+  { node: 'pve-r730-01', status: 'online' },
+  { node: 'pve-r730-02', status: 'online' },
+]
+const RESOURCES = [
+  { vmid: 105, node: 'pve-r730-01', status: 'running', type: 'qemu' },
+  { vmid: 200, node: 'pve-r240', status: 'running', type: 'qemu' },
+]
+
+let vzdumpCalls: Array<{ node: string; body: string }>
+let job: Record<string, any>
+
+function wirePveFetch() {
+  pveFetchMock.mockImplementation(async (_conn: any, path: string, init?: any) => {
+    if (path.startsWith('/cluster/backup/')) return job
+    if (path === '/nodes') return NODES
+    if (path.startsWith('/cluster/resources')) return RESOURCES
+    if (path.startsWith('/nodes/') && path.endsWith('/vzdump')) {
+      const node = path.split('/')[2]
+      vzdumpCalls.push({ node, body: String(init?.body ?? '') })
+      return `UPID:${node}:0000`
+    }
+    throw new Error(`unexpected pveFetch path: ${path}`)
+  })
+}
+
+async function run(jobId = 'backup-1') {
+  const { POST } = await import('./route')
+  const res = await callRoute(POST as any, {
+    params: { id: 'conn-1', jobId },
+    searchParams: { action: 'run' },
+    method: 'POST',
+  })
+  return { status: res.status, body: await readJson<any>(res) }
+}
+
+beforeEach(() => {
+  vzdumpCalls = []
+  pveFetchMock.mockReset()
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'conn-1', apiToken: 't' })
+  getAllowedJobPoolsMock.mockReset().mockResolvedValue(null) // provider (full view)
+  maskingScopeMock.mockReset().mockReturnValue(null)
+  job = { id: 'backup-1', storage: 'PBS', vmid: '105', mode: 'snapshot', compress: 'zstd' }
+  wirePveFetch()
+})
+
+describe('POST /api/v1/connections/[id]/backup-jobs/[jobId]?action=run', () => {
+  it('#537: dispatches vzdump to the node hosting the selected VM, not nodes[0]', async () => {
+    const { status, body } = await run()
+
+    expect(status).toBe(200)
+    expect(vzdumpCalls).toHaveLength(1)
+    expect(vzdumpCalls[0].node).toBe('pve-r730-01') // NOT pve-r240
+    expect(vzdumpCalls[0].body).toContain('vmid=105')
+    expect(vzdumpCalls[0].body).toContain('storage=PBS')
+    expect(body.data.tasks).toHaveLength(1)
+    expect(body.message).toContain('1 node')
+  })
+
+  it('replays the job retention/options on the run', async () => {
+    job['prune-backups'] = 'keep-last=3'
+    const { body } = await run()
+    expect(vzdumpCalls[0].body).toContain('prune-backups=keep-last')
+    expect(body.data.tasks[0].node).toBe('pve-r730-01')
+  })
+
+  it('returns 400 when the selected guest is not on any online node', async () => {
+    job.vmid = '999' // unknown vmid
+    const { status, body } = await run()
+    expect(status).toBe(400)
+    expect(vzdumpCalls).toHaveLength(0)
+    expect(body.error).toMatch(/not on an online node/i)
+  })
+
+  it('honours a pinned node without a resource lookup', async () => {
+    job = { id: 'backup-1', storage: 'PBS', vmid: '105', node: 'pve-r240' }
+    const { status } = await run()
+    expect(status).toBe(200)
+    expect(vzdumpCalls[0].node).toBe('pve-r240')
+    // pinned path must not query /cluster/resources
+    expect(pveFetchMock.mock.calls.some((c) => String(c[1]).startsWith('/cluster/resources'))).toBe(false)
+  })
+
+  it('rejects the run when RBAC denies it', async () => {
+    checkPermissionMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'denied' }), { status: 403 }),
+    )
+    const { status } = await run()
+    expect(status).toBe(403)
+    expect(vzdumpCalls).toHaveLength(0)
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/backup-jobs/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { applyMaxfilesTranslation } from "@/lib/backups/prune"
+import { buildSharedVzdumpParams, planBackupRunDispatch, type VmLocation } from "@/lib/backups/runDispatch"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
@@ -330,46 +331,76 @@ export async function POST(req: Request, ctx: RouteContext) {
     const conn = await getConnectionById(id)
 
     if (action === 'run') {
-      // Exécuter le job immédiatement
-      // Note: Proxmox n'a pas d'endpoint direct pour ça, on doit utiliser vzdump
-      // avec les mêmes paramètres que le job
+      // Proxmox has no "run job by id" endpoint: an immediate run must POST to
+      // /nodes/{node}/vzdump, and vzdump is strictly node-local. We resolve the
+      // node(s) that actually host the job's selection and issue one vzdump per
+      // node, mirroring the scheduler. The old code sent the job to an
+      // arbitrary nodes[0], so it backed up nothing when the guest lived on a
+      // different node (issue #537).
       const owned = await loadJobForTenant(conn, id, jobId)
       if ('error' in owned) return owned.error
       const job = owned.job
 
-      // Construire la commande vzdump
-      const params = new URLSearchParams()
+      const nodesList = (await pveFetch<any[]>(conn, `/nodes`)) || []
+      const onlineNodes = nodesList
+        .filter((n: any) => n.status === 'online')
+        .map((n: any) => n.node)
 
-      params.set('storage', job.storage)
-      if (job.mode) params.set('mode', job.mode)
-      if (job.compress) params.set('compress', job.compress)
-
-      // VMs à sauvegarder
-      if (job.all) {
-        params.set('all', '1')
-        if (job.exclude) params.set('exclude', job.exclude)
-      } else if (job.vmid) {
-        params.set('vmid', job.vmid)
-      } else if (job.pool) {
-        params.set('pool', job.pool)
+      // Pinned jobs run exactly where configured and need no guest lookup.
+      let vmLocations: VmLocation[] = []
+      let poolVmids: number[] | undefined
+      if (!job.node) {
+        if (job.pool) {
+          const pool = await pveFetch<any>(conn, `/pools/${encodeURIComponent(job.pool)}`)
+          poolVmids = (pool?.members || [])
+            .map((m: any) => Number(m.vmid))
+            .filter((n: number) => Number.isFinite(n))
+        }
+        const resources = (await pveFetch<any[]>(conn, `/cluster/resources?type=vm`)) || []
+        vmLocations = resources
+          .filter((r: any) => Number.isFinite(Number(r.vmid)))
+          .map((r: any) => ({ vmid: Number(r.vmid), node: r.node, status: r.status }))
       }
 
-      // Déterminer le node (si spécifié ou premier node disponible)
-      const targetNode = job.node || (await pveFetch<any[]>(conn, `/nodes`))?.[0]?.node
+      const { entries, unresolved } = planBackupRunDispatch({ job, vmLocations, onlineNodes, poolVmids })
 
-      if (!targetNode) {
-        return NextResponse.json({ error: "No node available" }, { status: 400 })
+      if (entries.length === 0) {
+        const msg = unresolved.length > 0
+          ? "Selected guests are not on an online node"
+          : "No node available"
+        return NextResponse.json({ error: msg }, { status: 400 })
       }
 
-      const result = await pveFetch<any>(conn, `/nodes/${encodeURIComponent(targetNode)}/vzdump`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: params.toString()
-      })
+      // Replay the job's real options (retention, fleecing, notes, ...) on
+      // every target node so a manual run matches the scheduled one.
+      const shared = buildSharedVzdumpParams(job)
+
+      const tasks: Array<{ node: string; upid: any }> = []
+      const errors: Array<{ node: string; error: string }> = []
+      for (const entry of entries) {
+        const params = new URLSearchParams(shared)
+        for (const [k, v] of Object.entries(entry.selection)) params.set(k, v)
+        try {
+          const upid = await pveFetch<any>(conn, `/nodes/${encodeURIComponent(entry.node)}/vzdump`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+          })
+          tasks.push({ node: entry.node, upid })
+        } catch (err: any) {
+          errors.push({ node: entry.node, error: err?.message || String(err) })
+        }
+      }
+
+      // Nothing started — surface the failure instead of silently doing nothing.
+      if (tasks.length === 0) {
+        const detail = errors.map((e) => `${e.node}: ${e.error}`).join('; ')
+        return NextResponse.json({ error: detail || "Backup failed to start" }, { status: 502 })
+      }
 
       return NextResponse.json({
-        data: result,
-        message: 'Backup job started'
+        data: { tasks, errors, unresolved },
+        message: `Backup job started on ${tasks.length} node(s)`,
       })
     }
 

--- a/frontend/src/lib/backups/runDispatch.test.ts
+++ b/frontend/src/lib/backups/runDispatch.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+
+import { buildSharedVzdumpParams, planBackupRunDispatch, type VmLocation } from './runDispatch'
+
+const LOCATIONS: VmLocation[] = [
+  { vmid: 105, node: 'pve-r730-01', status: 'running' },
+  { vmid: 106, node: 'pve-r730-01', status: 'stopped' },
+  { vmid: 200, node: 'pve-r240', status: 'running' },
+  { vmid: 300, node: 'pve-r730-02', status: 'running' },
+]
+const ONLINE = ['pve-r240', 'pve-r730-01', 'pve-r730-02']
+
+describe('planBackupRunDispatch', () => {
+  it('runs a pinned job exactly on its node (vmid selection)', () => {
+    const plan = planBackupRunDispatch({
+      job: { node: 'pve-r240', vmid: '105' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    expect(plan.entries).toEqual([{ node: 'pve-r240', selection: { vmid: '105' } }])
+    expect(plan.unresolved).toEqual([])
+  })
+
+  it('keeps the exclude list for a pinned all-guests job', () => {
+    const plan = planBackupRunDispatch({
+      job: { node: 'pve-r240', all: 1, exclude: '999' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    expect(plan.entries).toEqual([{ node: 'pve-r240', selection: { all: '1', exclude: '999' } }])
+  })
+
+  it('#537: routes an unpinned single-VM job to the node hosting that VM, not nodes[0]', () => {
+    // The r730 cluster case: VM 105 lives on pve-r730-01 but the old code sent
+    // vzdump to nodes[0] (pve-r240) and backed up nothing.
+    const plan = planBackupRunDispatch({
+      job: { vmid: '105' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    expect(plan.entries).toEqual([{ node: 'pve-r730-01', selection: { vmid: '105' } }])
+    expect(plan.unresolved).toEqual([])
+  })
+
+  it('groups an unpinned multi-VM job by the node hosting each guest', () => {
+    const plan = planBackupRunDispatch({
+      job: { vmid: '105,106,200' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    // 105 & 106 -> pve-r730-01 (grouped), 200 -> pve-r240
+    expect(plan.entries).toContainEqual({ node: 'pve-r730-01', selection: { vmid: '105,106' } })
+    expect(plan.entries).toContainEqual({ node: 'pve-r240', selection: { vmid: '200' } })
+    expect(plan.entries).toHaveLength(2)
+  })
+
+  it('reports vmids that are unknown or on an offline node as unresolved', () => {
+    const plan = planBackupRunDispatch({
+      job: { vmid: '105,300,999' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ['pve-r730-01'], // pve-r730-02 (hosts 300) is offline
+    })
+    expect(plan.entries).toEqual([{ node: 'pve-r730-01', selection: { vmid: '105' } }])
+    expect(plan.unresolved).toEqual([300, 999])
+  })
+
+  it('fans an unpinned all-guests job out to every online node', () => {
+    const plan = planBackupRunDispatch({
+      job: { all: 1, exclude: '999' },
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    expect(plan.entries).toEqual(
+      ONLINE.map((node) => ({ node, selection: { all: '1', exclude: '999' } })),
+    )
+  })
+
+  it('resolves an unpinned pool job from its member vmids', () => {
+    const plan = planBackupRunDispatch({
+      job: { pool: 'prod' },
+      poolVmids: [105, 200],
+      vmLocations: LOCATIONS,
+      onlineNodes: ONLINE,
+    })
+    expect(plan.entries).toContainEqual({ node: 'pve-r730-01', selection: { vmid: '105' } })
+    expect(plan.entries).toContainEqual({ node: 'pve-r240', selection: { vmid: '200' } })
+  })
+
+  it('returns no entries when there is no selection', () => {
+    const plan = planBackupRunDispatch({ job: {}, vmLocations: LOCATIONS, onlineNodes: ONLINE })
+    expect(plan.entries).toEqual([])
+  })
+})
+
+describe('buildSharedVzdumpParams', () => {
+  it('replays the core + retention/notification options a job configures', () => {
+    const p = buildSharedVzdumpParams({
+      storage: 'PBS',
+      mode: 'snapshot',
+      compress: 'zstd',
+      'prune-backups': 'keep-last=3',
+      'notes-template': '{{guestname}}',
+      'pbs-change-detection-mode': 'data',
+      bwlimit: 51200,
+      zstd: 2,
+      protected: 1,
+      'notification-mode': 'notification-system',
+      mailto: 'ops@example.com',
+    })
+    expect(p).toEqual({
+      storage: 'PBS',
+      mode: 'snapshot',
+      compress: 'zstd',
+      'prune-backups': 'keep-last=3',
+      'notes-template': '{{guestname}}',
+      'pbs-change-detection-mode': 'data',
+      bwlimit: '51200',
+      zstd: '2',
+      protected: '1',
+      'notification-mode': 'notification-system',
+      mailto: 'ops@example.com',
+    })
+  })
+
+  it('skips object-typed prune-backups/fleecing so we never send [object Object]', () => {
+    const p = buildSharedVzdumpParams({
+      storage: 'PBS',
+      'prune-backups': { 'keep-last': 3 },
+      fleecing: { enabled: 1, storage: 'local' },
+    })
+    expect(p['prune-backups']).toBeUndefined()
+    expect(p.fleecing).toBeUndefined()
+  })
+
+  it('forwards string-typed fleecing as-is', () => {
+    const p = buildSharedVzdumpParams({ storage: 'PBS', fleecing: 'enabled=1,storage=local' })
+    expect(p.fleecing).toBe('enabled=1,storage=local')
+  })
+
+  it('never forwards the deprecated mailnotification (rejected by PVE 9)', () => {
+    const p = buildSharedVzdumpParams({ storage: 'PBS', mailnotification: 'always' } as any)
+    expect(p).not.toHaveProperty('mailnotification')
+  })
+})

--- a/frontend/src/lib/backups/runDispatch.ts
+++ b/frontend/src/lib/backups/runDispatch.ts
@@ -1,0 +1,198 @@
+/**
+ * Plan how a scheduled backup job should be executed immediately ("Run now").
+ *
+ * Proxmox has no "run job by id" API endpoint: an immediate run must POST to
+ * `/nodes/{node}/vzdump`, and vzdump is strictly node-local (it only backs up
+ * guests that live on the node it runs on). The scheduler normally executes a
+ * job on every node, each backing up its local guests matching the selection.
+ *
+ * The old "Run now" implementation just picked `nodes[0]` (the first node
+ * returned by `/nodes`, i.e. alphabetical) whenever the job was not pinned to a
+ * node. When the selected guest lived on a different node, vzdump ran on the
+ * wrong node, backed up nothing, and surfaced neither error nor success — the
+ * "clicking Start does nothing" report in issue #537.
+ *
+ * This planner resolves the node(s) that actually host the job's selection and
+ * returns one dispatch entry per node, mirroring what the scheduler does:
+ *   - pinned node        -> a single entry on that node, selection as configured
+ *   - all guests         -> one entry per ONLINE node (each backs up its locals)
+ *   - explicit vmid list -> group the vmids by their current node
+ *   - pool               -> group the pool's member vmids by their current node
+ *
+ * vmids that cannot be resolved (unknown, or on an offline node) are returned
+ * in `unresolved` so the caller can decide how to surface them.
+ */
+
+/** One VM's current location, from `/cluster/resources?type=vm`. */
+export interface VmLocation {
+  vmid: number
+  node: string
+  status?: string
+}
+
+/** A single vzdump invocation to issue for an immediate run. */
+export interface RunDispatchEntry {
+  node: string
+  /** vzdump selection params for THIS node (all/exclude or a vmid subset). */
+  selection: Record<string, string>
+}
+
+export interface PlanRunInput {
+  /** Raw job object from `/cluster/backup/{id}`. */
+  job: {
+    node?: string
+    all?: number | boolean
+    vmid?: string | number
+    pool?: string
+    exclude?: string
+  }
+  /** All VM locations on the cluster (`/cluster/resources?type=vm`). */
+  vmLocations: VmLocation[]
+  /** Node names that are currently online. */
+  onlineNodes: string[]
+  /** For pool selection: the pool's member vmids (`/pools/{pool}`). */
+  poolVmids?: number[]
+}
+
+export interface RunDispatchPlan {
+  entries: RunDispatchEntry[]
+  /** vmids that could not be placed on an online node. */
+  unresolved: number[]
+}
+
+/** Parse a PVE comma list of vmids ("100,101") into numbers. */
+function parseVmidList(raw: string | number | undefined): number[] {
+  if (raw === undefined || raw === null || raw === '') return []
+  return String(raw)
+    .split(',')
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isFinite(n))
+}
+
+/** The selection params for a job run on the node it is pinned to. */
+function pinnedSelection(job: PlanRunInput['job']): Record<string, string> {
+  if (job.all) {
+    return job.exclude ? { all: '1', exclude: job.exclude } : { all: '1' }
+  }
+  if (job.vmid !== undefined && job.vmid !== '') {
+    return { vmid: String(job.vmid) }
+  }
+  if (job.pool) {
+    return { pool: job.pool }
+  }
+  return {}
+}
+
+/** Group a set of vmids by the online node that currently hosts each one. */
+function groupVmidsByNode(
+  vmids: number[],
+  vmLocations: VmLocation[],
+  onlineNodes: string[],
+): { byNode: Map<string, number[]>; unresolved: number[] } {
+  const location = new Map<number, string>()
+  for (const vm of vmLocations) location.set(vm.vmid, vm.node)
+
+  const online = new Set(onlineNodes)
+  const byNode = new Map<string, number[]>()
+  const unresolved: number[] = []
+
+  for (const vmid of vmids) {
+    const node = location.get(vmid)
+    if (!node || !online.has(node)) {
+      unresolved.push(vmid)
+      continue
+    }
+    const list = byNode.get(node) ?? []
+    list.push(vmid)
+    byNode.set(node, list)
+  }
+
+  return { byNode, unresolved }
+}
+
+/**
+ * The vzdump params shared by every node in an immediate run, replayed from the
+ * job's own configuration so a manual run produces the SAME backup as the
+ * schedule (retention, fleecing, notes, notifications, ...).
+ *
+ * Only options that `vzdump` itself accepts are emitted (see `man vzdump`);
+ * selection (all/vmid/pool/exclude) is added per-node by the caller. Fields
+ * that PVE may return as an object rather than a string (`prune-backups`,
+ * `fleecing`) are only forwarded when already a plain string, so we never send
+ * a malformed `[object Object]`. The PBS namespace is deliberately NOT sent:
+ * it is a property of the storage config, not a vzdump option.
+ */
+export function buildSharedVzdumpParams(job: Record<string, any>): Record<string, string> {
+  const p: Record<string, string> = {}
+
+  if (job.storage) p.storage = String(job.storage)
+  if (job.mode) p.mode = String(job.mode)
+  if (job.compress) p.compress = String(job.compress)
+
+  if (typeof job['prune-backups'] === 'string' && job['prune-backups']) {
+    p['prune-backups'] = job['prune-backups']
+  }
+  if (job['notes-template']) p['notes-template'] = String(job['notes-template'])
+  if (typeof job.fleecing === 'string' && job.fleecing) p.fleecing = job.fleecing
+  if (job['pbs-change-detection-mode']) {
+    p['pbs-change-detection-mode'] = String(job['pbs-change-detection-mode'])
+  }
+  if (job.bwlimit) p.bwlimit = String(job.bwlimit)
+  if (job.zstd) p.zstd = String(job.zstd)
+  if (job.protected === 1 || job.protected === true) p.protected = '1'
+
+  // Notifications: prefer the modern `notification-mode`; skip the deprecated
+  // `mailnotification` which newer PVE (9.x) may reject.
+  if (job['notification-mode']) p['notification-mode'] = String(job['notification-mode'])
+  if (job.mailto) p.mailto = String(job.mailto)
+
+  return p
+}
+
+export function planBackupRunDispatch(input: PlanRunInput): RunDispatchPlan {
+  const { job, vmLocations, onlineNodes, poolVmids } = input
+
+  // A job pinned to a node runs exactly there, as configured. This is the one
+  // case the old code already handled correctly, so keep it identical.
+  if (job.node) {
+    return { entries: [{ node: job.node, selection: pinnedSelection(job) }], unresolved: [] }
+  }
+
+  // "All guests": mirror the scheduler and run one vzdump per online node, each
+  // backing up its own local guests (with the shared exclude list).
+  if (job.all) {
+    const selection: Record<string, string> = job.exclude
+      ? { all: '1', exclude: job.exclude }
+      : { all: '1' }
+    return {
+      entries: onlineNodes.map((node) => ({ node, selection: { ...selection } })),
+      unresolved: [],
+    }
+  }
+
+  // Explicit vmid list: group by the node currently hosting each guest.
+  if (job.vmid !== undefined && job.vmid !== '') {
+    const { byNode, unresolved } = groupVmidsByNode(parseVmidList(job.vmid), vmLocations, onlineNodes)
+    return {
+      entries: [...byNode.entries()].map(([node, vmids]) => ({
+        node,
+        selection: { vmid: vmids.join(',') },
+      })),
+      unresolved,
+    }
+  }
+
+  // Pool: resolve the pool's members to their current nodes and group.
+  if (job.pool) {
+    const { byNode, unresolved } = groupVmidsByNode(poolVmids ?? [], vmLocations, onlineNodes)
+    return {
+      entries: [...byNode.entries()].map(([node, vmids]) => ({
+        node,
+        selection: { vmid: vmids.join(',') },
+      })),
+      unresolved,
+    }
+  }
+
+  return { entries: [], unresolved: [] }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -1681,6 +1681,7 @@
     "failedToSaveBackupJob": "fehlgeschlagen to speichern backup job",
     "failedToDeleteBackupJob": "fehlgeschlagen to löschen backup job",
     "failedToRunBackupJob": "fehlgeschlagen to run backup job",
+    "backupJobStarted": "Sicherung auf {count} Knoten gestartet",
     "allNodes": "— Alle —",
     "quorateYes": "Quorum: Ja",
     "healthLabel": "Zustand",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1715,6 +1715,7 @@
     "failedToSaveBackupJob": "Failed to save backup job",
     "failedToDeleteBackupJob": "Failed to delete backup job",
     "failedToRunBackupJob": "Failed to run backup job",
+    "backupJobStarted": "Backup started on {count} node(s)",
     "allNodes": "— All —",
     "quorateYes": "Quorate: Yes",
     "healthLabel": "Health",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -1741,6 +1741,7 @@
     "failedToSaveBackupJob": "Échec de l'enregistrement du job de sauvegarde",
     "failedToDeleteBackupJob": "Échec de la suppression du job de sauvegarde",
     "failedToRunBackupJob": "Échec de l'exécution du job de sauvegarde",
+    "backupJobStarted": "Sauvegarde lancée sur {count} nœud(s)",
     "allNodes": "— Tous —",
     "quorateYes": "Quorum : Oui",
     "healthLabel": "Santé",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -1684,6 +1684,7 @@
     "failedToSaveBackupJob": "保存备份任务失败",
     "failedToDeleteBackupJob": "删除备份任务失败",
     "failedToRunBackupJob": "运行备份任务失败",
+    "backupJobStarted": "已在 {count} 个节点上启动备份",
     "allNodes": "— 全部 —",
     "quorateYes": "法定人数：是",
     "healthLabel": "健康状况",


### PR DESCRIPTION
## Problem

From **Datacenter → Backups**, clicking **Run now** (▶) on a scheduled backup job did nothing: no task in the PVE log, no backup on PBS, and no error in the UI. The same backup worked from the VM's own Backups tab and from Proxmox's native Run now (issue #537).

## Root cause

Proxmox has no "run job by id" API, so Run now reconstructs a `vzdump` call. When the job was **not pinned to a node** (Node column shows `— All —`), the code sent the vzdump to `nodes[0]` (the first node returned by `/nodes`, i.e. alphabetical). `vzdump` is strictly node-local, so when the selected guest lived on a different node it backed up nothing. The route still returned `200` with no visible success, so the click looked like a no-op.

Reporter's case: the job selected one VM living on `pve-r730-01`, but `nodes[0]` was `pve-r240`.

## Fix

- New `lib/backups/runDispatch.ts`: resolve the node(s) actually hosting the job's selection via `/cluster/resources`, then plan one `vzdump` per node, mirroring the scheduler:
  - pinned node → that node
  - all guests → every online node (each backs up its locals)
  - vmid / pool → grouped by each guest's current node
- Replay the job's real options on the run (retention/prune, fleecing, notes-template, pbs-change-detection-mode, bwlimit, zstd, protected, notification-mode, mailto) so a manual run matches the scheduled one. Only `vzdump`-supported params are sent (no `namespace`: that lives on the storage config).
- Report unresolved guests (unknown or on an offline node) and return an error when nothing could start, instead of a silent `200`.
- UI: show a success alert ("Backup started on N node(s)") and surface per-node errors, so a run is no longer silent.

## Tests

- `runDispatch.test.ts`: planner + params builder (pinned, all fan-out, multi-node grouping, unresolved/offline, pool).
- `route.test.ts`: the run endpoint dispatches to the guest's real node (regression for #537), replays options, returns 400 when off-node, honours a pinned node, and respects RBAC denial.
- 17/17 green.

Frontend-only. Refs #537
