### PR TITLE
feat(inventory): group VMs on SDN VNets by VNet with VXLAN/zone info

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -3,8 +3,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem, type SdnVnetItem } from '@/lib/proxmox/fetchConnectionsNetworks'
 import { bridgeLabel } from '@/lib/proxmox/hostVlanMap'
+import { sdnSegmentLabel, type SdnVnet } from '@/lib/proxmox/sdnVnetMap'
 
 import { SimpleTreeView, TreeItem } from '@mui/x-tree-view'
 import { 
@@ -85,6 +86,7 @@ export type InventorySelection =
   | { type: 'net-conn'; id: string }
   | { type: 'net-node'; id: string }
   | { type: 'net-vlan'; id: string }
+  | { type: 'net-vnet'; id: string } // SDN VNet: id = `connId:node:vnetId`
   | { type: 'net-bridge'; id: string } // host bridge: id = `connId:node:iface:tag`
   /** Tenant-only: SDN VNet selected from the Network tree.
    *  id = `tvnet:<vdcId>:<displayName>` */
@@ -423,7 +425,7 @@ function selectionFromItemId(itemId: string): InventorySelection | null {
     return { type: type as any, id } as InventorySelection
   }
 
-  if (type === 'net-conn' || type === 'net-node' || type === 'net-vlan' || type === 'storage-cluster' || type === 'storage-node') {
+  if (type === 'net-conn' || type === 'net-node' || type === 'net-vlan' || type === 'net-vnet' || type === 'storage-cluster' || type === 'storage-node') {
     return { type: type as any, id } as InventorySelection
   }
 
@@ -2249,6 +2251,7 @@ return favorites.has(vmKey)
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
   const [networkBridges, setNetworkBridges] = useState<HostBridgeItem[]>([])
   const [networkVlans, setNetworkVlans] = useState<HostVlanItem[]>([])
+  const [networkSdnVnets, setNetworkSdnVnets] = useState<SdnVnetItem[]>([])
   const [networkVnetAliases, setNetworkVnetAliases] = useState<Record<string, Record<string, string>>>({})
   const [networkLoading, setNetworkLoading] = useState(false)
   const [networkFailedConnIds, setNetworkFailedConnIds] = useState<string[]>([])
@@ -2281,7 +2284,7 @@ return favorites.has(vmKey)
       return next
     })
   }, [])
-  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliasesByConn: Record<string, Record<string, string>> } | null>(null)
+  const networkCacheRef = useRef<{ connIds: string; data: VmNetData[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; sdnVnets: SdnVnetItem[]; vnetAliasesByConn: Record<string, Record<string, string>> } | null>(null)
 
   // Fetch the tenant's VNets (display + subnet info) — only meaningful for
   // non-provider tenants. Provider keeps the legacy bridge/VLAN walk.
@@ -2327,20 +2330,22 @@ return favorites.has(vmKey)
       setNetworkData(networkCacheRef.current.data)
       setNetworkBridges(networkCacheRef.current.bridges)
       setNetworkVlans(networkCacheRef.current.vlans)
+      setNetworkSdnVnets(networkCacheRef.current.sdnVnets)
       setNetworkVnetAliases(networkCacheRef.current.vnetAliasesByConn)
       return
     }
     setNetworkLoading(true)
-    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, bridges, vlans, vnetAliasesByConn, failedConnIds }) => {
+    fetchConnectionsNetworks(connIds, { retries: 2 }).then(({ data, bridges, vlans, sdnVnets, vnetAliasesByConn, failedConnIds }) => {
       setNetworkData(data)
       setNetworkBridges(bridges)
       setNetworkVlans(vlans)
+      setNetworkSdnVnets(sdnVnets)
       setNetworkVnetAliases(vnetAliasesByConn)
       setNetworkLoading(false)
       setNetworkFailedConnIds(failedConnIds)
       // Only cache when all connections succeeded so re-opening retries any partial failure
       if (failedConnIds.length === 0) {
-        networkCacheRef.current = { connIds: cacheKey, data, bridges, vlans, vnetAliasesByConn }
+        networkCacheRef.current = { connIds: cacheKey, data, bridges, vlans, sdnVnets, vnetAliasesByConn }
       } else {
         // Allow the next expand to re-fetch
         networkFetchedRef.current = false
@@ -2386,7 +2391,7 @@ return favorites.has(vmKey)
   // buckets are seeded from both guest NIC tags and host VLAN sub-interfaces so
   // VLANs with no attached VM still appear, mirroring empty bridges (issue #542).
   const networkTree = useMemo(() => {
-    if (!networkData.length && !networkBridges.length && !networkVlans.length) return []
+    if (!networkData.length && !networkBridges.length && !networkVlans.length && !networkSdnVnets.length) return []
 
     type BucketEntry = { vm: VmNetData; netId: string; bridge: string }
     type Bucket = { tag: number | 'untagged'; entries: BucketEntry[] }
@@ -2403,12 +2408,37 @@ return favorites.has(vmKey)
       return vlanMap.get(tag)!
     }
 
+    type VnetBucket = { vnet: SdnVnet; entries: BucketEntry[] }
+    // connId -> node -> vnetId -> bucket
+    const vnetConnMap = new Map<string, Map<string, Map<string, VnetBucket>>>()
+    // connId -> vnetId -> SdnVnet  (per-connection: a plain bridge on conn B must
+    // not match a vnet id from conn A)
+    const sdnByConnVnet = new Map<string, Map<string, SdnVnet>>()
+    for (const v of networkSdnVnets) {
+      const cid = v.connId || 'unknown'
+      if (!sdnByConnVnet.has(cid)) sdnByConnVnet.set(cid, new Map())
+      sdnByConnVnet.get(cid)!.set(v.vnet, v)
+    }
+    const ensureVnetBucket = (cid: string, node: string, vnet: SdnVnet): VnetBucket => {
+      if (!vnetConnMap.has(cid)) vnetConnMap.set(cid, new Map())
+      const nodeMap = vnetConnMap.get(cid)!
+      if (!nodeMap.has(node)) nodeMap.set(node, new Map())
+      const byVnet = nodeMap.get(node)!
+      if (!byVnet.has(vnet.vnet)) byVnet.set(vnet.vnet, { vnet, entries: [] })
+      return byVnet.get(vnet.vnet)!
+    }
+
     for (const vm of networkData) {
       const cid = vm.connId || 'unknown'
+      const vnetsForConn = sdnByConnVnet.get(cid)
       for (const net of vm.nets) {
-        const tag = net.tag ?? 'untagged'
-        const bucket = ensureVmBucket(cid, vm.node, tag)
-        bucket.entries.push({ vm, netId: net.id, bridge: net.bridge })
+        const vnet = vnetsForConn?.get(net.bridge)
+        if (vnet) {
+          ensureVnetBucket(cid, vm.node, vnet).entries.push({ vm, netId: net.id, bridge: net.bridge })
+        } else {
+          const tag = net.tag ?? 'untagged'
+          ensureVmBucket(cid, vm.node, tag).entries.push({ vm, netId: net.id, bridge: net.bridge })
+        }
       }
     }
 
@@ -2430,14 +2460,15 @@ return favorites.has(vmKey)
     }
 
     // Union of all connIds from VMs and bridges
-    const allConnIds = new Set([...vmConnMap.keys(), ...bridgeNodeMap.keys()])
+    const allConnIds = new Set([...vmConnMap.keys(), ...bridgeNodeMap.keys(), ...vnetConnMap.keys()])
 
     return Array.from(allConnIds).map(connId => {
       const connName = clusters.find(c => c.connId === connId)?.name || connId
       // Union of nodes from VM map and bridge map
       const vmNodeMap = vmConnMap.get(connId) ?? new Map<string, Map<number | 'untagged', Bucket>>()
       const bridgesByNode = bridgeNodeMap.get(connId) ?? new Map<string, HostBridgeItem[]>()
-      const allNodes = new Set([...vmNodeMap.keys(), ...bridgesByNode.keys()])
+      const vnetsByNode = vnetConnMap.get(connId) ?? new Map<string, Map<string, VnetBucket>>()
+      const allNodes = new Set([...vmNodeMap.keys(), ...bridgesByNode.keys(), ...vnetsByNode.keys()])
 
       const nodes = Array.from(allNodes)
         .sort((a, b) => a.localeCompare(b))
@@ -2456,12 +2487,17 @@ return favorites.has(vmKey)
             }))
           const taggedVlans = vlans.filter(v => v.tag !== 'untagged').length
           const totalVms = vlans.reduce((sum, v) => sum + v.entries.length, 0)
+          const vnets = Array.from((vnetsByNode.get(node) ?? new Map<string, VnetBucket>()).values())
+            .map((b) => ({ ...b, entries: b.entries.slice().sort((a, z) => a.vm.name.localeCompare(z.vm.name)) }))
+            .sort((a, b) => (a.vnet.alias || a.vnet.vnet).localeCompare(b.vnet.alias || b.vnet.vnet))
           const totalBridges = nodeBridges.length
-          return { node, bridges: nodeBridges, vlans, totalVlans: taggedVlans, totalVms, totalBridges }
+          const totalVnets = vnets.length
+          const vnetVms = vnets.reduce((sum, v) => sum + v.entries.length, 0)
+          return { node, bridges: nodeBridges, vlans, vnets, totalVlans: taggedVlans, totalVms: totalVms + vnetVms, totalBridges, totalVnets }
         })
       return { connId, connName, nodes }
     }).sort((a, b) => a.connName.localeCompare(b.connName))
-  }, [networkData, networkBridges, networkVlans, clusters])
+  }, [networkData, networkBridges, networkVlans, networkSdnVnets, clusters])
 
   // Expand all network tree items helper
   const expandNetworkOnLoadRef = useRef(false)
@@ -2469,9 +2505,10 @@ return favorites.has(vmKey)
     const items: string[] = []
     networkTree.forEach(({ connId, nodes }) => {
       items.push(`net-conn:${connId}`)
-      nodes.forEach(({ node, vlans }) => {
+      nodes.forEach(({ node, vlans, vnets }) => {
         items.push(`net-node:${connId}:${node}`)
         vlans.forEach(({ tag }) => items.push(`net-vlan:${connId}:${node}:${tag}`))
+        vnets.forEach(({ vnet }) => items.push(`net-vnet:${connId}:${node}:${vnet.vnet}`))
       })
     })
     setNetworkTreeExpandedItems(items)
@@ -3796,6 +3833,11 @@ return (
                 ]).size} VLANs)
               </Typography>
             )}
+            {isFullClusterView && networkSdnVnets.length > 0 && (
+              <Typography variant="caption" sx={{ opacity: 0.5 }}>
+                ({new Set(networkSdnVnets.map(v => v.vnet)).size} VNets)
+              </Typography>
+            )}
             {!isFullClusterView && tenantVnets.length > 0 && (
               <Typography variant="caption" sx={{ opacity: 0.5 }}>
                 ({tenantVnets.length} VNet{tenantVnets.length > 1 ? 's' : ''})
@@ -3896,11 +3938,12 @@ return (
                     </Box>
                   }
                 >
-                  {nodes.map(({ node, bridges: nodeBridges, vlans, totalVlans, totalVms, totalBridges }) => {
+                  {nodes.map(({ node, bridges: nodeBridges, vlans, vnets, totalVlans, totalVms, totalBridges, totalVnets }) => {
                     const nodeStatus = clusters.find(c => c.connId === cId)?.nodes.find(n => n.node === node)?.status
                     const nodeCountLabel = [
                       totalBridges > 0 ? `${totalBridges} bridge${totalBridges > 1 ? 's' : ''}` : '',
                       totalVlans > 0 ? `${totalVlans} VLAN${totalVlans > 1 ? 's' : ''}` : '',
+                      totalVnets > 0 ? `${totalVnets} VNet${totalVnets > 1 ? 's' : ''}` : '',
                       totalVms > 0 ? `${totalVms} VM${totalVms > 1 ? 's' : ''}` : '',
                     ].filter(Boolean).join(', ')
                     return (
@@ -3968,6 +4011,42 @@ return (
                           })}
                         </TreeItem>
                       ))}
+                      {vnets.map(({ vnet, entries }) => {
+                        const seg = sdnSegmentLabel(vnet)
+                        return (
+                        <TreeItem
+                          key={`net-vnet:${cId}:${node}:${vnet.vnet}`}
+                          itemId={`net-vnet:${cId}:${node}:${vnet.vnet}`}
+                          label={
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                              <i className="ri-git-branch-line" style={{ fontSize: 14, opacity: 0.5 }} />
+                              <span style={{ fontSize: 13 }}>{vnet.alias || vnet.vnet}</span>
+                              {seg && <span style={{ opacity: 0.55, fontSize: 11 }}>{seg}</span>}
+                              <span style={{ opacity: 0.4, fontSize: 11 }}>({entries.length})</span>
+                            </Box>
+                          }
+                        >
+                          {entries.map(({ vm, netId, bridge }) => {
+                            const vmKey = `${vm.connId}:${vm.node}:${vm.type}:${vm.vmid}`
+                            return (
+                              <TreeItem
+                                key={`${vmKey}-${netId}-${vnet.vnet}`}
+                                itemId={`vm:${vmKey}:${netId}:${vnet.vnet}`}
+                                label={
+                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                                    <StatusIcon status={vm.status} type="vm" vmType={vm.type} />
+                                    <Typography variant="body2" sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                      {vm.name}
+                                    </Typography>
+                                    <span style={{ opacity: 0.4, fontSize: 11 }}>{vm.vmid}</span>
+                                    <span style={{ opacity: 0.4, fontSize: 10 }}>{bridgeLabel(networkVnetAliases[cId], bridge)}</span>
+                                  </Box>
+                                }
+                              />
+                            )
+                          })}
+                        </TreeItem>
+                      )})}
                     </TreeItem>
                   )})}
                 </TreeItem>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/NetworkDashboard.tsx
@@ -24,7 +24,8 @@ import { Bar, BarChart, Cell, Tooltip, XAxis, YAxis } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 import VnetsSection from './VnetsSection'
 import { useTenant } from '@/contexts/TenantContext'
-import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { fetchConnectionsNetworks, type HostBridgeItem, type HostVlanItem, type SdnVnetItem } from '@/lib/proxmox/fetchConnectionsNetworks'
+import { sdnSegmentLabel, type SdnVnet } from '@/lib/proxmox/sdnVnetMap'
 
 type VmNetData = {
   vmid: string
@@ -279,6 +280,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   const [networkData, setNetworkData] = useState<VmNetData[]>([])
   const [hostBridges, setHostBridges] = useState<HostBridgeItem[]>([])
   const [hostVlans, setHostVlans] = useState<HostVlanItem[]>([])
+  const [sdnVnets, setSdnVnets] = useState<SdnVnetItem[]>([])
   const [vnetAliasesByConn, setVnetAliasesByConn] = useState<Record<string, Record<string, string>>>({})
   // VNet KPIs are computed from the same data VnetsSection fetches; pulling
   // it up here lets the donut row and the list stay in sync without a
@@ -293,11 +295,12 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     const ids = connIdsKey.split(',')
     let alive = true
     setLoading(true)
-    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data, bridges, vlans, vnetAliasesByConn }) => {
+    fetchConnectionsNetworks(ids, { retries: 2 }).then(({ data, bridges, vlans, sdnVnets, vnetAliasesByConn }) => {
       if (!alive) return
       setNetworkData(data)
       setHostBridges(bridges)
       setHostVlans(vlans)
+      setSdnVnets(sdnVnets)
       setVnetAliasesByConn(vnetAliasesByConn)
     }).finally(() => {
       if (!alive) return
@@ -355,6 +358,13 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   const summary = useMemo(() => {
     const bridgeMap = new Map<string, { bridge: string; node: string; connName: string; type: string; vmCount: number }>()
     const vlanMap = new Map<number, { vlan: number; vmCount: number; bridges: Set<string>; vms: Array<{ vmid: string; name: string; node: string; status: string; bridge: string }> }>()
+    const sdnByConnVnet = new Map<string, Map<string, SdnVnet>>()
+    for (const v of sdnVnets) {
+      const cid = v.connId || ''
+      if (!sdnByConnVnet.has(cid)) sdnByConnVnet.set(cid, new Map())
+      sdnByConnVnet.get(cid)!.set(v.vnet, v)
+    }
+    const vnetMap = new Map<string, { vnet: SdnVnet; vmCount: number }>() // key: connId + ' ' + vnetId
     let totalVmsWithNetwork = 0
 
     // Seed bridgeMap and vlanMap from host bridges so bridges/VLANs appear
@@ -393,7 +403,16 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
 
     for (const vm of networkData) {
       if (vm.nets.length > 0) totalVmsWithNetwork++
+      const vnetsForConn = sdnByConnVnet.get(vm.connId || '')
       for (const net of vm.nets) {
+        const vnet = net.bridge ? vnetsForConn?.get(net.bridge) : undefined
+        if (vnet) {
+          const key = `${vm.connId || ''} ${vnet.vnet}`
+          const existing = vnetMap.get(key)
+          if (existing) existing.vmCount++
+          else vnetMap.set(key, { vnet, vmCount: 1 })
+          continue // a vnet-backed nic is neither a plain bridge nor a VLAN bucket
+        }
         if (net.bridge) {
           const key = `${vm.connId}:${vm.node}:${net.bridge}`
           const existing = bridgeMap.get(key)
@@ -429,11 +448,13 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
     return {
       totalBridges: bridgeMap.size,
       totalVlans: vlanMap.size,
+      totalVnets: vnetMap.size,
       totalVmsWithNetwork,
       vlanBreakdown: [...vlanMap.values()].map(v => ({ ...v, bridges: [...v.bridges] })).sort((a, b) => b.vmCount - a.vmCount),
       bridgeBreakdown: [...bridgeMap.values()],
+      vnetBreakdown: [...vnetMap.entries()].map(([key, v]) => ({ ...v, key })).sort((a, b) => b.vmCount - a.vmCount),
     }
-  }, [networkData, connectionNames, hostBridges, hostVlans])
+  }, [networkData, connectionNames, hostBridges, hostVlans, sdnVnets])
 
   // Flat map of vnet id → alias across all connections (vnet ids are globally unique within a cluster)
   const flatAliases = useMemo(
@@ -444,7 +465,7 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
   // Only block the dashboard with a spinner on the initial load — after
   // that, background refetches keep the existing KPIs / tables visible
   // so the page doesn't flicker on every inventory poll.
-  if (loading && networkData.length === 0 && hostBridges.length === 0 && hostVlans.length === 0) {
+  if (loading && networkData.length === 0 && hostBridges.length === 0 && hostVlans.length === 0 && sdnVnets.length === 0) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
         <CircularProgress />
@@ -559,6 +580,42 @@ export default function NetworkDashboard({ connectionIds, connectionNames }: Pro
       {/* VMs by VLAN */}
       {summary.vlanBreakdown.length > 0 && (
         <VlanVmsList vlans={summary.vlanBreakdown} aliases={flatAliases} />
+      )}
+
+      {/* SDN VNets with attached VMs */}
+      {summary.vnetBreakdown.length > 0 && (
+        <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+          <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+              <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className="ri-git-branch-line" style={{ fontSize: 18, opacity: 0.7 }} />
+                SDN VNets ({summary.totalVnets})
+              </Typography>
+            </Box>
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VNet</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Zone</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Segment</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VMs</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {summary.vnetBreakdown.map(({ vnet, vmCount, key }) => (
+                    <TableRow key={key}>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12 }}>{vnet.alias || vnet.vnet}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{vnet.zone || '—'}{vnet.zoneType ? ` (${vnet.zoneType})` : ''}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{sdnSegmentLabel(vnet) || '—'}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12 }}>{vmCount}</Typography></TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </CardContent>
+        </Card>
       )}
 
       {/* Bridge Table — provider/MSP only. vDC tenants don't see / can't act

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/NetworkDetailPanel.tsx
@@ -23,6 +23,7 @@ import { alpha } from '@mui/material/styles'
 
 import type { InventorySelection } from '../types'
 import { bridgeLabel, foldEffectiveVlanTags, type HostBridge, type HostVlan } from '@/lib/proxmox/hostVlanMap'
+import { sdnSegmentLabel, type SdnVnet } from '@/lib/proxmox/sdnVnetMap'
 import { StatusIcon } from '../InventoryTree'
 
 type NetIface = { id: string; model: string; bridge: string; macaddr?: string; tag?: number; firewall?: boolean; rate?: number }
@@ -37,14 +38,16 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   const [netData, setNetData] = React.useState<VmNet[]>([])
   const [hostBridges, setHostBridges] = React.useState<HostBridge[]>([])
   const [hostVlans, setHostVlans] = React.useState<HostVlan[]>([])
+  const [sdnVnets, setSdnVnets] = React.useState<SdnVnet[]>([])
   const [vnetAliases, setVnetAliases] = React.useState<Record<string, string>>({})
   const [loading, setLoading] = React.useState(true)
 
   // Parse selection id
   const parts = selection.id.split(':')
   const connId = parts[0]
-  const nodeName = selection.type === 'net-node' || selection.type === 'net-vlan' ? parts[1] : undefined
+  const nodeName = selection.type === 'net-node' || selection.type === 'net-vlan' || selection.type === 'net-vnet' ? parts[1] : undefined
   const vlanTag = selection.type === 'net-vlan' ? parts[2] : undefined
+  const vnetId = selection.type === 'net-vnet' ? parts[2] : undefined
   const bridgeNode = selection.type === 'net-bridge' ? parts[1] : undefined
   const bridgeIface = selection.type === 'net-bridge' ? parts[2] : undefined
 
@@ -60,9 +63,10 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
         // raw HostBridge[] / HostVlan[] (no connId — this panel is scoped to a single connection)
         setHostBridges(json.bridges || [])
         setHostVlans(json.vlans || [])
+        setSdnVnets(json.sdnVnets || [])
         setVnetAliases(json.vnetAliases || {})
       })
-      .catch(() => { setNetData([]); setHostBridges([]); setHostVlans([]); setVnetAliases({}) })
+      .catch(() => { setNetData([]); setHostBridges([]); setHostVlans([]); setSdnVnets([]); setVnetAliases({}) })
       .finally(() => setLoading(false))
   }, [connId])
 
@@ -84,28 +88,33 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     return `${(bytes / Math.pow(k, i)).toFixed(i > 0 ? 1 : 0)} ${sizes[i]}`
   }
 
+  // Flat lookup: this panel is scoped to a single connection, so vnetId → SdnVnet.
+  const sdnByVnet = new Map<string, SdnVnet>(sdnVnets.map((v) => [v.vnet, v]))
+
   if (loading) return <Box sx={{ p: 4, textAlign: 'center' }}><CircularProgress size={28} /></Box>
 
   // --- NET-CONN: Cluster-level network overview ---
   if (selection.type === 'net-conn') {
-    const nodeMap = new Map<string, { vlans: Set<string | number>; bridges: Set<string>; vms: Set<string> }>()
+    const nodeMap = new Map<string, { vlans: Set<string | number>; bridges: Set<string>; vms: Set<string>; vnets: Set<string> }>()
     // Seed nodeMap from host bridges so VM-less nodes appear in the table.
     for (const b of hostBridges) {
-      if (!nodeMap.has(b.node)) nodeMap.set(b.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
+      if (!nodeMap.has(b.node)) nodeMap.set(b.node, { vlans: new Set(), bridges: new Set(), vms: new Set(), vnets: new Set() })
       const nd = nodeMap.get(b.node)!
       nd.bridges.add(b.iface)
     }
     // Seed nodeMap VLANs from host VLAN sub-interfaces so VLANs with no attached
     // VM are counted per node, mirroring host bridges (issue #542).
     for (const v of hostVlans) {
-      if (!nodeMap.has(v.node)) nodeMap.set(v.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
+      if (!nodeMap.has(v.node)) nodeMap.set(v.node, { vlans: new Set(), bridges: new Set(), vms: new Set(), vnets: new Set() })
       nodeMap.get(v.node)!.vlans.add(v.tag)
     }
     for (const vm of netData) {
-      if (!nodeMap.has(vm.node)) nodeMap.set(vm.node, { vlans: new Set(), bridges: new Set(), vms: new Set() })
+      if (!nodeMap.has(vm.node)) nodeMap.set(vm.node, { vlans: new Set(), bridges: new Set(), vms: new Set(), vnets: new Set() })
       const nd = nodeMap.get(vm.node)!
       nd.vms.add(vm.vmid)
       for (const net of vm.nets) {
+        const vnet = sdnByVnet.get(net.bridge)
+        if (vnet) { nd.vnets.add(vnet.vnet); continue }
         nd.bridges.add(net.bridge)
         nd.vlans.add(net.tag ?? 'untagged')
       }
@@ -113,12 +122,15 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     const nodes = Array.from(nodeMap.entries()).sort((a, b) => a[0].localeCompare(b[0]))
     // VLANs and bridges both include host-level interfaces so VM-less nodes
     // still report accurate counts.
+    const allVnets = new Set<string>(
+      netData.flatMap(vm => vm.nets.map(n => sdnByVnet.get(n.bridge)?.vnet).filter((x): x is string => !!x)),
+    )
     const allVlans = new Set<string | number>([
-      ...netData.flatMap(vm => vm.nets.map(n => n.tag ?? 'untagged')),
+      ...netData.flatMap(vm => vm.nets.filter(n => !sdnByVnet.has(n.bridge)).map(n => n.tag ?? 'untagged')),
       ...hostVlans.map(v => v.tag),
     ])
     const allBridges = new Set<string>([
-      ...netData.flatMap(vm => vm.nets.map(n => n.bridge)),
+      ...netData.flatMap(vm => vm.nets.filter(n => !sdnByVnet.has(n.bridge)).map(n => n.bridge)),
       ...hostBridges.map(b => b.iface),
     ])
     const totalVlans = allVlans.size
@@ -138,6 +150,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
           {[
             { label: 'Nodes', value: nodes.length, icon: 'ri-server-line' },
             { label: 'VLANs', value: totalVlans, icon: 'ri-wifi-line' },
+            ...(allVnets.size > 0 ? [{ label: 'VNets', value: allVnets.size, icon: 'ri-git-branch-line' }] : []),
             { label: 'Bridges', value: totalBridges, icon: 'ri-git-branch-line' },
             { label: 'VMs', value: totalVms, icon: 'ri-computer-line' },
           ].map(kpi => (
@@ -211,6 +224,14 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
   // --- NET-NODE: Node-level network view ---
   if (selection.type === 'net-node' && nodeName) {
     const nodeVms = netData.filter(vm => vm.node === nodeName)
+    const nodeVnets = new Set<string>(
+      nodeVms.flatMap(vm => vm.nets.map(n => sdnByVnet.get(n.bridge)?.vnet).filter((x): x is string => !!x)),
+    )
+    const nodeVnetList = Array.from(nodeVnets).sort((a, b) => a.localeCompare(b)).map(id => ({
+      id,
+      vnet: sdnByVnet.get(id),
+      vmCount: new Set(nodeVms.filter(vm => vm.nets.some(n => n.bridge === id)).map(vm => vm.vmid)).size,
+    }))
     const nodeHostBridges = hostBridges.filter(b => b.node === nodeName).slice().sort((a, b) => a.iface.localeCompare(b.iface))
     // Build vlanMap from VMs plus host VLAN sub-interfaces on this node, so VLANs
     // with no attached VM still appear (issue #542).
@@ -220,6 +241,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     }
     for (const vm of nodeVms) {
       for (const net of vm.nets) {
+        if (sdnByVnet.has(net.bridge)) continue // shown under VNets, not VLAN/Untagged
         const tag = net.tag ?? 'untagged'
         if (!vlanMap.has(tag)) vlanMap.set(tag, { bridges: new Set(), vms: [] })
         const v = vlanMap.get(tag)!
@@ -251,6 +273,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
         <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
           {[
             { label: 'VLANs', value: vlans.length, icon: 'ri-wifi-line' },
+            ...(nodeVnets.size > 0 ? [{ label: 'VNets', value: nodeVnets.size, icon: 'ri-git-branch-line' }] : []),
             { label: 'Bridges', value: totalBridges, icon: 'ri-git-branch-line' },
             { label: 'VMs', value: nodeVms.length, icon: 'ri-computer-line' },
           ].map(kpi => (
@@ -316,6 +339,54 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
           </Card>
         )}
 
+        {/* SDN VNets on this node */}
+        {nodeVnetList.length > 0 && (
+          <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+              <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className="ri-git-branch-line" style={{ fontSize: 18, opacity: 0.7 }} />
+                  VNets
+                </Typography>
+              </Box>
+              <TableContainer>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VNet</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Segment</TableCell>
+                      <TableCell sx={{ fontWeight: 700, fontSize: 12 }} align="center">VMs</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {nodeVnetList.map(({ id, vnet, vmCount }) => (
+                      <TableRow
+                        key={id}
+                        hover
+                        sx={{ cursor: 'pointer' }}
+                        onClick={() => onSelect?.({ type: 'net-vnet', id: `${connId}:${nodeName}:${id}` })}
+                      >
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                            <i className="ri-git-branch-line" style={{ fontSize: 14, opacity: 0.6 }} />
+                            <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{vnet?.alias || id}</Typography>
+                          </Box>
+                        </TableCell>
+                        <TableCell>
+                          <Typography variant="body2" sx={{ fontSize: 12, opacity: 0.7 }}>{(vnet && sdnSegmentLabel(vnet)) || '—'}</Typography>
+                        </TableCell>
+                        <TableCell align="center">
+                          <Chip size="small" label={vmCount} sx={{ minWidth: 32, fontWeight: 700, fontSize: 12 }} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </CardContent>
+          </Card>
+        )}
+
         {/* VLANs list */}
         <Stack spacing={1.5}>
           {vlans.map(([tag, data]) => (
@@ -366,6 +437,7 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
     const vlanVms: { vm: VmNet; net: NetIface }[] = []
     for (const vm of nodeVms) {
       for (const net of vm.nets) {
+        if (sdnByVnet.has(net.bridge)) continue
         const tag = net.tag ?? 'untagged'
         if (String(tag) === vlanTag) {
           vlanVms.push({ vm, net })
@@ -557,6 +629,118 @@ export default function NetworkDetailPanel({ selection, onSelect }: {
                           <i className="ri-shield-line" style={{ fontSize: 14, opacity: 0.2 }} />
                         )}
                       </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </CardContent>
+        </Card>
+      </Box>
+    )
+  }
+
+  // --- NET-VNET: SDN VNet detail view ---
+  if (selection.type === 'net-vnet' && nodeName && vnetId) {
+    const vnet = sdnByVnet.get(vnetId)
+    const nodeVms = netData.filter(vm => vm.node === nodeName)
+    const vnetVms: { vm: VmNet; net: NetIface }[] = []
+    for (const vm of nodeVms) {
+      for (const net of vm.nets) {
+        if (net.bridge === vnetId) vnetVms.push({ vm, net })
+      }
+    }
+    const seg = vnet ? sdnSegmentLabel(vnet) : ''
+    return (
+      <Box sx={{ p: 2.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+          <Chip size="small" label="NETWORK" icon={<i className="ri-global-line" style={{ fontSize: 14, marginLeft: 8 }} />} />
+          <Typography variant="body2" sx={{ opacity: 0.5, cursor: 'pointer', '&:hover': { opacity: 0.8 } }} onClick={() => onSelect?.({ type: 'net-conn', id: connId })}>{connName}</Typography>
+          <i className="ri-arrow-right-s-line" style={{ opacity: 0.3 }} />
+          <Typography variant="body2" sx={{ opacity: 0.5, cursor: 'pointer', '&:hover': { opacity: 0.8 }, display: 'flex', alignItems: 'center', gap: 0.5 }} onClick={() => onSelect?.({ type: 'net-node', id: `${connId}:${nodeName}` })}>
+            <img src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={14} height={14} />
+            {nodeName}
+          </Typography>
+          <i className="ri-arrow-right-s-line" style={{ opacity: 0.3 }} />
+          <Typography variant="h6" fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+            <i className="ri-git-branch-line" style={{ fontSize: 18, opacity: 0.7 }} />
+            {vnet?.alias || vnetId}
+          </Typography>
+        </Box>
+
+        <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+          {[
+            { label: 'VMs', value: new Set(vnetVms.map(v => v.vm.vmid)).size, icon: 'ri-computer-line' },
+            { label: 'Zone type', value: vnet?.zoneType || '—', icon: 'ri-stack-line' },
+            { label: seg ? seg.split(' ')[0] : 'Segment', value: seg ? seg.split(' ')[1] : '—', icon: 'ri-router-line' },
+          ].map(kpi => (
+            <Card key={kpi.label} variant="outlined" sx={{ flex: 1, minWidth: 100, borderRadius: 2 }}>
+              <CardContent sx={{ p: 1.5, '&:last-child': { pb: 1.5 }, display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                <Box sx={{ width: 36, height: 36, borderRadius: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', bgcolor: alpha(theme.palette.primary.main, 0.1) }}>
+                  <i className={kpi.icon} style={{ fontSize: 18, color: theme.palette.primary.main }} />
+                </Box>
+                <Box>
+                  <Typography variant="h6" fontWeight={900} sx={{ lineHeight: 1.2 }}>{kpi.value}</Typography>
+                  <Typography variant="caption" sx={{ opacity: 0.6 }}>{kpi.label}</Typography>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+
+        {vnet && (
+          <Card variant="outlined" sx={{ borderRadius: 2, mb: 2 }}>
+            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+              <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+                <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <i className="ri-stack-line" style={{ fontSize: 18, opacity: 0.7 }} /> Zone
+                </Typography>
+              </Box>
+              <Box sx={{ px: 2, py: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                <Typography variant="body2" sx={{ fontSize: 12 }}>Zone: {vnet.zone || '—'} {vnet.zoneType ? `(${vnet.zoneType})` : ''}</Typography>
+                {seg && <Typography variant="body2" sx={{ fontSize: 12 }}>{seg}</Typography>}
+                {vnet.peers && vnet.peers.length > 0 && (
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
+                    <Typography variant="body2" sx={{ fontSize: 12 }}>Peers:</Typography>
+                    {vnet.peers.map(p => <Chip key={p} size="small" variant="outlined" label={p} sx={{ fontSize: 11, height: 22 }} />)}
+                  </Box>
+                )}
+              </Box>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card variant="outlined" sx={{ borderRadius: 2 }}>
+          <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider' }}>
+              <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <i className="ri-computer-line" style={{ fontSize: 18, opacity: 0.7 }} /> Virtual Machines
+              </Typography>
+            </Box>
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Status</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VM</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>VMID</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>Interface</TableCell>
+                    <TableCell sx={{ fontWeight: 700, fontSize: 12 }}>MAC</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {vnetVms.length === 0 && (
+                    <TableRow><TableCell colSpan={5}>
+                      <Typography variant="body2" sx={{ py: 1, textAlign: 'center', opacity: 0.5 }}>No VMs on this VNet.</Typography>
+                    </TableCell></TableRow>
+                  )}
+                  {vnetVms.map(({ vm, net }, idx) => (
+                    <TableRow key={`${vm.vmid}-${net.id}-${idx}`} hover sx={{ cursor: 'pointer' }} onClick={() => onSelect?.({ type: 'vm', id: `${vm.connId || connId}:${vm.node}:${vm.type}:${vm.vmid}` })}>
+                      <TableCell><StatusIcon status={vm.status} type="vm" vmType={vm.type} size={16} /></TableCell>
+                      <TableCell><Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>{vm.name}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12, opacity: 0.6 }}>{vm.vmid}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 12 }}>{net.id}</Typography></TableCell>
+                      <TableCell><Typography variant="body2" sx={{ fontSize: 11, opacity: 0.6 }}>{net.macaddr || '—'}</Typography></TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/types.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/types.ts
@@ -19,6 +19,7 @@ export type InventorySelection =
   | { type: 'net-conn'; id: string }
   | { type: 'net-node'; id: string }
   | { type: 'net-vlan'; id: string }
+  | { type: 'net-vnet'; id: string } // SDN VNet: id = `connId:node:vnetId`
   | { type: 'net-bridge'; id: string } // host bridge: id = `connId:node:iface:tag`
   /** Tenant-only: a single SDN VNet selected from the Network tree.
    *  ID format: `tvnet:<vdcId>:<displayName>`. */

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.test.ts
@@ -287,7 +287,7 @@ describe('GET /api/v1/connections/[id]/networks — host VLANs (#542)', () => {
     const res = await callRoute(await importGET(), { params: { id: 'c1' } })
     expect(res.status).toBe(200)
     const body = await readJson<any>(res)
-    expect(body).toEqual({ data: [], bridges: [], vlans: [], vnetAliases: {} })
+    expect(body).toEqual({ data: [], bridges: [], vlans: [], sdnVnets: [], vnetAliases: {} })
   })
 
   it('returns vlans: [] for tenant (vDC) scope even when host VLANs exist', async () => {
@@ -306,6 +306,96 @@ describe('GET /api/v1/connections/[id]/networks — host VLANs (#542)', () => {
 
     const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
     expect(body.vlans).toEqual([])
+  })
+})
+
+describe('GET /api/v1/connections/[id]/networks — SDN VNets', () => {
+  const NODE_NETWORK = [
+    { iface: 'vmbr0', type: 'bridge', bridge_ports: 'bond0', bridge_vlan_aware: 1 },
+  ]
+  const ZONES = [{ zone: 'zovhpvec', type: 'vxlan', peers: '10.0.0.1,10.0.0.2' }]
+  const VNETS = [{ vnet: 'v42fc503', alias: 'lan', zone: 'zovhpvec', tag: 10000 }]
+
+  it('returns sdnVnets joined with zones for provider scope', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return [{ vmid: 100, node: 'pve1', type: 'qemu', name: 'u', status: 'running' }]
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return VNETS
+      if (path === '/cluster/sdn/zones') return ZONES
+      if (path === '/nodes/pve1/qemu/100/config') return { net0: 'virtio=AA:BB:CC:00:00:01,bridge=v42fc503' }
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.sdnVnets).toHaveLength(1)
+    expect(body.sdnVnets[0]).toMatchObject({ vnet: 'v42fc503', alias: 'lan', zoneType: 'vxlan', tag: 10000 })
+    expect(body.sdnVnets[0].peers).toEqual(['10.0.0.1', '10.0.0.2'])
+  })
+
+  it('still returns vnets with zoneType "" when /cluster/sdn/zones fails', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') return VNETS
+      if (path === '/cluster/sdn/zones') throw new Error('zones unavailable')
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.sdnVnets).toHaveLength(1)
+    expect(body.sdnVnets[0].zoneType).toBe('')
+  })
+
+  it('returns sdnVnets: [] when /cluster/sdn/vnets fails, without failing the request', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      if (path === '/nodes/pve1/network') return NODE_NETWORK
+      if (path === '/cluster/sdn/vnets') throw new Error('sdn unavailable')
+      if (path === '/cluster/sdn/zones') return ZONES
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const res = await callRoute(await importGET(), { params: { id: 'c1' } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.sdnVnets).toEqual([])
+  })
+
+  it('excludes a VNet id from bridges when it also appears as a node bridge', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      if (path === '/cluster/resources?type=node') return [{ node: 'pve1' }]
+      // v42fc503 materialized as a bridge iface on the node:
+      if (path === '/nodes/pve1/network') return [...NODE_NETWORK, { iface: 'v42fc503', type: 'bridge' }]
+      if (path === '/cluster/sdn/vnets') return VNETS
+      if (path === '/cluster/sdn/zones') return ZONES
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue(null)
+
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.bridges.map((b: any) => b.iface)).not.toContain('v42fc503')
+    expect(body.sdnVnets.map((v: any) => v.vnet)).toContain('v42fc503')
+  })
+
+  it('returns sdnVnets: [] for tenant (vDC) scope', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources?type=vm') return []
+      throw new Error(`unexpected pveFetch path: ${path}`)
+    })
+    getVdcScopeMock.mockResolvedValue({
+      connectionIds: new Set(['c1']),
+      poolsByConnection: new Map([['c1', new Set(['pool1'])]]),
+      vdcIds: new Set(), vdcNames: new Set(),
+    })
+    const body = await readJson<any>(await callRoute(await importGET(), { params: { id: 'c1' } }))
+    expect(body.sdnVnets).toEqual([])
   })
 })
 

--- a/frontend/src/app/api/v1/connections/[id]/networks/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/networks/route.ts
@@ -6,6 +6,7 @@ import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 import { buildBridgeVlanMap, extractHostBridges, extractHostVlans, resolveEffectiveTag, type HostBridge, type HostVlan } from "@/lib/proxmox/hostVlanMap"
+import { buildSdnVnets, type SdnVnet } from "@/lib/proxmox/sdnVnetMap"
 
 export const runtime = "nodejs"
 
@@ -96,7 +97,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
     // Get all VMs/CTs from cluster resources
     const allResources = await pveFetch<any[]>(conn, "/cluster/resources?type=vm")
     if (!allResources || !Array.isArray(allResources)) {
-      return NextResponse.json({ data: [], bridges: [], vlans: [], vnetAliases: {} })
+      return NextResponse.json({ data: [], bridges: [], vlans: [], sdnVnets: [], vnetAliases: {} })
     }
 
     // Restrict to the tenant's vDC pool(s) on this connection. Without this,
@@ -121,10 +122,15 @@ export async function GET(_req: Request, ctx: RouteContext) {
     // names instead of raw VNet ids (e.g. "v42fc503"). Fault-tolerant: if SDN is
     // unavailable the map stays empty and raw ids are shown.
     let vnetAliases: Record<string, string> = {}
+    let sdnVnetsRaw: any[] = []
+    let sdnZonesRaw: any[] = []
     if (isProviderScope) {
+      // VNets: drives both the alias map and the new sdnVnets grouping. A failure
+      // here means no SDN grouping at all.
       try {
         const vnets = await pveFetch<any[]>(conn, "/cluster/sdn/vnets")
         if (Array.isArray(vnets)) {
+          sdnVnetsRaw = vnets
           for (const v of vnets) {
             if (
               v &&
@@ -137,8 +143,15 @@ export async function GET(_req: Request, ctx: RouteContext) {
             }
           }
         }
-      } catch { /* SDN unavailable — fall back to raw bridge names */ }
+      } catch { /* SDN unavailable — fall back to raw bridge names, no VNet grouping */ }
+      // Zones: independent — a failure here still leaves VNets usable (zoneType '').
+      try {
+        const zones = await pveFetch<any[]>(conn, "/cluster/sdn/zones")
+        if (Array.isArray(zones)) sdnZonesRaw = zones
+      } catch { /* zone metadata unavailable — VNets keep zoneType '' */ }
     }
+    const sdnVnets: SdnVnet[] = isProviderScope ? buildSdnVnets(sdnVnetsRaw, sdnZonesRaw) : []
+    const sdnVnetIds = new Set(sdnVnets.map((v) => v.vnet))
 
     // For provider scope, enumerate ALL cluster nodes so host bridges are surfaced
     // even when no VMs exist on them. For tenant scope, only visit nodes that
@@ -190,7 +203,10 @@ export async function GET(_req: Request, ctx: RouteContext) {
     if (isProviderScope) {
       for (const [node, ifaces] of hostBridgesIfacesByNode) {
         const map = bridgeVlanByNode.get(node) ?? new Map<string, number>()
-        hostBridges.push(...extractHostBridges(node, ifaces, map))
+        // Drop interfaces that are actually SDN VNets so a VNet is not listed
+        // both as a bridge leaf and as a VNet bucket (only relevant when
+        // `sdn apply` materialized the VNet as a node bridge).
+        hostBridges.push(...extractHostBridges(node, ifaces, map).filter((b) => !sdnVnetIds.has(b.iface)))
         hostVlans.push(...extractHostVlans(node, ifaces))
       }
     }
@@ -247,7 +263,7 @@ export async function GET(_req: Request, ctx: RouteContext) {
       }
     }
 
-    return NextResponse.json({ data: results, bridges: isProviderScope ? hostBridges : [], vlans: isProviderScope ? hostVlans : [], vnetAliases })
+    return NextResponse.json({ data: results, bridges: isProviderScope ? hostBridges : [], vlans: isProviderScope ? hostVlans : [], sdnVnets, vnetAliases })
   } catch (e: any) {
     console.error("[networks] Error:", e)
     return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.test.ts
@@ -337,4 +337,31 @@ describe('fetchConnectionsNetworks', () => {
     expect(Object.keys(result.vnetAliasesByConn)).toEqual(['good-conn'])
     expect(result.failedConnIds).toContain('bad-conn')
   })
+
+  it('threads sdnVnets from route response, tagging each with connId', async () => {
+    const fetchImpl = makeOkFetch({
+      conn1: { data: [], sdnVnets: [{ vnet: 'v42fc503', alias: 'lan', zone: 'z', zoneType: 'vxlan', tag: 10000 }] } as any,
+      conn2: { data: [], sdnVnets: [{ vnet: 'vaaa', zone: 'z2', zoneType: 'vlan', tag: 30 }] } as any,
+    })
+    const result = await fetchConnectionsNetworks(['conn1', 'conn2'], { retries: 0, retryDelayMs: 0, fetchImpl: fetchImpl as any })
+    expect(result.sdnVnets).toHaveLength(2)
+    expect(result.sdnVnets.every((v) => typeof v.connId === 'string')).toBe(true)
+    expect(result.sdnVnets.find((v) => v.vnet === 'v42fc503')?.connId).toBe('conn1')
+    expect(result.sdnVnets.find((v) => v.vnet === 'vaaa')?.connId).toBe('conn2')
+  })
+
+  it('returns sdnVnets: [] when the route omits the field (back-compat) and for empty input', async () => {
+    const r1 = await fetchConnectionsNetworks(['conn1'], { retries: 0, retryDelayMs: 0, fetchImpl: makeOkFetch({ conn1: { data: [] } }) as any })
+    expect(r1.sdnVnets).toEqual([])
+    const r2 = await fetchConnectionsNetworks([], { retries: 0, retryDelayMs: 0, fetchImpl: vi.fn() as any })
+    expect(r2.sdnVnets).toEqual([])
+  })
+
+  it('contributes no sdnVnets from a failed connection', async () => {
+    const fetchImpl = makeFailFetch('bad', { good: { data: [], sdnVnets: [{ vnet: 'v1', zone: 'z', zoneType: 'vxlan', tag: 5 }] } as any })
+    const result = await fetchConnectionsNetworks(['good', 'bad'], { retries: 0, retryDelayMs: 0, fetchImpl: fetchImpl as any })
+    expect(result.failedConnIds).toEqual(['bad'])
+    expect(result.sdnVnets).toHaveLength(1)
+    expect(result.sdnVnets[0].connId).toBe('good')
+  })
 })

--- a/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
+++ b/frontend/src/lib/proxmox/fetchConnectionsNetworks.ts
@@ -1,4 +1,5 @@
 import { foldEffectiveVlanTags, type HostBridge, type HostVlan } from './hostVlanMap'
+import { type SdnVnet } from './sdnVnetMap'
 
 export type VmNetItem = {
   vmid: string
@@ -12,6 +13,7 @@ export type VmNetItem = {
 
 export type HostBridgeItem = HostBridge & { connId: string }
 export type HostVlanItem = HostVlan & { connId: string }
+export type SdnVnetItem = SdnVnet & { connId: string }
 
 const DEFAULT_RETRIES = 2
 const DEFAULT_RETRY_DELAY_MS = 300
@@ -21,7 +23,7 @@ async function fetchWithRetry(
   retries: number,
   retryDelayMs: number,
   fetchImpl: typeof fetch,
-): Promise<{ ok: true; items: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliases: Record<string, string> } | { ok: false }> {
+): Promise<{ ok: true; items: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; sdnVnets: SdnVnetItem[]; vnetAliases: Record<string, string> } | { ok: false }> {
   let attempt = 0
   while (attempt <= retries) {
     try {
@@ -43,8 +45,12 @@ async function fetchWithRetry(
         ...v,
         connId,
       }))
+      const sdnVnets: SdnVnetItem[] = (json.sdnVnets ?? []).map((v: SdnVnet) => ({
+        ...v,
+        connId,
+      }))
       const vnetAliases: Record<string, string> = json.vnetAliases ?? {}
-      return { ok: true, items, bridges, vlans, vnetAliases }
+      return { ok: true, items, bridges, vlans, sdnVnets, vnetAliases }
     } catch {
       if (attempt < retries) {
         if (retryDelayMs > 0) {
@@ -61,15 +67,15 @@ async function fetchWithRetry(
 
 /**
  * Fetch VM network data from multiple connections concurrently with per-connection
- * retry logic. Returns flat data, flat host bridges and flat host VLAN sub-interfaces
- * (each tagged with connId), plus the list of connection IDs that failed after all
- * retries. Never rejects — partial failure is surfaced via failedConnIds.
+ * retry logic. Returns flat data, flat host bridges, flat host VLAN sub-interfaces
+ * and flat SDN VNets (each tagged with connId), plus the list of connection IDs that
+ * failed after all retries. Never rejects — partial failure is surfaced via failedConnIds.
  */
 export async function fetchConnectionsNetworks(
   connIds: string[],
   opts?: { retries?: number; retryDelayMs?: number; fetchImpl?: typeof fetch },
-): Promise<{ data: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; vnetAliasesByConn: Record<string, Record<string, string>>; failedConnIds: string[] }> {
-  if (connIds.length === 0) return { data: [], bridges: [], vlans: [], vnetAliasesByConn: {}, failedConnIds: [] }
+): Promise<{ data: VmNetItem[]; bridges: HostBridgeItem[]; vlans: HostVlanItem[]; sdnVnets: SdnVnetItem[]; vnetAliasesByConn: Record<string, Record<string, string>>; failedConnIds: string[] }> {
+  if (connIds.length === 0) return { data: [], bridges: [], vlans: [], sdnVnets: [], vnetAliasesByConn: {}, failedConnIds: [] }
 
   const retries = opts?.retries ?? DEFAULT_RETRIES
   const retryDelayMs = opts?.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
@@ -82,6 +88,7 @@ export async function fetchConnectionsNetworks(
   const data: VmNetItem[] = []
   const bridges: HostBridgeItem[] = []
   const vlans: HostVlanItem[] = []
+  const sdnVnets: SdnVnetItem[] = []
   const vnetAliasesByConn: Record<string, Record<string, string>> = {}
   const failedConnIds: string[] = []
 
@@ -91,11 +98,12 @@ export async function fetchConnectionsNetworks(
       data.push(...result.items)
       bridges.push(...result.bridges)
       vlans.push(...result.vlans)
+      sdnVnets.push(...result.sdnVnets)
       vnetAliasesByConn[connIds[i]] = result.vnetAliases
     } else {
       failedConnIds.push(connIds[i])
     }
   }
 
-  return { data, bridges, vlans, vnetAliasesByConn, failedConnIds }
+  return { data, bridges, vlans, sdnVnets, vnetAliasesByConn, failedConnIds }
 }

--- a/frontend/src/lib/proxmox/sdnVnetMap.test.ts
+++ b/frontend/src/lib/proxmox/sdnVnetMap.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { buildSdnVnets, sdnSegmentLabel, type SdnVnetRaw, type SdnZoneRaw } from './sdnVnetMap'
+
+// Live-cluster shape (zone zovhpvec / vnet v42fc503, VNI 10000).
+const ZONES: SdnZoneRaw[] = [
+  { zone: 'zovhpvec', type: 'vxlan', peers: '10.99.99.203,10.99.99.201,10.99.99.202' },
+]
+const VNETS: SdnVnetRaw[] = [
+  { vnet: 'v42fc503', alias: 'lan', zone: 'zovhpvec', tag: 10000 },
+]
+
+describe('buildSdnVnets', () => {
+  it('joins a vnet with its vxlan zone and keeps the VNI verbatim (> 4094)', () => {
+    const [v] = buildSdnVnets(VNETS, ZONES)
+    expect(v).toMatchObject({ vnet: 'v42fc503', alias: 'lan', zone: 'zovhpvec', zoneType: 'vxlan', tag: 10000 })
+    expect(v.peers).toEqual(['10.99.99.203', '10.99.99.201', '10.99.99.202'])
+  })
+
+  it('coerces a numeric-string tag', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1', zone: 'z', tag: '30' }], [{ zone: 'z', type: 'vlan' }])
+    expect(v.tag).toBe(30)
+  })
+
+  it('rejects a non-numeric tag (no parseInt partial)', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1', zone: 'z', tag: '10abc' }], [{ zone: 'z', type: 'vlan' }])
+    expect(v.tag).toBeUndefined()
+  })
+
+  it('uses empty-string sentinels for a vnet whose zone is missing/unresolved', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1', zone: 'ghost' }], [])
+    expect(v.zone).toBe('ghost')
+    expect(v.zoneType).toBe('')
+  })
+
+  it('defaults zone to "" when the vnet carries no zone', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1' }], [])
+    expect(v.zone).toBe('')
+    expect(v.zoneType).toBe('')
+  })
+
+  it('accepts peers already provided as an array', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1', zone: 'z', tag: 5 }], [{ zone: 'z', type: 'evpn', peers: ['a', 'b'] }])
+    expect(v.peers).toEqual(['a', 'b'])
+  })
+
+  it('only attaches peers for vxlan/evpn zones', () => {
+    const [v] = buildSdnVnets([{ vnet: 'v1', zone: 'z', tag: 5 }], [{ zone: 'z', type: 'vlan', peers: 'x' }])
+    expect(v.peers).toBeUndefined()
+  })
+
+  it('sorts by alias||vnet and skips malformed entries', () => {
+    const out = buildSdnVnets(
+      [{ vnet: 'zzz' }, { vnet: 'aaa', alias: 'mmm' }, null as unknown as SdnVnetRaw, { vnet: 42 as unknown as string }],
+      [],
+    )
+    expect(out.map((v) => v.vnet)).toEqual(['aaa', 'zzz'])
+  })
+
+  it('is null/array-safe', () => {
+    expect(buildSdnVnets(undefined as unknown as SdnVnetRaw[], ZONES)).toEqual([])
+    expect(buildSdnVnets(VNETS, undefined as unknown as SdnZoneRaw[])[0].zoneType).toBe('')
+  })
+})
+
+describe('sdnSegmentLabel', () => {
+  it('labels vxlan/evpn as VNI and vlan/qinq as VLAN', () => {
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'vxlan', tag: 10000 })).toBe('VNI 10000')
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'evpn', tag: 7 })).toBe('VNI 7')
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'vlan', tag: 100 })).toBe('VLAN 100')
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'qinq', tag: 100 })).toBe('VLAN 100')
+  })
+  it('returns "" for simple/unknown zones or a missing tag', () => {
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'simple' })).toBe('')
+    expect(sdnSegmentLabel({ vnet: 'v', zone: '', zoneType: '' })).toBe('')
+    expect(sdnSegmentLabel({ vnet: 'v', zone: 'z', zoneType: 'vxlan' })).toBe('')
+  })
+})

--- a/frontend/src/lib/proxmox/sdnVnetMap.ts
+++ b/frontend/src/lib/proxmox/sdnVnetMap.ts
@@ -1,0 +1,90 @@
+/**
+ * SDN VNet resolution for the inventory Network view (provider scope).
+ *
+ * A guest whose NIC bridge is an SDN VNet (`net0=...,bridge=v42fc503`) carries no
+ * per-NIC VLAN tag, so it used to fall under "Untagged". These helpers join the
+ * cluster's VNets with their zones so the VNet can be shown as the guest's real
+ * segment (VXLAN VNI, VLAN, ...). Distinct from hostVlanMap.ts: a VXLAN VNI is
+ * NOT range-limited to 1-4094, so no VLAN range check is applied here.
+ */
+
+/** A Proxmox /cluster/sdn/zones entry (minimal shape). */
+export type SdnZoneRaw = { zone: string; type?: string; peers?: string | string[]; [k: string]: unknown }
+/** A Proxmox /cluster/sdn/vnets entry (minimal shape). */
+export type SdnVnetRaw = { vnet: string; alias?: string; zone?: string; tag?: number | string; [k: string]: unknown }
+
+/** A resolved SDN VNet: a vnet joined with its zone. */
+export type SdnVnet = {
+  vnet: string        // id, e.g. "v42fc503"
+  alias?: string      // friendly name, e.g. "lan"
+  zone: string        // zone id; '' when the vnet has no/unknown zone
+  zoneType: string    // "vxlan" | "vlan" | "qinq" | "evpn" | "simple" | "" (unknown)
+  tag?: number        // VLAN id (vlan/qinq) or VXLAN VNI (vxlan/evpn); undefined when absent/invalid
+  peers?: string[]    // parsed peers, only for vxlan/evpn zones
+}
+
+/** Strict positive-integer coercion. Rejects "10abc", NaN, empty, 0, negatives. */
+function toTag(raw: unknown): number | undefined {
+  if (raw === null || raw === undefined || raw === '') return undefined
+  const n = Number(raw)
+  return Number.isInteger(n) && n > 0 ? n : undefined
+}
+
+/** Parse peers from a comma string or an already-normalized string[]. */
+function toPeers(raw: unknown): string[] | undefined {
+  let arr: string[]
+  if (Array.isArray(raw)) arr = raw.map((p) => String(p))
+  else if (typeof raw === 'string') arr = raw.split(',')
+  else return undefined
+  const cleaned = arr.map((s) => s.trim()).filter(Boolean)
+  return cleaned.length > 0 ? cleaned : undefined
+}
+
+/**
+ * Join `/cluster/sdn/vnets` with `/cluster/sdn/zones` by zone id. Unresolved
+ * zones yield `zone`/`zoneType` sentinels of '' so a VNet-backed guest still
+ * leaves "Untagged". Sorted by alias||vnet. Array/null-safe.
+ */
+export function buildSdnVnets(vnets: SdnVnetRaw[], zones: SdnZoneRaw[]): SdnVnet[] {
+  if (!Array.isArray(vnets)) return []
+
+  const zoneById = new Map<string, SdnZoneRaw>()
+  if (Array.isArray(zones)) {
+    for (const z of zones) {
+      if (z && typeof z.zone === 'string') zoneById.set(z.zone, z)
+    }
+  }
+
+  const out: SdnVnet[] = []
+  for (const v of vnets) {
+    if (!v || typeof v.vnet !== 'string') continue
+    const zoneId = typeof v.zone === 'string' ? v.zone : ''
+    const zone = zoneById.get(zoneId)
+    const zoneType = zone && typeof zone.type === 'string' ? zone.type : ''
+
+    const sv: SdnVnet = {
+      vnet: v.vnet,
+      zone: zoneId,
+      zoneType,
+      ...(typeof v.alias === 'string' && v.alias.length > 0 ? { alias: v.alias } : {}),
+    }
+    const tag = toTag(v.tag)
+    if (tag !== undefined) sv.tag = tag
+    if (zoneType === 'vxlan' || zoneType === 'evpn') {
+      const peers = toPeers(zone?.peers)
+      if (peers) sv.peers = peers
+    }
+    out.push(sv)
+  }
+
+  out.sort((a, b) => (a.alias || a.vnet).localeCompare(b.alias || b.vnet))
+  return out
+}
+
+/** Segment-identifier text for a VNet, by zone type. "" when none applies. */
+export function sdnSegmentLabel(v: SdnVnet): string {
+  if (v.tag === undefined) return ''
+  if (v.zoneType === 'vxlan' || v.zoneType === 'evpn') return `VNI ${v.tag}`
+  if (v.zoneType === 'vlan' || v.zoneType === 'qinq') return `VLAN ${v.tag}`
+  return ''
+}


### PR DESCRIPTION
## Problem

In the provider (full-cluster) **Inventory → Network** view, a VM whose NIC uses a Proxmox **SDN VNet** as its bridge (`net0=...,bridge=v42fc503`, no per-NIC tag) was bucketed under **"Untagged"**. The VM is not on "no network" — it rides an overlay segment (a VXLAN VNI, or a VLAN behind a VLAN zone), and that information was hidden. Follow-on to #389 / #542 (host VLAN handling), same "resolve a guest's real L2 segment" theme extended to SDN.

## Fix

- **`sdnVnetMap.ts`** (new, pure, unit-tested): `buildSdnVnets()` joins `/cluster/sdn/vnets` with `/cluster/sdn/zones` into `SdnVnet` (vnet, alias, zone, zoneType, tag, peers); `sdnSegmentLabel()` renders `VNI <n>` (vxlan/evpn) / `VLAN <n>` (vlan/qinq). A VXLAN VNI is intentionally not range-limited to 1–4094 (unlike host VLANs), with strict numeric coercion.
- **Networks route**: returns a new `sdnVnets[]` (provider scope only), reusing the already-fetched `/cluster/sdn/vnets` plus one fault-tolerant `/cluster/sdn/zones` call. Independent fault handling: a vnets failure ⇒ no grouping; a zones failure alone ⇒ vnets returned with unknown zone type. VNet ids are excluded from the host-bridge list so a VNet is never listed both as a bridge and a VNet.
- **`fetchConnectionsNetworks`**: threads a connId-stamped `SdnVnetItem`.
- **Inventory tree / dashboard / detail panel**: VNet-backed VMs are grouped under a per-node **VNet bucket** instead of "Untagged", labelled with zone type + VNI/VLAN. Lookup is keyed by connection so a plain bridge on one connection can't match a VNet id on another. A new **`net-vnet`** detail view shows the zone, type, VNI/tag and peers. Grouping is **VM-driven** (a VNet with no attached VM is not listed) and consistent across all surfaces (a VNet-backed VM never appears under both VNet and VLAN/Untagged/bridge).

Tenant/vDC scope is unchanged (keeps its own VNets tree; `sdnVnets: []`).

## Testing

- New unit tests: `buildSdnVnets`/`sdnSegmentLabel` (zone join, VNI passthrough > 4094, numeric-string vs invalid tag, sentinels, peers string|array, sort, null-safety); route (`sdnVnets` populated for provider scope, `[]` for tenant + empty-resource, zones-failure keeps vnets, vnet excluded from bridges); `fetchConnectionsNetworks` threading.
- Full frontend suite green (2460 tests); `tsc` clean (no new errors). The three inventory view components are in `sonar.coverage.exclusions`.
- Validated on a live cluster: a VM on the VXLAN VNet `v42fc503` (VNI 10000) now shows under a `lan · VNI 10000` bucket with zone/peers in its detail, instead of "Untagged".
