### PR TITLE
fix(inventory): guard null data in external hypervisor VM sorting

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -410,7 +410,7 @@ export default function InventoryDetails({
   const emptySet = useMemo(() => new Set<string>(), [])
 
   const sortedExtVms = useMemo(() => {
-    const vms = data.esxiHostInfo?.vms
+    const vms = data?.esxiHostInfo?.vms
     if (!vms || vms.length === 0) return []
     const sorted = [...vms].sort((a: any, b: any) => {
       let cmp = 0
@@ -425,7 +425,7 @@ export default function InventoryDetails({
       return extVmSortDir === 'asc' ? cmp : -cmp
     })
     return sorted
-  }, [data.esxiHostInfo?.vms, extVmSortCol, extVmSortDir])
+  }, [data?.esxiHostInfo?.vms, extVmSortCol, extVmSortDir])
 
   useEffect(() => {
     if (!nodeActionDialog) return
@@ -3527,7 +3527,7 @@ return vm?.isCluster ?? false
           )}
 
           {/* External Host — Dashboard */}
-          {selection?.type === 'ext' && data.esxiHostInfo && (() => {
+          {selection?.type === 'ext' && data?.esxiHostInfo && (() => {
             const isXcpng = data.esxiHostInfo.hostType === 'xcpng'
             const isVcenter = data.esxiHostInfo.hostType === 'vcenter'
             const isHyperv = data.esxiHostInfo.hostType === 'hyperv'
@@ -3644,7 +3644,7 @@ return vm?.isCluster ?? false
           })()}
 
           {/* External Host — VM List with Migrate buttons */}
-          {selection?.type === 'ext' && data.esxiHostInfo && (() => {
+          {selection?.type === 'ext' && data?.esxiHostInfo && (() => {
             const isXcpng = data.esxiHostInfo.hostType === 'xcpng'
             const isVcenter = data.esxiHostInfo.hostType === 'vcenter'
             const isHypervHost = data.esxiHostInfo.hostType === 'hyperv'


### PR DESCRIPTION
## Problem

Opening the inventory dashboard crashed with:

```
TypeError: can't access property "esxiHostInfo", data is null
  at InventoryDetails (.../InventoryDetails.tsx:428)
```

The `sortedExtVms` `useMemo` (added for external-hypervisor VM column sorting) reads `data.esxiHostInfo?.vms`. The optional chaining guards `esxiHostInfo` but **not `data` itself**, which is `null` on the initial render before the inventory data loads. Since a `useMemo` runs on every render, this threw before any loading guard and broke the whole panel.

## Fix

Guard the four unguarded `data.esxiHostInfo` accesses with `data?.`:

- `sortedExtVms` `useMemo` body and dependency array
- the two `selection?.type === 'ext' && data.esxiHostInfo && (...)` JSX blocks (same crash on an external-host selection before data loads)

The inner `data.esxiHostInfo.*` reads stay unchanged — they only run inside the now-guarded blocks, so `data` is non-null there. Optional chaining is behavior-preserving when `data` is present.

## Testing

- `tsc --noEmit` clean on the changed file.
- Verified the dashboard no longer throws on load (crash gone on reload).
