### PR TITLE
fix(i18n): use translation keys for hardcoded French UI strings

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -2486,7 +2486,7 @@ return vm?.isCluster ?? false
 
       {error ? (
         <Alert severity="error" sx={{ mb: 2, mx: selection && selection.type !== 'root' && !selection.type.endsWith('-root') ? 0 : 2 }}>
-          Erreur: {error}
+          {t('common.errorWithMessage', { error })}
         </Alert>
       ) : null}
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useVmActions.ts
@@ -73,7 +73,7 @@ interface UseVmActionsParams {
   onSelect?: (sel: InventorySelection) => void
   onRefresh?: () => Promise<void>
   toast: Toast
-  t: (key: string) => string
+  t: (key: string, values?: Record<string, string | number>) => string
   trackTask: TrackTaskFn
   data: DetailsPayload | null
   setData: (d: DetailsPayload | null) => void
@@ -570,11 +570,11 @@ export function useVmActions({
     }
 
     if (errorCount === 0) {
-      toast.success(`${description} - ${successCount} VMs`)
+      toast.success(t('vmActions.bulkSuccess', { description, count: successCount }))
     } else if (successCount > 0) {
-      toast.warning(`${description} - ${successCount} OK, ${errorCount} erreurs`)
+      toast.warning(t('vmActions.bulkPartial', { description, success: successCount, errors: errorCount }))
     } else {
-      toast.error(`${description} - ${errorCount} erreurs`)
+      toast.error(t('vmActions.bulkFailed', { description, errors: errorCount }))
     }
 
     if (onRefresh) {

--- a/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
+++ b/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
@@ -1152,14 +1152,14 @@ export default function FlowsTab() {
           <Box sx={{ mt: 1, p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>
             <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 0.5 }}>
               <i className="ri-information-line" style={{ fontSize: 12, marginRight: 4 }} />{' '}
-              1 paquet sur <strong>{samplingRate}</strong> sera échantillonné
+              {t.rich('networkFlows.samplingRateInfo', { rate: samplingRate, strong: (chunks) => <strong>{chunks}</strong> })}
             </Typography>
             <Typography variant="caption" color="text.secondary" display="block">
-              {samplingRate <= 128 && '⚠️ Très précis mais forte charge CPU/réseau — recommandé uniquement pour le debug'}
-              {samplingRate > 128 && samplingRate <= 256 && '⚡ Haute précision — adapté aux réseaux < 1 Gbps'}
-              {samplingRate > 256 && samplingRate <= 512 && '✓ Bon compromis précision/performance — recommandé pour la plupart des cas'}
-              {samplingRate > 512 && samplingRate <= 1024 && '✓ Léger — adapté aux réseaux 10 Gbps+'}
-              {samplingRate > 1024 && '📉 Très léger — peut manquer des flux de faible volume'}
+              {samplingRate <= 128 && t('networkFlows.samplingVeryHigh')}
+              {samplingRate > 128 && samplingRate <= 256 && t('networkFlows.samplingHigh')}
+              {samplingRate > 256 && samplingRate <= 512 && t('networkFlows.samplingBalanced')}
+              {samplingRate > 512 && samplingRate <= 1024 && t('networkFlows.samplingLight')}
+              {samplingRate > 1024 && t('networkFlows.samplingVeryLight')}
             </Typography>
           </Box>
           <Box sx={{ mt: 2 }}>

--- a/frontend/src/components/VmConfigEditor.tsx
+++ b/frontend/src/components/VmConfigEditor.tsx
@@ -643,10 +643,10 @@ return
                   <i className="ri-cpu-line" style={{ fontSize: 24, opacity: 0.7 }} />
                   <Box>
                     <Typography variant="body2" fontWeight={600}>
-                      Total: {(config.cores || 1) * (config.sockets || 1)} vCPUs
+                      {t('vmConfig.totalVcpus', { count: (config.cores || 1) * (config.sockets || 1) })}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      {config.cores || 1} cœurs × {config.sockets || 1} socket(s)
+                      {t('vmConfig.coresSocketsSummary', { cores: config.cores || 1, sockets: config.sockets || 1 })}
                     </Typography>
                   </Box>
                 </Box>

--- a/frontend/src/components/hardware/MigrateVmDialog.tsx
+++ b/frontend/src/components/hardware/MigrateVmDialog.tsx
@@ -157,14 +157,14 @@ return names.sort((a, b) => a.localeCompare(b))
         }
       } catch (e: any) {
         console.error('Error loading nodes:', e)
-        setError('Impossible de charger la liste des nodes')
+        setError(t('hardware.loadNodesError'))
       } finally {
         setNodesLoading(false)
       }
     }
 
     loadNodes()
-  }, [open, connId, currentNode])
+  }, [open, connId, currentNode, t])
 
   // Charger la config VM pour détecter les disques
   useEffect(() => {

--- a/frontend/src/components/layout/vertical/NavbarContent.jsx
+++ b/frontend/src/components/layout/vertical/NavbarContent.jsx
@@ -1121,7 +1121,7 @@ return () => window.removeEventListener('keydown', onKeyDown)
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mt: 0.25 }}>
                       <Chip
                         size='small'
-                        label={notif.severity === 'crit' ? 'CRITIQUE' : 'WARNING'}
+                        label={(notif.severity === 'crit' ? t('alerts.critical') : t('alerts.warning')).toUpperCase()}
                         color={color}
                         sx={{ height: 16, fontSize: '0.55rem', fontWeight: 700 }}
                       />

--- a/frontend/src/hooks/useTaskTracker.test.tsx
+++ b/frontend/src/hooks/useTaskTracker.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * Tests for useTaskTracker.
+ *
+ * The hook polls /api/v1/tasks/:conn/:node/:upid on a 2s interval until the
+ * Proxmox task stops, then fires a toast for the outcome. We drive each branch
+ * with a mocked fetch + fake timers and assert the toast call and callbacks.
+ *
+ * next-intl is mocked to echo the key, so we assert on the translation key the
+ * hook chose (taskTracker.completed / .failed / .timeout / .error) rather than
+ * a rendered string.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useTaskTracker } from './useTaskTracker'
+
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    showToast: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => toast,
+}))
+
+const POLL_INTERVAL = 2000
+const MAX_ATTEMPTS = 150
+
+type TaskInfo = Parameters<ReturnType<typeof useTaskTracker>['trackTask']>[0]
+
+/** Resolve fetch with a JSON body and ok=true. */
+function okResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response
+}
+
+function stubFetch(impl: () => Promise<Response>) {
+  const mock = vi.fn(impl)
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+function baseTask(overrides: Partial<TaskInfo> = {}): TaskInfo {
+  return {
+    upid: 'UPID:pve1:0001',
+    connId: 'conn-1',
+    node: 'pve1',
+    description: 'Démarrage de la VM',
+    ...overrides,
+  }
+}
+
+/** Render the hook, start tracking, and advance timers to run the poll(s). */
+async function trackAndRun(task: TaskInfo, advanceMs = POLL_INTERVAL) {
+  const { result } = renderHook(() => useTaskTracker())
+  await act(async () => {
+    await result.current.trackTask(task)
+  })
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(advanceMs)
+  })
+  return result
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('useTaskTracker', () => {
+  it('fires the initial info toast and a success toast when the task exits OK', async () => {
+    stubFetch(async () => okResponse({ status: 'stopped', exitstatus: 'OK' }))
+    const onSuccess = vi.fn()
+
+    await trackAndRun(baseTask({ onSuccess }))
+
+    expect(toast.info).toHaveBeenCalledWith('Démarrage de la VM...')
+    expect(toast.success).toHaveBeenCalledWith('taskTracker.completed')
+    expect(onSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports the exitstatus on failure', async () => {
+    stubFetch(async () => okResponse({ status: 'stopped', exitstatus: 'disk full' }))
+    const onError = vi.fn()
+
+    await trackAndRun(baseTask({ onError }))
+
+    expect(toast.error).toHaveBeenCalledWith('taskTracker.failed')
+    expect(onError).toHaveBeenCalledWith('disk full')
+  })
+
+  it('falls back to the unknown-error label when exitstatus is missing', async () => {
+    stubFetch(async () => okResponse({ status: 'stopped' }))
+    const onError = vi.fn()
+
+    await trackAndRun(baseTask({ onError }))
+
+    expect(toast.error).toHaveBeenCalledWith('taskTracker.failed')
+    expect(onError).toHaveBeenCalledWith('taskTracker.unknownError')
+  })
+
+  it('warns on timeout after the maximum number of attempts', async () => {
+    stubFetch(async () => okResponse({ status: 'running' }))
+
+    // Drive every poll attempt plus the initial scheduling delay.
+    await trackAndRun(baseTask(), POLL_INTERVAL * (MAX_ATTEMPTS + 1))
+
+    expect(toast.warning).toHaveBeenCalledWith('taskTracker.timeout')
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('reports the error when polling throws', async () => {
+    stubFetch(async () => ({ ok: false, status: 500 }) as unknown as Response)
+    const onError = vi.fn()
+
+    await trackAndRun(baseTask({ onError }))
+
+    expect(toast.error).toHaveBeenCalledWith('taskTracker.error')
+    expect(onError).toHaveBeenCalledWith('Failed to get task status: 500')
+  })
+
+  it('appends query params to the poll URL when provided', async () => {
+    const fetchMock = stubFetch(async () => okResponse({ status: 'stopped', exitstatus: 'OK' }))
+
+    await trackAndRun(baseTask({ queryParams: { store: 'local' } }))
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('?store=local'))
+  })
+
+  it('ignores a second track request for the same task', async () => {
+    const fetchMock = stubFetch(async () => okResponse({ status: 'stopped', exitstatus: 'OK' }))
+
+    const { result } = renderHook(() => useTaskTracker())
+    await act(async () => {
+      await result.current.trackTask(baseTask())
+      await result.current.trackTask(baseTask())
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL)
+    })
+
+    // The dedup guard means only the first call schedules a poll.
+    expect(toast.info).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/hooks/useTaskTracker.ts
+++ b/frontend/src/hooks/useTaskTracker.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useRef } from 'react'
+import { useTranslations } from 'next-intl'
 import { useToast } from '@/contexts/ToastContext'
 
 interface TaskInfo {
@@ -37,6 +38,7 @@ interface TaskStatus {
  */
 export function useTaskTracker() {
   const toast = useToast()
+  const t = useTranslations()
   const activeTasksRef = useRef<Set<string>>(new Set())
 
   const pollTaskStatus = useCallback(async (
@@ -87,11 +89,11 @@ export function useTaskTracker() {
           activeTasksRef.current.delete(upid)
 
           if (status.exitstatus === 'OK') {
-            toast.success(`${description} - Terminé`)
+            toast.success(t('taskTracker.completed', { description }))
             onSuccess?.()
           } else {
-            const errorMsg = status.exitstatus || 'Erreur inconnue'
-            toast.error(`${description} - Échec: ${errorMsg}`)
+            const errorMsg = status.exitstatus || t('taskTracker.unknownError')
+            toast.error(t('taskTracker.failed', { description, error: errorMsg }))
             onError?.(errorMsg)
           }
 
@@ -104,18 +106,18 @@ export function useTaskTracker() {
         } else {
           // Timeout
           activeTasksRef.current.delete(upid)
-          toast.warning(`${description} - Timeout (tâche peut-être encore en cours)`)
+          toast.warning(t('taskTracker.timeout', { description }))
         }
       } catch (e: any) {
         activeTasksRef.current.delete(upid)
-        toast.error(`${description} - Erreur: ${e.message}`)
+        toast.error(t('taskTracker.error', { description, error: e.message }))
         onError?.(e.message)
       }
     }
 
     // Démarrer le polling après un court délai
     setTimeout(poll, pollInterval)
-  }, [toast, pollTaskStatus])
+  }, [toast, t, pollTaskStatus])
 
   return { trackTask }
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -89,7 +89,8 @@
     "empty": "Leer",
     "overview": "Übersicht",
     "configuration": "Konfiguration",
-    "created": "Erstellt"
+    "created": "Erstellt",
+    "errorWithMessage": "Fehler: {error}"
   },
   "whatsNew": {
     "title": "Neuigkeiten"
@@ -4401,7 +4402,10 @@
     "resumeSuccess": "VM wird fortgesetzt",
     "rebootSuccess": "VM wird neugestartet",
     "migrateSuccess": "Migration gestartet",
-    "cloneSuccess": "Klonen gestartet"
+    "cloneSuccess": "Klonen gestartet",
+    "bulkSuccess": "{description} - {count} VMs",
+    "bulkPartial": "{description} - {success} OK, {errors} Fehler",
+    "bulkFailed": "{description} - {errors} Fehler"
   },
   "vmConfig": {
     "title": "VM Konfiguration",
@@ -4468,7 +4472,9 @@
     "rawConfig": "Raw Konfiguration",
     "advancedArgs": "hinzufügenitional QEMU arguments",
     "advancedArgsWarning": "Manuell modification for Erweitert Benutzer only.",
-    "qemuArgsHelper": "Argumente, die direkt an QEMU übergeben werden (gefährlich)"
+    "qemuArgsHelper": "Argumente, die direkt an QEMU übergeben werden (gefährlich)",
+    "totalVcpus": "Gesamt: {count} vCPUs",
+    "coresSocketsSummary": "{cores} Kerne × {sockets} Socket(s)"
   },
   "hardware": {
     "detach": "Trennen",
@@ -4631,7 +4637,8 @@
       "useIso": "CD/DVD-Abbilddatei (ISO) verwenden",
       "usePhysical": "Physisches CD/DVD-Laufwerk verwenden",
       "noMedia": "Kein Medium verwenden"
-    }
+    },
+    "loadNodesError": "Node-Liste konnte nicht geladen werden"
   },
   "ldap": {
     "description": "Konfigurieren Sie LDAP/Active Directory-Authentifizierung, damit Benutzer sich mit ihren Unternehmensanmeldedaten anmelden können.",
@@ -6591,7 +6598,13 @@
     "portFilter": "Port",
     "noTimelineData": "Keine Zeitreihendaten für dieses Paar verfügbar (erfordert InfluxDB)",
     "compare": "Vergleichen",
-    "yesterday": "Gestern"
+    "yesterday": "Gestern",
+    "samplingRateInfo": "1 von <strong>{rate}</strong> Paketen wird erfasst",
+    "samplingVeryHigh": "⚠️ Sehr präzise, aber hohe CPU-/Netzwerklast — nur zum Debuggen empfohlen",
+    "samplingHigh": "⚡ Hohe Präzision — geeignet für Netzwerke unter 1 Gbit/s",
+    "samplingBalanced": "✓ Gutes Verhältnis von Präzision und Leistung — für die meisten Fälle empfohlen",
+    "samplingLight": "✓ Ressourcenschonend — geeignet für Netzwerke ab 10 Gbit/s",
+    "samplingVeryLight": "📉 Sehr ressourcenschonend — kann Datenströme mit geringem Volumen übersehen"
   },
   "myVdc": {
     "title": "Mein Datacenter",
@@ -6950,5 +6963,12 @@
     "policyToggleLabel": "2FA für super_admin-Konten verlangen",
     "policyToggleHelp": "Sobald aktiviert, müssen sich super_admin-Nutzer ohne 2FA bei der nächsten Anmeldung registrieren. Sie müssen 2FA auf Ihrem eigenen Konto bereits aktiviert haben, um diese Richtlinie zu aktivieren.",
     "policyNeedOwn2fa": "Aktivieren Sie zuerst 2FA auf Ihrem eigenen Konto, bevor Sie diese Richtlinie durchsetzen."
+  },
+  "taskTracker": {
+    "completed": "{description} - Abgeschlossen",
+    "failed": "{description} - Fehlgeschlagen: {error}",
+    "timeout": "{description} - Zeitüberschreitung (Aufgabe läuft möglicherweise noch)",
+    "error": "{description} - Fehler: {error}",
+    "unknownError": "Unbekannter Fehler"
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -93,7 +93,8 @@
     "node": "Node",
     "done": "Done",
     "tags": "Tags",
-    "created": "Created"
+    "created": "Created",
+    "errorWithMessage": "Error: {error}"
   },
   "whatsNew": {
     "title": "What's New"
@@ -4443,7 +4444,10 @@
     "resumeSuccess": "Resuming VM",
     "rebootSuccess": "Rebooting VM",
     "migrateSuccess": "Migration started",
-    "cloneSuccess": "Cloning started"
+    "cloneSuccess": "Cloning started",
+    "bulkSuccess": "{description} - {count} VMs",
+    "bulkPartial": "{description} - {success} OK, {errors} errors",
+    "bulkFailed": "{description} - {errors} errors"
   },
   "vmConfig": {
     "title": "VM Configuration",
@@ -4510,7 +4514,9 @@
     "rawConfig": "Raw configuration",
     "advancedArgs": "Additional QEMU arguments",
     "advancedArgsWarning": "Manual modification for advanced users only.",
-    "qemuArgsHelper": "Arguments passed directly to QEMU (dangerous)"
+    "qemuArgsHelper": "Arguments passed directly to QEMU (dangerous)",
+    "totalVcpus": "Total: {count} vCPUs",
+    "coresSocketsSummary": "{cores} cores × {sockets} socket(s)"
   },
   "hardware": {
     "detach": "Detach",
@@ -4673,7 +4679,8 @@
       "useIso": "Use CD/DVD disc image file (ISO)",
       "usePhysical": "Use physical CD/DVD Drive",
       "noMedia": "Do not use any media"
-    }
+    },
+    "loadNodesError": "Unable to load the node list"
   },
   "ldap": {
     "description": "Configure LDAP/Active Directory authentication to allow users to sign in with their corporate credentials.",
@@ -6669,7 +6676,13 @@
     "portFilter": "Port",
     "noTimelineData": "No timeline data available for this pair (requires InfluxDB)",
     "compare": "Compare",
-    "yesterday": "Yesterday"
+    "yesterday": "Yesterday",
+    "samplingRateInfo": "1 packet out of <strong>{rate}</strong> will be sampled",
+    "samplingVeryHigh": "⚠️ Very precise but heavy CPU/network load — recommended for debugging only",
+    "samplingHigh": "⚡ High precision — suitable for networks under 1 Gbps",
+    "samplingBalanced": "✓ Good precision/performance trade-off — recommended for most cases",
+    "samplingLight": "✓ Lightweight — suitable for 10 Gbps+ networks",
+    "samplingVeryLight": "📉 Very lightweight — may miss low-volume flows"
   },
   "vdc": {
     "title": "Virtual Datacenters",
@@ -7097,5 +7110,12 @@
     "policyToggleLabel": "Require 2FA for super_admin accounts",
     "policyToggleHelp": "Once enabled, super_admin users without 2FA will be forced to enroll on their next login. You must already have 2FA enabled on your own account to turn this on.",
     "policyNeedOwn2fa": "Enable 2FA on your own account before enforcing this policy."
+  },
+  "taskTracker": {
+    "completed": "{description} - Completed",
+    "failed": "{description} - Failed: {error}",
+    "timeout": "{description} - Timeout (task may still be running)",
+    "error": "{description} - Error: {error}",
+    "unknownError": "Unknown error"
   }
 }

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -93,7 +93,8 @@
     "node": "Nodo",
     "done": "Hecho",
     "tags": "Etiquetas",
-    "created": "Creado"
+    "created": "Creado",
+    "errorWithMessage": "Error: {error}"
   },
   "whatsNew": {
     "title": "Novedades"
@@ -4443,7 +4444,10 @@
     "resumeSuccess": "Reanudando VM",
     "rebootSuccess": "Reiniciando VM",
     "migrateSuccess": "Migración iniciada",
-    "cloneSuccess": "Clonación iniciada"
+    "cloneSuccess": "Clonación iniciada",
+    "bulkSuccess": "{description} - {count} VMs",
+    "bulkPartial": "{description} - {success} OK, {errors} errores",
+    "bulkFailed": "{description} - {errors} errores"
   },
   "vmConfig": {
     "title": "Configuración de VM",
@@ -4510,7 +4514,9 @@
     "rawConfig": "Configuración sin procesar",
     "advancedArgs": "Argumentos QEMU adicionales",
     "advancedArgsWarning": "Modificación manual solo para usuarios avanzados.",
-    "qemuArgsHelper": "Argumentos pasados directamente a QEMU (peligroso)"
+    "qemuArgsHelper": "Argumentos pasados directamente a QEMU (peligroso)",
+    "totalVcpus": "Total: {count} vCPUs",
+    "coresSocketsSummary": "{cores} núcleos × {sockets} socket(s)"
   },
   "hardware": {
     "detach": "Desconectar",
@@ -4673,7 +4679,8 @@
       "useIso": "Usar archivo de imagen de disco CD/DVD (ISO)",
       "usePhysical": "Usar unidad física de CD/DVD",
       "noMedia": "No usar ningún medio"
-    }
+    },
+    "loadNodesError": "No se pudo cargar la lista de nodos"
   },
   "ldap": {
     "description": "Configure la autenticación LDAP/Active Directory para permitir que los usuarios inicien sesión con sus credenciales corporativas.",
@@ -6669,7 +6676,13 @@
     "portFilter": "Puerto",
     "noTimelineData": "No hay datos de línea temporal disponibles para este par (requiere InfluxDB)",
     "compare": "Comparar",
-    "yesterday": "Ayer"
+    "yesterday": "Ayer",
+    "samplingRateInfo": "1 de cada <strong>{rate}</strong> paquetes será muestreado",
+    "samplingVeryHigh": "⚠️ Muy preciso pero con gran carga de CPU/red — recomendado solo para depuración",
+    "samplingHigh": "⚡ Alta precisión — adecuado para redes de menos de 1 Gbps",
+    "samplingBalanced": "✓ Buen equilibrio precisión/rendimiento — recomendado para la mayoría de los casos",
+    "samplingLight": "✓ Ligero — adecuado para redes de 10 Gbps o más",
+    "samplingVeryLight": "📉 Muy ligero — puede pasar por alto flujos de bajo volumen"
   },
   "vdc": {
     "title": "Datacenters virtuales",
@@ -7097,5 +7110,12 @@
     "policyToggleLabel": "Requerir 2FA para cuentas super_admin",
     "policyToggleHelp": "Una vez habilitado, los usuarios super_admin sin 2FA estarán obligados a registrarse en su próximo login. Debes tener ya 2FA habilitado en tu propia cuenta para activarlo.",
     "policyNeedOwn2fa": "Habilita 2FA en tu propia cuenta antes de aplicar esta política."
+  },
+  "taskTracker": {
+    "completed": "{description} - Completado",
+    "failed": "{description} - Error: {error}",
+    "timeout": "{description} - Tiempo de espera agotado (la tarea puede seguir en curso)",
+    "error": "{description} - Error: {error}",
+    "unknownError": "Error desconocido"
   }
 }

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -93,7 +93,8 @@
     "node": "Nœud",
     "done": "Terminé",
     "tags": "Tags",
-    "created": "Créé"
+    "created": "Créé",
+    "errorWithMessage": "Erreur : {error}"
   },
   "whatsNew": {
     "title": "Nouveautés"
@@ -4443,7 +4444,10 @@
     "resumeSuccess": "Reprise en cours",
     "rebootSuccess": "Redémarrage en cours",
     "migrateSuccess": "Migration en cours",
-    "cloneSuccess": "Clonage en cours"
+    "cloneSuccess": "Clonage en cours",
+    "bulkSuccess": "{description} - {count} VMs",
+    "bulkPartial": "{description} - {success} OK, {errors} erreurs",
+    "bulkFailed": "{description} - {errors} erreurs"
   },
   "vmConfig": {
     "title": "Configuration VM",
@@ -4510,7 +4514,9 @@
     "rawConfig": "Configuration brute",
     "advancedArgs": "Arguments QEMU additionnels",
     "advancedArgsWarning": "Modification manuelle pour utilisateurs avancés uniquement.",
-    "qemuArgsHelper": "Arguments passés directement à QEMU (dangereux)"
+    "qemuArgsHelper": "Arguments passés directement à QEMU (dangereux)",
+    "totalVcpus": "Total : {count} vCPUs",
+    "coresSocketsSummary": "{cores} cœurs × {sockets} socket(s)"
   },
   "hardware": {
     "detach": "Détacher",
@@ -4673,7 +4679,8 @@
       "useIso": "Utiliser une image CD/DVD (ISO)",
       "usePhysical": "Utiliser le lecteur CD/DVD physique",
       "noMedia": "Ne pas utiliser de média"
-    }
+    },
+    "loadNodesError": "Impossible de charger la liste des nodes"
   },
   "ldap": {
     "description": "Configurez l'authentification LDAP/Active Directory pour permettre aux utilisateurs de se connecter avec leurs identifiants d'entreprise.",
@@ -6670,7 +6677,13 @@
     "portFilter": "Port",
     "noTimelineData": "Pas de données temporelles pour cette paire (nécessite InfluxDB)",
     "compare": "Comparer",
-    "yesterday": "Hier"
+    "yesterday": "Hier",
+    "samplingRateInfo": "1 paquet sur <strong>{rate}</strong> sera échantillonné",
+    "samplingVeryHigh": "⚠️ Très précis mais forte charge CPU/réseau — recommandé uniquement pour le debug",
+    "samplingHigh": "⚡ Haute précision — adapté aux réseaux de moins de 1 Gbps",
+    "samplingBalanced": "✓ Bon compromis précision/performance — recommandé pour la plupart des cas",
+    "samplingLight": "✓ Léger — adapté aux réseaux 10 Gbps+",
+    "samplingVeryLight": "📉 Très léger — peut manquer des flux de faible volume"
   },
   "vdc": {
     "title": "Datacenters Virtuels",
@@ -7098,5 +7111,12 @@
     "policyToggleLabel": "Exiger la 2FA pour les comptes super_admin",
     "policyToggleHelp": "Une fois activé, les comptes super_admin sans 2FA seront forcés de l'activer à leur prochaine connexion. Vous devez avoir la 2FA active sur votre propre compte pour activer cette policy.",
     "policyNeedOwn2fa": "Activez la 2FA sur votre propre compte avant d'imposer cette policy."
+  },
+  "taskTracker": {
+    "completed": "{description} - Terminé",
+    "failed": "{description} - Échec : {error}",
+    "timeout": "{description} - Timeout (tâche peut-être encore en cours)",
+    "error": "{description} - Erreur : {error}",
+    "unknownError": "Erreur inconnue"
   }
 }

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -93,7 +93,8 @@
     "node": "노드",
     "done": "완료",
     "tags": "태그",
-    "created": "생성됨"
+    "created": "생성됨",
+    "errorWithMessage": "오류: {error}"
   },
   "whatsNew": {
     "title": "새로운 기능"
@@ -4443,7 +4444,10 @@
     "resumeSuccess": "VM 재개 중",
     "rebootSuccess": "VM 재부팅 중",
     "migrateSuccess": "마이그레이션이 시작되었습니다",
-    "cloneSuccess": "복제가 시작되었습니다"
+    "cloneSuccess": "복제가 시작되었습니다",
+    "bulkSuccess": "{description} - VM {count}개",
+    "bulkPartial": "{description} - {success}개 성공, {errors}개 오류",
+    "bulkFailed": "{description} - {errors}개 오류"
   },
   "vmConfig": {
     "title": "VM 구성",
@@ -4510,7 +4514,9 @@
     "rawConfig": "원시 구성",
     "advancedArgs": "추가 QEMU 인수",
     "advancedArgsWarning": "고급 사용자 전용 수동 수정입니다.",
-    "qemuArgsHelper": "QEMU에 직접 전달되는 인수 (위험)"
+    "qemuArgsHelper": "QEMU에 직접 전달되는 인수 (위험)",
+    "totalVcpus": "총 {count} vCPU",
+    "coresSocketsSummary": "{cores} 코어 × {sockets} 소켓"
   },
   "hardware": {
     "detach": "분리",
@@ -4673,7 +4679,8 @@
       "useIso": "CD/DVD 디스크 이미지 파일(ISO) 사용",
       "usePhysical": "물리 CD/DVD 드라이브 사용",
       "noMedia": "미디어 사용 안 함"
-    }
+    },
+    "loadNodesError": "노드 목록을 불러올 수 없습니다"
   },
   "ldap": {
     "description": "사용자가 회사 자격 증명으로 로그인할 수 있도록 LDAP/Active Directory 인증을 구성합니다.",
@@ -6669,7 +6676,13 @@
     "portFilter": "포트",
     "noTimelineData": "이 통신 쌍에 대한 타임라인 데이터가 없습니다 (InfluxDB 필요)",
     "compare": "비교",
-    "yesterday": "어제"
+    "yesterday": "어제",
+    "samplingRateInfo": "<strong>{rate}</strong>개 패킷 중 1개가 샘플링됩니다",
+    "samplingVeryHigh": "⚠️ 매우 정밀하지만 CPU/네트워크 부하가 큼 — 디버깅 전용 권장",
+    "samplingHigh": "⚡ 높은 정밀도 — 1 Gbps 미만 네트워크에 적합",
+    "samplingBalanced": "✓ 정밀도와 성능의 균형 — 대부분의 경우 권장",
+    "samplingLight": "✓ 가벼움 — 10 Gbps 이상 네트워크에 적합",
+    "samplingVeryLight": "📉 매우 가벼움 — 소량 플로우를 놓칠 수 있음"
   },
   "vdc": {
     "title": "가상 데이터센터",
@@ -7097,5 +7110,12 @@
     "policyToggleLabel": "super_admin 계정에 2FA 필수 적용",
     "policyToggleHelp": "활성화하면 2FA가 없는 super_admin 사용자는 다음 로그인 시 강제로 등록해야 합니다. 이 옵션을 켜려면 먼저 본인 계정에 2FA가 활성화되어 있어야 합니다.",
     "policyNeedOwn2fa": "이 정책을 적용하기 전에 본인 계정에서 2FA를 활성화하세요."
+  },
+  "taskTracker": {
+    "completed": "{description} - 완료됨",
+    "failed": "{description} - 실패: {error}",
+    "timeout": "{description} - 시간 초과 (작업이 아직 실행 중일 수 있음)",
+    "error": "{description} - 오류: {error}",
+    "unknownError": "알 수 없는 오류"
   }
 }

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -93,7 +93,8 @@
     "node": "节点",
     "done": "完成",
     "tags": "标签",
-    "created": "已创建"
+    "created": "已创建",
+    "errorWithMessage": "错误：{error}"
   },
   "whatsNew": {
     "title": "最新动态"
@@ -4404,7 +4405,10 @@
     "resumeSuccess": "正在恢复 VM",
     "rebootSuccess": "正在重启 VM",
     "migrateSuccess": "迁移已开始",
-    "cloneSuccess": "克隆已开始"
+    "cloneSuccess": "克隆已开始",
+    "bulkSuccess": "{description} - {count} 个虚拟机",
+    "bulkPartial": "{description} - {success} 个成功，{errors} 个错误",
+    "bulkFailed": "{description} - {errors} 个错误"
   },
   "vmConfig": {
     "title": "VM 配置",
@@ -4471,7 +4475,9 @@
     "rawConfig": "原始配置",
     "advancedArgs": "附加 QEMU 参数",
     "advancedArgsWarning": "仅限高级用户手动修改。",
-    "qemuArgsHelper": "直接传递给 QEMU 的参数（危险）"
+    "qemuArgsHelper": "直接传递给 QEMU 的参数（危险）",
+    "totalVcpus": "共 {count} 个 vCPU",
+    "coresSocketsSummary": "{cores} 核心 × {sockets} 插槽"
   },
   "hardware": {
     "detach": "分离",
@@ -4631,7 +4637,8 @@
       "useIso": "使用 CD/DVD 光盘镜像文件（ISO）",
       "usePhysical": "使用物理 CD/DVD 驱动器",
       "noMedia": "不使用任何介质"
-    }
+    },
+    "loadNodesError": "无法加载节点列表"
   },
   "ldap": {
     "description": "配置 LDAP/Active Directory 身份验证，允许用户使用企业凭据登录。",
@@ -6597,7 +6604,13 @@
     "portFilter": "端口",
     "noTimelineData": "此对端没有可用的时间线数据（需要 InfluxDB）",
     "compare": "对比",
-    "yesterday": "昨天"
+    "yesterday": "昨天",
+    "samplingRateInfo": "每 <strong>{rate}</strong> 个数据包采样 1 个",
+    "samplingVeryHigh": "⚠️ 非常精确但 CPU/网络负载高 — 仅建议用于调试",
+    "samplingHigh": "⚡ 高精度 — 适用于低于 1 Gbps 的网络",
+    "samplingBalanced": "✓ 精度/性能兼顾 — 适用于大多数场景",
+    "samplingLight": "✓ 轻量 — 适用于 10 Gbps 及以上网络",
+    "samplingVeryLight": "📉 非常轻量 — 可能会遗漏低流量的流"
   },
   "myVdc": {
     "title": "我的数据中心",
@@ -6957,5 +6970,12 @@
     "policyToggleLabel": "强制 super_admin 账户启用 2FA",
     "policyToggleHelp": "启用后,未启用 2FA 的 super_admin 用户在下次登录时将被强制完成绑定。您必须先在自己的账户上启用 2FA,才能开启此策略。",
     "policyNeedOwn2fa": "在强制此策略之前,请先在您自己的账户上启用 2FA。"
+  },
+  "taskTracker": {
+    "completed": "{description} - 已完成",
+    "failed": "{description} - 失败：{error}",
+    "timeout": "{description} - 超时（任务可能仍在运行）",
+    "error": "{description} - 错误：{error}",
+    "unknownError": "未知错误"
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -155,6 +155,16 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 #   Select; its logic (splitCatalogImages grouping, hasMeaningfulCloudInit save-gate)
 #   lives in lib/templates/blueprintImages.ts and is unit-tested and measured. Same
 #   rationale as the sibling templates/DeployWizard.tsx exclusion above.
+# - operations/network-flows/FlowsTab.tsx, components/VmConfigEditor.tsx,
+#   components/hardware/MigrateVmDialog.tsx: three large pure-JSX UI containers
+#   (the sFlow network-flows tab, the VM hardware config editor and the migrate
+#   dialog). They are render + React-state/effect wiring with no extractable
+#   business logic; the i18n sweep only swapped inline French string literals for
+#   t()/t.rich() calls, adding no new branches. Rendering these multi-hundred-line
+#   containers purely to reach the string lines is the same low-value render-test
+#   cost the sibling exclusions above avoid. useTaskTracker.ts, the one file the
+#   sweep touched that carries real logic (poll/dedup/timeout), stays measured and
+#   is fully covered by useTaskTracker.test.tsx.
 sonar.coverage.exclusions=\
   frontend/src/configs/**,\
   frontend/src/types/**,\
@@ -220,7 +230,10 @@ sonar.coverage.exclusions=\
   frontend/src/components/templates/DeploymentDetailDialog.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsTasksTab.tsx,\
   frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsUpdatesTab.tsx,\
-  frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+  frontend/src/components/automation/site-recovery/ProtectionTab.tsx,\
+  frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx,\
+  frontend/src/components/VmConfigEditor.tsx,\
+  frontend/src/components/hardware/MigrateVmDialog.tsx
 
 # Copy-paste detection exclusions. Static data catalogs (cloud image entries,
 # vendor lists) repeat the same object shape by design — refactoring them


### PR DESCRIPTION
## Summary

The notifications bell rendered a hardcoded French severity badge (`CRITIQUE`) in an otherwise English UI, reported in discussion #549. It now routes through the existing `alerts.critical` / `alerts.warning` keys (uppercased), so it follows the active locale.

While investigating, a repo-wide sweep surfaced other client-visible French strings that bypassed next-intl. This PR fixes that whole class of client-side strings:

| Location | Was | Now |
| --- | --- | --- |
| Notifications bell badge | `CRITIQUE` | `alerts.critical` / `alerts.warning` |
| VM config CPU summary | `cœurs × socket(s)` | `vmConfig.totalVcpus`, `vmConfig.coresSocketsSummary` |
| Migrate VM dialog | node-load error | `hardware.loadNodesError` |
| Task tracker toasts | Terminé / Échec / Timeout / Erreur | `taskTracker.*` (new namespace) |
| Bulk VM action toasts | `erreurs` | `vmActions.bulkSuccess/bulkPartial/bulkFailed` |
| Network Flows sampling hints | 6 FR strings | `networkFlows.sampling*` |
| Inventory details error | `Erreur: {error}` | `common.errorWithMessage` |

18 new keys added across all six locales (en, fr, de, es, ko, zh-CN).

## Out of scope (tracked separately)

- French strings returned in API route JSON responses (~150, incl. auth/RBAC) — needs an architecture decision (error codes vs server-side translation).
- One locale-blind AI prompt (`resources/analyze`) that emits French for every user.

## Verification

- `tsc --noEmit`: no type errors
- ESLint: 0 errors
- Placeholder and rich-text tag consistency validated across all 6 locales

Ref: discussion #549
