### PR TITLE
ci: add ESLint job as a frontend lint gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+name: Lint
+
+# ESLint gate for the frontend. Added after the linter was found to have been
+# silently broken for a while (eslint-config-next 16 dropped eslintrc support
+# and there was no CI job running `npm run lint`). Keep this a required check
+# in branch protection ("Settings -> Branches -> main -> Require status checks
+# -> ESLint") so a lint failure blocks the merge.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci --legacy-peer-deps --ignore-scripts
+
+      - name: Generate Prisma client
+        # Not connecting — `prisma generate` only reads the schema, but it needs
+        # DATABASE_URL to be defined and produces @prisma/client so ESLint's
+        # import/no-unresolved can resolve it.
+        working-directory: frontend
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost:5432/db
+        run: npx prisma generate
+
+      - name: Build icon CSS
+        # Normally a postinstall step; skipped above by --ignore-scripts. ESLint's
+        # import/no-unresolved needs this generated file, which layout.jsx imports.
+        working-directory: frontend
+        run: npm run build:icons
+
+      - name: ESLint
+        working-directory: frontend
+        run: npm run lint


### PR DESCRIPTION
## Why

There was no CI step running `npm run lint`. That's exactly why the linter could stay broken unnoticed after `eslint-config-next` was bumped to 16 (flat-config only). This adds a lint gate so any future lint regression (broken config or new errors) is caught on the PR.

## What

A `Lint` workflow running ESLint on PRs to `main` and on pushes to `main`. It mirrors the SonarCloud workflow's install setup:

- `npm ci --legacy-peer-deps --ignore-scripts`
- `prisma generate` (needs `DATABASE_URL` defined; produces `@prisma/client` so `import/no-unresolved` resolves it — no DB connection)
- `npm run build:icons` (a postinstall step skipped by `--ignore-scripts`; ESLint needs the generated `generated-icons.css` that `layout.jsx` imports)
- `npm run lint`

The lint config only fails on **errors** (warnings, e.g. the react-hooks v7 findings, stay non-blocking), so this gate stays green today while catching real regressions.

## Follow-up

Make **ESLint** a required status check in branch protection (Settings → Branches → main → Require status checks) so a lint failure blocks the merge, same as SonarCloud.
