### PR TITLE
fix(inventory): correct node Local Time double UTC offset (#567)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -63,6 +63,7 @@ import NodeFirewallTab from '@/components/NodeFirewallTab'
 import NodeUpdateDialog from '@/components/NodeUpdateDialog'
 import RollingUpdateWizard from '@/components/RollingUpdateWizard'
 import { loadNodeAptUpdates } from '@/lib/proxmox/loadNodeAptUpdates'
+import { formatNodeLocalTime } from '@/lib/inventory/nodeTime'
 import ComplianceTab from '@/components/ComplianceTab'
 import DatacenterSettingsTab from '@/components/datacenter-settings'
 import MetricServerTab from '@/components/MetricServerTab'
@@ -1972,7 +1973,7 @@ export default function NodeTabs(props: any) {
                                       <TableRow>
                                         <TableCell sx={{ fontWeight: 600 }}>Local Time</TableCell>
                                         <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
-                                          {nodeSystemData.time?.localtime ? new Date(nodeSystemData.time.localtime * 1000).toLocaleString() : '-'}
+                                          {formatNodeLocalTime(nodeSystemData.time?.time, nodeSystemData.time?.timezone)}
                                         </TableCell>
                                       </TableRow>
                                       <TableRow>

--- a/frontend/src/lib/inventory/nodeTime.test.ts
+++ b/frontend/src/lib/inventory/nodeTime.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+
+import { formatNodeLocalTime } from './nodeTime'
+
+// The Proxmox `/nodes/{node}/time` endpoint returns the real UTC epoch in
+// `time` alongside a pre-shifted `localtime` epoch and the node `timezone`.
+// The node's wall clock must be rendered from the UTC `time` in the node's OWN
+// timezone. Feeding the pre-shifted `localtime` through toLocaleString() made
+// the browser add its offset a second time (issue #567: a Europe/Berlin host
+// showed UTC+4 instead of UTC+2). `sv-SE` gives a stable `YYYY-MM-DD HH:mm:ss`
+// rendering that does not vary across ICU/locale versions.
+describe('formatNodeLocalTime', () => {
+  it('renders the node wall clock in its timezone during DST (Berlin = UTC+2)', () => {
+    const utc = Date.UTC(2024, 6, 1, 12, 0, 0) / 1000 // 2024-07-01T12:00:00Z
+    expect(formatNodeLocalTime(utc, 'Europe/Berlin', 'sv-SE')).toBe('2024-07-01 14:00:00')
+  })
+
+  it('renders the node wall clock outside DST (Berlin = UTC+1)', () => {
+    const utc = Date.UTC(2024, 0, 1, 12, 0, 0) / 1000 // 2024-01-01T12:00:00Z
+    expect(formatNodeLocalTime(utc, 'Europe/Berlin', 'sv-SE')).toBe('2024-01-01 13:00:00')
+  })
+
+  it('uses the node zone, never the viewer timezone', () => {
+    const utc = Date.UTC(2024, 6, 1, 0, 0, 0) / 1000 // 2024-07-01T00:00:00Z
+    // Tokyo is UTC+9 year-round -> 09:00 the same day.
+    expect(formatNodeLocalTime(utc, 'Asia/Tokyo', 'sv-SE')).toBe('2024-07-01 09:00:00')
+  })
+
+  it('falls back to the viewer local time when the zone is unknown (no throw)', () => {
+    const utc = Date.UTC(2024, 6, 1, 12, 0, 0) / 1000
+    const expected = new Date(utc * 1000).toLocaleString('sv-SE')
+    expect(formatNodeLocalTime(utc, 'Not/AZone', 'sv-SE')).toBe(expected)
+  })
+
+  it('falls back to the viewer local time when no zone is provided', () => {
+    const utc = Date.UTC(2024, 6, 1, 12, 0, 0) / 1000
+    const expected = new Date(utc * 1000).toLocaleString('sv-SE')
+    expect(formatNodeLocalTime(utc, undefined, 'sv-SE')).toBe(expected)
+  })
+
+  it('returns a dash when the timestamp is missing', () => {
+    expect(formatNodeLocalTime(undefined, 'Europe/Berlin')).toBe('-')
+    expect(formatNodeLocalTime(0, 'Europe/Berlin')).toBe('-')
+    expect(formatNodeLocalTime(null, 'Europe/Berlin')).toBe('-')
+  })
+})

--- a/frontend/src/lib/inventory/nodeTime.ts
+++ b/frontend/src/lib/inventory/nodeTime.ts
@@ -1,0 +1,44 @@
+/**
+ * Display helpers for a node's system time (Inventory > Host > Time).
+ *
+ * Proxmox `GET /nodes/{node}/time` returns three fields:
+ *   - `time`      the real UTC epoch (seconds)
+ *   - `localtime` the SAME instant already shifted by the node's UTC offset
+ *   - `timezone`  the node's IANA zone, e.g. "Europe/Berlin"
+ *
+ * `localtime` is a trap: it is a pre-shifted epoch. Rendering it with
+ * `new Date(localtime * 1000).toLocaleString()` makes the browser apply its own
+ * offset a SECOND time, double-counting it (issue #567: a Europe/Berlin host in
+ * summer showed UTC+4 instead of UTC+2). The correct wall clock is obtained by
+ * formatting the real UTC `time` in the node's own timezone, which is also
+ * independent of the viewer's browser timezone.
+ */
+
+/**
+ * Format a node's wall-clock local time from the UTC epoch and the node's zone.
+ *
+ * @param timeEpochSec UTC epoch in seconds (Proxmox `time` field).
+ * @param timezone     Node IANA timezone (Proxmox `timezone` field).
+ * @param locale       Optional locale override; defaults to the runtime locale.
+ * @returns The localized wall clock, or `-` when the timestamp is missing.
+ */
+export function formatNodeLocalTime(
+  timeEpochSec: number | null | undefined,
+  timezone: string | null | undefined,
+  locale?: string,
+): string {
+  if (!timeEpochSec) return '-'
+
+  const date = new Date(timeEpochSec * 1000)
+
+  if (timezone) {
+    try {
+      return date.toLocaleString(locale, { timeZone: timezone })
+    } catch {
+      // Unknown/invalid IANA zone: fall through to the viewer's local time
+      // rather than throwing inside a render.
+    }
+  }
+
+  return date.toLocaleString(locale)
+}


### PR DESCRIPTION
## Problem

On **Inventory > Host > System > Time**, the **Local Time** row showed the wrong time. For a host in `Europe/Berlin` (or `Europe/Paris`) in summer it displayed UTC+4 instead of UTC+2, while the **UTC Time** row was correct.

## Root cause

The Proxmox `GET /nodes/{node}/time` endpoint returns `localtime` as a **pre-shifted epoch** (`utc + offset`), not a plain UTC epoch. The cell rendered it with:

```
new Date(nodeSystemData.time.localtime * 1000).toLocaleString()
```

`toLocaleString()` with no timezone then applied the **browser's** offset a second time, double-counting it. For a UTC+2 zone that yields UTC+4, exactly the reported symptom. The UTC Time row was unaffected because it uses the raw `time` field with `toISOString()`.

## Fix

Render the node's wall clock from the real UTC `time`, formatted in the node's **own** IANA timezone, via a new pure helper `formatNodeLocalTime` (`src/lib/inventory/nodeTime.ts`):

- Uses the reliable UTC `time` value, so it is independent of the viewer's browser timezone.
- Falls back to the viewer's local time (no throw) when the zone is unknown/invalid, and returns `-` when the timestamp is missing.

The `NodeTabs.tsx` Local Time cell now calls this helper.

This was the only occurrence of the bug class: the PBS panel already formats a true UTC epoch (`backupTime`), so it stays correct.

## Tests

New `nodeTime.test.ts` (6 cases): DST and non-DST Berlin, a fixed-offset zone (Tokyo), unknown-zone and no-zone fallbacks, and the missing-timestamp case. Assertions use the `sv-SE` locale for a stable `YYYY-MM-DD HH:mm:ss` rendering across ICU versions.

Verified manually in the running app: `Europe/Paris` host, UTC `09:42:49Z` now renders Local Time `11:42:49` (UTC+2).

Closes #567
