### PR TITLE
fix(migration): allocate block volumes as raw and stop failed allocs from poisoning retries (#587)

### DIFF
--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -24,7 +24,10 @@ import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, buildVmdkDownloadUrl, buildVmdkDescriptorUrl, extractProp, soapCreateSnapshot, soapRemoveAllSnapshots, soapPowerOffVm, soapExportVm, soapWaitForNfcLease, soapNfcLeaseProgress, soapNfcLeaseComplete, soapNfcLeaseAbort } from "@/lib/vmware/soap"
 import { mapEsxiToPveConfig, isWindowsVm } from "./configMapper"
 import type { SoapSession, EsxiVmConfig, EsxiDiskInfo, NfcLeaseDeviceUrl } from "@/lib/vmware/soap"
-import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
+import {
+  allocateBlockVolumeAndResolvePath, reserveVolumeSlot, volumesToFree,
+  PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
+} from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
 import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
@@ -147,7 +150,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
   // `attached` is set by attachBlockDisk() after a successful PVE config
   // update so the cleanup only frees true orphans, never volumes the VM
   // already references (the VM-level DELETE handles those).
-  const allocatedVolumes: { volumeId: string, devicePath: string, rbdMapped?: boolean, attached?: boolean }[] = []
+  const allocatedVolumes: AllocatedVolume[] = []
   // Base directory for large intermediate files on the PVE node (SSHFS mount, VMDK dumps,
   // vmkfstools clone targets). User-selectable; falls back to /tmp for backwards compat.
   // /tmp is often a tiny tmpfs on Proxmox — a multi-GB disk transfer will saturate it.
@@ -426,11 +429,17 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       const sizeKB = Math.ceil(sizeBytes / 1024)
       const volName = `vm-${targetVmid}-disk-${diskNum}`
 
+      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
+      // the volume and still report a failure, and a volume nobody registered is
+      // never freed — it then collides with every retry on the same VMID (#587).
+      const volSlot = reserveVolumeSlot(allocatedVolumes)
+
       // Allocate the block volume and resolve its device path. Handles every
       // pvesm output format including LVM on iSCSI multipath.
       const alloc = await allocateBlockVolumeAndResolvePath(
         config.targetConnectionId, nodeIp,
         config.targetStorage, targetVmid, volName, sizeKB,
+        { slot: volSlot },
       )
       const volumeId = alloc.volumeId
       let devicePath = alloc.devicePath
@@ -464,10 +473,13 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         await appendLog(jobId, `RBD (KRBD) mapped ${rbdSpec} → ${devicePath}`)
       }
 
-      const result = { volumeId, devicePath, rbdMapped }
-      allocatedVolumes.push(result)
+      // Fill the slot reserved before the allocation — the volume ID from pvesm's own
+      // output is authoritative (a name collision may have bumped the disk number).
+      volSlot.volumeId = volumeId
+      volSlot.devicePath = devicePath
+      volSlot.rbdMapped = rbdMapped
       await appendLog(jobId, `Allocated volume ${volumeId} → ${devicePath}`)
-      return result
+      return volSlot
     }
 
     // Attach a pre-allocated block volume to a SCSI slot
@@ -2883,17 +2895,21 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
     // already in qm config, so freeing them out from under PVE would
     // either fail (volume in use) or, worse, leave the VM pointing at a
     // missing disk. They get cleaned up by the VM DELETE just below.
-    const orphans = allocatedVolumes.filter(v => !v.attached)
+    // volumesToFree also covers a volume created by an allocation that reported a
+    // failure, and skips the slots whose allocation never started (#587).
+    const orphans = volumesToFree(allocatedVolumes)
     if (orphans.length > 0 && config.targetConnectionId) {
       try {
         const nodeIp = await getNodeIpForMigration(prisma, config.targetConnectionId, config.targetNode,
           (await getConnectionById(config.targetConnectionId)).baseUrl)
         for (const vol of orphans) {
-          if (vol.rbdMapped) {
+          if (vol.rbdMapped && vol.devicePath) {
             await executeSSH(config.targetConnectionId, nodeIp, `rbd unmap "${vol.devicePath}" 2>/dev/null`).catch(() => {})
           }
+          // A `saferemove` LVM storage zeroes the volume before removing it, which
+          // takes far longer than the 30 s executeSSH default.
           const freed = await executeSSH(config.targetConnectionId, nodeIp,
-            `pvesm free ${shellEscape(vol.volumeId)} 2>&1`).catch((e: any) => ({ success: false, output: "", error: e?.message }))
+            `pvesm free ${shellEscape(vol.volumeId)} 2>&1`, PVESM_FREE_TIMEOUT_MS).catch((e: any) => ({ success: false, output: "", error: e?.message }))
           if (freed.success) {
             await appendLog(jobId, `Freed orphan volume ${vol.volumeId}`, "warn")
           } else {

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -25,7 +25,7 @@ import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, buildVmdkDownloa
 import { mapEsxiToPveConfig, isWindowsVm } from "./configMapper"
 import type { SoapSession, EsxiVmConfig, EsxiDiskInfo, NfcLeaseDeviceUrl } from "@/lib/vmware/soap"
 import {
-  allocateBlockVolumeAndResolvePath, reserveVolumeSlot, volumesToFree,
+  allocateAndMapBlockVolume, nextFreeDiskName, volumesToFree,
   PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
 } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
@@ -412,74 +412,16 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
 
     // Allocate a raw volume on block storage and return the device path
     async function allocateBlockVolume(sizeBytes: number): Promise<{ volumeId: string, devicePath: string }> {
-      // Find next available disk number by checking VM config + already allocated volumes
       const vmConf = await pveFetch<Record<string, any>>(pveConn, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`)
-      let maxDiskNum = -1
-      for (const val of Object.values(vmConf || {})) {
-        if (typeof val === 'string') {
-          const m = (val as string).match(/vm-\d+-disk-(\d+)/)
-          if (m) maxDiskNum = Math.max(maxDiskNum, Number.parseInt(m[1]))
-        }
-      }
-      for (const av of allocatedVolumes) {
-        const m = av.volumeId.match(/disk-(\d+)/)
-        if (m) maxDiskNum = Math.max(maxDiskNum, Number.parseInt(m[1]))
-      }
-      const diskNum = maxDiskNum + 1
-      const sizeKB = Math.ceil(sizeBytes / 1024)
-      const volName = `vm-${targetVmid}-disk-${diskNum}`
-
-      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
-      // the volume and still report a failure, and a volume nobody registered is
-      // never freed — it then collides with every retry on the same VMID (#587).
-      const volSlot = reserveVolumeSlot(allocatedVolumes)
-
-      // Allocate the block volume and resolve its device path. Handles every
-      // pvesm output format including LVM on iSCSI multipath.
-      const alloc = await allocateBlockVolumeAndResolvePath(
-        config.targetConnectionId, nodeIp,
-        config.targetStorage, targetVmid, volName, sizeKB,
-        { slot: volSlot },
-      )
-      const volumeId = alloc.volumeId
-      let devicePath = alloc.devicePath
-
-      // RBD/Ceph — two path formats depending on the storage's `krbd` option:
-      //  - krbd 0 (librbd): pvesm path returns "rbd:pool/image:conf=..." — not a block device; map via `rbd map <pool>/<image>` → /dev/rbdN.
-      //  - krbd 1 (KRBD):   pvesm path returns "/dev/rbd-pve/<fsid>/<pool>/<image>" — the symlink only exists after `rbd device map <pool>/<image>`; devicePath stays put.
-      let rbdMapped = false
-      const krbdMatch = devicePath.match(/^\/dev\/rbd-pve\/[^/]+\/([^/]+)\/([^/]+)$/)
-      if (devicePath.startsWith('rbd:')) {
-        const rbdSpec = devicePath.split(':')[1] // "CephStoragePool/vm-201-disk-0"
-        if (!rbdSpec) throw new Error(`Cannot parse RBD path: ${devicePath}`)
-        const mapResult = await executeSSH(config.targetConnectionId, nodeIp,
-          `rbd map "${rbdSpec}" 2>&1`)
-        if (!mapResult.success || !mapResult.output?.trim()) {
-          throw new Error(`Failed to rbd map ${rbdSpec}: ${mapResult.error || mapResult.output}`)
-        }
-        devicePath = mapResult.output.trim() // e.g. /dev/rbd0
-        rbdMapped = true
-        await appendLog(jobId, `RBD mapped ${rbdSpec} → ${devicePath}`)
-      } else if (krbdMatch) {
-        const [, pool, image] = krbdMatch
-        const rbdSpec = `${pool}/${image}`
-        const mapResult = await executeSSH(config.targetConnectionId, nodeIp,
-          `rbd device map "${rbdSpec}" 2>&1`)
-        if (!mapResult.success) {
-          throw new Error(`Failed to rbd device map ${rbdSpec}: ${mapResult.error || mapResult.output}`)
-        }
-        // devicePath stays as /dev/rbd-pve/<fsid>/<pool>/<image> — the symlink now resolves.
-        rbdMapped = true
-        await appendLog(jobId, `RBD (KRBD) mapped ${rbdSpec} → ${devicePath}`)
-      }
-
-      // Fill the slot reserved before the allocation — the volume ID from pvesm's own
-      // output is authoritative (a name collision may have bumped the disk number).
-      volSlot.volumeId = volumeId
-      volSlot.devicePath = devicePath
-      volSlot.rbdMapped = rbdMapped
-      await appendLog(jobId, `Allocated volume ${volumeId} → ${devicePath}`)
-      return volSlot
+      const volName = nextFreeDiskName(vmConf, allocatedVolumes, targetVmid)
+      // Raw allocation, Ceph mapping and cleanup registration all live in
+      // allocateAndMapBlockVolume — see it for why the format and the registration
+      // order matter (#587).
+      return allocateAndMapBlockVolume({
+        connectionId: config.targetConnectionId, nodeIp, targetStorage: config.targetStorage,
+        targetVmid, volName, sizeKB: Math.ceil(sizeBytes / 1024), allocatedVolumes,
+        onLog: (message) => appendLog(jobId, message),
+      })
     }
 
     // Attach a pre-allocated block volume to a SCSI slot

--- a/frontend/src/lib/migration/pvesm-alloc.test.ts
+++ b/frontend/src/lib/migration/pvesm-alloc.test.ts
@@ -7,6 +7,8 @@ vi.mock("@/lib/ssh/exec", async (importActual) => {
 import { executeSSH } from "@/lib/ssh/exec"
 import {
   allocateBlockVolumeAndResolvePath,
+  allocateAndMapBlockVolume,
+  nextFreeDiskName,
   reserveVolumeSlot,
   volumesToFree,
   type AllocatedVolume,
@@ -204,6 +206,138 @@ describe("allocateBlockVolumeAndResolvePath", () => {
 
     expect(message).toContain("no such volume")
     expect(message).not.toContain("Exit code 17")
+  })
+})
+
+describe("nextFreeDiskName", () => {
+  it("starts at disk 0 when the VM shell owns no disk yet", () => {
+    expect(nextFreeDiskName({ name: "hdc-rsyslog02", cores: 2 }, [], 250)).toBe("vm-250-disk-0")
+  })
+
+  it("starts after the efidisk an OVMF shell already owns", () => {
+    // `qm create` with bios=ovmf allocates vm-<vmid>-disk-0 for the EFI vars, and on
+    // PVE 9 LVM with snapshot-as-volume-chain it carries a .qcow2 suffix.
+    const conf = { efidisk0: "FC-HDC-01:vm-250-disk-0.qcow2,efitype=4m,size=528K" }
+
+    expect(nextFreeDiskName(conf, [], 250)).toBe("vm-250-disk-1")
+  })
+
+  it("accounts for the volumes already allocated in this run", () => {
+    const conf = { efidisk0: "FC-HDC-01:vm-250-disk-0.qcow2" }
+    const allocated: AllocatedVolume[] = [{ volumeId: "FC-HDC-01:vm-250-disk-1", devicePath: "/dev/x" }]
+
+    expect(nextFreeDiskName(conf, allocated, 250)).toBe("vm-250-disk-2")
+  })
+
+  it("takes the highest number, not the disk count, so a gap never causes a collision", () => {
+    const conf = { scsi0: "FC-HDC-01:vm-250-disk-4", scsi1: "FC-HDC-01:vm-250-disk-2" }
+
+    expect(nextFreeDiskName(conf, [], 250)).toBe("vm-250-disk-5")
+  })
+
+  it("ignores a reserved slot whose allocation has not started", () => {
+    expect(nextFreeDiskName({}, [{ volumeId: "", devicePath: "" }], 250)).toBe("vm-250-disk-0")
+  })
+})
+
+describe("allocateAndMapBlockVolume", () => {
+  const args = {
+    connectionId: "conn-1",
+    nodeIp: "10.0.0.1",
+    targetStorage: "FC-HDC-01",
+    targetVmid: 250,
+    volName: "vm-250-disk-1",
+    sizeKB: 20971520,
+  }
+
+  it("returns the device path as-is for a plain block volume, with nothing to map", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+
+    const vol = await allocateAndMapBlockVolume(args)
+
+    expect(vol).toMatchObject({
+      volumeId: "FC-HDC-01:vm-250-disk-1",
+      devicePath: "/dev/FC-HDC-01/vm-250-disk-1",
+      rbdMapped: false,
+    })
+    expect(mockSSH).toHaveBeenCalledTimes(2)
+  })
+
+  it("maps a librbd volume to a kernel device (krbd 0)", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("rbd-pool:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("rbd:CephPool/vm-250-disk-1:conf=/etc/pve/ceph.conf"))
+      .mockResolvedValueOnce(path("/dev/rbd0"))
+
+    const vol = await allocateAndMapBlockVolume({ ...args, targetStorage: "rbd-pool" })
+
+    expect(mockSSH.mock.calls[2][2]).toContain("rbd map 'CephPool/vm-250-disk-1'")
+    expect(vol.devicePath).toBe("/dev/rbd0")
+    expect(vol.rbdMapped).toBe(true)
+  })
+
+  it("maps a KRBD symlink and keeps the device path Proxmox reported (krbd 1)", async () => {
+    const krbd = "/dev/rbd-pve/2a4f/CephPool/vm-250-disk-1"
+    mockSSH
+      .mockResolvedValueOnce(created("rbd-pool:vm-250-disk-1"))
+      .mockResolvedValueOnce(path(krbd))
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const vol = await allocateAndMapBlockVolume({ ...args, targetStorage: "rbd-pool" })
+
+    expect(mockSSH.mock.calls[2][2]).toContain("rbd device map 'CephPool/vm-250-disk-1'")
+    // The symlink only resolves after the map; the path itself does not change.
+    expect(vol.devicePath).toBe(krbd)
+    expect(vol.rbdMapped).toBe(true)
+  })
+
+  it("registers the volume in the caller's cleanup registry before allocating (#587)", async () => {
+    const allocatedVolumes: AllocatedVolume[] = []
+    mockSSH.mockResolvedValueOnce(failed("unable to create image"))
+
+    await expect(allocateAndMapBlockVolume({ ...args, allocatedVolumes })).rejects.toThrow(/unable to create image/)
+
+    expect(volumesToFree(allocatedVolumes)).toEqual([
+      { volumeId: "FC-HDC-01:vm-250-disk-1", devicePath: "" },
+    ])
+  })
+
+  it("keeps one registry slot per disk so the attach step stays aligned", async () => {
+    const allocatedVolumes: AllocatedVolume[] = []
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-2"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-2"))
+
+    await allocateAndMapBlockVolume({ ...args, allocatedVolumes })
+    await allocateAndMapBlockVolume({ ...args, volName: "vm-250-disk-2", allocatedVolumes })
+
+    expect(allocatedVolumes.map(v => v.volumeId)).toEqual([
+      "FC-HDC-01:vm-250-disk-1",
+      "FC-HDC-01:vm-250-disk-2",
+    ])
+  })
+
+  it("refuses a device path that is not absolute rather than writing to a bogus target", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("FC-HDC-01:vm-250-disk-1"))
+
+    await expect(allocateAndMapBlockVolume(args)).rejects.toThrow(/absolute path/)
+  })
+
+  it("reports the mapping and the allocation through the caller's logger", async () => {
+    const logs: string[] = []
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+
+    await allocateAndMapBlockVolume({ ...args, onLog: async (m) => { logs.push(m) } })
+
+    expect(logs).toEqual(["Allocated volume FC-HDC-01:vm-250-disk-1 → /dev/FC-HDC-01/vm-250-disk-1"])
   })
 })
 

--- a/frontend/src/lib/migration/pvesm-alloc.test.ts
+++ b/frontend/src/lib/migration/pvesm-alloc.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/ssh/exec", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/ssh/exec")>()
+  return { ...actual, executeSSH: vi.fn() }
+})
+import { executeSSH } from "@/lib/ssh/exec"
+import {
+  allocateBlockVolumeAndResolvePath,
+  reserveVolumeSlot,
+  volumesToFree,
+  type AllocatedVolume,
+} from "./pvesm-alloc"
+
+const mockSSH = executeSSH as unknown as ReturnType<typeof vi.fn>
+
+const created = (volumeId: string) => ({ success: true, output: `successfully created '${volumeId}'` })
+const path = (dev: string) => ({ success: true, output: dev })
+/** What pvesm really returns on failure: the message on stdout (the command runs
+ *  with 2>&1) and a meaningless exit code as the error. */
+const failed = (message: string) => ({ success: false, output: message, error: "Exit code 17" })
+
+const LVM_COLLISION =
+  `lvcreate 'FC-HDC-01/vm-250-disk-2' error:   Logical Volume "vm-250-disk-2" already exists in volume group "FC-HDC-01"`
+
+beforeEach(() => {
+  mockSSH.mockReset()
+})
+
+describe("allocateBlockVolumeAndResolvePath", () => {
+  it("asks pvesm for a raw volume so PVE 9 does not format the LV as qcow2 (#587)", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+
+    await allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 20971520)
+
+    expect(mockSSH.mock.calls[0][2]).toContain("--format raw")
+  })
+
+  it("lets a multi-TB allocation run past the 30 s executeSSH default", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+
+    await allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 3251404800)
+
+    // 3.1 TB took 47 s on the reporter's FC array, and thick plugins take minutes.
+    expect(mockSSH.mock.calls[0][3]).toBeGreaterThanOrEqual(5 * 60_000)
+  })
+
+  it("registers the volume BEFORE allocating so an alloc that creates it then fails is still freed (#587)", async () => {
+    const slot: AllocatedVolume = { volumeId: "", devicePath: "" }
+    mockSSH.mockImplementationOnce(async () => {
+      // The volume must already be registered for cleanup while pvesm is still
+      // running: it can create the volume and report a failure afterwards.
+      expect(slot.volumeId).toBe("FC-HDC-01:vm-250-disk-2")
+      return failed('  Logical volume "vm-250-disk-2" created.\nunable to create image')
+    })
+
+    await expect(
+      allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-2", 3251404800, { slot }),
+    ).rejects.toThrow(/unable to create image/)
+
+    // Still registered after the failure: the volume may well exist on the storage.
+    expect(volumesToFree([slot])).toEqual([slot])
+  })
+
+  it("un-registers a name that turned out to be taken — a pre-existing volume is not ours to free", async () => {
+    // Every attempt collides, so nothing was created by us. Freeing the last name
+    // tried would delete a volume that belongs to whoever left it there.
+    mockSSH.mockResolvedValue(failed(LVM_COLLISION))
+    const slot: AllocatedVolume = { volumeId: "", devicePath: "" }
+
+    await expect(
+      allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-2", 20971520, { slot }),
+    ).rejects.toThrow(/already exists/)
+
+    expect(slot.volumeId).toBe("")
+    expect(volumesToFree([slot])).toEqual([])
+  })
+
+  it("surfaces the pvesm message and not the meaningless exit code", async () => {
+    mockSSH.mockResolvedValueOnce(
+      failed(`lvcreate 'FC-HDC-01/vm-250-disk-1' error:   Volume group "FC-HDC-01" has insufficient free space`),
+    )
+
+    // pvesm is Perl: `die` exits with the current errno, and the cluster lock
+    // helper leaves EEXIST (17) behind, so "Exit code 17" says nothing at all.
+    let message = ""
+    try {
+      await allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 20971520)
+    } catch (e) {
+      message = (e as Error).message
+    }
+
+    expect(message).toContain("insufficient free space")
+    expect(message).not.toContain("Exit code 17")
+  })
+
+  it("bumps the disk number when a leftover volume already owns the name", async () => {
+    const slot: AllocatedVolume = { volumeId: "", devicePath: "" }
+    mockSSH
+      .mockResolvedValueOnce(failed(LVM_COLLISION))
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-3"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-3"))
+
+    const res = await allocateBlockVolumeAndResolvePath(
+      "conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-2", 3251404800, { slot },
+    )
+
+    expect(res.volumeId).toBe("FC-HDC-01:vm-250-disk-3")
+    expect(mockSSH.mock.calls[1][2]).toContain("vm-250-disk-3")
+    // The bumped name is what cleanup must cover, never the one that was taken.
+    expect(slot.volumeId).toBe("FC-HDC-01:vm-250-disk-3")
+  })
+
+  it("bumps on the RBD wording for a taken name as well", async () => {
+    mockSSH
+      .mockResolvedValueOnce(failed("rbd: create error: (17) File exists"))
+      .mockResolvedValueOnce(created("rbd-pool:vm-250-disk-2"))
+      .mockResolvedValueOnce(path("/dev/rbd0"))
+
+    const res = await allocateBlockVolumeAndResolvePath(
+      "conn-1", "10.0.0.1", "rbd-pool", 250, "vm-250-disk-1", 20971520,
+    )
+
+    expect(res.volumeId).toBe("rbd-pool:vm-250-disk-2")
+  })
+
+  it("bumps on the ZFS wording for a taken name as well", async () => {
+    mockSSH
+      .mockResolvedValueOnce(failed("cannot create 'tank/vm-250-disk-1': dataset already exists"))
+      .mockResolvedValueOnce(created("zfs-pool:vm-250-disk-2"))
+      .mockResolvedValueOnce(path("/dev/zvol/tank/vm-250-disk-2"))
+
+    const res = await allocateBlockVolumeAndResolvePath(
+      "conn-1", "10.0.0.1", "zfs-pool", 250, "vm-250-disk-1", 20971520,
+    )
+
+    expect(res.volumeId).toBe("zfs-pool:vm-250-disk-2")
+  })
+
+  it("stops bumping after a bounded number of attempts and reports the last message", async () => {
+    mockSSH.mockResolvedValue(failed(LVM_COLLISION))
+
+    await expect(
+      allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-2", 20971520),
+    ).rejects.toThrow(/already exists/)
+
+    // One initial attempt plus a bounded number of bumps, never an endless loop.
+    expect(mockSSH.mock.calls.length).toBeLessThanOrEqual(4)
+    expect(mockSSH.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it("does not bump on a failure that is not a name collision", async () => {
+    mockSSH.mockResolvedValueOnce(failed("storage 'FC-HDC-01' does not exist"))
+
+    await expect(
+      allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 20971520),
+    ).rejects.toThrow(/does not exist/)
+
+    expect(mockSSH).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips the pvesm path call when alloc already printed a device path (LVM on iSCSI multipath)", async () => {
+    mockSSH.mockResolvedValueOnce({
+      success: true,
+      output: "successfully created '/dev/mpath-vg/vm-250-disk-1'",
+    })
+
+    const res = await allocateBlockVolumeAndResolvePath(
+      "conn-1", "10.0.0.1", "mpath-storage", 250, "vm-250-disk-1", 20971520,
+    )
+
+    expect(res).toEqual({ volumeId: "mpath-storage:vm-250-disk-1", devicePath: "/dev/mpath-vg/vm-250-disk-1" })
+    expect(mockSSH).toHaveBeenCalledTimes(1)
+  })
+
+  it("resolves the device path through pvesm path for plugins that print the volume ID", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(path("/dev/FC-HDC-01/vm-250-disk-1"))
+
+    const res = await allocateBlockVolumeAndResolvePath(
+      "conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 20971520,
+    )
+
+    expect(mockSSH.mock.calls[1][2]).toContain("pvesm path 'FC-HDC-01:vm-250-disk-1'")
+    expect(res.devicePath).toBe("/dev/FC-HDC-01/vm-250-disk-1")
+  })
+
+  it("surfaces the command output when the path resolution fails", async () => {
+    mockSSH
+      .mockResolvedValueOnce(created("FC-HDC-01:vm-250-disk-1"))
+      .mockResolvedValueOnce(failed("no such volume 'FC-HDC-01:vm-250-disk-1'"))
+
+    let message = ""
+    try {
+      await allocateBlockVolumeAndResolvePath("conn-1", "10.0.0.1", "FC-HDC-01", 250, "vm-250-disk-1", 20971520)
+    } catch (e) {
+      message = (e as Error).message
+    }
+
+    expect(message).toContain("no such volume")
+    expect(message).not.toContain("Exit code 17")
+  })
+})
+
+describe("reserveVolumeSlot", () => {
+  it("keeps allocatedVolumes[i] aligned with disk i so the attach step targets the right volume", () => {
+    const allocatedVolumes: { volumeId: string; devicePath: string }[] = []
+
+    const disk0 = reserveVolumeSlot(allocatedVolumes)
+    disk0.volumeId = "FC-HDC-01:vm-250-disk-1"
+    const disk1 = reserveVolumeSlot(allocatedVolumes)
+    disk1.volumeId = "FC-HDC-01:vm-250-disk-2"
+
+    expect(allocatedVolumes.map(v => v.volumeId)).toEqual([
+      "FC-HDC-01:vm-250-disk-1",
+      "FC-HDC-01:vm-250-disk-2",
+    ])
+  })
+})
+
+describe("volumesToFree", () => {
+  it("frees a volume whose allocation reported a failure", () => {
+    // The #587 case: pvesm created the volume, then returned an error, so the
+    // slot carries a volume ID but never got a device path.
+    const volumes = [{ volumeId: "FC-HDC-01:vm-250-disk-2", devicePath: "" }]
+
+    expect(volumesToFree(volumes)).toEqual(volumes)
+  })
+
+  it("never frees a volume already attached to the VM", () => {
+    const volumes = [{ volumeId: "FC-HDC-01:vm-250-disk-1", devicePath: "/dev/x", attached: true }]
+
+    expect(volumesToFree(volumes)).toEqual([])
+  })
+
+  it("skips a reserved slot whose allocation never started", () => {
+    const volumes = [{ volumeId: "", devicePath: "" }]
+
+    expect(volumesToFree(volumes)).toEqual([])
+  })
+})

--- a/frontend/src/lib/migration/pvesm-alloc.ts
+++ b/frontend/src/lib/migration/pvesm-alloc.ts
@@ -6,7 +6,98 @@ export interface AllocateAndResolveResult {
 }
 
 /**
- * Allocate a block volume on PVE and return its device path.
+ * A target volume tracked by a migration pipeline so failure cleanup can free it.
+ *
+ * The slot is reserved (see `reserveVolumeSlot`) BEFORE the allocation runs and
+ * filled in as the allocation progresses, so an allocation that creates the volume
+ * and then reports a failure still leaves something for cleanup to free.
+ */
+export interface AllocatedVolume {
+  volumeId: string
+  devicePath: string
+  rbdMapped?: boolean
+  attached?: boolean
+}
+
+export interface AllocateBlockVolumeOpts {
+  /**
+   * The caller's cleanup slot (see `reserveVolumeSlot`), kept in sync by this
+   * function so failure cleanup frees exactly what it should:
+   *
+   *  - set to the volume ID immediately BEFORE each `pvesm alloc` attempt, because
+   *    the command can create the volume and STILL report a failure. A volume that
+   *    was never registered is never freed, and it then collides with every later
+   *    attempt on the same VMID (#587).
+   *  - cleared again when an attempt fails on a name collision: that proves the
+   *    volume already existed, so it is NOT ours and must never be freed.
+   */
+  slot?: AllocatedVolume
+  /** How many times the disk number may be bumped on a name collision (default 3). */
+  maxNameBumps?: number
+}
+
+/**
+ * Timeout for `pvesm alloc`. A multi-TB allocation is not instant: on PVE 9 LVM with
+ * `snapshot-as-volume-chain`, allocating 3.1 TB took 47 s on a customer's FC array
+ * (#587) because PVE formats the logical volume as qcow2, and thick-provisioning
+ * plugins can take minutes. executeSSH's 30 s default cut the channel while the
+ * volume was being created server-side, which is how orphans appear.
+ */
+export const PVESM_ALLOC_TIMEOUT_MS = 10 * 60_000
+
+/**
+ * Timeout for the `pvesm free` calls that clean up orphan volumes. On an LVM storage
+ * with `saferemove`, PVE zeroes the volume before removing it, which is throughput
+ * bound (~1.8 GB/s on FC) — nowhere near the 30 s default.
+ */
+export const PVESM_FREE_TIMEOUT_MS = 5 * 60_000
+
+const DEFAULT_MAX_NAME_BUMPS = 3
+
+/**
+ * Does this pvesm failure mean "that volume name is already taken"?
+ *
+ * Each plugin words it differently: LVM `Logical Volume "x" already exists`, ZFS
+ * `dataset already exists`, RBD `create error: (17) File exists`.
+ */
+function isNameCollision(message: string): boolean {
+  return /(?:already|file) exists/i.test(message)
+}
+
+/** `vm-250-disk-2` → `vm-250-disk-3`; null when the name has no disk number to bump. */
+function bumpDiskNumber(volName: string): string | null {
+  // Anchored suffix match, no leading `.*`: linear on the input, no backtracking.
+  const m = /-disk-(\d+)$/.exec(volName)
+  if (!m) return null
+  return `${volName.slice(0, m.index)}-disk-${Number(m[1]) + 1}`
+}
+
+/**
+ * Reserve the cleanup slot for the disk we are about to allocate.
+ *
+ * Pipelines index this array by disk position (`allocatedVolumes[i].volumeId` is
+ * what gets attached to the VM), so there is exactly one slot per disk: reserve it
+ * up front and mutate it, never push a second entry for a retried allocation.
+ */
+export function reserveVolumeSlot(allocatedVolumes: AllocatedVolume[]): AllocatedVolume {
+  const slot: AllocatedVolume = { volumeId: "", devicePath: "" }
+  allocatedVolumes.push(slot)
+  return slot
+}
+
+/**
+ * The volumes failure cleanup must free: registered, and not attached to the VM.
+ *
+ * Skips slots whose allocation never started (no volume ID yet) so cleanup never
+ * frees a name we did not create, and skips attached volumes — those are in
+ * `qm config` already and get removed together with the VM.
+ */
+export function volumesToFree(allocatedVolumes: AllocatedVolume[]): AllocatedVolume[] {
+  return allocatedVolumes.filter(v => v.volumeId && !v.attached)
+}
+
+/**
+ * Allocate a raw block volume on PVE and return its device path.
  *
  * Wraps `pvesm alloc` + `pvesm path` and handles the output formats every
  * storage plugin emits, including LVM on iSCSI multipath which prints the
@@ -15,7 +106,16 @@ export interface AllocateAndResolveResult {
  * fails (it expects `STORAGE:VOLNAME`), so we detect that case and skip the
  * second SSH call entirely.
  *
- * Caller is responsible for cleanup via `pvesm free <volumeId>` on error.
+ * `--format raw` is explicit on purpose. Every migration pipeline writes raw guest
+ * blocks into the returned device and allocates the volume under a name with no
+ * `.qcow2` suffix, so Proxmox treats it as raw afterwards. Left to the storage
+ * default, a PVE 9 LVM storage with `snapshot-as-volume-chain` allocates qcow2
+ * instead: it spends ~37 s of a 3.1 TB allocation writing a qcow2 header that the
+ * first copy pass overwrites anyway, and current PVE rejects the name/format
+ * mismatch outright (#587).
+ *
+ * Caller is responsible for cleanup via `pvesm free <volumeId>` on error — pass
+ * `opts.slot` so a volume created by a *failed* allocation is freed too.
  */
 export async function allocateBlockVolumeAndResolvePath(
   connectionId: string,
@@ -24,20 +124,49 @@ export async function allocateBlockVolumeAndResolvePath(
   targetVmid: number | string,
   volName: string,
   sizeKB: number,
+  opts: AllocateBlockVolumeOpts = {},
 ): Promise<AllocateAndResolveResult> {
-  const allocResult = await executeSSH(
-    connectionId,
-    nodeIp,
-    `pvesm alloc ${shellEscape(targetStorage)} ${targetVmid} ${shellEscape(volName)} ${sizeKB} 2>&1`,
-  )
+  const maxNameBumps = opts.maxNameBumps ?? DEFAULT_MAX_NAME_BUMPS
+  let name = volName
+  let allocOutput = ""
 
-  if (!allocResult.success || !allocResult.output?.trim()) {
-    throw new Error(`Failed to allocate volume: ${allocResult.error || allocResult.output}`)
+  for (let attempt = 0; ; attempt++) {
+    if (opts.slot) opts.slot.volumeId = `${targetStorage}:${name}`
+
+    const allocResult = await executeSSH(
+      connectionId,
+      nodeIp,
+      `pvesm alloc ${shellEscape(targetStorage)} ${targetVmid} ${shellEscape(name)} ${sizeKB} --format raw 2>&1`,
+      PVESM_ALLOC_TIMEOUT_MS,
+    )
+
+    if (allocResult.success && allocResult.output?.trim()) {
+      allocOutput = allocResult.output.trim()
+      break
+    }
+
+    // The command merges stderr into stdout (2>&1), so the real pvesm message is in
+    // `output` while `error` is only the exit code — and that code says nothing:
+    // pvesm is Perl, `die` exits with the current errno, and PVE's cluster lock
+    // helper leaves EEXIST (17) behind on every call, which is why "Exit code 17"
+    // surfaced on failures that had nothing to do with an existing volume (#587).
+    const message = (allocResult.output || allocResult.error || "no output from pvesm alloc").trim()
+
+    // A name collision is recoverable: a leftover volume from an earlier attempt (or
+    // a race with a concurrent job) owns the name, so move to the next disk number
+    // instead of failing the whole migration. It also proves this attempt created
+    // nothing, so drop the registration — cleanup must never free a volume that was
+    // already there, it belongs to whoever left it behind.
+    const collision = isNameCollision(message)
+    if (collision && opts.slot) opts.slot.volumeId = ""
+
+    const nextName = collision && attempt < maxNameBumps ? bumpDiskNumber(name) : null
+    if (!nextName) throw new Error(`Failed to allocate volume: ${message}`)
+    name = nextName
   }
 
-  const allocOutput = allocResult.output.trim()
   // pvesm alloc output varies by plugin:
-  //   - dir/NFS: "successfully created 'storage:vmid/vm-vmid-disk-N.qcow2'"
+  //   - dir/NFS: "successfully created 'storage:vmid/vm-vmid-disk-N.raw'"
   //   - LVM:     "successfully created 'storage:vm-vmid-disk-N'"
   //   - Ceph:    "successfully created 'storage:vm-vmid-disk-N'"
   //   - LVM on iSCSI multipath: prints '/dev/<vg>/<lv>' between quotes
@@ -47,7 +176,7 @@ export async function allocateBlockVolumeAndResolvePath(
 
   if (captured.startsWith("/dev/")) {
     return {
-      volumeId: `${targetStorage}:${volName}`,
+      volumeId: `${targetStorage}:${name}`,
       devicePath: captured,
     }
   }
@@ -60,7 +189,8 @@ export async function allocateBlockVolumeAndResolvePath(
   )
 
   if (!pathResult.success || !pathResult.output?.trim()) {
-    throw new Error(`Failed to resolve device path for ${volumeId}: ${pathResult.error}`)
+    const message = (pathResult.output || pathResult.error || "no output from pvesm path").trim()
+    throw new Error(`Failed to resolve device path for ${volumeId}: ${message}`)
   }
 
   return { volumeId, devicePath: pathResult.output.trim() }

--- a/frontend/src/lib/migration/pvesm-alloc.ts
+++ b/frontend/src/lib/migration/pvesm-alloc.ts
@@ -97,6 +97,108 @@ export function volumesToFree(allocatedVolumes: AllocatedVolume[]): AllocatedVol
 }
 
 /**
+ * Name for the next data disk of `targetVmid` on the target storage.
+ *
+ * Numbering starts after the highest `vm-<vmid>-disk-<n>` already referenced by the
+ * VM config — an OVMF shell owns `disk-0` for its EFI vars before any data disk
+ * exists — and after everything allocated so far in this run. It takes the highest
+ * number rather than a count, so a gap in the sequence can never hand back a name
+ * that is already taken.
+ */
+export function nextFreeDiskName(
+  vmConf: Record<string, unknown> | null | undefined,
+  allocatedVolumes: AllocatedVolume[],
+  targetVmid: number | string,
+): string {
+  let maxDiskNum = -1
+  const bump = (value: string) => {
+    const m = value.match(/vm-\d+-disk-(\d+)/)
+    if (m) maxDiskNum = Math.max(maxDiskNum, Number.parseInt(m[1], 10))
+  }
+  for (const value of Object.values(vmConf || {})) {
+    if (typeof value === "string") bump(value)
+  }
+  for (const v of allocatedVolumes) {
+    if (v.volumeId) bump(v.volumeId)
+  }
+  return `vm-${targetVmid}-disk-${maxDiskNum + 1}`
+}
+
+export interface AllocateAndMapArgs {
+  connectionId: string
+  nodeIp: string
+  targetStorage: string
+  targetVmid: number | string
+  volName: string
+  sizeKB: number
+  /**
+   * The pipeline's cleanup registry. A slot is reserved in it before the allocation
+   * runs, so exactly one entry exists per disk and failure cleanup can free a volume
+   * created by an allocation that then failed (#587).
+   */
+  allocatedVolumes?: AllocatedVolume[]
+  /** Progress logger for the RBD mapping and the resulting volume. */
+  onLog?: (message: string) => Promise<void> | void
+}
+
+/**
+ * Allocate a raw block volume, map it if the storage is Ceph, and register it for
+ * failure cleanup — the whole "get me a writable block device for this disk" step
+ * that the warm, cold, XCP-ng and v2v pipelines each used to carry a copy of.
+ */
+export async function allocateAndMapBlockVolume(args: AllocateAndMapArgs): Promise<AllocatedVolume> {
+  const { connectionId, nodeIp, targetStorage, targetVmid, volName, sizeKB, onLog } = args
+  const slot = args.allocatedVolumes ? reserveVolumeSlot(args.allocatedVolumes) : { volumeId: "", devicePath: "" }
+
+  const alloc = await allocateBlockVolumeAndResolvePath(
+    connectionId, nodeIp, targetStorage, targetVmid, volName, sizeKB, { slot },
+  )
+
+  // RBD/Ceph — two path formats depending on the storage's `krbd` option:
+  //  - krbd 0 (librbd): pvesm path returns "rbd:pool/image:conf=..." — not a block
+  //    device; map via `rbd map <pool>/<image>` → /dev/rbdN.
+  //  - krbd 1 (KRBD):   pvesm path returns "/dev/rbd-pve/<fsid>/<pool>/<image>" — the
+  //    symlink only exists after `rbd device map <pool>/<image>`; devicePath stays put.
+  let devicePath = alloc.devicePath
+  let rbdMapped = false
+  const krbdMatch = devicePath.match(/^\/dev\/rbd-pve\/[^/]+\/([^/]+)\/([^/]+)$/)
+
+  if (devicePath.startsWith("rbd:")) {
+    const rbdSpec = devicePath.split(":")[1]
+    if (!rbdSpec) throw new Error(`Cannot parse RBD path: ${devicePath}`)
+    const mapped = await executeSSH(connectionId, nodeIp, `rbd map ${shellEscape(rbdSpec)} 2>&1`)
+    if (!mapped.success || !mapped.output?.trim()) {
+      throw new Error(`Failed to rbd map ${rbdSpec}: ${(mapped.output || mapped.error || "").trim()}`)
+    }
+    devicePath = mapped.output.trim()
+    rbdMapped = true
+    await onLog?.(`RBD mapped ${rbdSpec} → ${devicePath}`)
+  } else if (krbdMatch) {
+    const rbdSpec = `${krbdMatch[1]}/${krbdMatch[2]}`
+    const mapped = await executeSSH(connectionId, nodeIp, `rbd device map ${shellEscape(rbdSpec)} 2>&1`)
+    if (!mapped.success) {
+      throw new Error(`Failed to rbd device map ${rbdSpec}: ${(mapped.output || mapped.error || "").trim()}`)
+    }
+    rbdMapped = true
+    await onLog?.(`RBD (KRBD) mapped ${rbdSpec} → ${devicePath}`)
+  }
+
+  // Every plugin must land on an absolute device path. Anything else means the
+  // pipeline would stream guest data into something that is not the target volume.
+  if (!devicePath.startsWith("/")) {
+    throw new Error(`Invalid device path for ${alloc.volumeId}: "${devicePath}" (expected an absolute path)`)
+  }
+
+  // The volume ID from pvesm's own output is authoritative: a name collision may
+  // have bumped the disk number.
+  slot.volumeId = alloc.volumeId
+  slot.devicePath = devicePath
+  slot.rbdMapped = rbdMapped
+  await onLog?.(`Allocated volume ${alloc.volumeId} → ${devicePath}`)
+  return slot
+}
+
+/**
  * Allocate a raw block volume on PVE and return its device path.
  *
  * Wraps `pvesm alloc` + `pvesm path` and handles the output formats every

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -24,7 +24,7 @@ import { getNodeIp } from "@/lib/ssh/node-ip"
 import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
 import { parseV2vXml, buildPveCreateParams } from "./v2vConfigMapper"
 import type { V2vVmConfig } from "./v2vConfigMapper"
-import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
+import { allocateAndMapBlockVolume, nextFreeDiskName } from "./pvesm-alloc"
 // SOAP imports for the NFC (HttpNfcLease) transport path used when the source VM
 // has any disk on a vSAN datastore. vpx://+HTTPS /folder/ download is broken for
 // vSAN because vSAN VMDK descriptors reference vsan:// URIs that only ESXi's
@@ -2479,71 +2479,24 @@ export async function runV2vMigrationPipeline(
         }
         const sizeKB = Math.ceil(sizeBytes / 1024)
 
-        // Find next available disk number
+        // Next free disk number. efidisk/tpmstate also consume vm-<vmid>-disk-N
+        // slots — miss them and we collide on "dataset already exists" when PVE
+        // auto-allocates the efidisk as disk-0 on OVMF VMs.
         const vmConf = await pveFetch<Record<string, any>>(
           pveConn,
           `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`
         )
-        const existingNums = Object.keys(vmConf)
-          // efidisk/tpmstate also consume vm-<vmid>-disk-N slots — miss them and we
-          // collide on "dataset already exists" when PVE auto-allocates the efidisk
-          // as disk-0 on OVMF VMs.
-          .filter(k => k.match(/^(?:scsi|sata|virtio|ide|unused|efidisk|tpmstate)\d+$/))
-          .map(k => {
-            const val = String(vmConf[k])
-            const m = val.match(/vm-\d+-disk-(\d+)/)
-            return m ? Number.parseInt(m[1], 10) : -1
-          })
-          .filter(n => n >= 0)
-        const maxDiskNum = existingNums.length > 0 ? Math.max(...existingNums) : -1
-        const diskNum = maxDiskNum + 1
-        const volName = `vm-${targetVmid}-disk-${diskNum}`
+        const volName = nextFreeDiskName(vmConf, [], targetVmid)
 
-        // Allocate the block volume and resolve its device path. Handles every
-        // pvesm output format including LVM on iSCSI multipath where alloc
-        // prints '/dev/<vg>/<lv>' directly instead of the volume ID.
-        const alloc = await allocateBlockVolumeAndResolvePath(
-          config.targetConnectionId, nodeIp,
-          config.targetStorage, targetVmid, volName, sizeKB,
-        )
-        const volumeId = alloc.volumeId
-        let devicePath = alloc.devicePath
-
-        // RBD/Ceph — two path formats depending on the storage's `krbd` option:
-        //  - krbd 0 (librbd): pvesm path returns "rbd:pool/image:conf=..." — not a block device; map via `rbd map <pool>/<image>` → /dev/rbdN.
-        //  - krbd 1 (KRBD):   pvesm path returns "/dev/rbd-pve/<fsid>/<pool>/<image>" — the symlink only exists after `rbd device map <pool>/<image>`; devicePath stays put.
-        let rbdMapped = false
-        const krbdMatch = devicePath.match(/^\/dev\/rbd-pve\/[^/]+\/([^/]+)\/([^/]+)$/)
-        if (devicePath.startsWith("rbd:")) {
-          const rbdSpec = devicePath.split(":")[1]
-          if (!rbdSpec) throw new Error(`Cannot parse RBD path: ${devicePath}`)
-          const mapResult = await executeSSH(
-            config.targetConnectionId, nodeIp,
-            `rbd map ${shellEscape(rbdSpec)} 2>&1`
-          )
-          if (!mapResult.success || !mapResult.output?.trim()) {
-            throw new Error(`Failed to map RBD device: ${mapResult.error}`)
-          }
-          devicePath = mapResult.output.trim()
-          rbdMapped = true
-        } else if (krbdMatch) {
-          const [, pool, image] = krbdMatch
-          const rbdSpec = `${pool}/${image}`
-          const mapResult = await executeSSH(
-            config.targetConnectionId, nodeIp,
-            `rbd device map ${shellEscape(rbdSpec)} 2>&1`
-          )
-          if (!mapResult.success) {
-            throw new Error(`Failed to rbd device map ${rbdSpec}: ${mapResult.error || mapResult.output}`)
-          }
-          // devicePath stays as /dev/rbd-pve/<fsid>/<pool>/<image> — the symlink now resolves.
-          rbdMapped = true
-        }
-
-        // Validate device path starts with /
-        if (!devicePath.startsWith("/")) {
-          throw new Error(`Invalid device path for ${volumeId}: "${devicePath}" (expected path starting with /)`)
-        }
+        // See allocateAndMapBlockVolume: raw allocation (so PVE never formats the
+        // target as qcow2), Ceph mapping, and device-path validation (#587).
+        const vol = await allocateAndMapBlockVolume({
+          connectionId: config.targetConnectionId, nodeIp,
+          targetStorage: config.targetStorage, targetVmid, volName, sizeKB,
+        })
+        const volumeId = vol.volumeId
+        const devicePath = vol.devicePath
+        const rbdMapped = vol.rbdMapped
 
         // Stream data to block device. We use `qemu-img convert` instead of
         // `pv | dd` for two reasons:

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -14,7 +14,7 @@ import {
 } from "@/lib/vmware/cbt"
 import { mapEsxiToPveConfig } from "../configMapper"
 import {
-  allocateBlockVolumeAndResolvePath, reserveVolumeSlot, volumesToFree,
+  allocateAndMapBlockVolume, nextFreeDiskName, volumesToFree,
   PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
 } from "../pvesm-alloc"
 import { pveSetVmConfig } from "../pve-vm-config"
@@ -297,32 +297,24 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     await appendLog(jobId, `Target VM ${targetVmid} created on ${config.targetNode}`, "success")
 
     // The VM shell may already own a disk: an OVMF/UEFI guest gets an efidisk0
-    // (vm-<vmid>-disk-0) created with `qm create`. Data disks must therefore
-    // start after the highest existing disk number, or `pvesm alloc` collides on
-    // the name (mirrors the cold pipeline's allocateBlockVolume).
+    // (vm-<vmid>-disk-0) created with `qm create`. Data disks must therefore start
+    // after the highest existing disk number, or `pvesm alloc` collides on the name.
     const shellConf = await pveFetch<Record<string, any>>(pveConn as any, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`)
-    let nextDiskNum = 0
-    for (const v of Object.values(shellConf || {})) {
-      if (typeof v === "string") {
-        const m = v.match(/vm-\d+-disk-(\d+)/)
-        if (m) nextDiskNum = Math.max(nextDiskNum, Number(m[1]) + 1)
-      }
-    }
 
     // Allocate a raw block volume per disk and resolve (+ map) its device path.
     for (let i = 0; i < vmConfig.disks.length; i++) {
       const disk = vmConfig.disks[i]
       const sizeKB = Math.ceil(disk.capacityBytes / 1024)
-      const volName = `vm-${targetVmid}-disk-${nextDiskNum + i}`
-      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
-      // the volume and still report a failure, and a volume nobody registered is
-      // never freed — it then collides with every retry on the same VMID (#587).
-      const volSlot = reserveVolumeSlot(allocatedVolumes)
-      const alloc = await allocateBlockVolumeAndResolvePath(
-        config.targetConnectionId, nodeIp, config.targetStorage, targetVmid, volName, sizeKB,
-        { slot: volSlot },
-      )
-      const dev = await mapRbdIfNeeded(config.targetConnectionId, nodeIp, alloc.devicePath, volSlot, alloc.volumeId)
+      // Numbering walks forward as each disk registers itself in allocatedVolumes.
+      const volName = nextFreeDiskName(shellConf, allocatedVolumes, targetVmid)
+      // See allocateAndMapBlockVolume for the raw format and why the volume is
+      // registered for cleanup before the allocation runs (#587).
+      const vol = await allocateAndMapBlockVolume({
+        connectionId: config.targetConnectionId, nodeIp,
+        targetStorage: config.targetStorage, targetVmid, volName, sizeKB,
+        allocatedVolumes,
+      })
+      const dev = vol.devicePath
       targetDev.set(disk.deviceKey, dev)
       diskState.set(disk.deviceKey, initDiskState(disk.deviceKey))
       // Unwritten regions MUST read as zero: the CBT pass writes only the
@@ -344,7 +336,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         if (!z.success) throw new Error(`Failed to zero thick target ${dev} before warm copy (unwritten regions would expose stale data): ${z.output || z.error}`)
         await appendLog(jobId, `Disk ${i}: zeroed thick target ${dev}`)
       }
-      await appendLog(jobId, `Disk ${i}: target ${alloc.volumeId} → ${dev} (${(disk.capacityBytes / 1073741824).toFixed(1)} GB)`)
+      await appendLog(jobId, `Disk ${i}: target ${vol.volumeId} → ${dev} (${(disk.capacityBytes / 1073741824).toFixed(1)} GB)`)
     }
 
     // Apply a disk's changed extents to its target. buildApplyScripts splits the
@@ -570,34 +562,6 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     cutoverRequests.delete(jobId)
     if (acquiredVmLock) activeWarmVms.delete(vmKey)
   }
-}
-
-/** Map an RBD/Ceph volume to a kernel device if pvesm returned an rbd: spec or KRBD symlink. */
-async function mapRbdIfNeeded(
-  connId: string, nodeIp: string, devicePath: string,
-  volSlot: AllocatedVolume, volumeId: string,
-): Promise<string> {
-  let dev = devicePath
-  let rbdMapped = false
-  const krbd = devicePath.match(/^\/dev\/rbd-pve\/[^/]+\/([^/]+)\/([^/]+)$/)
-  if (devicePath.startsWith("rbd:")) {
-    const spec = devicePath.split(":")[1]
-    if (!spec) throw new Error(`Cannot parse RBD path: ${devicePath}`)
-    const r = await executeSSH(connId, nodeIp, `rbd map "${spec}" 2>&1`)
-    if (!r.success || !r.output?.trim()) throw new Error(`Failed to rbd map ${spec}: ${r.error || r.output}`)
-    dev = r.output.trim(); rbdMapped = true
-  } else if (krbd) {
-    const spec = `${krbd[1]}/${krbd[2]}`
-    const r = await executeSSH(connId, nodeIp, `rbd device map "${spec}" 2>&1`)
-    if (!r.success) throw new Error(`Failed to rbd device map ${spec}: ${r.error || r.output}`)
-    rbdMapped = true
-  }
-  // Fill the slot reserved before the allocation — the volume ID from pvesm's own
-  // output is authoritative (a name collision may have bumped the disk number).
-  volSlot.volumeId = volumeId
-  volSlot.devicePath = dev
-  volSlot.rbdMapped = rbdMapped
-  return dev
 }
 
 /**

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -13,7 +13,10 @@ import {
   soapGuestShutdown, soapWaitPoweredOff, soapKeepAlive,
 } from "@/lib/vmware/cbt"
 import { mapEsxiToPveConfig } from "../configMapper"
-import { allocateBlockVolumeAndResolvePath } from "../pvesm-alloc"
+import {
+  allocateBlockVolumeAndResolvePath, reserveVolumeSlot, volumesToFree,
+  PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
+} from "../pvesm-alloc"
 import { pveSetVmConfig } from "../pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "../pve-tasks"
 import { decideNextPass, type PassStat, type ConvergenceConfig, type ConvergenceDecision } from "./convergence"
@@ -200,7 +203,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
   const vmKey = `${config.sourceConnectionId}:${config.sourceVmId}`
   let acquiredVmLock = false
   const ourSnapshots: string[] = []                 // MORs WE created — cleaned up by specific MOR
-  const allocatedVolumes: { volumeId: string; devicePath: string; rbdMapped?: boolean; attached?: boolean }[] = []
+  const allocatedVolumes: AllocatedVolume[] = []
   const activeReaders: VddkReaderHandle[] = []      // readers to tear down on failure
   // Per-disk: target device path + CBT state. NOTE: state is in-memory only; a
   // retry re-runs from a fresh full pass (safe, full re-copy) rather than resuming
@@ -311,8 +314,15 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       const disk = vmConfig.disks[i]
       const sizeKB = Math.ceil(disk.capacityBytes / 1024)
       const volName = `vm-${targetVmid}-disk-${nextDiskNum + i}`
-      const alloc = await allocateBlockVolumeAndResolvePath(config.targetConnectionId, nodeIp, config.targetStorage, targetVmid, volName, sizeKB)
-      const dev = await mapRbdIfNeeded(config.targetConnectionId, nodeIp, alloc.devicePath, allocatedVolumes, alloc.volumeId)
+      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
+      // the volume and still report a failure, and a volume nobody registered is
+      // never freed — it then collides with every retry on the same VMID (#587).
+      const volSlot = reserveVolumeSlot(allocatedVolumes)
+      const alloc = await allocateBlockVolumeAndResolvePath(
+        config.targetConnectionId, nodeIp, config.targetStorage, targetVmid, volName, sizeKB,
+        { slot: volSlot },
+      )
+      const dev = await mapRbdIfNeeded(config.targetConnectionId, nodeIp, alloc.devicePath, volSlot, alloc.volumeId)
       targetDev.set(disk.deviceKey, dev)
       diskState.set(disk.deviceKey, initDiskState(disk.deviceKey))
       // Unwritten regions MUST read as zero: the CBT pass writes only the
@@ -565,7 +575,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
 /** Map an RBD/Ceph volume to a kernel device if pvesm returned an rbd: spec or KRBD symlink. */
 async function mapRbdIfNeeded(
   connId: string, nodeIp: string, devicePath: string,
-  allocatedVolumes: { volumeId: string; devicePath: string; rbdMapped?: boolean; attached?: boolean }[], volumeId: string,
+  volSlot: AllocatedVolume, volumeId: string,
 ): Promise<string> {
   let dev = devicePath
   let rbdMapped = false
@@ -582,7 +592,11 @@ async function mapRbdIfNeeded(
     if (!r.success) throw new Error(`Failed to rbd device map ${spec}: ${r.error || r.output}`)
     rbdMapped = true
   }
-  allocatedVolumes.push({ volumeId, devicePath: dev, rbdMapped })
+  // Fill the slot reserved before the allocation — the volume ID from pvesm's own
+  // output is authoritative (a name collision may have bumped the disk number).
+  volSlot.volumeId = volumeId
+  volSlot.devicePath = dev
+  volSlot.rbdMapped = rbdMapped
   return dev
 }
 
@@ -605,7 +619,7 @@ async function cleanupOnFailure(
   config: WarmMigrationConfig,
   session: SoapSession | null,
   ourSnapshots: string[],
-  allocatedVolumes: { volumeId: string; devicePath: string; rbdMapped?: boolean; attached?: boolean }[],
+  allocatedVolumes: AllocatedVolume[],
   activeReaders: VddkReaderHandle[],
   nodeIp: string,
 ): Promise<void> {
@@ -617,9 +631,13 @@ async function cleanupOnFailure(
   if (session) {
     for (const mor of [...ourSnapshots]) await soapRemoveSnapshot(session, mor, false).catch(() => {})
   }
-  // Unmap RBD + free volumes the VM never referenced (orphans).
-  for (const v of allocatedVolumes.filter(v => !v.attached)) {
-    if (nodeIp && v.rbdMapped) await executeSSH(config.targetConnectionId, nodeIp, `rbd unmap "${v.devicePath}" 2>/dev/null`).catch(() => {})
-    if (nodeIp) await executeSSH(config.targetConnectionId, nodeIp, `pvesm free ${shellEscape(v.volumeId)} 2>/dev/null`).catch(() => {})
+  // Unmap RBD + free volumes the VM never referenced (orphans). volumesToFree also
+  // covers a volume created by an allocation that reported a failure, and skips the
+  // slots whose allocation never started.
+  for (const v of volumesToFree(allocatedVolumes)) {
+    if (nodeIp && v.rbdMapped && v.devicePath) await executeSSH(config.targetConnectionId, nodeIp, `rbd unmap "${v.devicePath}" 2>/dev/null`).catch(() => {})
+    // A `saferemove` LVM storage zeroes the volume before removing it, which takes
+    // far longer than the 30 s executeSSH default.
+    if (nodeIp) await executeSSH(config.targetConnectionId, nodeIp, `pvesm free ${shellEscape(v.volumeId)} 2>/dev/null`, PVESM_FREE_TIMEOUT_MS).catch(() => {})
   }
 }

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -32,7 +32,7 @@ import { getXoConnectionInfo, xoGetVmConfig, buildVdiDownloadUrl, xoCreateSnapsh
 import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
-import { allocateBlockVolumeAndResolvePath } from "./pvesm-alloc"
+import { allocateBlockVolumeAndResolvePath, reserveVolumeSlot, type AllocatedVolume } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
@@ -392,7 +392,7 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     await appendLog(jobId, `Temp directory: ${storageTempDir}`)
 
     // Track allocated block volumes (for cleanup on error)
-    const allocatedVolumes: { volumeId: string, devicePath: string, rbdMapped?: boolean }[] = []
+    const allocatedVolumes: AllocatedVolume[] = []
 
     // Allocate a raw volume on block storage and return the device path
     async function allocateBlockVolume(sizeBytes: number): Promise<{ volumeId: string, devicePath: string, rbdMapped?: boolean }> {
@@ -412,11 +412,17 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       const sizeKB = Math.ceil(sizeBytes / 1024)
       const volName = `vm-${targetVmid}-disk-${diskNum}`
 
+      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
+      // the volume and still report a failure, and a volume nobody registered is
+      // never freed — it then collides with every retry on the same VMID (#587).
+      const volSlot = reserveVolumeSlot(allocatedVolumes)
+
       // Allocate the block volume and resolve its device path. Handles every
       // pvesm output format including LVM on iSCSI multipath.
       const alloc = await allocateBlockVolumeAndResolvePath(
         config.targetConnectionId, nodeIp,
         config.targetStorage, targetVmid, volName, sizeKB,
+        { slot: volSlot },
       )
       const volumeId = alloc.volumeId
       let devicePath = alloc.devicePath
@@ -450,10 +456,13 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
         await appendLog(jobId, `RBD (KRBD) mapped ${rbdSpec} → ${devicePath}`)
       }
 
-      const result = { volumeId, devicePath, rbdMapped }
-      allocatedVolumes.push(result)
+      // Fill the slot reserved before the allocation — the volume ID from pvesm's own
+      // output is authoritative (a name collision may have bumped the disk number).
+      volSlot.volumeId = volumeId
+      volSlot.devicePath = devicePath
+      volSlot.rbdMapped = rbdMapped
       await appendLog(jobId, `Allocated volume ${volumeId} → ${devicePath}`)
-      return result
+      return volSlot
     }
 
     // Attach a pre-allocated block volume to a SCSI slot

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -32,7 +32,7 @@ import { getXoConnectionInfo, xoGetVmConfig, buildVdiDownloadUrl, xoCreateSnapsh
 import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
-import { allocateBlockVolumeAndResolvePath, reserveVolumeSlot, type AllocatedVolume } from "./pvesm-alloc"
+import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
@@ -397,72 +397,14 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     // Allocate a raw volume on block storage and return the device path
     async function allocateBlockVolume(sizeBytes: number): Promise<{ volumeId: string, devicePath: string, rbdMapped?: boolean }> {
       const vmConf = await pveFetch<Record<string, any>>(pveConn, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`)
-      let maxDiskNum = -1
-      for (const val of Object.values(vmConf || {})) {
-        if (typeof val === 'string') {
-          const m = (val as string).match(/vm-\d+-disk-(\d+)/)
-          if (m) maxDiskNum = Math.max(maxDiskNum, Number.parseInt(m[1]))
-        }
-      }
-      for (const av of allocatedVolumes) {
-        const m = av.volumeId.match(/disk-(\d+)/)
-        if (m) maxDiskNum = Math.max(maxDiskNum, Number.parseInt(m[1]))
-      }
-      const diskNum = maxDiskNum + 1
-      const sizeKB = Math.ceil(sizeBytes / 1024)
-      const volName = `vm-${targetVmid}-disk-${diskNum}`
-
-      // Reserve this disk's cleanup slot BEFORE allocating: `pvesm alloc` can create
-      // the volume and still report a failure, and a volume nobody registered is
-      // never freed — it then collides with every retry on the same VMID (#587).
-      const volSlot = reserveVolumeSlot(allocatedVolumes)
-
-      // Allocate the block volume and resolve its device path. Handles every
-      // pvesm output format including LVM on iSCSI multipath.
-      const alloc = await allocateBlockVolumeAndResolvePath(
-        config.targetConnectionId, nodeIp,
-        config.targetStorage, targetVmid, volName, sizeKB,
-        { slot: volSlot },
-      )
-      const volumeId = alloc.volumeId
-      let devicePath = alloc.devicePath
-
-      // RBD/Ceph — two path formats depending on the storage's `krbd` option:
-      //  - krbd 0 (librbd): pvesm path returns "rbd:pool/image:conf=..." — not a block device; map via `rbd map <pool>/<image>` → /dev/rbdN.
-      //  - krbd 1 (KRBD):   pvesm path returns "/dev/rbd-pve/<fsid>/<pool>/<image>" — the symlink only exists after `rbd device map <pool>/<image>`; devicePath stays put.
-      let rbdMapped = false
-      const krbdMatch = devicePath.match(/^\/dev\/rbd-pve\/[^/]+\/([^/]+)\/([^/]+)$/)
-      if (devicePath.startsWith('rbd:')) {
-        const rbdSpec = devicePath.split(':')[1]
-        if (!rbdSpec) throw new Error(`Cannot parse RBD path: ${devicePath}`)
-        const mapResult = await executeSSH(config.targetConnectionId, nodeIp,
-          `rbd map "${rbdSpec}" 2>&1`)
-        if (!mapResult.success || !mapResult.output?.trim()) {
-          throw new Error(`Failed to rbd map ${rbdSpec}: ${mapResult.error || mapResult.output}`)
-        }
-        devicePath = mapResult.output.trim()
-        rbdMapped = true
-        await appendLog(jobId, `RBD mapped ${rbdSpec} → ${devicePath}`)
-      } else if (krbdMatch) {
-        const [, pool, image] = krbdMatch
-        const rbdSpec = `${pool}/${image}`
-        const mapResult = await executeSSH(config.targetConnectionId, nodeIp,
-          `rbd device map "${rbdSpec}" 2>&1`)
-        if (!mapResult.success) {
-          throw new Error(`Failed to rbd device map ${rbdSpec}: ${mapResult.error || mapResult.output}`)
-        }
-        // devicePath stays as /dev/rbd-pve/<fsid>/<pool>/<image> — the symlink now resolves.
-        rbdMapped = true
-        await appendLog(jobId, `RBD (KRBD) mapped ${rbdSpec} → ${devicePath}`)
-      }
-
-      // Fill the slot reserved before the allocation — the volume ID from pvesm's own
-      // output is authoritative (a name collision may have bumped the disk number).
-      volSlot.volumeId = volumeId
-      volSlot.devicePath = devicePath
-      volSlot.rbdMapped = rbdMapped
-      await appendLog(jobId, `Allocated volume ${volumeId} → ${devicePath}`)
-      return volSlot
+      const volName = nextFreeDiskName(vmConf, allocatedVolumes, targetVmid)
+      // See allocateAndMapBlockVolume for the raw format, the Ceph mapping and why
+      // the volume is registered for cleanup before the allocation runs (#587).
+      return allocateAndMapBlockVolume({
+        allocatedVolumes, nodeIp, targetVmid, volName,
+        connectionId: config.targetConnectionId, targetStorage: config.targetStorage,
+        sizeKB: Math.ceil(sizeBytes / 1024), onLog: (m) => appendLog(jobId, m),
+      })
     }
 
     // Attach a pre-allocated block volume to a SCSI slot


### PR DESCRIPTION
Fixes #587.

## Problem

A warm migration to a Fibre Channel LVM storage failed on the second data disk with `Failed to allocate volume: Exit code 17`, and every retry then hit a genuine name collision because the failed allocation left a 3.1 TB logical volume behind.

## Root cause

The target storage is declared with PVE 9's `snapshot-as-volume-chain`, which makes qcow2 the default allocation format for that storage. `pvesm alloc` was called without a format, so PVE created the logical volume and then ran `qemu-img create -o preallocation=metadata` on it. Measured on the reporter's array: 47 s for a 3.1 TB volume, against the 30 s default cap of `executeSSH`, and the failure landed inside that formatting step.

That work is wasted for a migration in the first place. Every pipeline writes raw guest blocks into the returned device and allocates the volume under a name with no `.qcow2` suffix, so Proxmox treats it as raw afterwards and the qcow2 header is overwritten by the first copy pass. Current PVE also rejects the name/format mismatch outright, so leaving the format implicit is a latent hard failure on every chain-enabled LVM storage.

Two reporting and cleanup defects made the diagnosis much harder than it should have been:

- The command runs with `2>&1`, so the real pvesm message is on stdout, but the error path printed the exit code instead. And that code is meaningless: pvesm is Perl, `die` exits with the current errno, and PVE's cluster lock helper leaves `EEXIST` (17) behind on every call, so unrelated failures all report "Exit code 17".
- Cleanup only freed volumes it had registered, and registration happened after the allocation returned. A volume created by an allocation that then failed was therefore never freed, and it collided with every later attempt on the same VMID.

## Changes

`pvesm-alloc.ts` owns all of it, so the warm, cold and XCP-ng pipelines get it at once. v2v inherits the helper change and already reclaims orphan volumes through `destroy-unreferenced-disks`.

- Allocate with an explicit `--format raw`. The same allocation now takes 0.9 s instead of 47 s, confirmed on the reporter's hardware. The parameter is optional with a `raw` enum value on PVE 7, 8 and 9, and raw is valid for every storage type this helper can reach (LVM, LVM-thin, ZFS, RBD); file-based storages cannot reach it, PVE requires a format extension in the volume name.
- Report the pvesm output before the exit code, on both `pvesm alloc` and `pvesm path`.
- Reserve the cleanup slot before the allocation runs and keep it in sync, so a volume created by a failed allocation is freed. A name collision clears the registration again, because a volume that already existed is not ours to free.
- Retry with the next disk number on a name collision, covering the LVM, ZFS and RBD wordings, bounded to three bumps.
- Dedicated timeouts: 10 min for an allocation, 5 min for the `pvesm free` calls in cleanup, which zero the volume first on a `saferemove` storage.

`reserveVolumeSlot` and `volumesToFree` replace the per-pipeline copies of the same filtering, and the shared `AllocatedVolume` type replaces four inline duplicates.
