### PR TITLE
chore(deps): bump actions/checkout, setup-node and setup-go to v7

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -309,7 +309,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -458,7 +458,7 @@ jobs:
           token: ${{ secrets.ORCHESTRATOR_PAT }}
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.25'
           cache-dependency-path: backend/go.sum

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -50,7 +50,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## Summary

Moves the three remaining GitHub Actions to v7, replacing #577, #575 and #576.

Most of the repo was already on `actions/checkout@v7` (15 call sites). This clears the last stragglers: 6 occurrences across three workflows.

| Workflow | Action |
|---|---|
| `lint.yml` | `checkout` v6 → v7, `setup-node` v6 → v7 |
| `sonarcloud.yml` | `setup-node` v6 → v7 |
| `docker-publish.yml` | `setup-node` v6 → v7, `checkout` v6 → v7 (the HA image job), `setup-go` v6 → v7 |

## Breaking changes checked, none apply

`actions/checkout@v7` blocks checking out fork PRs under `pull_request_target` and `workflow_run`. No workflow in this repo uses either trigger, so nothing is affected.

`actions/setup-node@v7` removed the dummy `NODE_AUTH_TOKEN` export. Nothing here sets `registry-url` or reads `NODE_AUTH_TOKEN` — we do not publish to npm from CI. The inputs actually in use (`node-version`, `cache`, `cache-dependency-path`) are unchanged in v7.

`actions/setup-go@v7` is an ESM migration and a cache dependency bump, with no input changes. The single call site passes only `go-version` and `cache-dependency-path`.

## Verification

The workflows themselves are the test: this PR runs on the bumped actions, so a green CI here is the proof that the three upgrades work in this repo.
