### PR TITLE
sec(ssh): validate node/vmid/storage before interpolating into SSH commands

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/remoteMigrateScope.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/remoteMigrateScope.test.ts
@@ -177,3 +177,35 @@ describe("POST .../remote-migrate — MSP ownership gate", () => {
     expect(res.status).toBe(400)
   })
 })
+
+// The [vmid] segment reaches `qm unlock ${vmid}` in the cleanup watcher and the
+// [node] segment can become the SSH host (getNodeIp fallback), so both are
+// re-derived at the boundary and injection payloads must 400 before the gate.
+describe("POST .../remote-migrate — node/vmid validation (command injection)", () => {
+  it("rejects a vmid with shell metacharacters (400, before the RBAC gate / watcher)", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, {
+      method: "POST",
+      params: { ...PARAMS, vmid: "100; touch /tmp/pwn" },
+      body: VALID_BODY,
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/invalid node name or vmid/i)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+    expect(watchMigrationMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects a node name with shell metacharacters (400, before the RBAC gate / watcher)", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, {
+      method: "POST",
+      params: { ...PARAMS, node: "pve1$(reboot)" },
+      body: VALID_BODY,
+    })
+    expect(res.status).toBe(400)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+    expect(watchMigrationMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/route.ts
@@ -6,6 +6,7 @@ import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, canMigrateConnections } from "@/lib/tenant/infraScope"
 import { watchMigrationAndCleanup } from "@/lib/migration/cross-cluster-watcher"
+import { assertVmid, assertNodeName } from "@/lib/ssh/validate"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
@@ -41,8 +42,22 @@ export async function POST(
       )
     }
 
+    // Constrain the node name and VMID before either can reach a shell command
+    // on the node: the fire-and-forget cleanup watcher runs `qm unlock ${vmid}`
+    // over SSH, and getNodeIp() may fall back to the raw node name as the SSH
+    // host. Both are re-derived here so no attacker-controlled characters flow
+    // through (command injection / log injection in the SSH layer).
+    let safeVmid: string
+    let safeNode: string
+    try {
+      safeVmid = assertVmid(vmid)
+      safeNode = assertNodeName(node)
+    } catch {
+      return NextResponse.json({ error: "Invalid node name or vmid" }, { status: 400 })
+    }
+
     // RBAC: Check vm.migrate permission
-    const resourceId = buildVmResourceId(id, node, type, vmid)
+    const resourceId = buildVmResourceId(id, safeNode, type, safeVmid)
     const denied = await checkPermission(PERMISSIONS.VM_MIGRATE, "vm", resourceId)
     if (denied) return denied
 
@@ -256,8 +271,8 @@ export async function POST(
         connectionId: id,
         tenantId,
         sourceConn,
-        sourceNode: node,
-        vmid,
+        sourceNode: safeNode,
+        vmid: safeVmid,
         upid: result,
         deleteSource,
       }).catch(err => {

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.test.ts
@@ -204,3 +204,21 @@ describe('GET .../screenshot — display detection', () => {
     expect(pveFetchMock).toHaveBeenCalledTimes(2)
   })
 })
+
+// The [vmid] segment is interpolated into `qm monitor ${vmid}` / the tmp file
+// path in the SSH command, so a non-numeric vmid must be rejected up front —
+// before the config probe or any SSH runs.
+describe('GET .../screenshot — vmid validation (command injection)', () => {
+  const MALICIOUS = ['1; touch /tmp/pwn', '$(id)', '`whoami`', '1 && reboot', '100abc', '../../etc']
+
+  for (const vmid of MALICIOUS) {
+    it(`rejects ${JSON.stringify(vmid)} with 400 and never probes or runs SSH`, async () => {
+      const res = await GET(new Request('http://localhost'), makeCtx({ vmid }))
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toEqual({ data: null, reason: 'invalid_vmid' })
+      expect(pveFetchMock).not.toHaveBeenCalled()
+      expect(executeSSHMock).not.toHaveBeenCalled()
+    })
+  }
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/screenshot/route.ts
@@ -6,6 +6,7 @@ import { pveFetch } from "@/lib/proxmox/client"
 import { locateVmInCluster } from "@/lib/proxmox/locateVm"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { executeSSH } from "@/lib/ssh/exec"
+import { assertVmid } from "@/lib/ssh/validate"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
@@ -72,6 +73,15 @@ export async function GET(
     return NextResponse.json({ data: null, reason: 'lxc' })
   }
 
+  // Constrain the VMID to a positive integer before it reaches the
+  // `qm monitor ... ${vmid}` / `${tmpFile}` shell command run on the node.
+  let safeVmid: string
+  try {
+    safeVmid = assertVmid(vmid)
+  } catch {
+    return NextResponse.json({ data: null, reason: 'invalid_vmid' }, { status: 400 })
+  }
+
   // RBAC: Check vm.console permission
   const resourceId = buildVmResourceId(id, node, type, vmid)
   const denied = await checkPermission(PERMISSIONS.VM_CONSOLE, "vm", resourceId)
@@ -121,8 +131,8 @@ export async function GET(
   }
 
   try {
-    const tmpFile = `/tmp/pxc-screen-${vmid}.ppm`
-    const cmd = `qm monitor ${vmid} <<< 'screendump ${tmpFile}' > /dev/null 2>&1 && base64 -w0 ${tmpFile} && rm -f ${tmpFile}`
+    const tmpFile = `/tmp/pxc-screen-${safeVmid}.ppm`
+    const cmd = `qm monitor ${safeVmid} <<< 'screendump ${tmpFile}' > /dev/null 2>&1 && base64 -w0 ${tmpFile} && rm -f ${tmpFile}`
 
     // Try the originally-requested node first.
     let resolvedNode = node
@@ -135,7 +145,7 @@ export async function GET(
     // is still holding the stale source node. Re-resolve via /cluster/resources
     // and retry once before surfacing the failure.
     if (!sshResult.success) {
-      const located = await locateVmInCluster(conn, vmid, "qemu")
+      const located = await locateVmInCluster(conn, safeVmid, "qemu")
       if (located && located.node !== resolvedNode) {
         resolvedNode = located.node
         movedTo = located.node

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/unlock/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/unlock/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<any>>(),
+  buildVmResourceId: vi.fn<(id: string, node: string, type: string, vmid: string) => string>(
+    (id, node, type, vmid) => `${id}/${node}/${type}/${vmid}`,
+  ),
+  PERMISSIONS: { VM_CONFIG: 'vm.config', VM_VIEW: 'vm.view' },
+}))
+
+vi.mock('@/lib/ssh/exec', () => ({
+  executeSSH: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/ssh/node-ip', () => ({
+  getNodeIp: vi.fn<(...args: any[]) => Promise<string>>(),
+}))
+
+// NOTE: @/lib/ssh/validate is intentionally NOT mocked — the real assertVmid
+// is what this suite exercises.
+
+import { POST } from './route'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+import { checkPermission } from '@/lib/rbac'
+import { executeSSH } from '@/lib/ssh/exec'
+import { getNodeIp } from '@/lib/ssh/node-ip'
+
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+const checkPermissionMock = checkPermission as any
+const executeSSHMock = executeSSH as any
+const getNodeIpMock = getNodeIp as any
+
+const CONN_ID = 'conn-1'
+const NODE = 'pve-node-01'
+const NODE_IP = '10.0.0.1'
+
+const baseParams = { id: CONN_ID, type: 'qemu', node: NODE, vmid: '100' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: CONN_ID })
+  pveFetchMock.mockResolvedValue({ lock: 'backup' })
+  getNodeIpMock.mockResolvedValue(NODE_IP)
+  executeSSHMock.mockResolvedValue({ success: true, output: 'ok' })
+})
+
+describe('POST .../unlock — happy path', () => {
+  it('unlocks a QEMU VM and runs `qm unlock <vmid>` over SSH', async () => {
+    const res = await callRoute(POST as any, { method: 'POST', params: baseParams })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data.unlocked).toBe(true)
+    expect(executeSSHMock).toHaveBeenCalledWith(CONN_ID, NODE_IP, 'qm unlock 100')
+  })
+
+  it('uses `pct unlock` for LXC containers', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { ...baseParams, type: 'lxc' },
+    })
+    expect(res.status).toBe(200)
+    expect(executeSSHMock).toHaveBeenCalledWith(CONN_ID, NODE_IP, 'pct unlock 100')
+  })
+
+  it('rejects a vmid with leading zeros (grammar) with 400', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      params: { ...baseParams, vmid: '00100' },
+    })
+    expect(res.status).toBe(400)
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST .../unlock — vmid validation (command injection)', () => {
+  const MALICIOUS = [
+    '100; touch /tmp/pwn',
+    '$(id)',
+    '`whoami`',
+    '100 && reboot',
+    '100|cat /etc/passwd',
+    '100abc',
+  ]
+
+  for (const vmid of MALICIOUS) {
+    it(`rejects ${JSON.stringify(vmid)} with 400 and never runs SSH`, async () => {
+      const res = await callRoute(POST as any, { method: 'POST', params: { ...baseParams, vmid } })
+      expect(res.status).toBe(400)
+      const body = await readJson<any>(res)
+      expect(body.error).toMatch(/invalid vmid/i)
+      // Rejection happens before RBAC / config probe / SSH.
+      expect(checkPermissionMock).not.toHaveBeenCalled()
+      expect(pveFetchMock).not.toHaveBeenCalled()
+      expect(executeSSHMock).not.toHaveBeenCalled()
+    })
+  }
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/unlock/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/unlock/route.ts
@@ -4,6 +4,7 @@ import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 import { executeSSH } from "@/lib/ssh/exec"
+import { assertVmid } from "@/lib/ssh/validate"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
@@ -26,6 +27,15 @@ export async function POST(
 
     if (type !== 'qemu' && type !== 'lxc') {
       return NextResponse.json({ error: "Invalid type. Must be 'qemu' or 'lxc'" }, { status: 400 })
+    }
+
+    // Constrain the VMID to a positive integer before it is interpolated into
+    // the `qm/pct unlock` shell command executed on the node (command injection).
+    let safeVmid: string
+    try {
+      safeVmid = assertVmid(vmid)
+    } catch {
+      return NextResponse.json({ error: "Invalid vmid" }, { status: 400 })
     }
 
     // RBAC
@@ -53,7 +63,7 @@ export async function POST(
 
     // Get node IP and execute unlock via SSH
     const nodeIp = await getNodeIp(conn, node)
-    const unlockCmd = type === 'qemu' ? `qm unlock ${vmid}` : `pct unlock ${vmid}`
+    const unlockCmd = type === 'qemu' ? `qm unlock ${safeVmid}` : `pct unlock ${safeVmid}`
     const sshResult = await executeSSH(id, nodeIp, unlockCmd)
 
     if (sshResult.success) {

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.test.ts
@@ -292,3 +292,47 @@ describe('DELETE /api/v1/connections/[id]/nodes/[node]/maintenance', () => {
     expect(body.error).toBe('timeout')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Command-injection guard: the [node] path segment is interpolated into the
+// `ha-manager crm-command ... ${node}` shell command, so a name carrying shell
+// metacharacters must be rejected with 400 before any SSH runs.
+// ---------------------------------------------------------------------------
+describe('node-name validation (command injection)', () => {
+  const MALICIOUS = [
+    'pve1; touch /tmp/pwn',
+    'pve1$(id)',
+    'pve1`whoami`',
+    'pve1 && reboot',
+    'pve1|cat /etc/passwd',
+    '-injected',
+    'a\nb',
+  ]
+
+  for (const node of MALICIOUS) {
+    it(`POST rejects ${JSON.stringify(node)} with 400 and never runs SSH`, async () => {
+      const res = await callRoute(POST as any, { method: 'POST', params: { id: CONN_ID, node } })
+      expect(res.status).toBe(400)
+      const body = await readJson<any>(res)
+      expect(body.error).toMatch(/invalid node name/i)
+      expect(executeSSHMock).not.toHaveBeenCalled()
+      expect(getNodeIpMock).not.toHaveBeenCalled()
+    })
+
+    it(`DELETE rejects ${JSON.stringify(node)} with 400 and never runs SSH`, async () => {
+      const res = await callRoute(DELETE as any, { method: 'DELETE', params: { id: CONN_ID, node } })
+      expect(res.status).toBe(400)
+      expect(executeSSHMock).not.toHaveBeenCalled()
+    })
+  }
+
+  it('accepts a well-formed node name and reaches SSH', async () => {
+    const res = await callRoute(POST as any, { method: 'POST', params: { id: CONN_ID, node: 'pve-node-02' } })
+    expect(res.status).toBe(200)
+    expect(executeSSHMock).toHaveBeenCalledWith(
+      CONN_ID,
+      NODE_IP,
+      'ha-manager crm-command node-maintenance enable pve-node-02',
+    )
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/maintenance/route.ts
@@ -3,6 +3,8 @@ import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById, isConnectionNotFoundError } from "@/lib/connections/getConnection"
 import { checkPermission, buildNodeResourceId, PERMISSIONS } from "@/lib/rbac"
 import { executeSSH } from "@/lib/ssh/exec"
+import { assertNodeName } from "@/lib/ssh/validate"
+import { safeLog } from "@/lib/log/sanitize"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 
 export const runtime = "nodejs"
@@ -30,16 +32,26 @@ async function toggleMaintenance(
   try {
     const { id, node } = await ctx.params
 
-    const resourceId = buildNodeResourceId(id, node)
+    // Constrain the node name to the PVE hostname grammar before it is
+    // interpolated into the `ha-manager crm-command ... ${node}` shell command
+    // executed on the node (command injection).
+    let safeNode: string
+    try {
+      safeNode = assertNodeName(node)
+    } catch {
+      return NextResponse.json({ error: "Invalid node name" }, { status: 400 })
+    }
+
+    const resourceId = buildNodeResourceId(id, safeNode)
     const denied = await checkPermission(PERMISSIONS.NODE_MANAGE, "node", resourceId)
     if (denied) return denied
 
     const conn = await getConnectionById(id)
 
-    const nodeIp = await getNodeIp(conn, node)
-    const command = `ha-manager crm-command node-maintenance ${enable ? 'enable' : 'disable'} ${node}`
+    const nodeIp = await getNodeIp(conn, safeNode)
+    const command = `ha-manager crm-command node-maintenance ${enable ? 'enable' : 'disable'} ${safeNode}`
 
-    console.log(`[maintenance] ${label} ${node}: executing via SSH on ${nodeIp}: ${command}`)
+    console.log(`[maintenance] ${label} ${safeLog(safeNode)}: executing via SSH on ${safeLog(nodeIp)}: ${safeLog(command)}`)
     const result = await executeSSH(id, nodeIp, command)
 
     if (result.success) {

--- a/frontend/src/app/api/v1/migrations/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/route.test.ts
@@ -78,6 +78,25 @@ describe("POST /api/v1/migrations — warm routing", () => {
     expect(warm).not.toHaveBeenCalled()
   })
 
+  // targetStorage is interpolated into `qm disk import ... ${targetStorage}` on
+  // the target node by the pipelines, so a value carrying shell metacharacters
+  // must be rejected before any job is created (command injection).
+  it.each([
+    "local-lvm; rm -rf /",
+    "$(id)",
+    "store`whoami`",
+    "a/b",
+    "store with spaces",
+  ])("rejects a malformed targetStorage %j before creating a job", async (targetStorage) => {
+    const res = await callRoute(POST, { body: { ...body, targetStorage } })
+    expect(res.status).toBe(400)
+    expect((await readJson<any>(res))?.error).toMatch(/targetStorage/i)
+    expect(h.prisma.migrationJob.create).not.toHaveBeenCalled()
+    await runAfters()
+    expect(warm).not.toHaveBeenCalled()
+    expect(cold).not.toHaveBeenCalled()
+  })
+
   it("dispatches a vCenter warm request to runWarmMigration, never the cold pipeline", async () => {
     h.prisma.connection.findUnique
       .mockResolvedValueOnce({ id: "src", type: "vmware", subType: "vcenter", name: "vc", baseUrl: "https://vc" })

--- a/frontend/src/app/api/v1/migrations/route.ts
+++ b/frontend/src/app/api/v1/migrations/route.ts
@@ -10,6 +10,7 @@ import { runV2vMigrationPipeline } from "@/lib/migration/v2v-pipeline"
 import { runWarmMigration } from "@/lib/migration/warm/warm-pipeline"
 import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig } from "@/lib/vmware/soap"
 import { decryptSecret } from "@/lib/crypto/secret"
+import { assertStorageName } from "@/lib/ssh/validate"
 
 export const runtime = "nodejs"
 
@@ -42,6 +43,15 @@ export async function POST(req: Request) {
 
     if (!sourceConnectionId || !sourceVmId || !targetConnectionId || !targetNode || !targetStorage) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+    }
+
+    // targetStorage is interpolated into the `qm disk import ... ${targetStorage}`
+    // shell command run on the target node by the migration pipelines, so
+    // constrain it to the PVE storage-id grammar here (command injection).
+    try {
+      assertStorageName(targetStorage)
+    } catch {
+      return NextResponse.json({ error: "Invalid targetStorage" }, { status: 400 })
     }
 
     // Optional caller-supplied target VMID. When omitted, the pipeline falls

--- a/frontend/src/app/api/v1/orchestrator/sflow/agents/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/sflow/agents/route.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: vi.fn<() => Promise<string>>(),
+  getSessionPrisma: vi.fn<() => Promise<any>>(),
+}))
+
+vi.mock('@/lib/orchestrator', () => ({
+  orchestratorFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<any>>(),
+  PERMISSIONS: { CONNECTION_MANAGE: 'connection.manage' },
+}))
+
+vi.mock('@/lib/ssh/exec', () => ({
+  executeSSH: vi.fn<(...args: any[]) => Promise<any>>(),
+  // Mirror the real single-quote shell escaper so command assertions match.
+  shellEscape: (arg: string) => "'" + arg.replaceAll("'", "'\\''") + "'",
+}))
+
+import { POST } from './route'
+import { getCurrentTenantId, getSessionPrisma } from '@/lib/tenant'
+import { checkPermission } from '@/lib/rbac'
+import { executeSSH } from '@/lib/ssh/exec'
+
+const getCurrentTenantIdMock = getCurrentTenantId as any
+const getSessionPrismaMock = getSessionPrisma as any
+const checkPermissionMock = checkPermission as any
+const executeSSHMock = executeSSH as any
+
+const NODE_REQ = { node: 'pve1', ip: '10.0.0.1', connectionId: 'conn-1' }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getCurrentTenantIdMock.mockResolvedValue('tenant-1')
+  getSessionPrismaMock.mockResolvedValue({
+    connection: { findMany: vi.fn().mockResolvedValue([{ id: 'conn-1' }]) },
+  })
+  executeSSHMock.mockResolvedValue({ success: true, output: '' })
+})
+
+describe('POST /sflow/agents — happy path', () => {
+  it('shell-escapes the collector target and coerces the rates into the command', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      body: {
+        nodes: [NODE_REQ],
+        collectorTarget: '10.0.0.5:6343',
+        samplingRate: 1024,
+        pollingInterval: 15,
+      },
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.configured).toBe(1)
+
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+    const [, , cmd] = executeSSHMock.mock.calls[0]
+    expect(cmd).toContain("target='10.0.0.5:6343'")
+    expect(cmd).toContain('sampling=1024')
+    expect(cmd).toContain('polling=15')
+  })
+
+  it('coerces string-typed numeric rates from the body', async () => {
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      body: { nodes: [NODE_REQ], collectorTarget: 'collector.local:6343', samplingRate: '256', pollingInterval: '20' },
+    })
+    expect(res.status).toBe(200)
+    const [, , cmd] = executeSSHMock.mock.calls[0]
+    expect(cmd).toContain('sampling=256')
+    expect(cmd).toContain('polling=20')
+  })
+})
+
+describe('POST /sflow/agents — input validation (command injection)', () => {
+  it('403 when RBAC denies connection.manage', async () => {
+    checkPermissionMock.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 }),
+    )
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      body: { nodes: [NODE_REQ], collectorTarget: '10.0.0.5:6343' },
+    })
+    expect(res.status).toBe(403)
+    expect(executeSSHMock).not.toHaveBeenCalled()
+  })
+
+  const BAD_TARGETS = [
+    '10.0.0.5:6343; reboot',
+    '$(id)',
+    '`whoami`',
+    '10.0.0.5:6343 && curl evil',
+    "10.0.0.5';rm -rf /;'",
+    'target with spaces',
+  ]
+  for (const collectorTarget of BAD_TARGETS) {
+    it(`rejects collector target ${JSON.stringify(collectorTarget)} with 400 and never runs SSH`, async () => {
+      const res = await callRoute(POST as any, {
+        method: 'POST',
+        body: { nodes: [NODE_REQ], collectorTarget },
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<any>(res)
+      expect(body.error).toMatch(/collector target/i)
+      expect(executeSSHMock).not.toHaveBeenCalled()
+    })
+  }
+
+  const BAD_RATES = [
+    { samplingRate: '10; reboot' },
+    { samplingRate: 0 },
+    { samplingRate: 1.5 },
+    { pollingInterval: '$(id)' },
+    { pollingInterval: 0 },
+    { pollingInterval: 999999 },
+  ]
+  for (const extra of BAD_RATES) {
+    it(`rejects rates ${JSON.stringify(extra)} with 400 and never runs SSH`, async () => {
+      const res = await callRoute(POST as any, {
+        method: 'POST',
+        body: { nodes: [NODE_REQ], collectorTarget: '10.0.0.5:6343', ...extra },
+      })
+      expect(res.status).toBe(400)
+      expect(executeSSHMock).not.toHaveBeenCalled()
+    })
+  }
+})

--- a/frontend/src/app/api/v1/orchestrator/sflow/agents/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/sflow/agents/route.ts
@@ -2,8 +2,13 @@ import { NextRequest, NextResponse } from "next/server"
 
 import { getCurrentTenantId, getSessionPrisma } from "@/lib/tenant"
 import { orchestratorFetch } from "@/lib/orchestrator"
-import { executeSSH } from "@/lib/ssh/exec"
+import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+
+// sFlow collector target: an "ip:port" / "host:port" string. Constrain it to
+// hostname / IPv4 / IPv6 characters plus the port colon so it can be safely
+// interpolated into the ovs-vsctl shell command below.
+const COLLECTOR_TARGET_RE = /^[A-Za-z0-9._:[\]-]{1,255}$/
 
 export const runtime = "nodejs"
 
@@ -167,6 +172,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Collector target is required (ip:port)" }, { status: 400 })
     }
 
+    // These three values are interpolated into the ovs-vsctl shell command run
+    // on every node, so constrain them before use (command injection):
+    // collectorTarget to a host:port charset, and the two rates to integers.
+    if (typeof collectorTarget !== "string" || !COLLECTOR_TARGET_RE.test(collectorTarget)) {
+      return NextResponse.json({ error: "Invalid collector target (expected ip:port)" }, { status: 400 })
+    }
+    const safeSampling = Number(samplingRate)
+    const safePolling = Number(pollingInterval)
+    if (!Number.isInteger(safeSampling) || safeSampling < 1 || safeSampling > 1_000_000_000) {
+      return NextResponse.json({ error: "samplingRate must be an integer between 1 and 1000000000" }, { status: 400 })
+    }
+    if (!Number.isInteger(safePolling) || safePolling < 1 || safePolling > 86_400) {
+      return NextResponse.json({ error: "pollingInterval must be an integer between 1 and 86400" }, { status: 400 })
+    }
+
     const prisma = await getSessionPrisma()
     const connections = await prisma.connection.findMany({
       where: { type: "pve", sshEnabled: true },
@@ -185,7 +205,7 @@ export async function POST(request: NextRequest) {
 
       try {
         // Configure sFlow on all OVS bridges
-        const cmd = `for br in $(ovs-vsctl list-br); do ovs-vsctl -- clear Bridge $br sflow; ovs-vsctl -- set Bridge $br sflow=@s -- --id=@s create sflow agent=$br target=\\"${collectorTarget}\\" header=128 sampling=${samplingRate} polling=${pollingInterval}; done`
+        const cmd = `for br in $(ovs-vsctl list-br); do ovs-vsctl -- clear Bridge $br sflow; ovs-vsctl -- set Bridge $br sflow=@s -- --id=@s create sflow agent=$br target=${shellEscape(collectorTarget)} header=128 sampling=${safeSampling} polling=${safePolling}; done`
 
         const result = await executeSSH(conn.id, ip, cmd)
 

--- a/frontend/src/app/api/v1/tasks/[connectionId]/[node]/[upid]/route.ts
+++ b/frontend/src/app/api/v1/tasks/[connectionId]/[node]/[upid]/route.ts
@@ -5,6 +5,7 @@ import { isVmConfigNotFoundError } from '@/lib/proxmox/locateVm'
 import { getConnectionById, type PveConn } from '@/lib/connections/getConnection'
 import { formatBytes as formatSize } from '@/utils/format'
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { assertVmid } from '@/lib/ssh/validate'
 
 export const runtime = 'nodejs'
 
@@ -36,6 +37,16 @@ async function handleSourceVmCleanupAfterMigration(args: {
   deleteSource: boolean
 }): Promise<{ message: string | null }> {
   const { connection, connectionId, node, vmid, deleteSource } = args
+  // vmid comes from the PVE task status `id`; re-derive it before it can reach
+  // the `qm unlock ${vmid}` shell command below (defence-in-depth against a
+  // crafted upstream task id).
+  let safeVmid: string
+  try {
+    safeVmid = assertVmid(vmid)
+  } catch {
+    console.warn(`[task-api] skipping cleanup: invalid vmid ${JSON.stringify(vmid)}`)
+    return { message: null }
+  }
   let vmConfig: any
   try {
     vmConfig = await pveFetch<any>(
@@ -57,7 +68,7 @@ async function handleSourceVmCleanupAfterMigration(args: {
       const { executeSSH } = await import('@/lib/ssh/exec')
       const { getNodeIp } = await import('@/lib/ssh/node-ip')
       const nodeIp = await getNodeIp(connection, node)
-      const result = await executeSSH(connectionId, nodeIp, `qm unlock ${vmid}`)
+      const result = await executeSSH(connectionId, nodeIp, `qm unlock ${safeVmid}`)
       if (result.success) {
         console.log(`[task-api] Auto-unlocked VM ${vmid} on ${node} after cross-cluster migration`)
         unlocked = true

--- a/frontend/src/lib/migration/cross-cluster-watcher.ts
+++ b/frontend/src/lib/migration/cross-cluster-watcher.ts
@@ -3,6 +3,7 @@ import { decryptSecret } from '@/lib/crypto/secret'
 import { getTenantPrisma } from '@/lib/tenant'
 import { getNodeIp } from '@/lib/ssh/node-ip'
 import { executeSSHDirect, shellEscape, type SSHResult } from '@/lib/ssh/exec'
+import { assertVmid } from '@/lib/ssh/validate'
 import type { PveConn } from '@/lib/connections/getConnection'
 import { safeLog } from '@/lib/log/sanitize'
 import { orchestratorHeaders } from '@/lib/orchestrator/headers'
@@ -121,6 +122,17 @@ export async function watchMigrationAndCleanup(opts: WatcherOpts): Promise<void>
   const { connectionId, tenantId, sourceConn, sourceNode, vmid, upid, deleteSource } = opts
   const tag = `[migrate-watcher:${safeLog(vmid)}]`
 
+  // Defence in depth: the remote-migrate route already validates vmid, but
+  // re-derive it here so the value interpolated into `qm unlock ${vmid}` below
+  // can never carry shell metacharacters even if a future caller forgets to.
+  let safeVmid: string
+  try {
+    safeVmid = assertVmid(vmid)
+  } catch {
+    console.warn(`${tag} invalid vmid, skipping cleanup`)
+    return
+  }
+
   console.log(`${tag} started (deleteSource=${deleteSource}, upid=${safeLog(upid)})`)
 
   let taskStatus: any = null
@@ -173,7 +185,7 @@ export async function watchMigrationAndCleanup(opts: WatcherOpts): Promise<void>
     )
     if (vmConfig?.lock) {
       const nodeIp = await getNodeIp(sourceConn, sourceNode)
-      const result = await runSshForWatcher(connectionId, tenantId, nodeIp, `qm unlock ${vmid}`)
+      const result = await runSshForWatcher(connectionId, tenantId, nodeIp, `qm unlock ${safeVmid}`)
       if (result.success) {
         console.log(`${tag} auto-unlocked VM on ${sourceNode}`)
         unlocked = true

--- a/frontend/src/lib/ssh/validate.ts
+++ b/frontend/src/lib/ssh/validate.ts
@@ -42,8 +42,12 @@ export function assertVmid(raw: unknown): string {
     throw new InvalidShellArgError(`vmid out of range: ${s}`)
   }
 
-  
-return s
+  // Return the value re-derived from the parsed integer (not the original
+  // string). For any input that passes VMID_RE this is character-identical to
+  // `s`, but routing it through Number() severs the string taint so a value
+  // interpolated into a shell command can no longer carry attacker-controlled
+  // characters (also satisfies CodeQL js/command-line-injection).
+  return String(n)
 }
 
 /**


### PR DESCRIPTION
## Summary

Two code-scanning alerts (`js/command-line-injection`, `js/log-injection`) on `lib/ssh/exec.ts` turned out **not** to be false positives. An audit of the callers found a real command-injection **bug class**: several route handlers interpolated request-derived values straight into shell commands run over SSH as **root** on Proxmox nodes. On the default root / no-sudo path the command reaches `conn.exec` verbatim, so an authenticated user could execute arbitrary commands on a node; the raw node name could also become the SSH host and reach log lines.

Prior inline `// codeql[...]` suppressions never cleared the alerts (GitHub code scanning does not honour them in this setup), and the `safeLog` sanitizer was not credited.

## Affected inputs (whole class)

| Route | Untrusted input | Sink |
|---|---|---|
| `.../unlock` | `vmid` (URL) | `qm/pct unlock ${vmid}` |
| `.../screenshot` | `vmid` (URL) | `qm monitor ${vmid} ... ${tmpFile}` |
| `.../nodes/[node]/maintenance` | `node` (URL) | `ha-manager crm-command ... ${node}` |
| `.../remote-migrate` + cross-cluster watcher | `vmid`, `node` (URL) | `qm unlock ${vmid}` |
| `.../tasks/[upid]` | task `id` | `qm unlock ${vmid}` (defence in depth) |
| `orchestrator/sflow/agents` | `collectorTarget`, rates (body) | `ovs-vsctl ... target=${collectorTarget} sampling=${rate}` |
| `migrations` | `targetStorage` (body) | `qm disk import ... ${targetStorage}` (pipeline) |

## Fix

Apply the existing but previously **unused** validators in `lib/ssh/validate.ts` at every boundary, plus numeric coercion and shell-escaping for free-form values:

- `assertVmid` (now returns `String(Number(...))`, which severs the string taint) for every vmid path.
- `assertNodeName` for node segments, and sanitize the maintenance log line with `safeLog`.
- `assertStorageName(targetStorage)` in the migrations route, covering the `qm disk import` sink in the pipelines.
- sFlow: charset-validate + `shellEscape` the collector target, `Number()`-coerce the sampling/polling rates.

Invalid input is rejected with `400` before any SSH command runs.

## Tests

New route tests for `unlock` and `sflow/agents`; extended `maintenance`, `screenshot`, `migrations` and `remote-migrate` to assert injection payloads are rejected before any SSH runs. Full suite green (237 files, 2415 tests).

## CodeQL note

The numeric (vmid / rate) paths clear automatically via `Number()` coercion. The string-name paths (node, collector target) are validated against strict allowlist grammars, but CodeQL may not credit the regex-throw guards / custom `shellEscape`; any residual alert after this lands is a post-fix false positive to dismiss with justification.
