### PR TITLE
fix(connections): include Sys.PowerMgmt in generated PVE token setup script

### DIFF
--- a/frontend/src/components/settings/ConnectionDialog.tsx
+++ b/frontend/src/components/settings/ConnectionDialog.tsx
@@ -891,7 +891,7 @@ export default function ConnectionDialog({
                     onClick={() => {
                       const text = isPbs
                         ? `proxmox-backup-manager user create proxcenter@pbs --comment "ProxCenter service account"\nproxmox-backup-manager user generate-token proxcenter@pbs proxcenter\nproxmox-backup-manager acl update / DatastoreReader --auth-id proxcenter@pbs\nproxmox-backup-manager acl update / DatastoreReader --auth-id 'proxcenter@pbs!proxcenter'`
-                        : `pveum user add proxcenter@pve --comment "ProxCenter service account"\npveum user token add proxcenter@pve proxcenter-token --privsep=0\npveum aclmod / -user proxcenter@pve -role PVEAdmin\npveum role add ProxCenter -privs "Sys.Modify"\npveum aclmod / -user proxcenter@pve -role ProxCenter`
+                        : `pveum user add proxcenter@pve --comment "ProxCenter service account"\npveum user token add proxcenter@pve proxcenter-token --privsep=0\npveum aclmod / -user proxcenter@pve -role PVEAdmin\npveum role add ProxCenter -privs "Sys.Modify,Sys.PowerMgmt"\npveum aclmod / -user proxcenter@pve -role ProxCenter`
                       navigator.clipboard.writeText(text)
                     }}
                     sx={{
@@ -929,7 +929,7 @@ export default function ConnectionDialog({
                       <Box component="span" sx={{ color: 'grey.500' }}># {t('settings.pveStep3')}</Box>{'\n'}
                       pveum aclmod / -user proxcenter@pve -role PVEAdmin{'\n\n'}
                       <Box component="span" sx={{ color: 'grey.500' }}># {t('settings.pveStep4')}</Box>{'\n'}
-                      pveum role add ProxCenter -privs &quot;Sys.Modify&quot;{'\n'}
+                      pveum role add ProxCenter -privs &quot;Sys.Modify,Sys.PowerMgmt&quot;{'\n'}
                       pveum aclmod / -user proxcenter@pve -role ProxCenter
                     </>
                   )}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2401,7 +2401,7 @@
     "pveStep1": "erstellen a dedicated user",
     "pveStep2": "API-Token erstellen (privsep=0 erbt Benutzerberechtigungen)",
     "pveStep3": "PVEAdmin-Rolle für den gesamten Cluster zuweisen",
-    "pveStep4": "Das von Rolling Update benötigte Privileg Sys.Modify hinzufügen (apt-Paketaktualisierung)",
+    "pveStep4": "Die Privilegien Sys.Modify und Sys.PowerMgmt hinzufügen (apt-Paketaktualisierung für Rolling Update, Neustart/Herunterfahren von Knoten)",
     "pbsStep1": "erstellen a dedicated user",
     "pbsStep2": "API-Token generieren",
     "pbsStep3": "Lesezugriff auf Datastores gewähren",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2435,7 +2435,7 @@
     "pveStep1": "Create a dedicated user",
     "pveStep2": "Create an API token (privsep=0 inherits user permissions)",
     "pveStep3": "Grant PVEAdmin role on the entire cluster",
-    "pveStep4": "Add the Sys.Modify privilege required by Rolling Update (apt package refresh)",
+    "pveStep4": "Add the Sys.Modify and Sys.PowerMgmt privileges (Rolling Update apt refresh, and node reboot/shutdown)",
     "pbsStep1": "Create a dedicated user",
     "pbsStep2": "Generate an API token",
     "pbsStep3": "Grant read access to datastores",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2435,7 +2435,7 @@
     "pveStep1": "Crear un usuario dedicado",
     "pveStep2": "Crear an API token (privsep=0 inherits usuario permisos)",
     "pveStep3": "Grant PVEAdmin rol en el entire cluster",
-    "pveStep4": "Añade el privilegio Sys.Modify requerido por Rolling Update (actualización de paquetes apt)",
+    "pveStep4": "Añade los privilegios Sys.Modify y Sys.PowerMgmt (actualización de paquetes apt de Rolling Update, reinicio/apagado de nodos)",
     "pbsStep1": "Crear un usuario dedicado",
     "pbsStep2": "Generar un token API",
     "pbsStep3": "Conceder acceso de lectura a datastores",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2435,7 +2435,7 @@
     "pveStep1": "Créer un utilisateur dédié",
     "pveStep2": "Créer un token API (privsep=0 hérite des permissions utilisateur)",
     "pveStep3": "Attribuer le rôle PVEAdmin sur l'ensemble du cluster",
-    "pveStep4": "Ajouter le privilège Sys.Modify requis par Rolling Update (rafraîchissement des paquets apt)",
+    "pveStep4": "Ajouter les privilèges Sys.Modify et Sys.PowerMgmt (rafraîchissement des paquets apt de Rolling Update, redémarrage/arrêt des nœuds)",
     "pbsStep1": "Créer un utilisateur dédié",
     "pbsStep2": "Générer un token API",
     "pbsStep3": "Accorder l'accès en lecture aux datastores",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2435,7 +2435,7 @@
     "pveStep1": "전용 사용자 생성",
     "pveStep2": "API 토큰 생성 (privsep=0은 사용자 권한을 상속)",
     "pveStep3": "전체 클러스터에 PVEAdmin 역할 부여",
-    "pveStep4": "롤링 업데이트에 필요한 Sys.Modify 권한 추가 (apt 패키지 새로 고침)",
+    "pveStep4": "Sys.Modify 및 Sys.PowerMgmt 권한 추가 (롤링 업데이트 apt 새로 고침, 노드 재부팅/종료)",
     "pbsStep1": "전용 사용자 생성",
     "pbsStep2": "API 토큰 생성",
     "pbsStep3": "데이터스토어에 대한 읽기 권한 부여",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2404,7 +2404,7 @@
     "pveStep1": "创建专用用户",
     "pveStep2": "创建 API 令牌（privsep=0 继承用户权限）",
     "pveStep3": "在整个集群上授予 PVEAdmin 角色",
-    "pveStep4": "添加 Rolling Update 所需的 Sys.Modify 权限（刷新 apt 软件包列表）",
+    "pveStep4": "添加 Sys.Modify 和 Sys.PowerMgmt 权限（Rolling Update 刷新 apt 软件包列表，节点重启/关机）",
     "pbsStep1": "创建专用用户",
     "pbsStep2": "生成 API 令牌",
     "pbsStep3": "授予数据存储读取权限",


### PR DESCRIPTION
## Problem

Node **Reboot/Shutdown** from ProxCenter fails with a Proxmox permissions error even when the connection's API token holds `PVEAdmin` (reported in discussion #550).

Root cause: the token setup script we generate in the connection dialog creates a custom `ProxCenter` role with only `Sys.Modify`, and the built-in `PVEAdmin` role does not include `Sys.PowerMgmt`. The standalone node Reboot/Shutdown action calls the Proxmox API (`POST /nodes/{node}/status`), which is gated on `Sys.PowerMgmt`. Rolling Update's post-upgrade reboot runs over SSH, so it was unaffected, which is what masked this.

## Change

- `ConnectionDialog.tsx`: the generated `pveum role add ProxCenter` command now grants `-privs "Sys.Modify,Sys.PowerMgmt"` (both the copy-to-clipboard string and the displayed block).
- Update the `pveStep4` caption in all locales (en, fr, ko, es, de, zh-CN) to reflect both privileges and both purposes (Rolling Update apt refresh, and node reboot/shutdown).

New installs following the generated script now get node reboot working out of the box. Existing installs can run `pveum role modify ProxCenter -privs "Sys.Modify,Sys.PowerMgmt"`.

Docs are updated separately in the docs repo (permissions table plus the PVEAdmin note corrected, since it previously claimed `Sys.PowerMgmt` was not required).

## Testing

- Verified in the browser: the connection dialog token-setup accordion shows the updated step 4, and the copy button copies the updated command.
- JSON validity of all 6 locale files confirmed.

Fixes the reboot permissions issue in discussion #550.
