### PR TITLE
fix(inventory): show host VLANs with no attached VM (#542)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { fetchConnectionsNetworks, type HostBridgeItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem } from '@/lib/proxmox/fetchConnectionsNetworks'
 import { bridgeLabel } from '@/lib/proxmox/hostVlanMap'
 
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
@@ -2248,6 +2248,7 @@ return favorites.has(vmKey)
   type VmNetData = { vmid: string; name: string; node: string; type: string; status: string; connId?: string; nets: NetIface[] }
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
   const [networkBridges, setNetworkBridges] = useState<HostBridgeItem[]>([])
+  const [networkVlans, setNetworkVlans] = useState<HostVlanItem[]>([])
   const [networkVnetAliases, setNetworkVnetAliases] = useState<Record<string, Record<string, string>>>({})
   const [networkLoading, setNetworkLoading] = useState(false)
   const [networkFailedConnIds, setNetworkFailedConnIds] = useState<string[]>([])
@@ -2280,7 +2281,7 @@ return favorites.has(vmKey)
       return next
     })
   }, [])
-  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[]; bridges: HostBridgeItem[]; vnetAliasesByConn: Record<string, Record<string, string>> } | null>(null)
+  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliasesByConn: Record<string, Record<string, string>> } | null>(null)
 
   // Fetch the tenant's VNets (display + subnet info) — only meaningful for
   // non-provider tenants. Provider keeps the legacy bridge/VLAN walk.
@@ -2325,19 +2326,21 @@ return favorites.has(vmKey)
     if (networkCacheRef.current?.connIds === cacheKey) {
       setNetworkData(networkCacheRef.current.data)
       setNetworkBridges(networkCacheRef.current.bridges)
+      setNetworkVlans(networkCacheRef.current.vlans)
       setNetworkVnetAliases(networkCacheRef.current.vnetAliasesByConn)
       return
     }
     setNetworkLoading(true)
-    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, bridges, vnetAliasesByConn, failedConnIds }) => {
+    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, bridges, vlans, vnetAliasesByConn, failedConnIds }) => {
       setNetworkData(data)
       setNetworkBridges(bridges)
+      setNetworkVlans(vlans)
       setNetworkVnetAliases(vnetAliasesByConn)
       setNetworkLoading(false)
       setNetworkFailedConnIds(failedConnIds)
       // Only cache when all connections succeeded so re-opening retries any partial failure
       if (failedConnIds.length === 0) {
-        networkCacheRef.current = { connIds: cacheKey, data, bridges, vnetAliasesByConn }
+        networkCacheRef.current = { connIds: cacheKey, data, bridges, vlans, vnetAliasesByConn }
       } else {
         // Allow the next expand to re-fetch
         networkFetchedRef.current = false
@@ -2379,9 +2382,11 @@ return favorites.has(vmKey)
     }
   }, [isHydrated, expandedNetSections, clusters.length, isFullClusterView, fetchTenantVnets])
 
-  // Build network tree: Connection → Node → [bridges] + VLAN buckets (VMs only)
+  // Build network tree: Connection → Node → [bridges] + VLAN buckets. VLAN
+  // buckets are seeded from both guest NIC tags and host VLAN sub-interfaces so
+  // VLANs with no attached VM still appear, mirroring empty bridges (issue #542).
   const networkTree = useMemo(() => {
-    if (!networkData.length && !networkBridges.length) return []
+    if (!networkData.length && !networkBridges.length && !networkVlans.length) return []
 
     type BucketEntry = { vm: VmNetData; netId: string; bridge: string }
     type Bucket = { tag: number | 'untagged'; entries: BucketEntry[] }
@@ -2405,6 +2410,13 @@ return favorites.has(vmKey)
         const bucket = ensureVmBucket(cid, vm.node, tag)
         bucket.entries.push({ vm, netId: net.id, bridge: net.bridge })
       }
+    }
+
+    // Seed a bucket for every host VLAN sub-interface so VLANs with no attached
+    // VM still appear (issue #542). ensureVmBucket is a no-op when a VM already
+    // created the bucket, so counts are never double-added.
+    for (const v of networkVlans) {
+      ensureVmBucket(v.connId || 'unknown', v.node, v.tag)
     }
 
     // Group host bridges by connId → node
@@ -2449,7 +2461,7 @@ return favorites.has(vmKey)
         })
       return { connId, connName, nodes }
     }).sort((a, b) => a.connName.localeCompare(b.connName))
-  }, [networkData, networkBridges, clusters])
+  }, [networkData, networkBridges, networkVlans, clusters])
 
   // Expand all network tree items helper
   const expandNetworkOnLoadRef = useRef(false)
@@ -3776,9 +3788,12 @@ return (
             </Box>
             <i className="ri-router-fill" style={{ fontSize: 14, opacity: 0.7 }} />
             <Typography variant="body2" sx={{ fontWeight: 700 }}>NETWORK</Typography>
-            {isFullClusterView && networkData.length > 0 && (
+            {isFullClusterView && (networkData.length > 0 || networkVlans.length > 0) && (
               <Typography variant="caption" sx={{ opacity: 0.5 }}>
-                ({new Set(networkData.flatMap(v => v.nets.filter(n => n.tag != null).map(n => n.tag))).size} VLANs)
+                ({new Set([
+                  ...networkData.flatMap(v => v.nets.filter(n => n.tag != null).map(n => n.tag as number)),
+                  ...networkVlans.map(v => v.tag),
+                ]).size} VLANs)
               </Typography>
             )}
             {!isFullClusterView && tenantVnets.length > 0 && (

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
@@ -24,7 +24,7 @@ import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 import VnetsSection from './VnetsSection'
 import { useTenant } from '@/contexts/TenantContext'
-import { fetchConnectionsNetworks, type HostBridgeItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem } from '@/lib/proxmox/fetchConnectionsNetworks'
 
 type VmNetData = {
   vmid: string
@@ -278,6 +278,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   const [loading, setLoading] = useState(false)
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
   const [hostBridges, setHostBridges] = useState<HostBridgeItem[]>([])
+  const [hostVlans, setHostVlans] = useState<HostVlanItem[]>([])
   const [vnetAliasesByConn, setVnetAliasesByConn] = useState<Record<string, Record<string, string>>>({})
   // VNet KPIs are computed from the same data VnetsSection fetches; pulling
   // it up here lets the donut row and the list stay in sync without a
@@ -292,10 +293,11 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     const ids = connIdsKey.split(',')
     let alive = true
     setLoading(true)
-    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data, bridges, vnetAliasesByConn }) => {
+    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data, bridges, vlans, vnetAliasesByConn }) => {
       if (!alive) return
       setNetworkData(data)
       setHostBridges(bridges)
+      setHostVlans(vlans)
       setVnetAliasesByConn(vnetAliasesByConn)
     }).finally(() => {
       if (!alive) return
@@ -380,6 +382,15 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
       }
     }
 
+    // Seed vlanMap from host VLAN sub-interfaces so VLANs with no attached VM
+    // still appear — including VLAN-aware-bridge layouts where the bridge tag
+    // does not fold to a single VLAN (issue #542).
+    for (const v of hostVlans) {
+      if (!vlanMap.has(v.tag)) {
+        vlanMap.set(v.tag, { vlan: v.tag, vmCount: 0, bridges: new Set(), vms: [] })
+      }
+    }
+
     for (const vm of networkData) {
       if (vm.nets.length > 0) totalVmsWithNetwork++
       for (const net of vm.nets) {
@@ -422,7 +433,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
       vlanBreakdown: [...vlanMap.values()].map(v => ({ ...v, bridges: [...v.bridges] })).sort((a, b) => b.vmCount - a.vmCount),
       bridgeBreakdown: [...bridgeMap.values()],
     }
-  }, [networkData, connectionNames, hostBridges])
+  }, [networkData, connectionNames, hostBridges, hostVlans])
 
   // Flat map of vnet id → alias across all connections (vnet ids are globally unique within a cluster)
   const flatAliases = useMemo(
@@ -433,7 +444,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   // Only block the dashboard with a spinner on the initial load — after
   // that, background refetches keep the existing KPIs / tables visible
   // so the page doesn't flicker on every inventory poll.
-  if (loading && networkData.length === 0 && hostBridges.length === 0) {
+  if (loading && networkData.length === 0 && hostBridges.length === 0 && hostVlans.length === 0) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
         <CircularProgress />

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import type { InventorySelection } from '../types'
-import { bridgeLabel, foldEffectiveVlanTags, type HostBridge } from '@/lib/proxmox/hostVlanMap'
+import { bridgeLabel, foldEffectiveVlanTags, type HostBridge, type HostVlan } from '@/lib/proxmox/hostVlanMap'
 import { StatusIcon } from '../InventoryTree'
 
 type NetIface = { id: string; model: string; bridge: string; macaddr?: string; tag?: number; firewall?: boolean; rate?: number }
@@ -36,6 +36,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   const theme = useTheme()
   const [netData, setNetData] = React.useState<VmNet[]>([])
   const [hostBridges, setHostBridges] = React.useState<HostBridge[]>([])
+  const [hostVlans, setHostVlans] = React.useState<HostVlan[]>([])
   const [vnetAliases, setVnetAliases] = React.useState<Record<string, string>>({})
   const [loading, setLoading] = React.useState(true)
 
@@ -56,11 +57,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       // bondX.N bridge with no per-NIC tag group under their real VLAN (see helper).
       .then(json => {
         setNetData((json.data || []).map((vm: any) => ({ ...vm, connId, nets: foldEffectiveVlanTags(vm.nets) })))
-        // raw HostBridge[] (no connId — this panel is scoped to a single connection)
+        // raw HostBridge[] / HostVlan[] (no connId — this panel is scoped to a single connection)
         setHostBridges(json.bridges || [])
+        setHostVlans(json.vlans || [])
         setVnetAliases(json.vnetAliases || {})
       })
-      .catch(() => { setNetData([]); setHostBridges([]); setVnetAliases({}) })
+      .catch(() => { setNetData([]); setHostBridges([]); setHostVlans([]); setVnetAliases({}) })
       .finally(() => setLoading(false))
   }, [connId])
 
@@ -93,6 +95,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       const nd = nodeMap.get(b.node)!
       nd.bridges.add(b.iface)
     }
+    // Seed nodeMap VLANs from host VLAN sub-interfaces so VLANs with no attached
+    // VM are counted per node, mirroring host bridges (issue #542).
+    for (const v of hostVlans) {
+      if (!nodeMap.has(v.node)) nodeMap.set(v.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
+      nodeMap.get(v.node)!.vlans.add(v.tag)
+    }
     for (const vm of netData) {
       if (!nodeMap.has(vm.node)) nodeMap.set(vm.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
       const nd = nodeMap.get(vm.node)!
@@ -103,11 +111,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
       }
     }
     const nodes = Array.from(nodeMap.entries()).sort((a, b) => a[0].localeCompare(b[0]))
-    // VLANs are VM-derived only; bridges include host bridges so VM-less nodes
-    // still report a bridge count.
-    const allVlans = new Set<string | number>(
-      netData.flatMap(vm => vm.nets.map(n => n.tag ?? 'untagged'))
-    )
+    // VLANs and bridges both include host-level interfaces so VM-less nodes
+    // still report accurate counts.
+    const allVlans = new Set<string | number>([
+      ...netData.flatMap(vm => vm.nets.map(n => n.tag ?? 'untagged')),
+      ...hostVlans.map(v => v.tag),
+    ])
     const allBridges = new Set<string>([
       ...netData.flatMap(vm => vm.nets.map(n => n.bridge)),
       ...hostBridges.map(b => b.iface),
@@ -203,8 +212,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   if (selection.type === 'net-node' && nodeName) {
     const nodeVms = netData.filter(vm => vm.node === nodeName)
     const nodeHostBridges = hostBridges.filter(b => b.node === nodeName).slice().sort((a, b) => a.iface.localeCompare(b.iface))
-    // Build vlanMap from VMs only (no host bridge seeding)
+    // Build vlanMap from VMs plus host VLAN sub-interfaces on this node, so VLANs
+    // with no attached VM still appear (issue #542).
     const vlanMap = new Map<string | number, { bridges: Set<string>; vms: VmNet[] }>()
+    for (const v of hostVlans) {
+      if (v.node === nodeName && !vlanMap.has(v.tag)) vlanMap.set(v.tag, { bridges: new Set(), vms: [] })
+    }
     for (const vm of nodeVms) {
       for (const net of vm.nets) {
         const tag = net.tag ?? 'untagged'
@@ -361,6 +374,12 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     }
     // Bridges used by the VMs in this VLAN only (no host-bridge seeding)
     const bridges = [...new Set(vlanVms.map(v => v.net.bridge))]
+    // Host VLAN sub-interface(s) that define this VLAN on the node. A VLAN can
+    // exist here with zero VMs (issue #542) — surface the interface so the view
+    // is informative instead of blank.
+    const hostVlanIfaces = isUntagged
+      ? []
+      : hostVlans.filter(v => v.node === nodeName && String(v.tag) === vlanTag)
 
     return (
       <Box sx={{ p: 2.5 }}>
@@ -420,6 +439,49 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
           </Box>
         )}
 
+        {/* Host VLAN interface(s) — the sub-interface(s) that define this VLAN on the node */}
+        {hostVlanIfaces.length > 0 && (
+          <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+              <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className="ri-router-line" style={{ fontSize: 18, opacity: 0.7 }} />
+                  Host interface
+                </Typography>
+              </Box>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Interface</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>IP / CIDR</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Active</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {hostVlanIfaces.map(v => (
+                      <TableRow key={v.iface}>
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                            <i className="ri-wifi-line" style={{ fontSize: 14, opacity: 0.6 }} />
+                            <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{v.iface}</Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{v.cidr || '—'}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip size="small" label={v.active ? 'Yes' : 'No'} color={v.active ? 'success' : 'default'} sx={{ height: 20, fontSize: 10 }} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </CardContent>
+          </Card>
+        )}
+
         {/* VM table */}
         <Card variant="outlined" sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
@@ -444,6 +506,17 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
                   </TableRow>
                 </TableHead>
                 <TableBody>
+                  {vlanVms.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={8}>
+                        <Typography variant="body2" sx={{ py: 1, textAlign: 'center', opacity: 0.5 }}>
+                          {hostVlanIfaces.length > 0
+                            ? 'This VLAN is configured on the host but has no attached VM.'
+                            : 'No VMs on this VLAN.'}
+                        </Typography>
+                      </TableCell>
+                    </TableRow>
+                  )}
                   {vlanVms.map(({ vm, net }, idx) => (
                     <TableRow
                       key={`${vm.vmid}-${net.id}-${idx}`}

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
@@ -229,6 +229,86 @@ describe('GET /api/v1/connections/[id]/networks — host bridges', () => {
   })
 })
 
+describe('GET /api/v1/connections/[id]/networks — host VLANs (#542)', () => {
+  // VLAN-aware-bridge layout: many VLAN sub-interfaces over few bridges, and
+  // none of the VLANs has an attached VM. Previously none would surface.
+  const NODE_NETWORK = [
+    { iface: 'bond0', type: 'bond' },
+    { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+    { iface: 'vmbr0.10', type: 'vlan' },
+    { iface: 'vmbr0.20', type: 'vlan' },
+    { iface: 'vmbr0.30', type: 'vlan' },
+  ]
+
+  it('returns host VLANs even when no VM is attached (provider scope)', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+
+    expect(body.data).toEqual([])
+    expect(Array.isArray(body.vlans)).toBe(true)
+    expect(body.vlans.map((v: any) => v.tag)).toEqual([10, 20, 30])
+    expect(body.vlans.every((v: any) => v.node === 'pve1')).toBe(true)
+  })
+
+  it('surfaces VLANs across every node in the cluster', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }, { node: 'pve2' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/nodes/pve2/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    const nodes = [...new Set(body.vlans.map((v: any) => v.node))]
+    expect(nodes).toContain('pve1')
+    expect(nodes).toContain('pve2')
+  })
+
+  it('returns empty data/bridges/vlans when the VM resource list is unavailable', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return null
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body).toEqual({ data: [], bridges: [], vlans: [], vnetAliases: {} })
+  })
+
+  it('returns vlans: [] for tenant (vDC) scope even when host VLANs exist', async () => {
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue({
+      connectionIds: new Set(['c1']),
+      poolsByConnection: new Map([['c1', new Set(['pool1'])]]),
+      vdcIds: new Set(),
+      vdcNames: new Set(),
+    })
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.vlans).toEqual([])
+  })
+})
+
 describe('GET /api/v1/connections/[id]/networks — vnetAliases', () => {
   const NODE_NETWORK = [
     { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.ts
@@ -5,7 +5,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
-import { buildBridgeVlanMap, extractHostBridges, resolveEffectiveTag, type HostBridge } from "@/lib/proxmox/hostVlanMap"
+import { buildBridgeVlanMap, extractHostBridges, extractHostVlans, resolveEffectiveTag, type HostBridge, type HostVlan } from "@/lib/proxmox/hostVlanMap"
 
 export const runtime = "nodejs"
 
@@ -96,7 +96,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
     // Get all VMs/CTs from cluster resources
     const allResources = await pveFetch<any[]>(conn, "/cluster/resources?type=vm")
     if (!allResources || !Array.isArray(allResources)) {
-      return NextResponse.json({ data: [], bridges: [], vnetAliases: {} })
+      return NextResponse.json({ data: [], bridges: [], vlans: [], vnetAliases: {} })
     }
 
     // Restrict to the tenant's vDC pool(s) on this connection. Without this,
@@ -181,12 +181,17 @@ export async function GET(_req: Request, ctx: RouteContext) {
       })
     )
 
-    // Collect host bridges for provider scope
+    // Collect host bridges and host VLAN sub-interfaces for provider scope, so
+    // both surface in the inventory Network view even when no VM is attached.
+    // VLANs previously only came from guest NIC tags, so empty VLANs never
+    // appeared while empty bridges did (issue #542).
     const hostBridges: HostBridge[] = []
+    const hostVlans: HostVlan[] = []
     if (isProviderScope) {
       for (const [node, ifaces] of hostBridgesIfacesByNode) {
         const map = bridgeVlanByNode.get(node) ?? new Map<string, number>()
         hostBridges.push(...extractHostBridges(node, ifaces, map))
+        hostVlans.push(...extractHostVlans(node, ifaces))
       }
     }
 
@@ -242,7 +247,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
       }
     }
 
-    return NextResponse.json({ data: results, bridges: isProviderScope ? hostBridges : [], vnetAliases })
+    return NextResponse.json({ data: results, bridges: isProviderScope ? hostBridges : [], vlans: isProviderScope ? hostVlans : [], vnetAliases })
   } catch (e: any) {
     console.error("[networks] Error:", e)
     return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
@@ -200,6 +200,80 @@ describe('fetchConnectionsNetworks', () => {
     expect(result.bridges).toEqual([])
   })
 
+  it('threads vlans from route response, tagging each with connId (#542)', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: {
+        data: [],
+        vlans: [
+          { node: 'pve1', iface: 'vmbr0.10', tag: 10 },
+          { node: 'pve1', iface: 'vmbr0.20', tag: 20 },
+        ],
+      } as any,
+      conn2: {
+        data: [],
+        vlans: [
+          { node: 'pve2', iface: 'bond0.7', tag: 7 },
+        ],
+      } as any,
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1', 'conn2'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.vlans).toHaveLength(3)
+    expect(result.vlans.every((v) => typeof v.connId === 'string')).toBe(true)
+    expect(result.vlans.filter((v) => v.connId === 'conn1').map((v) => v.tag)).toEqual([10, 20])
+    const conn2Vlans = result.vlans.filter((v) => v.connId === 'conn2')
+    expect(conn2Vlans).toHaveLength(1)
+    expect(conn2Vlans[0].node).toBe('pve2')
+  })
+
+  it('contributes no vlans from a failed connection', async () => {
+    const fetchImpl = makeFailFetch('bad-conn', {
+      'good-conn': {
+        data: [],
+        vlans: [{ node: 'pve1', iface: 'vmbr0.10', tag: 10 }],
+      } as any,
+    })
+
+    const result = await fetchConnectionsNetworks(['good-conn', 'bad-conn'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.failedConnIds).toEqual(['bad-conn'])
+    expect(result.vlans).toHaveLength(1)
+    expect(result.vlans[0].connId).toBe('good-conn')
+  })
+
+  it('returns vlans: [] when the route response has no vlans field (backward compat)', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: { data: [] },
+    })
+
+    const result = await fetchConnectionsNetworks(['conn1'], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: fetchImpl as any,
+    })
+
+    expect(result.vlans).toEqual([])
+  })
+
+  it('returns vlans: [] immediately for empty connIds input', async () => {
+    const result = await fetchConnectionsNetworks([], {
+      retries: 0,
+      retryDelayMs: 0,
+      fetchImpl: vi.fn() as any,
+    })
+
+    expect(result.vlans).toEqual([])
+  })
+
   it('collects vnetAliases per connection into vnetAliasesByConn', async () => {
     const fetchImpl = vi.fn(async (url: string) => {
       const match = /\/connections\/([^/]+)\/networks/.exec(url)

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
@@ -1,4 +1,4 @@
-import { foldEffectiveVlanTags, type HostBridge } from './hostVlanMap'
+import { foldEffectiveVlanTags, type HostBridge, type HostVlan } from './hostVlanMap'
 
 export type VmNetItem = {
   vmid: string
@@ -11,6 +11,7 @@ export type VmNetItem = {
 }
 
 export type HostBridgeItem = HostBridge & { connId: string }
+export type HostVlanItem = HostVlan & { connId: string }
 
 const DEFAULT_RETRIES = 2
 const DEFAULT_RETRY_DELAY_MS = 300
@@ -20,7 +21,7 @@ async function fetchWithRetry(
   retries: number,
   retryDelayMs: number,
   fetchImpl: typeof fetch,
-): Promise<{ ok: true; items: VmNetItem[]; bridges: HostBridgeItem[]; vnetAliases: Record<string, string> } | { ok: false }> {
+): Promise<{ ok: true; items: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliases: Record<string, string> } | { ok: false }> {
   let attempt = 0
   while (attempt <= retries) {
     try {
@@ -38,8 +39,12 @@ async function fetchWithRetry(
         ...b,
         connId,
       }))
+      const vlans: HostVlanItem[] = (json.vlans ?? []).map((v: HostVlan) => ({
+        ...v,
+        connId,
+      }))
       const vnetAliases: Record<string, string> = json.vnetAliases ?? {}
-      return { ok: true, items, bridges, vnetAliases }
+      return { ok: true, items, bridges, vlans, vnetAliases }
     } catch {
       if (attempt < retries) {
         if (retryDelayMs > 0) {
@@ -56,15 +61,15 @@ async function fetchWithRetry(
 
 /**
  * Fetch VM network data from multiple connections concurrently with per-connection
- * retry logic. Returns flat data, flat host bridges (tagged with connId), plus the
- * list of connection IDs that failed after all retries. Never rejects — partial
- * failure is surfaced via failedConnIds.
+ * retry logic. Returns flat data, flat host bridges and flat host VLAN sub-interfaces
+ * (each tagged with connId), plus the list of connection IDs that failed after all
+ * retries. Never rejects — partial failure is surfaced via failedConnIds.
  */
 export async function fetchConnectionsNetworks(
   connIds: string[],
   opts?: { retries?: number; retryDelayMs?: number; fetchImpl?: typeof fetch },
-): Promise<{ data: VmNetItem[]; bridges: HostBridgeItem[]; vnetAliasesByConn: Record<string, Record<string, string>>; failedConnIds: string[] }> {
-  if (connIds.length === 0) return { data: [], bridges: [], vnetAliasesByConn: {}, failedConnIds: [] }
+): Promise<{ data: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliasesByConn: Record<string, Record<string, string>>; failedConnIds: string[] }> {
+  if (connIds.length === 0) return { data: [], bridges: [], vlans: [], vnetAliasesByConn: {}, failedConnIds: [] }
 
   const retries = opts?.retries ?? DEFAULT_RETRIES
   const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
@@ -76,6 +81,7 @@ export async function fetchConnectionsNetworks(
 
   const data: VmNetItem[] = []
   const bridges: HostBridgeItem[] = []
+  const vlans: HostVlanItem[] = []
   const vnetAliasesByConn: Record<string, Record<string, string>> = {}
   const failedConnIds: string[] = []
 
@@ -84,11 +90,12 @@ export async function fetchConnectionsNetworks(
     if (result.ok) {
       data.push(...result.items)
       bridges.push(...result.bridges)
+      vlans.push(...result.vlans)
       vnetAliasesByConn[connIds[i]] = result.vnetAliases
     } else {
       failedConnIds.push(connIds[i])
     }
   }
 
-  return { data, bridges, vnetAliasesByConn, failedConnIds }
+  return { data, bridges, vlans, vnetAliasesByConn, failedConnIds }
 }

--- a/frontend/src/lib/proxmox/hostVlanMap.test.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.test.ts
@@ -6,6 +6,7 @@ import {
   resolveEffectiveTag,
   foldEffectiveVlanTags,
   extractHostBridges,
+  extractHostVlans,
   bridgeLabel,
   type HostNetIface,
 } from './hostVlanMap'
@@ -282,6 +283,108 @@ describe('extractHostBridges', () => {
     ]
     const result = extractHostBridges('pve1', ifaces, new Map())
     expect(result.map((b) => b.iface)).toEqual(['vmbr0'])
+  })
+})
+
+describe('extractHostVlans', () => {
+  it('extracts VLAN sub-interfaces with ids parsed from bondX.N names', () => {
+    // DRO34 layout: one bond sub-interface per VLAN. All must surface even
+    // though no guest is attached (issue #542).
+    const result = extractHostVlans('pve1', DRO34_IFACES)
+    expect(result.map((v) => v.tag)).toEqual([5, 7, 10])
+    expect(result.map((v) => v.iface)).toEqual(['bond0.5', 'bond1.7', 'bond0.10'])
+  })
+
+  it('excludes non-VLAN interfaces (bonds, bridges, physical NICs)', () => {
+    const result = extractHostVlans('pve1', DRO34_IFACES)
+    const ifaces = result.map((v) => v.iface)
+    expect(ifaces).not.toContain('bond0')
+    expect(ifaces).not.toContain('vmbr0V5')
+  })
+
+  it('resolves the VLAN id from an explicit vlan-id field over the name', () => {
+    const result = extractHostVlans('pve1', [
+      { iface: 'vlanA', type: 'vlan', 'vlan-id': 42, 'vlan-raw-device': 'bond0' },
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0].tag).toBe(42)
+    expect(result[0].iface).toBe('vlanA')
+  })
+
+  it('surfaces VLANs riding a vmbrX.N sub-interface (vlan-aware-bridge layout)', () => {
+    // Many VLANs over few bridges: the topology in issue #542.
+    const ifaces: HostNetIface[] = [
+      { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+      { iface: 'vmbr0.10', type: 'vlan' },
+      { iface: 'vmbr0.20', type: 'vlan' },
+      { iface: 'vmbr0.30', type: 'vlan' },
+    ]
+    const result = extractHostVlans('pve1', ifaces)
+    expect(result.map((v) => v.tag)).toEqual([10, 20, 30])
+  })
+
+  it('de-duplicates by VLAN id, keeping the first interface seen', () => {
+    // Same VLAN over two uplinks collapses to a single VLAN entry.
+    const ifaces: HostNetIface[] = [
+      { iface: 'bond0.10', type: 'vlan' },
+      { iface: 'bond1.10', type: 'vlan' },
+    ]
+    const result = extractHostVlans('pve1', ifaces)
+    expect(result).toHaveLength(1)
+    expect(result[0].tag).toBe(10)
+    expect(result[0].iface).toBe('bond0.10')
+  })
+
+  it('skips VLAN interfaces whose id cannot be resolved', () => {
+    const result = extractHostVlans('pve1', [
+      { iface: 'opaqueVlan', type: 'vlan' },
+    ])
+    expect(result).toEqual([])
+  })
+
+  it('stamps the node and carries active/autostart/cidr', () => {
+    const result = extractHostVlans('mynode', [
+      { iface: 'bond0.10', type: 'vlan', active: 1, autostart: 1, cidr: '10.0.10.1/24' },
+    ])
+    expect(result[0]).toMatchObject({
+      node: 'mynode',
+      iface: 'bond0.10',
+      tag: 10,
+      active: true,
+      autostart: true,
+      cidr: '10.0.10.1/24',
+    })
+  })
+
+  it('omits cidr when absent and defaults active/autostart to false', () => {
+    const result = extractHostVlans('pve1', [{ iface: 'bond0.10', type: 'vlan' }])
+    expect(result[0].cidr).toBeUndefined()
+    expect(result[0].active).toBe(false)
+    expect(result[0].autostart).toBe(false)
+  })
+
+  it('sorts results by VLAN id ascending', () => {
+    const result = extractHostVlans('pve1', [
+      { iface: 'bond0.30', type: 'vlan' },
+      { iface: 'bond0.5', type: 'vlan' },
+      { iface: 'bond0.100', type: 'vlan' },
+    ])
+    expect(result.map((v) => v.tag)).toEqual([5, 30, 100])
+  })
+
+  it('returns an empty array for empty or non-array input', () => {
+    expect(extractHostVlans('pve1', [])).toEqual([])
+    expect(extractHostVlans('pve1', undefined as unknown as HostNetIface[])).toEqual([])
+  })
+
+  it('skips entries without a string iface field', () => {
+    const ifaces: HostNetIface[] = [
+      null as unknown as HostNetIface,
+      { iface: 42 as unknown as string, type: 'vlan' },
+      { iface: 'bond0.10', type: 'vlan' },
+    ]
+    const result = extractHostVlans('pve1', ifaces)
+    expect(result.map((v) => v.iface)).toEqual(['bond0.10'])
   })
 })
 

--- a/frontend/src/lib/proxmox/hostVlanMap.ts
+++ b/frontend/src/lib/proxmox/hostVlanMap.ts
@@ -186,3 +186,54 @@ export function extractHostBridges(
   bridges.sort((a, b) => a.iface.localeCompare(b.iface))
   return bridges
 }
+
+/**
+ * A host-level VLAN sub-interface as reported by `/nodes/{node}/network`
+ * (type `vlan`, e.g. `bond0.10`, `vmbr0.10` or `eno1.100`), with its resolved
+ * VLAN id.
+ */
+export type HostVlan = {
+  node: string
+  iface: string
+  tag: number
+  active?: boolean
+  autostart?: boolean
+  cidr?: string
+}
+
+/**
+ * Extract all host VLAN sub-interfaces from a node's network config.
+ *
+ * Includes only `type === 'vlan'` entries whose VLAN id resolves (an explicit
+ * `vlan-id` field, else a `.N` name suffix in 1-4094). This surfaces VLANs that
+ * exist on the host but have no attached guest — mirroring `extractHostBridges`
+ * for bridges — so the inventory Network view lists them like it already lists
+ * empty bridges (issue #542).
+ *
+ * Results are de-duplicated by VLAN id (a node may carry the same VLAN over
+ * several uplinks, e.g. `bond0.10` + `bond1.10`) and sorted by id. The first
+ * interface seen for a given id wins. Array- and null-safe.
+ */
+export function extractHostVlans(node: string, ifaces: HostNetIface[]): HostVlan[] {
+  if (!Array.isArray(ifaces)) return []
+
+  const byTag = new Map<number, HostVlan>()
+  for (const iface of ifaces) {
+    if (!iface || typeof iface.iface !== 'string') continue
+    if (iface.type !== 'vlan') continue
+
+    const tag = vlanIdOf(iface)
+    if (tag == null || byTag.has(tag)) continue
+
+    byTag.set(tag, {
+      node,
+      iface: iface.iface,
+      tag,
+      active: Boolean(iface.active),
+      autostart: Boolean(iface.autostart),
+      ...(typeof iface.cidr === 'string' ? { cidr: iface.cidr } : {}),
+    })
+  }
+
+  return [...byTag.values()].sort((a, b) => a.tag - b.tag)
+}


### PR DESCRIPTION
## Problem

Fixes #542. In **Inventory → Network**, host **bridges** appear even when no VM is attached, but **VLANs** were only ever derived from guest NIC tags. A VLAN configured on a host as a `type: vlan` sub-interface (e.g. `vmbr0.100`, `bond0.10`) with no attached VM therefore never appeared — only VLANs carried by a VM showed up.

This is a follow-on to #389, which resolved a *guest's* effective VLAN through its bridge but never listed VLANs that no guest uses.

## Fix

Mirror the existing host-bridge path for VLANs:

- **`hostVlanMap.ts`** — new `extractHostVlans()`: collects `type: 'vlan'` interfaces from a node's network config and resolves the VLAN id (explicit `vlan-id` field, else `.N` name suffix, validated 1–4094), de-duplicated by id. A VXLAN VNI or an out-of-range value can't leak in as a VLAN.
- **Networks route** — returns a new `vlans[]` array (provider scope only), reusing the per-node network config already fetched for #389, so there are **no extra Proxmox calls**.
- **`fetchConnectionsNetworks`** — threads a connId-tagged `HostVlanItem` alongside the existing bridges.
- **Inventory tree / Network dashboard / detail panel** — seed VLAN buckets from the host VLAN list. Seeding is **additive** (a VM-created bucket is never re-created), so VM counts are unchanged. The VLAN detail view now shows the backing host interface (name + CIDR) and an explicit empty state instead of a blank table.

Tenant/vDC scope is unchanged (keeps the VNet view; `vlans: []`).

## Testing

- New unit tests: `extractHostVlans` (bond/bridge sub-interface topologies, explicit `vlan-id`, dedup, range validation, null-safety), the route (`vlans[]` populated for provider scope including VM-less nodes, `[]` for tenant scope, empty resource list), and `fetchConnectionsNetworks` threading.
- Full frontend suite green (2440 tests); `tsc` clean (no new errors).
- Validated on a live cluster: a host VLAN `vmbr0.100` with no VM now appears as “VLAN 100” under its node, alongside the bridges.

## Notes

Follow-up (separate): a VM whose NIC uses an **SDN VNet** as its bridge still groups under “Untagged”. Surfacing the VNet's zone type / VXLAN VNI is tracked as a distinct enhancement and is intentionally out of scope here.
