### PR TITLE
chore(deps): bump @mui/x-data-grid to 9.9.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@mui/lab": "7.0.1-beta.25",
         "@mui/material": "7.3.9",
         "@mui/material-nextjs": "7.3.9",
-        "@mui/x-data-grid": "^8.28.1",
+        "@mui/x-data-grid": "^9.9.0",
         "@mui/x-tree-view": "^8.27.1",
         "@novnc/novnc": "^1.7.0",
         "@prisma/adapter-pg": "^7.9.1",
@@ -453,9 +453,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -2900,15 +2900,16 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "8.28.1",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-8.28.1.tgz",
-      "integrity": "sha512-MUX3QiO9KXPEFqH+mZyYI1qV1v1BMPdjCWjpTB2BdeHKHSAfmJNb/puOAEwCR0MtEVRiwWF6ML2iUJ/2POA5dA==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-9.9.0.tgz",
+      "integrity": "sha512-HN9dsojdIvoXTGgS1tAqSYXVOsFeOe7zO+e27bu2N/B5tbBq8cClUT63Vj3CYVn/VBXphOtnnKW2aqLQ+g9JWg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0",
-        "@mui/x-virtualizer": "0.3.4",
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "^0.3.0",
+        "@mui/utils": "^9.2.0",
+        "@mui/x-internals": "^9.9.0",
+        "@mui/x-virtualizer": "0.6.0",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
         "use-sync-external-store": "^1.6.0"
@@ -2923,8 +2924,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.9.0",
         "@emotion/styled": "^11.8.1",
-        "@mui/material": "^5.15.14 || ^6.0.0 || ^7.0.0",
-        "@mui/system": "^5.15.14 || ^6.0.0 || ^7.0.0",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -2936,6 +2937,104 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/types": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/utils": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.2.0.tgz",
+      "integrity": "sha512-OsUH5zhlSOM4xmLl53+agug1M1UyWb4zxFxWQCqwKTKUeQPvTENtg3JhrroBD2qpCLKsX5W/DYGERJ4mBUbc8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/@mui/x-internals": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.10.1.tgz",
+      "integrity": "sha512-pKFVzFQHB34TuMG3gOVx+LfIR8VBsi/ZhX/erRX2WOXu+ewEYGvdeK1mW9hLe7e2v3uyUbgT8RNeN0cy10cDjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "^0.3.1",
+        "@mui/utils": "^9.2.0",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid/node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/@mui/x-internals": {
       "version": "8.26.0",
@@ -2999,14 +3098,15 @@
       }
     },
     "node_modules/@mui/x-virtualizer": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@mui/x-virtualizer/-/x-virtualizer-0.3.4.tgz",
-      "integrity": "sha512-b80Wt08bT+KVDunurdd4es76PdYaazoNGpGde3Ki7jGVaSpoljMYSRVlCtifei+4cOUD3NKJhG4e3av/czTekg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-virtualizer/-/x-virtualizer-0.6.0.tgz",
+      "integrity": "sha512-6LsLn+JFg3tkDdtxfa/KoCRMzzLxPdCHp4sXSMyFO+GOGuamTHe+7xijJVADD7a0dlGKUNCVFFBRDffmZXYqZA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.5",
-        "@mui/x-internals": "8.26.0"
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "^0.3.0",
+        "@mui/utils": "^9.2.0",
+        "@mui/x-internals": "^9.9.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3019,6 +3119,104 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@base-ui/utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@floating-ui/utils": "^0.2.11",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/types": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-9.1.1.tgz",
+      "integrity": "sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/utils": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.2.0.tgz",
+      "integrity": "sha512-OsUH5zhlSOM4xmLl53+agug1M1UyWb4zxFxWQCqwKTKUeQPvTENtg3JhrroBD2qpCLKsX5W/DYGERJ4mBUbc8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.1.1",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/@mui/x-internals": {
+      "version": "9.10.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-internals/-/x-internals-9.10.1.tgz",
+      "integrity": "sha512-pKFVzFQHB34TuMG3gOVx+LfIR8VBsi/ZhX/erRX2WOXu+ewEYGvdeK1mW9hLe7e2v3uyUbgT8RNeN0cy10cDjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@base-ui/utils": "^0.3.1",
+        "@mui/utils": "^9.2.0",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@mui/x-virtualizer/node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -14120,9 +14318,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/react-leaflet": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
     "@mui/lab": "7.0.1-beta.25",
     "@mui/material": "7.3.9",
     "@mui/material-nextjs": "7.3.9",
-    "@mui/x-data-grid": "^8.28.1",
+    "@mui/x-data-grid": "^9.9.0",
     "@mui/x-tree-view": "^8.27.1",
     "@novnc/novnc": "^1.7.0",
     "@prisma/adapter-pg": "^7.9.1",


### PR DESCRIPTION
## Summary

Bumps `@mui/x-data-grid` from 8.28.1 to 9.9.0, replacing #486.

**No source change was needed.** The diff is `package.json` and `package-lock.json` only. That is the headline result, and it is backed by a type-level check rather than optimism: `tsc --noEmit` reports **70 errors on `origin/main` and the same 70 after the bump**, byte-identical when sorted. Nothing in our usage of the grid broke.

`@mui/material` stays at 7.3.9 and `@mui/lab` is untouched — the v9 peer range is `^7.3.0 || ^9.0.0`, so there is no MUI cascade hiding in this bump.

## The two risky spots, checked

**`autoHeight`** survives. It is not merely still present in v9, it is no longer marked deprecated — the JSDoc now recommends it as the alternative to a flex container. All 11 call sites are unchanged (`NodesTable`, `VmsTable`, `BackupJobsTabs` ×2, `BackupJobsSection`, `PbsJobsSection`, `BackupJobsPanel`, `settings/page`, `TenantsTab`, `VdcTab`, `ClusterSdnZonesPanel`).

**`GridRowSelectionModel`** keeps the same shape in v9 (`{ type: 'include' | 'exclude', ids: Set<GridRowId> }`). Our single usage in `operations/alerts/page.tsx` already uses the object form.

## v9 breaking changes cross-checked against our surface

| Change | Applies to us |
|---|---|
| Peer requires `@mui/material` `^7.3.0 \|\| ^9.0.0` | No — we are on 7.3.9 |
| `experimentalFeatures.charts` removed | No — unused |
| `localeText.filterPanelColumns` renamed | No — unused |
| Virtual scroller DOM restructured | Our 3 `.MuiDataGrid-virtualScroller` selectors style the element itself, and `.MuiDataGrid-virtualScrollerRenderZone` still exists |

One cosmetic behaviour change does land: **pagination numbers are now locale-formatted by default**, visible in every grid footer.

`.jsx` files are not typechecked, so their grid surface was reviewed by hand against the v9 types — `valueGetter` already uses the `(value, row)` signature, `renderCell(params)`, the only slot used is `noRowsOverlay`, plus `localeText` keys and `.MuiDataGrid-*` classes. All compatible.

## Two pre-existing bugs found along the way (not fixed here)

Both already broken on `main` under v8, so they are out of scope for a dependency bump, but worth recording:

- `localeText.MuiTablePagination.labelRowsPerPage` in `BackupJobsTabs.jsx:604`, `:1445` and `PbsJobsSection.jsx:463` — that key stopped existing in v8, so it is dead code today and the "Rows per page" label is already untranslated. The correct key is `paginationRowsPerPage`.
- `.MuiDataGrid-columnHeadersInner` in `VmsTable.tsx:1942` — the class exists in neither v8 nor v9. Dead CSS.

## Collateral lockfile bumps

Two top-level packages move, both required by grid 9.9.0: `@babel/runtime` 7.28.6 → 7.29.7 and `react-is` 19.2.4 → 19.2.8. Everything else (`@mui/types` 9, `@mui/utils` 9, `@mui/x-internals` 9, `@mui/x-virtualizer` 0.6.0, `reselect`, `@base-ui/utils`) is nested under `node_modules/@mui/x-data-grid/` and leaves the top-level copies alone.

## Verification

- Full suite: **277 files, 2705 tests passed**.
- `npm run build`: green, 126/126 static pages. The two Turbopack warnings are pre-existing.
- Lockfile pinned to exactly 9.9.0, matching the Dependabot PR (a plain install had drifted to 9.10.1).

## Needs a human before this is trusted

A green build and 2705 passing tests do **not** prove a data grid still renders correctly — v9 restructured the virtual scroller's internal DOM and changed pagination formatting. Screens worth opening, in priority order, derived from the files that actually use the grid:

1. **/operations/alerts** — the only grid with checkbox selection; test check, uncheck, select-all and the batch actions.
2. **/operations/backups**, all three PVE/PBS tabs — `autoHeight` grids plus the pagination footer and its "Rows per page" label.
3. **Cluster views using `VmsTable` and `NodesTable`** — the heaviest `sx` in the repo, touching `virtualScroller`, `virtualScrollerRenderZone` and conditional `autoHeight`; check horizontal scrolling and row widths.
4. **Tasks footer** — custom webkit scrollbar on `.MuiDataGrid-virtualScroller`.
5. **/settings** — licence table, plus the Tenants and vDC tabs.
6. **/infrastructure/inventory** — the Backup Jobs panel.
7. **Cluster SDN** — zones, VNets, IPAM, options, fabrics, VNet firewall (6 small grids).
8. Quick pass: /operations/events, /operations/task-center, /operations/reports, /security/audit, /security/rbac, /security/users, /storage/ceph, /storage/overview, and the Blueprints and Deployments templates.
