### PR TITLE
fix(ui): resilient clipboard fallback for SSH-command and task-log copy buttons (#573)

### DIFF
--- a/frontend/src/components/TaskDetailDialog.jsx
+++ b/frontend/src/components/TaskDetailDialog.jsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material'
 
 import { useTaskDetail } from '@/hooks/useTaskDetail'
+import { copyToClipboard } from '@/lib/clipboard'
 
 /* --------------------------------
    Helpers
@@ -149,12 +150,8 @@ export default function TaskDetailDialog({ open, task, onClose }) {
       .map(l => `${l.n.toString().padStart(4, ' ')} ${l.t}`)
       .join('\n')
 
-    try {
-      await navigator.clipboard.writeText(logsText)
-      setSnackbar({ open: true, message: t('common.copied') })
-    } catch (e) {
-      setSnackbar({ open: true, message: t('common.error') })
-    }
+    const ok = await copyToClipboard(logsText)
+    setSnackbar({ open: true, message: ok ? t('common.copied') : t('common.error') })
   }
 
   // Stop task

--- a/frontend/src/components/settings/ssh-commands/SecurityRecommendationsCard.jsx
+++ b/frontend/src/components/settings/ssh-commands/SecurityRecommendationsCard.jsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material'
 
 import { buildSudoersTemplate, buildInstallCommand } from './sudoersTemplate'
+import { copyToClipboard } from '@/lib/clipboard'
 
 const fetcher = url => fetch(url).then(r => {
   if (!r.ok) throw new Error(`HTTP ${r.status}`)
@@ -81,14 +82,9 @@ export default function SecurityRecommendationsCard() {
   )
 
   const copy = async (label, text) => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(label)
-      setTimeout(() => setCopied(''), 2000)
-    } catch {
-      setCopied('error')
-      setTimeout(() => setCopied(''), 2000)
-    }
+    const ok = await copyToClipboard(text)
+    setCopied(ok ? label : 'error')
+    setTimeout(() => setCopied(''), 2000)
   }
 
   return (


### PR DESCRIPTION
## Summary

Two copy buttons called `navigator.clipboard.writeText` directly:

- `SecurityRecommendationsCard` — the "copy SSH command" buttons under **Settings > SSH Commands**
- `TaskDetailDialog` — the "copy logs" button in the task detail dialog

The async Clipboard API is unavailable over plain HTTP or a bare LAN IP (a non-secure browser context, which is how self-hosted ProxCenter is commonly accessed), so both copies failed silently there. This is the same bug class as the connection API-token copy button, which was already fixed for PVE/PBS in #563.

## Fix

Route both handlers through the existing `copyToClipboard` util (`@/lib/clipboard`), which falls back to a hidden-textarea `execCommand('copy')` when the async Clipboard API is unavailable, and never throws. Behavior is unchanged in secure contexts (localhost/HTTPS).

## Notes

- Behavior-preserving: success still shows the "copied" feedback, failure still shows the error state.
- No new i18n keys.
- Both files are `.jsx`, excluded from Sonar analysis, so no coverage impact. The `copyToClipboard` util is already unit-tested (`clipboard.test.ts`).
- The PVE/PBS token-setup copy button reported in the issue is already fixed on `main` via #563; this PR closes the remaining buttons of the same class.

Refs #573
