### PR TITLE
fix(migration): migration log console hides last line under tasks footer (#582)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -4145,8 +4145,8 @@ return vm?.isCluster ?? false
                 </Card>
 
                 {/* Migration Logs — real data from migration job */}
-                <Card variant="outlined" sx={{ borderRadius: 2 }}>
-                  <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+                <Card variant="outlined" sx={{ borderRadius: 2, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+                  <CardContent sx={{ p: 0, '&:last-child': { pb: 0 }, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
                     <Box sx={{ px: 2, py: 1.5, borderBottom: '1px solid', borderColor: 'divider', flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                       <Typography fontWeight={900} sx={{ display: 'flex', alignItems: 'center', gap: 1, fontSize: 13 }}>
                         <i className="ri-terminal-box-line" style={{ fontSize: 16, opacity: 0.7 }} />
@@ -4166,7 +4166,7 @@ return vm?.isCluster ?? false
                         </MuiTooltip>
                       )}
                     </Box>
-                    <Box ref={migLogsRef} sx={{ p: 1.5, bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.03)', fontFamily: '"JetBrains Mono", monospace', fontSize: 11, overflow: 'auto', borderRadius: '0 0 8px 8px', lineHeight: 1.8, maxHeight: 'calc(100vh - 650px)', minHeight: 80 }}>
+                    <Box ref={migLogsRef} sx={{ p: 1.5, bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.03)', fontFamily: '"JetBrains Mono", monospace', fontSize: 11, overflow: 'auto', borderRadius: '0 0 8px 8px', lineHeight: 1.8, flex: 1, minHeight: 80 }}>
                       {vmMigJob?.logs?.length > 0 ? (
                         vmMigJob.logs.map((log: any, i: number) => (
                           <Box key={i}>


### PR DESCRIPTION
## Problem

Reported in #582: on the ESXi / warm-migration view, the **Migration Logs** console hides its last log line, and the vertical scrollbar ends up underneath the fixed bottom tasks footer, so the log cannot be scrolled to the end.

## Root cause

The log box used a hard-coded `maxHeight: calc(100vh - 650px)`. That value:

1. is decoupled from the space actually available inside its flex column, and
2. does not subtract the fixed bottom tasks footer height (`--taskbar-height`), which the panel's grandparent container *does* subtract from its own height.

So when the footer is visible the log box is taller than the space left inside its `overflow: hidden` flex parent. The box overflows past the clip boundary and its bottom (last line + scrollbar) is hidden underneath the footer. The box itself was already `overflow: auto`, so the real defect was the height math, not the overflow value.

## Fix

Let the logs card fill the remaining space in its already-bounded flex column instead of using the magic viewport maxHeight:

- the logs `Card` and its `CardContent` become `flex: 1; minHeight: 0; display: flex; flexDirection: column`
- the log box switches from `maxHeight: calc(100vh - 650px)` to `flex: 1` (keeping `minHeight: 80` and `overflow: auto`)

This mirrors the full-height scrollable-card pattern already used elsewhere in the same view. The box now sizes to exactly the available space (footer-aware, since the parent already accounts for `--taskbar-height`) and scrolls internally, with the scrollbar always visible and the last line reachable — footer open or closed.

## Scope / risk

- 3-line CSS-only change, no logic touched.
- Impact analysis: low, no upstream dependents.
- `next build` compiles successfully; lint clean on the file.

Refs #582
