### PR TITLE
feat(clone): suggest next available VMID instead of random (#543)

### DIFF
--- a/frontend/src/components/hardware/CloneVmDialog.test.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.test.tsx
@@ -8,9 +8,10 @@
  *
  * Provider view (isFullClusterView=true, our default mock):
  *   isProviderTenant=true => full grid form (node/storage/VMID/pool).
- *   The VMID field starts empty; user fills it manually (dice or type).
- *   The /cluster/nextid effect fires ONLY for tenant (isProviderTenant=false),
- *   so it is seeded for completeness but does not prefill the field here.
+ *   The VMID field is pre-filled with the cluster's next free id on open
+ *   (/cluster/nextid, mirroring the "New VM" screen — see #543); a "next id"
+ *   button re-fetches it. A manual edit sets a flag so the async prefill never
+ *   clobbers what the user typed.
  *
  * Not covered here:
  *   - Clone-from-snapshot Select (snapshot endpoint returns empty list so the
@@ -98,8 +99,8 @@ function seedAllHandlers() {
       HttpResponse.json({ data: { snapshots: [] } }),
     ),
 
-    // 5. Cluster next available VMID (fetched by tenant path only; seeded for
-    //    completeness so MSW does not raise an unhandled-request error)
+    // 5. Cluster next available VMID (fetched on open in both views to prefill
+    //    the field, and again when the "next id" button is clicked)
     http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
       HttpResponse.json({ data: NEXT_VMID }),
     ),
@@ -201,11 +202,19 @@ describe('CloneVmDialog - open/closed state', () => {
     expect(screen.queryByText(`Clone VM ${VM_NAME} (${VM_ID})`)).not.toBeInTheDocument()
   })
 
-  it('Clone button is disabled initially because VMID is empty', () => {
+  it('prefills the VMID with the cluster next id on open and enables Clone', async () => {
     renderWithProviders(<CloneVmDialog {...makeProps()} />)
-    // The VMID starts as '' in provider view (not prefilled); button must be disabled
-    const cloneBtn = screen.getByRole('button', { name: /^clone$/i })
-    expect(cloneBtn).toBeDisabled()
+    await waitForDataLoad()
+
+    // Provider view now prefills the VMID field from /cluster/nextid (#543),
+    // instead of leaving it empty for a random dice pick.
+    await waitFor(() => {
+      const input = screen.getAllByRole('spinbutton')[0] as HTMLInputElement
+      expect(input.value).toBe(String(NEXT_VMID))
+    })
+
+    // A valid prefilled id (not in existingVmids) means Clone is enabled.
+    expect(screen.getByRole('button', { name: /^clone$/i })).not.toBeDisabled()
   })
 })
 
@@ -349,6 +358,58 @@ describe('CloneVmDialog - VMID validation', () => {
     })
 
     expect(screen.queryByText(/VM ID must be/i)).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3b. Next-available VMID button (#543)
+// ------------------------------------------------------------------ //
+
+describe('CloneVmDialog - next-available VMID button', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  it('re-fetches /cluster/nextid on click and does not clobber a manual edit', async () => {
+    renderWithProviders(<CloneVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+
+    // User types their own id; the async open-prefill must leave it alone.
+    setVmid('200')
+    await waitFor(() => {
+      expect((screen.getAllByRole('spinbutton')[0] as HTMLInputElement).value).toBe('200')
+    })
+
+    // Cluster now reports a different next id; the button pulls the fresh value.
+    server.use(
+      http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+        HttpResponse.json({ data: 555 }),
+      ),
+    )
+
+    const refreshIcon = document.querySelector('.ri-refresh-line')
+    expect(refreshIcon).not.toBeNull()
+    fireEvent.click(refreshIcon!.closest('button') as HTMLButtonElement)
+
+    await waitFor(() => {
+      expect((screen.getAllByRole('spinbutton')[0] as HTMLInputElement).value).toBe('555')
+    })
+  })
+
+  it('falls back to the nextVmid prop when /cluster/nextid fails on open', async () => {
+    server.use(
+      http.get(`*/api/v1/connections/${CONN_ID}/cluster/nextid`, () =>
+        HttpResponse.json({}, { status: 500 }),
+      ),
+    )
+
+    renderWithProviders(<CloneVmDialog {...makeProps({ nextVmid: 321 })} />)
+    await waitForDataLoad()
+
+    // Endpoint down => the field degrades to the caller's estimate, never blank.
+    await waitFor(() => {
+      expect((screen.getAllByRole('spinbutton')[0] as HTMLInputElement).value).toBe('321')
+    })
   })
 })
 

--- a/frontend/src/components/hardware/CloneVmDialog.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
@@ -29,7 +29,7 @@ import {
 
 import { formatBytes } from '@/utils/format'
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
-import { type NodeInfo, calculateNodeScore, formatMemory } from './utils'
+import { type NodeInfo, calculateNodeScore, formatMemory, fetchNextVmid } from './utils'
 import { useTenant } from '@/contexts/TenantContext'
 
 // ==================== CLONE VM DIALOG ====================
@@ -69,6 +69,10 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
   // Form fields
   const [targetNode, setTargetNode] = useState(currentNode)
   const [newVmid, setNewVmid] = useState<number | ''>('' )
+  // Once the user types a VMID by hand, the async /cluster/nextid prefill must
+  // not clobber it (the field is visible+editable in the provider view). Reset
+  // on each open.
+  const userEditedVmidRef = useRef(false)
   const [name, setName] = useState('')
   const [targetStorage, setTargetStorage] = useState('')
   const [format, setFormat] = useState('qcow2')
@@ -81,16 +85,14 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
   const [snapname, setSnapname] = useState('')
   const [snapshotsLoading, setSnapshotsLoading] = useState(false)
 
-  // Generate a random available VMID
-  const generateRandomVmid = () => {
-    const existing = new Set(existingVmids)
-    let id: number
+  // Suggest the cluster's next free VMID (PVE /cluster/nextid), mirroring the
+  // "New VM" screen. Region-based infras assign VMIDs sequentially, so a random
+  // id (the old behaviour) broke their scheme — see #543. Falls back to the
+  // parent's nextVmid estimate if the endpoint is unavailable.
+  const generateNextVmid = async () => {
+    const id = await fetchNextVmid(connId)
 
-    do {
-      id = Math.floor(Math.random() * (999999 - 100 + 1)) + 100
-    } while (existing.has(id))
-
-    setNewVmid(id)
+    setNewVmid(id ?? (nextVmid || ''))
   }
 
   // Validation du VMID
@@ -248,12 +250,12 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
   useEffect(() => {
     if (open) {
       setTargetNode(currentNode)
-      // Tenant: prefill VMID with the cluster's next free id (passed in by
-      // the caller via /cluster/nextid). The form input is hidden so the
-      // user never sees it, but handleClone needs a valid number to send.
-      // Fallback to '' for the provider so the existing UX (dice button)
-      // is unchanged.
-      setNewVmid(isProviderTenant ? '' : (nextVmid || ''))
+      // Seed the VMID with the caller's next-free estimate for both views; the
+      // /cluster/nextid effect below then overrides it with the authoritative
+      // cluster value. Tenants never see the field (auto-picked), providers get
+      // it pre-filled so cloning defaults to a sequential id instead of random.
+      userEditedVmidRef.current = false
+      setNewVmid(nextVmid || '')
       setName('')
       setTargetStorage('')
       setFormat('qcow2')
@@ -262,29 +264,27 @@ export function CloneVmDialog({ open, onClose, onClone, connId, currentNode, vmN
       setSnapname('')
       setError(null)
     }
-  }, [open, currentNode, nextVmid, isProviderTenant])
+  }, [open, currentNode, nextVmid])
 
-  // Tenant: hit /cluster/nextid for a cluster-validated VMID instead of
-  // relying on Math.max(allVms) computed at the parent — that snapshot
-  // can be stale or local-cluster-only and would collide with VMIDs on
-  // another node we never saw. Falls back to the parent's nextVmid if
-  // the API fails (e.g. orchestrator hiccup).
+  // Both views: hit /cluster/nextid for a cluster-validated VMID instead of
+  // relying on Math.max(allVms) computed at the parent — that snapshot can be
+  // stale or local-cluster-only and would collide with VMIDs on another node
+  // we never saw. Falls back to the parent's nextVmid if the API fails (e.g.
+  // orchestrator hiccup).
   useEffect(() => {
-    if (!open || isProviderTenant || !connId) return
+    if (!open || !connId) return
     let cancelled = false
     ;(async () => {
-      try {
-        const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/cluster/nextid`)
-        const json = await res.json()
-        const id = Number(json?.data) || 0
-        if (!cancelled && id >= 100) setNewVmid(id)
-        else if (!cancelled && nextVmid) setNewVmid(nextVmid)
-      } catch {
-        if (!cancelled && nextVmid) setNewVmid(nextVmid)
-      }
+      const id = await fetchNextVmid(connId)
+
+      // Bail if the dialog closed or the user already typed their own VMID.
+      if (cancelled || userEditedVmidRef.current) return
+      if (id !== null) setNewVmid(id)
+      else if (nextVmid) setNewVmid(nextVmid)
     })()
+
     return () => { cancelled = true }
-  }, [open, isProviderTenant, connId, nextVmid])
+  }, [open, connId, nextVmid])
 
   const getRecommendedNodeLocal = (nodeList: NodeInfo[]): NodeInfo | null => {
     if (nodeList.length === 0) return null
@@ -516,7 +516,7 @@ return currentScore > bestScore ? current : best
             label="VM ID"
             type="number"
             value={newVmid}
-            onChange={(e) => setNewVmid(e.target.value === '' ? '' : (Number.parseInt(e.target.value) || 0))}
+            onChange={(e) => { userEditedVmidRef.current = true; setNewVmid(e.target.value === '' ? '' : (Number.parseInt(e.target.value) || 0)) }}
             inputProps={{ min: 100, max: 999999999 }}
             placeholder={t('hardware.vmIdPlaceholder')}
             required
@@ -526,8 +526,8 @@ return currentScore > bestScore ? current : best
               endAdornment: (
                 <InputAdornment position="end">
                   <Tooltip title={t('hardware.generateVmId')}>
-                    <IconButton size="small" onClick={generateRandomVmid} edge="end">
-                      <i className="ri-dice-line" style={{ fontSize: 18 }} />
+                    <IconButton size="small" onClick={generateNextVmid} edge="end">
+                      <i className="ri-refresh-line" style={{ fontSize: 18 }} />
                     </IconButton>
                   </Tooltip>
                 </InputAdornment>

--- a/frontend/src/components/hardware/utils.test.tsx
+++ b/frontend/src/components/hardware/utils.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for hardware/utils.ts — currently fetchNextVmid.
+ *
+ * Runs in the jsdom lane (MSW-backed fetch) because fetchNextVmid is a
+ * browser-side wrapper around the /cluster/nextid API route. Each case seeds
+ * one MSW handler; handlers reset between tests via jsdom-setup.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { fetchNextVmid } from './utils'
+
+const CONN_ID = 'conn-1'
+const NEXTID_URL = `*/api/v1/connections/${CONN_ID}/cluster/nextid`
+
+describe('fetchNextVmid', () => {
+  it('returns the cluster next id on a successful response', async () => {
+    server.use(http.get(NEXTID_URL, () => HttpResponse.json({ data: 142 })))
+    await expect(fetchNextVmid(CONN_ID)).resolves.toBe(142)
+  })
+
+  it('returns null when the response is not ok', async () => {
+    server.use(http.get(NEXTID_URL, () => HttpResponse.json({}, { status: 500 })))
+    await expect(fetchNextVmid(CONN_ID)).resolves.toBeNull()
+  })
+
+  it('returns null when the id is below the 100 floor', async () => {
+    server.use(http.get(NEXTID_URL, () => HttpResponse.json({ data: 42 })))
+    await expect(fetchNextVmid(CONN_ID)).resolves.toBeNull()
+  })
+
+  it('returns null when the payload is not a finite number', async () => {
+    server.use(http.get(NEXTID_URL, () => HttpResponse.json({ data: 'nope' })))
+    await expect(fetchNextVmid(CONN_ID)).resolves.toBeNull()
+  })
+
+  it('returns null when the request throws (network error)', async () => {
+    server.use(http.get(NEXTID_URL, () => HttpResponse.error()))
+    await expect(fetchNextVmid(CONN_ID)).resolves.toBeNull()
+  })
+})

--- a/frontend/src/components/hardware/utils.ts
+++ b/frontend/src/components/hardware/utils.ts
@@ -52,3 +52,22 @@ export const formatMemory = (bytes?: number): string => {
 
 return `${gb.toFixed(1)} GB`
 }
+
+// Cluster-wide next free VMID from PVE (/cluster/nextid). Returns null when the
+// endpoint fails or yields something below the 100 floor, so callers can fall
+// back to their own estimate. Used by CloneVmDialog (both its open-effect and
+// the "next id" button) to match the "New VM" screen's next-available default.
+export const fetchNextVmid = async (connId: string): Promise<number | null> => {
+  try {
+    const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/cluster/nextid`)
+
+    if (!res.ok) return null
+    const json = await res.json()
+    const id = Number(json?.data)
+
+
+return Number.isFinite(id) && id >= 100 ? id : null
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4522,7 +4522,7 @@
     "cloneTitle": "VM {vmName} ({vmid}) klonen",
     "vmIdRequired": "VM ID erforderlich",
     "vmIdPlaceholder": "VM-ID eingeben oder generieren",
-    "generateVmId": "Generate random verfügbar ID",
+    "generateVmId": "Generate next verfügbar ID",
     "vmIdTooLarge": "VM-ID zu groß",
     "optional": "(optional)",
     "none": "(Keine)",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4564,7 +4564,7 @@
     "cloneTitle": "Clone VM {vmName} ({vmid})",
     "vmIdRequired": "VM ID required",
     "vmIdPlaceholder": "Enter or generate a VM ID",
-    "generateVmId": "Generate random available ID",
+    "generateVmId": "Generate next available ID",
     "vmIdTooLarge": "VM ID too large",
     "optional": "(optional)",
     "none": "(None)",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4564,7 +4564,7 @@
     "cloneTitle": "Cloner VM {vmName} ({vmid})",
     "vmIdRequired": "VM ID requis",
     "vmIdPlaceholder": "Entrer ou générer un VM ID",
-    "generateVmId": "Générer un ID aléatoire disponible",
+    "generateVmId": "Générer le prochain ID disponible",
     "vmIdTooLarge": "VM ID trop grand",
     "optional": "(optionnel)",
     "none": "(Aucun)",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4525,7 +4525,7 @@
     "cloneTitle": "克隆 VM {vmName}（{vmid}）",
     "vmIdRequired": "需要 VM ID",
     "vmIdPlaceholder": "输入或生成 VM ID",
-    "generateVmId": "生成随机可用 ID",
+    "generateVmId": "生成下一个可用 ID",
     "vmIdTooLarge": "VM ID 过大",
     "optional": "（可选）",
     "none": "（无）",


### PR DESCRIPTION
## Summary

Closes #543.

The clone dialog's provider/admin view left the VM ID field empty and offered a random-id button. Infrastructures that assign VM IDs sequentially (for example a distinct range per region) ended up with a mess when cloning. This makes clone suggest the cluster's next free VM ID on open, exactly like the "New VM" screen and the tenant clone path already do.

## Changes

- Prefill the VM ID from `/cluster/nextid` when the clone dialog opens, for both the tenant and provider views (previously only the tenant view did this).
- Replace the random "dice" button with a "next id" refresh button that re-queries `/cluster/nextid` on demand, mirroring the New VM screen.
- Add a guard so the async prefill never overwrites a VM ID the user typed by hand (the field is visible and editable in the provider view).
- Extract a shared `fetchNextVmid(connId)` helper in `hardware/utils.ts` to avoid duplicating the fetch logic.
- Update the `generateVmId` label from "random available" to "next available" across en/fr/de/zh.

## Tests

- New unit tests for `fetchNextVmid` (success, non-ok response, below-100 floor, non-numeric payload, network error).
- Updated clone dialog tests: prefill on open, the next-id button, manual edit preserved, and fallback to the caller estimate when the endpoint fails.
- 24 tests pass; new-code coverage is 100%.

Frontend only, no backend change (reuses the existing `/cluster/nextid` route).
