### PR TITLE
fix(migration): fail migration jobs orphaned by a server restart (#608)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,17 @@ ORCHESTRATOR_API_KEY=your-orchestrator-api-key-change-me
 # PROXCENTER_REPORTING_URL=http://weasyprint:5000
 
 # ========================================
+# Optional - Instance identity
+# ========================================
+# Identity this frontend stamps on the migration jobs it runs, so a boot can
+# fail the ones its own previous incarnation left behind instead of showing them
+# as "In progress" forever. The single-node compose stacks already set it; leave
+# it alone unless several frontends share one database, in which case every one
+# of them needs its OWN value. Two instances sharing a value means a boot fails
+# its live peers' migration jobs.
+# PROXCENTER_INSTANCE_ID=proxcenter-frontend
+
+# ========================================
 # Optional - Version pinning
 # ========================================
 # VERSION=latest

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -22,6 +22,13 @@ services:
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
       - APP_URL=${APP_URL:-http://localhost:3000}
+      # Identity this instance stamps on the migration jobs it runs, so a boot
+      # can fail the ones its previous incarnation left behind (#608). Fixed on
+      # purpose: the container id changes on every image upgrade, which would
+      # delay the cleanup of a job interrupted by that very upgrade. Only ever
+      # one frontend per stack here; give each instance its own value if you
+      # point several at one database.
+      - PROXCENTER_INSTANCE_ID=${PROXCENTER_INSTANCE_ID:-proxcenter-frontend}
       # No ORCHESTRATOR_URL = Community mode
       #
       # Docker Secrets support (Swarm / file-based):

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -22,6 +22,14 @@ services:
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-http://localhost:3000}
       - APP_URL=${APP_URL:-http://localhost:3000}
+      # Identity this instance stamps on the migration jobs it runs, so a boot
+      # can fail the ones its previous incarnation left behind (#608). Fixed on
+      # purpose: the container id changes on every image upgrade, which would
+      # delay the cleanup of a job interrupted by that very upgrade. Only ever
+      # one frontend per stack here; give each instance its own value if you
+      # point several at one database (the HA stack leaves it unset and falls
+      # back to the node hostname).
+      - PROXCENTER_INSTANCE_ID=${PROXCENTER_INSTANCE_ID:-proxcenter-frontend}
       - ORCHESTRATOR_URL=http://orchestrator:8080
       - ORCHESTRATOR_API_KEY=${ORCHESTRATOR_API_KEY:-}
       # PDF report renderer (WeasyPrint sidecar), used by Compliance > Frameworks PDF export.

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -100,6 +100,11 @@ services:
       ORCHESTRATOR_API_KEY: ${ORCHESTRATOR_API_KEY}
       PROXCENTER_REPORTING_URL: http://127.0.0.1:5000
       PG_POOL_MAX: ${PG_POOL_MAX:-}
+      # PROXCENTER_INSTANCE_ID is deliberately unset: with host networking the
+      # container inherits the node hostname, which is exactly what the
+      # orphaned-migration sweep needs (unique per node, stable across container
+      # recreation). Never give two nodes the same value: a boot would fail its
+      # live peers' migration jobs (#608).
       HA_ENABLED: "true"
       VIP: ${VIP}
       HA_REDIRECT_DISABLED: ${HA_REDIRECT_DISABLED:-}

--- a/frontend/prisma/migrations/20260729154515_migration_owner_instance/migration.sql
+++ b/frontend/prisma/migrations/20260729154515_migration_owner_instance/migration.sql
@@ -1,0 +1,2 @@
+-- Server instance that owns a migration job, so the startup sweep can fail jobs orphaned by a restart (#608).
+ALTER TABLE "migration_jobs" ADD COLUMN "owner_instance_id" TEXT;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -273,6 +273,11 @@ model MigrationJob {
 
   createdBy String? @map("created_by")
 
+  // Server instance (see resolveInstanceId) whose after() continuation runs the
+  // pipeline; the startup sweep fails non-terminal jobs whose owner restarted
+  // (#608). Null on rows created before this column existed.
+  ownerInstanceId String? @map("owner_instance_id")
+
   @@index([status])
   @@index([sourceConnectionId])
   @@index([targetConnectionId])

--- a/frontend/src/app/api/v1/migrations/[id]/retry/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/retry/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Capture the after() callbacks so the test can run the background dispatch.
+const h = vi.hoisted(() => ({
+  afterCbs: [] as Array<() => Promise<void>>,
+  prisma: {
+    migrationJob: { findUnique: vi.fn(), create: vi.fn(async () => ({ id: "job-2" })) },
+  },
+}))
+
+vi.mock("next/server", async (io) => {
+  const actual = await io<typeof import("next/server")>()
+  return { ...actual, after: (fn: () => Promise<void>) => { h.afterCbs.push(fn) } }
+})
+vi.mock("next-auth", () => ({ getServerSession: vi.fn(async () => ({ user: { id: "u1" } })) }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/rbac", () => ({ checkPermission: vi.fn(async () => null), PERMISSIONS: { VM_MIGRATE: "vm.migrate" } }))
+vi.mock("@/lib/tenant", () => ({
+  getSessionPrisma: vi.fn(async () => h.prisma),
+  getCurrentTenantId: vi.fn(async () => "default"),
+}))
+vi.mock("@/lib/migration/pipeline", () => ({ runMigrationPipeline: vi.fn() }))
+vi.mock("@/lib/migration/warm/warm-pipeline", () => ({ runWarmMigration: vi.fn() }))
+vi.mock("@/lib/migration/orphan-sweep", () => ({ resolveInstanceId: vi.fn(() => "inst-1") }))
+
+import { POST } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+import { runMigrationPipeline } from "@/lib/migration/pipeline"
+
+const cold = runMigrationPipeline as unknown as ReturnType<typeof vi.fn>
+
+const failedJob = {
+  id: "job-1", status: "failed",
+  sourceConnectionId: "src", sourceVmId: "vm-1", sourceVmName: null, sourceHost: null,
+  targetConnectionId: "tgt", targetNode: "pve1", targetStorage: "local-lvm",
+  config: { sourceConnectionId: "src", sourceVmId: "vm-1", migrationType: "cold" },
+}
+
+async function runAfters() { for (const cb of h.afterCbs) await cb() }
+
+beforeEach(() => {
+  h.afterCbs.length = 0
+  cold.mockReset()
+  h.prisma.migrationJob.findUnique.mockReset()
+  h.prisma.migrationJob.create.mockReset().mockResolvedValue({ id: "job-2" })
+})
+
+describe("POST /api/v1/migrations/[id]/retry", () => {
+  it("creates the retry job tagged with this server's instance id and dispatches it", async () => {
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce(failedJob)
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res))?.data?.jobId).toBe("job-2")
+    // #608 orphan detection: the retried pipeline runs in this process too
+    expect(h.prisma.migrationJob.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ ownerInstanceId: "inst-1", status: "pending" }) }),
+    )
+
+    await runAfters()
+    expect(cold).toHaveBeenCalledTimes(1)
+    expect(cold.mock.calls[0][0]).toBe("job-2")
+  })
+
+  it("refuses to retry a job that is still running", async () => {
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce({ ...failedJob, status: "transferring" })
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(400)
+    expect(h.prisma.migrationJob.create).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/migrations/[id]/retry/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/retry/route.ts
@@ -6,6 +6,7 @@ import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { authOptions } from "@/lib/auth/config"
 import { runMigrationPipeline } from "@/lib/migration/pipeline"
 import { runWarmMigration } from "@/lib/migration/warm/warm-pipeline"
+import { resolveInstanceId } from "@/lib/migration/orphan-sweep"
 
 export const runtime = "nodejs"
 
@@ -58,6 +59,9 @@ export async function POST(
         currentStep: "pending",
         startedAt: new Date(),
         createdBy: session?.user?.id || null,
+        // The retried pipeline runs in this process's after() continuation;
+        // the owner tag lets the startup sweep fail it after a restart (#608).
+        ownerInstanceId: resolveInstanceId(),
       },
     })
 

--- a/frontend/src/app/api/v1/migrations/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/route.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/migration/v2v-pipeline", () => ({ runV2vMigrationPipeline: vi.fn(
 vi.mock("@/lib/migration/xcpng-pipeline", () => ({ runXcpngMigrationPipeline: vi.fn() }))
 vi.mock("@/lib/vmware/soap", () => ({ soapLogin: vi.fn(), soapLogout: vi.fn(), soapGetVmConfig: vi.fn(), parseVmConfig: vi.fn() }))
 vi.mock("@/lib/crypto/secret", () => ({ decryptSecret: vi.fn(() => "root:pass") }))
+vi.mock("@/lib/migration/orphan-sweep", () => ({ resolveInstanceId: vi.fn(() => "inst-1") }))
 
 import { POST } from "./route"
 import { callRoute, readJson } from "@/__tests__/setup/route-test"
@@ -95,6 +96,21 @@ describe("POST /api/v1/migrations — warm routing", () => {
     await runAfters()
     expect(warm).not.toHaveBeenCalled()
     expect(cold).not.toHaveBeenCalled()
+  })
+
+  // #608 orphan detection: the pipeline runs in this process's after()
+  // continuation, so the created row must carry this server's instance id.
+  it("persists the owner instance id on the created job", async () => {
+    h.prisma.connection.findUnique
+      .mockResolvedValueOnce({ id: "src", type: "vmware", subType: null, name: "esxi", baseUrl: "https://esxi" })
+      .mockResolvedValueOnce({ id: "tgt", type: "pve", name: "pve" })
+
+    const res = await callRoute(POST, { body })
+    expect(res.status).toBe(200)
+    expect(h.prisma.migrationJob.create).toHaveBeenCalledTimes(1)
+    expect(h.prisma.migrationJob.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ ownerInstanceId: "inst-1" }) }),
+    )
   })
 
   it("dispatches a vCenter warm request to runWarmMigration, never the cold pipeline", async () => {

--- a/frontend/src/app/api/v1/migrations/route.ts
+++ b/frontend/src/app/api/v1/migrations/route.ts
@@ -8,6 +8,7 @@ import { runMigrationPipeline } from "@/lib/migration/pipeline"
 import { runXcpngMigrationPipeline } from "@/lib/migration/xcpng-pipeline"
 import { runV2vMigrationPipeline } from "@/lib/migration/v2v-pipeline"
 import { runWarmMigration } from "@/lib/migration/warm/warm-pipeline"
+import { resolveInstanceId } from "@/lib/migration/orphan-sweep"
 import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig } from "@/lib/vmware/soap"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { assertStorageName } from "@/lib/ssh/validate"
@@ -142,6 +143,9 @@ export async function POST(req: Request) {
         currentStep: "pending",
         startedAt: new Date(),
         createdBy: session?.user?.id || null,
+        // The pipeline runs in this process's after() continuation; the owner
+        // tag lets the startup sweep fail the job if this server restarts (#608).
+        ownerInstanceId: resolveInstanceId(),
       },
     })
 

--- a/frontend/src/components/SharedTaskDetailDialog.test.tsx
+++ b/frontend/src/components/SharedTaskDetailDialog.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Component tests for SharedTaskDetailDialog.tsx (#608)
+ *
+ * Strategy: the dialog reads the task through useSWRFetch, which the harness
+ * SWRConfig would never fire (revalidateOnMount: false), so the hook is mocked
+ * at module level and fed a per-test fixture. The cancel POST goes through the
+ * real fetch and is seeded with MSW. Revalidation is asserted through the
+ * mocked bound mutate (detail key) and a mocked useSWRConfig mutate (list key).
+ *
+ * Dialogs render into MUI portals; query with screen.* / within(dialog).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  within,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import SharedTaskDetailDialog from '@/components/SharedTaskDetailDialog'
+import type { SharedTask } from '@/lib/tasks/sharedTask'
+
+// ------------------------------------------------------------------ //
+// Module mocks (hoisted so the factories can reference them)
+// ------------------------------------------------------------------ //
+
+const { mutateDetail, mutateList, state } = vi.hoisted(() => ({
+  mutateDetail: vi.fn(),
+  mutateList: vi.fn(),
+  state: { task: null as SharedTask | null },
+}))
+
+// The dialog only reads { data, mutate } from useSWRFetch.
+vi.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (url: string | null) => ({
+    data: url && state.task ? { data: state.task } : undefined,
+    mutate: mutateDetail,
+  }),
+}))
+
+// Keep the real swr module (the harness needs SWRConfig) but intercept the
+// scoped mutate the component uses to revalidate the footer list key.
+vi.mock('swr', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('swr')>()
+  return { ...actual, useSWRConfig: () => ({ mutate: mutateList }) }
+})
+
+// ------------------------------------------------------------------ //
+// Fixtures
+// ------------------------------------------------------------------ //
+
+const JOB_ID = 'job-608'
+
+function makeTask(overrides: Partial<SharedTask> = {}): SharedTask {
+  return {
+    id: JOB_ID,
+    kind: 'migration',
+    label: 'web-01 (ESXi -> Proxmox)',
+    sourceVmName: 'web-01',
+    targetNode: 'pve-1',
+    targetVmid: 105,
+    status: 'full_copy',
+    currentStep: 'Copying disk 1/2',
+    progress: 42,
+    totalDisks: 2,
+    currentDisk: 1,
+    bytesTransferred: 1024,
+    totalBytes: 4096,
+    transferSpeed: '100 MiB/s',
+    error: null,
+    isMine: false,
+    createdByName: 'Alice',
+    createdAt: '2026-07-29T10:00:00.000Z',
+    startedAt: '2026-07-29T10:00:05.000Z',
+    completedAt: null,
+    ...overrides,
+  }
+}
+
+function renderDialog() {
+  return renderWithProviders(<SharedTaskDetailDialog jobId={JOB_ID} onClose={vi.fn()} />)
+}
+
+/** Open the confirmation dialog and return its root element. */
+function openConfirm(): HTMLElement {
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel migration' }))
+  const title = screen.getByText('Cancel this migration?')
+  return title.closest('[role="dialog"]') as HTMLElement
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  state.task = makeTask()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ------------------------------------------------------------------ //
+// 1. Button visibility
+// ------------------------------------------------------------------ //
+
+describe('SharedTaskDetailDialog - cancel button visibility', () => {
+  it('shows the cancel button for a non-terminal migration task', () => {
+    renderDialog()
+    expect(screen.getByRole('button', { name: 'Cancel migration' })).toBeInTheDocument()
+  })
+
+  it.each(['completed', 'failed', 'cancelled'])('hides the cancel button for a %s task', (status) => {
+    state.task = makeTask({ status })
+    renderDialog()
+    expect(screen.queryByRole('button', { name: 'Cancel migration' })).not.toBeInTheDocument()
+  })
+
+  it('hides the cancel button for a non-migration task kind', () => {
+    state.task = makeTask({ kind: 'backup' as SharedTask['kind'] })
+    renderDialog()
+    expect(screen.queryByRole('button', { name: 'Cancel migration' })).not.toBeInTheDocument()
+  })
+
+  it('hides the cancel button while the task is still loading', () => {
+    state.task = null
+    renderDialog()
+    expect(screen.queryByRole('button', { name: 'Cancel migration' })).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 2. Confirmation gate
+// ------------------------------------------------------------------ //
+
+describe('SharedTaskDetailDialog - confirmation', () => {
+  it('requires an explicit confirmation and fires nothing before it', () => {
+    const posted = vi.fn()
+    server.use(http.post(`*/api/v1/migrations/${JOB_ID}/cancel`, () => {
+      posted()
+      return HttpResponse.json({ data: { status: 'cancelled' } })
+    }))
+    renderDialog()
+
+    const confirm = openConfirm()
+    // The warning must spell out the leftovers on the target node.
+    expect(within(confirm).getByText(/partially created VMID may remain on the target node/i)).toBeInTheDocument()
+    expect(posted).not.toHaveBeenCalled()
+  })
+
+  it('keeps migrating when the confirmation is declined', async () => {
+    const posted = vi.fn()
+    server.use(http.post(`*/api/v1/migrations/${JOB_ID}/cancel`, () => {
+      posted()
+      return HttpResponse.json({ data: { status: 'cancelled' } })
+    }))
+    renderDialog()
+
+    const confirm = openConfirm()
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Keep migrating' }))
+    expect(posted).not.toHaveBeenCalled()
+    // MUI keeps the dialog mounted during the close transition.
+    await waitFor(() => expect(screen.queryByText('Cancel this migration?')).not.toBeInTheDocument())
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 3. Success path
+// ------------------------------------------------------------------ //
+
+describe('SharedTaskDetailDialog - cancel success', () => {
+  it('POSTs the cancel endpoint and revalidates detail + footer list keys', async () => {
+    const posted = vi.fn()
+    server.use(http.post(`*/api/v1/migrations/${JOB_ID}/cancel`, () => {
+      posted()
+      return HttpResponse.json({ data: { status: 'cancelled' } })
+    }))
+    renderDialog()
+
+    const confirm = openConfirm()
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel migration' }))
+
+    await waitFor(() => expect(posted).toHaveBeenCalledTimes(1))
+    await waitFor(() => {
+      expect(mutateDetail).toHaveBeenCalled()
+      expect(mutateList).toHaveBeenCalledWith('/api/v1/tasks/shared')
+    })
+    // Confirmation dialog is gone; no error surfaced.
+    await waitFor(() => expect(screen.queryByText('Cancel this migration?')).not.toBeInTheDocument())
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 4. Error path
+// ------------------------------------------------------------------ //
+
+describe('SharedTaskDetailDialog - cancel errors', () => {
+  it('surfaces the server 403 message in the dialog', async () => {
+    server.use(http.post(`*/api/v1/migrations/${JOB_ID}/cancel`, () =>
+      HttpResponse.json({ error: 'Permission denied: vm.migrate' }, { status: 403 }),
+    ))
+    renderDialog()
+
+    const confirm = openConfirm()
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel migration' }))
+
+    await waitFor(() => expect(screen.getByText('Permission denied: vm.migrate')).toBeInTheDocument())
+    // Confirm dialog closed so the error alert is not hidden behind it.
+    await waitFor(() => expect(screen.queryByText('Cancel this migration?')).not.toBeInTheDocument())
+    expect(mutateList).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a generic message when the server sends no error body', async () => {
+    server.use(http.post(`*/api/v1/migrations/${JOB_ID}/cancel`, () =>
+      new HttpResponse(null, { status: 500 }),
+    ))
+    renderDialog()
+
+    const confirm = openConfirm()
+    fireEvent.click(within(confirm).getByRole('button', { name: 'Cancel migration' }))
+
+    await waitFor(() => expect(screen.getByText('Failed to cancel the migration')).toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/SharedTaskDetailDialog.tsx
+++ b/frontend/src/components/SharedTaskDetailDialog.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import { Dialog, DialogTitle, DialogContent, IconButton, Box, Typography, LinearProgress, Chip } from '@mui/material'
+import { useState } from 'react'
+
+import { Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, IconButton, LinearProgress, Typography } from '@mui/material'
 import { useTranslations } from 'next-intl'
+import { useSWRConfig } from 'swr'
 import { useSWRFetch } from '@/hooks/useSWRFetch'
 import type { SharedTask } from '@/lib/tasks/sharedTask'
 
@@ -9,14 +12,54 @@ type DetailResponse = { data: SharedTask & { logs?: unknown[] } }
 
 export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: string | null; onClose: () => void }) {
   const t = useTranslations()
-  const { data } = useSWRFetch<DetailResponse>(jobId ? `/api/v1/tasks/shared/${jobId}` : null, { refreshInterval: 5000 })
+  const { mutate } = useSWRConfig()
+  const { data, mutate: mutateDetail } = useSWRFetch<DetailResponse>(jobId ? `/api/v1/tasks/shared/${jobId}` : null, { refreshInterval: 5000 })
   const task = data?.data
 
+  // Cancel is the escape hatch for a job whose server process died (#608):
+  // the initiator's dialog is gone after a reload, so any viewer must be able
+  // to reach the cancel route from here. No client-side permission gate, to
+  // match the other migration actions; the server enforces vm.migrate (403).
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [cancelling, setCancelling] = useState(false)
+  const [cancelError, setCancelError] = useState<string | null>(null)
+  const canCancel = !!task && task.kind === 'migration' && !['completed', 'failed', 'cancelled'].includes(task.status)
+
+  const handleClose = () => {
+    setConfirmOpen(false)
+    setCancelError(null)
+    onClose()
+  }
+
+  const cancelJob = async () => {
+    setCancelling(true)
+    setCancelError(null)
+    try {
+      const res = await fetch(`/api/v1/migrations/${jobId}/cancel`, { method: 'POST' })
+      const d = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        // Includes the 403 from the server-side vm.migrate check. Shown in
+        // the detail dialog, so the confirm dialog must not stay on top.
+        setCancelError(d.error || t('tasks.shared.cancelFailed'))
+        return
+      }
+      // Refresh both the detail view and the footer list so the row flips to
+      // cancelled (or drops out) without a page reload.
+      await Promise.all([mutateDetail(), mutate('/api/v1/tasks/shared')])
+    } catch (e: any) {
+      setCancelError(e?.message || t('tasks.shared.cancelFailed'))
+    } finally {
+      setCancelling(false)
+      setConfirmOpen(false)
+    }
+  }
+
   return (
-    <Dialog open={!!jobId} onClose={onClose} maxWidth="md" fullWidth>
+    <>
+    <Dialog open={!!jobId} onClose={handleClose} maxWidth="md" fullWidth>
       <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <span>{task?.label ?? t('tasks.shared.detailTitle')}</span>
-        <IconButton onClick={onClose} size="small"><i className="ri-close-line" /></IconButton>
+        <IconButton onClick={handleClose} size="small"><i className="ri-close-line" /></IconButton>
       </DialogTitle>
       <DialogContent dividers>
         {!task ? (
@@ -36,6 +79,7 @@ export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: stri
             <LinearProgress variant={task.progress > 0 ? 'determinate' : 'indeterminate'} value={task.progress} />
             {task.currentStep && <Typography variant="body2">{task.currentStep}</Typography>}
             {task.error && <Typography variant="body2" color="error">{task.error}</Typography>}
+            {cancelError && <Alert severity="error">{cancelError}</Alert>}
             {Array.isArray(task.logs) && task.logs.length > 0 && (
               <Box component="pre" sx={{ fontSize: '0.75rem', maxHeight: 320, overflow: 'auto', bgcolor: 'action.hover', p: 1, borderRadius: 1, whiteSpace: 'pre-wrap' }}>
                 {task.logs.map((l: unknown) => (typeof l === 'string' ? l : JSON.stringify(l))).join('\n')}
@@ -44,6 +88,38 @@ export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: stri
           </Box>
         )}
       </DialogContent>
+      {canCancel && (
+        <DialogActions sx={{ px: 3, py: 1.5 }}>
+          <Button color="error" onClick={() => setConfirmOpen(true)}>
+            {t('tasks.shared.cancelMigration')}
+          </Button>
+        </DialogActions>
+      )}
     </Dialog>
+
+    {/* Confirm Cancel: destructive on a possibly shared job, always ask. */}
+    <Dialog open={confirmOpen} onClose={() => { if (!cancelling) setConfirmOpen(false) }} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, color: 'error.main' }}>
+        <i className="ri-error-warning-line" style={{ fontSize: 20 }} />
+        {t('tasks.shared.cancelConfirmTitle')}
+      </DialogTitle>
+      <DialogContent>
+        <Typography sx={{ mb: 1.5 }}>
+          {t('tasks.shared.cancelConfirmStop')}
+        </Typography>
+        <Alert severity="warning">
+          {t('tasks.shared.cancelConfirmLeftovers')}
+        </Alert>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={() => setConfirmOpen(false)} disabled={cancelling}>
+          {t('tasks.shared.cancelConfirmKeep')}
+        </Button>
+        <Button variant="contained" color="error" onClick={cancelJob} disabled={cancelling}>
+          {cancelling ? t('tasks.shared.cancelling') : t('tasks.shared.cancelMigration')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+    </>
   )
 }

--- a/frontend/src/instrumentation-node.ts
+++ b/frontend/src/instrumentation-node.ts
@@ -8,6 +8,8 @@
 import path from 'node:path'
 
 import { importDiskAssets } from '@/lib/branding/importDiskAssets'
+import { prisma } from '@/lib/db/prisma'
+import { resolveInstanceId, sweepOrphanedMigrationJobs } from '@/lib/migration/orphan-sweep'
 
 export async function registerNode(): Promise<void> {
   if (process.env.DEMO_MODE === 'true') return
@@ -22,5 +24,16 @@ export async function registerNode(): Promise<void> {
     // Boot must never depend on this import: the assets are also served
     // from disk on node 1, and the next boot retries.
     console.error('[startup] disk-asset import failed (non-fatal):', err)
+  }
+
+  try {
+    const swept = await sweepOrphanedMigrationJobs({ prisma, instanceId: resolveInstanceId() })
+    if (swept.total > 0) {
+      console.log(`[startup] orphaned migration jobs failed: owned=${swept.owned} foreign=${swept.foreign}`)
+    }
+  } catch (err) {
+    // Boot must never depend on the sweep: the rows stay non-terminal and the
+    // next boot retries.
+    console.error('[startup] orphaned migration sweep failed (non-fatal):', err)
   }
 }

--- a/frontend/src/instrumentation.test.ts
+++ b/frontend/src/instrumentation.test.ts
@@ -2,9 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import path from 'node:path'
 
 const importDiskAssetsMock = vi.fn()
+const sweepMock = vi.fn()
 
 vi.mock('@/lib/branding/importDiskAssets', () => ({
   importDiskAssets: importDiskAssetsMock,
+}))
+
+vi.mock('@/lib/db/prisma', () => ({ prisma: {} }))
+
+vi.mock('@/lib/migration/orphan-sweep', () => ({
+  sweepOrphanedMigrationJobs: sweepMock,
+  resolveInstanceId: () => 'node-a',
 }))
 
 const { register } = await import('./instrumentation')
@@ -12,6 +20,8 @@ const { register } = await import('./instrumentation')
 describe('instrumentation register (startup disk-asset import)', () => {
   beforeEach(() => {
     importDiskAssetsMock.mockReset()
+    sweepMock.mockReset()
+    sweepMock.mockResolvedValue({ owned: 0, foreign: 0, total: 0 })
     vi.unstubAllEnvs()
   })
 
@@ -41,5 +51,40 @@ describe('instrumentation register (startup disk-asset import)', () => {
     vi.stubEnv('NEXT_RUNTIME', 'nodejs')
     importDiskAssetsMock.mockRejectedValue(new Error('db down'))
     await expect(register()).resolves.toBeUndefined()
+  })
+})
+
+// #608: a migration runs in an unsupervised after() continuation, so the only
+// moment we can be sure a job of ours is dead is our own boot.
+describe('instrumentation register (orphaned migration sweep)', () => {
+  beforeEach(() => {
+    importDiskAssetsMock.mockReset()
+    importDiskAssetsMock.mockResolvedValue({ imported: 0, skipped: 0 })
+    sweepMock.mockReset()
+    sweepMock.mockResolvedValue({ owned: 0, foreign: 0, total: 0 })
+    vi.unstubAllEnvs()
+  })
+
+  it('sweeps orphaned migration jobs under this instance identity', async () => {
+    vi.stubEnv('NEXT_RUNTIME', 'nodejs')
+    sweepMock.mockResolvedValue({ owned: 1, foreign: 2, total: 3 })
+    await register()
+    expect(sweepMock).toHaveBeenCalledTimes(1)
+    expect(sweepMock.mock.calls[0][0]).toMatchObject({ instanceId: 'node-a' })
+  })
+
+  it('never throws when the sweep fails (boot must not depend on it)', async () => {
+    vi.stubEnv('NEXT_RUNTIME', 'nodejs')
+    sweepMock.mockRejectedValue(new Error('db down'))
+    await expect(register()).resolves.toBeUndefined()
+  })
+
+  it('does not sweep on the edge runtime or in demo mode', async () => {
+    vi.stubEnv('NEXT_RUNTIME', 'edge')
+    await register()
+    vi.stubEnv('NEXT_RUNTIME', 'nodejs')
+    vi.stubEnv('DEMO_MODE', 'true')
+    await register()
+    expect(sweepMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/migration/job-heartbeat.test.ts
+++ b/frontend/src/lib/migration/job-heartbeat.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { startJobHeartbeat, JOB_HEARTBEAT_INTERVAL_MS } from "./job-heartbeat"
+
+function makePrisma(updateMany = vi.fn().mockResolvedValue({ count: 1 })) {
+  return { prisma: { migrationJob: { updateMany } } as any, updateMany }
+}
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+describe("startJobHeartbeat", () => {
+  it("touches the job row once per interval (N advances → N writes)", async () => {
+    const { prisma, updateMany } = makePrisma()
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000 })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(updateMany).toHaveBeenCalledTimes(3)
+    stop()
+  })
+
+  it("defaults to a 60 s interval", async () => {
+    const { prisma, updateMany } = makePrisma()
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma })
+    await vi.advanceTimersByTimeAsync(JOB_HEARTBEAT_INTERVAL_MS - 1)
+    expect(updateMany).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(updateMany).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it("scopes the write to the job AND a non-terminal status, and only bumps updatedAt", async () => {
+    const { prisma, updateMany } = makePrisma()
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000 })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "job-1", status: { notIn: ["completed", "failed", "cancelled"] } },
+      data: { updatedAt: expect.any(Date) },
+    })
+    // The touch must never carry status/progress/logs — those belong to the pipeline.
+    expect(Object.keys(updateMany.mock.calls[0][0].data)).toEqual(["updatedAt"])
+    stop()
+  })
+
+  it("stop() halts further writes; calling stop() twice is safe", async () => {
+    const { prisma, updateMany } = makePrisma()
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000 })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(updateMany).toHaveBeenCalledTimes(2)
+    stop()
+    stop() // second call must not throw
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(updateMany).toHaveBeenCalledTimes(2) // no additional writes
+  })
+
+  it("a rejected write does not throw and does not stop the heartbeat", async () => {
+    const { prisma, updateMany } = makePrisma(vi.fn().mockRejectedValue(new Error("db down")))
+    const onError = vi.fn()
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000, onError })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(updateMany).toHaveBeenCalledTimes(3)
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "db down" }))
+    stop()
+  })
+
+  it("a throwing onError hook is swallowed too", async () => {
+    const { prisma, updateMany } = makePrisma(vi.fn().mockRejectedValue(new Error("db down")))
+    const stop = startJobHeartbeat({
+      jobId: "job-1", prisma, intervalMs: 1000,
+      onError: () => { throw new Error("bad hook") },
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(updateMany).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("skips a tick while the previous write is still in-flight (no pile-up on a stalled DB)", async () => {
+    let resolveWrite: (v: { count: number }) => void
+    const pending = new Promise<{ count: number }>(r => { resolveWrite = r })
+    const { prisma, updateMany } = makePrisma(vi.fn().mockReturnValueOnce(pending).mockResolvedValue({ count: 1 }))
+    const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000 })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(updateMany).toHaveBeenCalledTimes(1)
+
+    resolveWrite!({ count: 1 })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(updateMany).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("unrefs the interval timer so it cannot keep the process alive", () => {
+    vi.useRealTimers()
+    const unref = vi.fn()
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue({ unref } as any)
+    try {
+      const { prisma } = makePrisma()
+      const stop = startJobHeartbeat({ jobId: "job-1", prisma, intervalMs: 1000 })
+      expect(unref).toHaveBeenCalledTimes(1)
+      stop()
+    } finally {
+      setIntervalSpy.mockRestore()
+    }
+  })
+})

--- a/frontend/src/lib/migration/job-heartbeat.ts
+++ b/frontend/src/lib/migration/job-heartbeat.ts
@@ -1,0 +1,74 @@
+/**
+ * Periodic liveness touch for a running migration job (issue #608).
+ *
+ * The startup orphan sweep (orphan-sweep.ts) uses `updatedAt` age as a liveness
+ * signal, but a healthy migration can legitimately write nothing for hours
+ * (#606: 2h31 zeroing a 3.1 TB thick warm target with zero log lines). Each
+ * pipeline therefore keeps this heartbeat running for the whole job: it bumps
+ * `updatedAt` every minute without altering any field the pipeline owns, so
+ * silence in the job row genuinely means the process is gone.
+ */
+
+import { prisma as globalPrisma } from "@/lib/db/prisma"
+import { TERMINAL_STATUSES } from "@/lib/tasks/sharedTask"
+
+export const JOB_HEARTBEAT_INTERVAL_MS = 60_000
+
+/**
+ * Minimal surface the heartbeat needs, kept structural on purpose: the
+ * pipelines pass the tenant-scoped client from getTenantPrisma(), whose
+ * $extends type is not assignable to PrismaClient.
+ */
+export type JobHeartbeatClient = {
+  migrationJob: { updateMany: (args: any) => Promise<unknown> }
+}
+
+export interface JobHeartbeatOptions {
+  jobId: string
+  /** Tenant-scoped client of the calling pipeline; defaults to the global client. */
+  prisma?: JobHeartbeatClient
+  intervalMs?: number
+  /** Observability hook — heartbeat failures are swallowed, never thrown into the pipeline. */
+  onError?: (err: unknown) => void
+}
+
+/**
+ * Start the heartbeat for a job.
+ *
+ * @returns A stop() function. Safe to call multiple times; pipelines call it in
+ *          their `finally` so the heartbeat can never outlive the job.
+ */
+export function startJobHeartbeat(options: JobHeartbeatOptions): () => void {
+  const { jobId, prisma = globalPrisma, intervalMs = JOB_HEARTBEAT_INTERVAL_MS, onError } = options
+  let stopped = false
+  let inFlight = false
+
+  const touch = () => {
+    if (stopped || inFlight) return
+    inFlight = true
+    // updateMany scoped to the row AND to a non-terminal status: a tick racing
+    // the pipeline's terminal write is a no-op, so the heartbeat can never
+    // resurrect (or even touch) a finished row. `updatedAt` is @updatedAt, but
+    // we set it explicitly so the touch does not depend on that attribute.
+    prisma.migrationJob
+      .updateMany({
+        where: { id: jobId, status: { notIn: [...TERMINAL_STATUSES] } },
+        data: { updatedAt: new Date() },
+      })
+      .then(
+        () => {},
+        (err) => { try { onError?.(err) } catch { /* observability must never kill the job */ } },
+      )
+      .finally(() => { inFlight = false })
+  }
+
+  const timer = setInterval(touch, intervalMs)
+  // Do not keep the Node process alive just for a heartbeat timer.
+  if (typeof (timer as any).unref === "function") (timer as any).unref()
+
+  return function stop() {
+    if (stopped) return
+    stopped = true
+    clearInterval(timer)
+  }
+}

--- a/frontend/src/lib/migration/orphan-sweep.test.ts
+++ b/frontend/src/lib/migration/orphan-sweep.test.ts
@@ -1,0 +1,157 @@
+import os from "node:os"
+
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { prismaTest, truncate } from "@/__tests__/setup/prisma-test"
+import {
+  FOREIGN_ORPHAN_MAX_AGE_MS,
+  ORPHANED_JOB_ERROR,
+  resolveInstanceId,
+  sweepOrphanedMigrationJobs,
+} from "./orphan-sweep"
+
+// The sweep module transitively imports @/lib/tenant via sharedTask; keep the
+// auth surface out of the node test environment.
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+
+const NOW = new Date("2026-07-29T12:00:00.000Z")
+const ME = "node-a"
+
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 60 * 60 * 1000)
+
+async function seedJob(over: Record<string, unknown> = {}) {
+  return prismaTest.migrationJob.create({
+    data: {
+      sourceConnectionId: "src",
+      sourceVmId: "vm-1",
+      targetConnectionId: "tgt",
+      targetNode: "pve1",
+      targetStorage: "local-lvm",
+      status: "transferring",
+      currentStep: "transferring",
+      updatedAt: NOW,
+      ...over,
+    },
+  })
+}
+
+const sweep = () => sweepOrphanedMigrationJobs({ prisma: prismaTest, instanceId: ME, now: NOW })
+const reload = (id: string) => prismaTest.migrationJob.findUniqueOrThrow({ where: { id } })
+
+beforeEach(async () => {
+  await truncate(["migration_jobs"])
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
+
+afterAll(async () => {
+  await prismaTest.$disconnect()
+})
+
+describe("sweepOrphanedMigrationJobs", () => {
+  it("fails non-terminal jobs owned by this instance regardless of age", async () => {
+    const fresh = await seedJob({ ownerInstanceId: ME, updatedAt: NOW })
+    const stale = await seedJob({ ownerInstanceId: ME, status: "pending", updatedAt: hoursAgo(48) })
+
+    const res = await sweep()
+    expect(res).toEqual({ owned: 2, foreign: 0, total: 2 })
+
+    for (const id of [fresh.id, stale.id]) {
+      const job = await reload(id)
+      expect(job.status).toBe("failed")
+      // currentStep must follow status: the task bar and the detail dialog both
+      // render the step, so leaving "transferring" shows a failed job as live.
+      expect(job.currentStep).toBe("failed")
+      expect(job.error).toBe(ORPHANED_JOB_ERROR)
+      expect(job.error).toMatch(/stopped/)
+      expect(job.completedAt?.getTime()).toBe(NOW.getTime())
+    }
+  })
+
+  it("fails an ownerless legacy job only once it has been silent for more than 12h", async () => {
+    const old = await seedJob({ updatedAt: hoursAgo(13) })
+    const atCutoff = await seedJob({ updatedAt: new Date(NOW.getTime() - FOREIGN_ORPHAN_MAX_AGE_MS) })
+    const recent = await seedJob({ updatedAt: hoursAgo(1) })
+
+    const res = await sweep()
+    expect(res).toEqual({ owned: 0, foreign: 1, total: 1 })
+
+    expect((await reload(old.id)).status).toBe("failed")
+    // strict `<` cutoff and a live-looking row: both stay untouched
+    for (const id of [atCutoff.id, recent.id]) {
+      const job = await reload(id)
+      expect(job.status).toBe("transferring")
+      expect(job.error).toBeNull()
+      expect(job.completedAt).toBeNull()
+    }
+  })
+
+  // The regression that would have kept spahit's job immortal: os.hostname() is
+  // the container id on a single-node install, so an image upgrade renames this
+  // instance and its own leftover rows come back as foreign.
+  it("fails a job left by a renamed instance once it is past the age bound", async () => {
+    const oldIncarnation = await seedJob({ ownerInstanceId: "previous-container-id", updatedAt: hoursAgo(18) })
+
+    const res = await sweep()
+    expect(res).toEqual({ owned: 0, foreign: 1, total: 1 })
+
+    const job = await reload(oldIncarnation.id)
+    expect(job.status).toBe("failed")
+    expect(job.currentStep).toBe("failed")
+    expect(job.error).toBe(ORPHANED_JOB_ERROR)
+  })
+
+  it("never touches a recent job owned by another instance, which may be a live peer", async () => {
+    const peer = await seedJob({ ownerInstanceId: "node-b", updatedAt: hoursAgo(2) })
+
+    const res = await sweep()
+    expect(res).toEqual({ owned: 0, foreign: 0, total: 0 })
+
+    const job = await reload(peer.id)
+    expect(job.status).toBe("transferring")
+    expect(job.error).toBeNull()
+    expect(job.completedAt).toBeNull()
+  })
+
+  it("never touches terminal jobs, even our own or ancient ownerless ones", async () => {
+    const done = new Date("2026-07-01T00:00:00.000Z")
+    const completed = await seedJob({ ownerInstanceId: ME, status: "completed", completedAt: done })
+    const cancelled = await seedJob({ status: "cancelled", updatedAt: hoursAgo(100), completedAt: done })
+    const failed = await seedJob({ ownerInstanceId: ME, status: "failed", error: "boom", completedAt: done })
+
+    const res = await sweep()
+    expect(res).toEqual({ owned: 0, foreign: 0, total: 0 })
+
+    expect((await reload(completed.id)).status).toBe("completed")
+    expect((await reload(cancelled.id)).status).toBe("cancelled")
+    const failedJob = await reload(failed.id)
+    expect(failedJob.error).toBe("boom")
+    expect(failedJob.completedAt?.getTime()).toBe(done.getTime())
+  })
+})
+
+describe("resolveInstanceId", () => {
+  it("prefers PROXCENTER_INSTANCE_ID", () => {
+    vi.stubEnv("PROXCENTER_INSTANCE_ID", "pve-node-1")
+    expect(resolveInstanceId()).toBe("pve-node-1")
+  })
+
+  it("falls back to os.hostname() when the override is unset or empty", () => {
+    vi.stubEnv("PROXCENTER_INSTANCE_ID", "")
+    vi.spyOn(os, "hostname").mockReturnValue("bare-metal-1")
+    expect(resolveInstanceId()).toBe("bare-metal-1")
+  })
+
+  // The Dockerfile sets HOSTNAME=0.0.0.0 for Next's standalone server, so every
+  // instance would claim the same identity and sweep its peers' live jobs.
+  it("ignores HOSTNAME, which the image pins to 0.0.0.0 for every instance", () => {
+    vi.stubEnv("PROXCENTER_INSTANCE_ID", "")
+    vi.stubEnv("HOSTNAME", "0.0.0.0")
+    vi.spyOn(os, "hostname").mockReturnValue("real-host")
+    expect(resolveInstanceId()).toBe("real-host")
+  })
+})

--- a/frontend/src/lib/migration/orphan-sweep.ts
+++ b/frontend/src/lib/migration/orphan-sweep.ts
@@ -1,0 +1,83 @@
+// Startup sweep for migration jobs orphaned by a server restart (#608).
+// Pipelines run in an unsupervised after() continuation of the POST request,
+// so a process death mid-transfer leaves the row non-terminal forever and the
+// task bar shows a dead job as "In progress" indefinitely.
+import os from "node:os"
+
+import type { PrismaClient } from "@prisma/client"
+
+import { TERMINAL_STATUSES } from "@/lib/tasks/sharedTask"
+
+// A live migration can legitimately be silent for hours (#606: 2h31 spent
+// zeroing a thick warm target without emitting a single log line), so a row we
+// do not own is only swept once it has been silent longer than any plausible
+// step. Jobs heartbeat while they run, so this bound is about a dead writer,
+// not about a slow one.
+export const FOREIGN_ORPHAN_MAX_AGE_MS = 12 * 60 * 60 * 1000
+
+// Status is "failed" (not "cancelled") so the existing retry route accepts it.
+export const ORPHANED_JOB_ERROR =
+  "Migration interrupted: the ProxCenter server running this job stopped (restart, upgrade or crash). It did not complete and can be retried."
+
+/** Stable identity of this server across restarts: same per host, distinct per HA replica. */
+export function resolveInstanceId(): string {
+  // Never process.env.HOSTNAME: the Dockerfile pins it to 0.0.0.0 so Next's
+  // standalone server binds every interface, so every replica would answer the
+  // same identity and each boot would sweep its live peers' jobs.
+  // os.hostname() is the node hostname under the HA compose (host networking)
+  // and the container id otherwise; PROXCENTER_INSTANCE_ID overrides it for
+  // deployments that want an identity surviving container recreation. It must
+  // be unique per running instance.
+  return process.env.PROXCENTER_INSTANCE_ID || os.hostname()
+}
+
+export interface OrphanSweepResult {
+  owned: number
+  foreign: number
+  total: number
+}
+
+/**
+ * Fail migration jobs that can no longer be running:
+ * - non-terminal rows owned by `instanceId` — we are just booting, so a row
+ *   owned by our own previous incarnation cannot still be running;
+ * - non-terminal rows owned by nobody (created before owner tagging existed)
+ *   or by another instance, once they have been silent for longer than
+ *   FOREIGN_ORPHAN_MAX_AGE_MS. Both cases matter: os.hostname() is the
+ *   container id on a single-node install, so an image upgrade turns our own
+ *   previous rows into foreign ones, and without this branch they would stay
+ *   non-terminal forever. The age bound is what keeps the sweep from killing a
+ *   live migration running on a peer replica.
+ */
+export async function sweepOrphanedMigrationJobs(deps: {
+  prisma: Pick<PrismaClient, "migrationJob">
+  instanceId: string
+  now?: Date
+}): Promise<OrphanSweepResult> {
+  const { prisma, instanceId, now = new Date() } = deps
+  const nonTerminal = { notIn: [...TERMINAL_STATUSES] }
+  // currentStep tracks status everywhere else (pipelines, cancel route).
+  const failure = {
+    status: "failed",
+    currentStep: "failed",
+    error: ORPHANED_JOB_ERROR,
+    completedAt: now,
+  }
+
+  const owned = await prisma.migrationJob.updateMany({
+    where: { ownerInstanceId: instanceId, status: nonTerminal },
+    data: failure,
+  })
+  const foreign = await prisma.migrationJob.updateMany({
+    where: {
+      // Spelled out rather than `{ not: instanceId }`: on a nullable column
+      // that comparison drops the NULL rows, which are exactly the legacy ones.
+      OR: [{ ownerInstanceId: null }, { ownerInstanceId: { not: instanceId } }],
+      status: nonTerminal,
+      updatedAt: { lt: new Date(now.getTime() - FOREIGN_ORPHAN_MAX_AGE_MS) },
+    },
+    data: failure,
+  })
+
+  return { owned: owned.count, foreign: foreign.count, total: owned.count + foreign.count }
+}

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -30,6 +30,7 @@ import {
 } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
+import { startJobHeartbeat } from "./job-heartbeat"
 import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
@@ -155,6 +156,10 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
   // vmkfstools clone targets). User-selectable; falls back to /tmp for backwards compat.
   // /tmp is often a tiny tmpfs on Proxmox — a multi-GB disk transfer will saturate it.
   const tempBase = (config.tempStorage && config.tempStorage.trim()) ? config.tempStorage.trim().replace(/\/+$/, '') : '/tmp'
+
+  // Liveness signal for the orphan sweep (#608): bump updatedAt while the job
+  // runs so a long silent step (#606) is never mistaken for a dead process.
+  const stopHeartbeat = startJobHeartbeat({ jobId, prisma })
 
   try {
     // ── STEP 0: Pre-flight ──
@@ -2785,7 +2790,9 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       bytesTransferred: BigInt(totalCapacity),
       totalBytes: BigInt(totalCapacity),
     })
-    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success")
+    // Non-fatal: a failing log append after the terminal write must not throw
+    // us into the catch, which would flip a completed job to "failed" (#608).
+    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success").catch(() => {})
 
     // Audit
     const { audit } = await import("@/lib/audit")
@@ -2803,8 +2810,11 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
     })
   } catch (err: any) {
     const errorMsg = err?.message || String(err)
-    await updateJob(jobId, "failed", { error: errorMsg })
-    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error")
+    // Terminal status first, and nothing may prevent it — a throwing appendLog
+    // or DB hiccup here would leave the row non-terminal forever (#608). The
+    // cleanup below must also run even if these writes fail.
+    await updateJob(jobId, "failed", { error: errorMsg }).catch(() => {})
+    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error").catch(() => {})
 
     // Cleanup: remove temp files on Proxmox node
     try {
@@ -2874,6 +2884,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       }
     }
   } finally {
+    stopHeartbeat()
     if (soapSession) {
       await soapLogout(soapSession)
     }

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -48,6 +48,7 @@ import {
 } from "@/lib/vmware/soap"
 import type { SoapSession, NfcLeaseDeviceUrl, EsxiVmConfig } from "@/lib/vmware/soap"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
+import { startJobHeartbeat } from "./job-heartbeat"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
 
@@ -1141,6 +1142,10 @@ export async function runV2vMigrationPipeline(
   // can remove the snapshot even on failure paths.
   let liveSnapshotMor: string | null = null
   let livePoweredOff = false
+
+  // Liveness signal for the orphan sweep (#608): bump updatedAt while the job
+  // runs so a long silent step (#606) is never mistaken for a dead process.
+  const stopHeartbeat = startJobHeartbeat({ jobId, prisma })
 
   try {
     // ── PHASE 1: Preflight ──
@@ -2585,7 +2590,9 @@ export async function runV2vMigrationPipeline(
     }
 
     await updateJob(jobId, "completed", { progress: 100 })
-    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success")
+    // Non-fatal: a failing log append after the terminal write must not throw
+    // us into the catch, which would flip a completed job to "failed" (#608).
+    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success").catch(() => {})
 
     const { audit } = await import("@/lib/audit")
     await audit({
@@ -2635,8 +2642,12 @@ export async function runV2vMigrationPipeline(
     } catch { /* best effort */ }
   } catch (err: any) {
     const errorMsg = err?.message || String(err)
-    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error")
-    await updateJob(jobId, "failed", { error: errorMsg })
+    // Terminal status first, and nothing may prevent it: appendLog is a
+    // read-modify-write of the unbounded logs JSONB, and when it used to run
+    // first a failing log write skipped the "failed" write entirely, leaving
+    // the row "in progress" forever (#608). Cleanup below must also still run.
+    await updateJob(jobId, "failed", { error: errorMsg }).catch(() => {})
+    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error").catch(() => {})
 
     // Live migration: we may have left a snapshot on the source VM. Remove it
     // if possible so the source keeps running cleanly. Skip if the source is
@@ -2785,6 +2796,7 @@ export async function runV2vMigrationPipeline(
       }
     }
   } finally {
+    stopHeartbeat()
     // Always close the vCenter SOAP session if one is open. Leaving it dangling
     // would slowly exhaust vCenter's session pool (default cap ~250). Idempotent
     // and fault-tolerant: we never want cleanup to mask the real migration error.

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -30,6 +30,7 @@ import { checkVddkPreflight } from "./vddk-preflight"
 import { parseSha1Thumbprint } from "./thumbprint"
 import type { Extent } from "./extents"
 import { startSoapKeepAlive } from "./session-keepalive"
+import { startJobHeartbeat } from "../job-heartbeat"
 
 export type WarmStatus =
   | "pending" | "planning" | "enabling_cbt" | "full_copy" | "delta_sync"
@@ -210,6 +211,11 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
   // mid-stream. Persisted/resumable per-disk state (design §5.3/§12) is deferred.
   const targetDev = new Map<number, string>()
   const diskState = new Map<number, DiskWarmState>()
+
+  // Liveness signal for the orphan sweep (#608): bump updatedAt while the job
+  // runs. Warm is the pipeline that motivated it — a thick pre-zero can be
+  // silent for hours (#606) and must not look like a dead process.
+  const stopHeartbeat = startJobHeartbeat({ jobId, prisma })
 
   try {
     // ── planning ──
@@ -556,14 +562,19 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     }
 
     await updateJob(jobId, "completed", { progress: 100 })
-    await appendLog(jobId, "Warm migration complete", "success")
+    // Non-fatal: a failing log append after the terminal write must not throw
+    // us into the catch, which would flip a completed job to "failed" (#608).
+    await appendLog(jobId, "Warm migration complete", "success").catch(() => {})
   } catch (err: any) {
-    await appendLog(jobId, `Warm migration failed: ${err?.message || err}`, "error").catch(() => {})
+    // Terminal status first, and nothing may prevent it — a row left
+    // non-terminal here would show as "in progress" forever (#608).
     await updateJob(jobId, isCancelled(jobId) ? "cancelled" : "failed", { error: String(err?.message || err) }).catch(() => {})
+    await appendLog(jobId, `Warm migration failed: ${err?.message || err}`, "error").catch(() => {})
     // Best-effort cleanup: stop readers, remove OUR snapshots (specific MOR), free orphan volumes.
     await cleanupOnFailure(jobId, config, soapSession, ourSnapshots, allocatedVolumes, activeReaders, nodeIp).catch(() => {})
     throw err
   } finally {
+    stopHeartbeat()
     stopKeepAlive?.()
     if (soapSession) await soapLogout(soapSession).catch(() => {})
     jobPrisma.delete(jobId)

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -34,6 +34,7 @@ import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
+import { startJobHeartbeat } from "./job-heartbeat"
 
 type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
 
@@ -231,6 +232,10 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
 
   let targetVmid: number | null = null
   let storageTempDir = ''
+
+  // Liveness signal for the orphan sweep (#608): bump updatedAt while the job
+  // runs so a long silent step (#606) is never mistaken for a dead process.
+  const stopHeartbeat = startJobHeartbeat({ jobId, prisma })
 
   try {
     // ── STEP 0: Pre-flight ──
@@ -808,7 +813,9 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       bytesTransferred: BigInt(totalDiskBytes),
       totalBytes: BigInt(totalDiskBytes),
     })
-    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success")
+    // Non-fatal: a failing log append after the terminal write must not throw
+    // us into the catch, which would flip a completed job to "failed" (#608).
+    await appendLog(jobId, `Migration completed successfully! VM ${targetVmid} is ready on ${config.targetNode}.`, "success").catch(() => {})
 
     const { audit } = await import("@/lib/audit")
     await audit({
@@ -825,8 +832,11 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     })
   } catch (err: any) {
     const errorMsg = err?.message || String(err)
-    await updateJob(jobId, "failed", { error: errorMsg })
-    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error")
+    // Terminal status first, and nothing may prevent it — a throwing appendLog
+    // or DB hiccup here would leave the row non-terminal forever (#608). The
+    // cleanup below must also run even if these writes fail.
+    await updateJob(jobId, "failed", { error: errorMsg }).catch(() => {})
+    await appendLog(jobId, `Migration failed: ${errorMsg}`, "error").catch(() => {})
 
     // Cleanup: remove temp files
     try {
@@ -851,6 +861,7 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       }
     }
   } finally {
+    stopHeartbeat()
     cancelledJobs.delete(jobId)
     jobPrisma.delete(jobId)
   }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -3577,7 +3577,14 @@
     },
     "shared": {
       "detailTitle": "Migrationsaufgabe",
-      "startedBy": "Gestartet von {name}"
+      "startedBy": "Gestartet von {name}",
+      "cancelMigration": "Migration abbrechen",
+      "cancelConfirmTitle": "Diese Migration abbrechen?",
+      "cancelConfirmStop": "Die Migration wird sofort gestoppt, auch wenn sie von einem anderen Benutzer gestartet wurde.",
+      "cancelConfirmLeftovers": "Bereits kopierte Volumes und eine teilweise erstellte VMID können auf dem Zielknoten verbleiben. Bereinigen Sie sie manuell, wenn Sie sie nicht benötigen.",
+      "cancelConfirmKeep": "Migration fortsetzen",
+      "cancelling": "Wird abgebrochen...",
+      "cancelFailed": "Migration konnte nicht abgebrochen werden"
     },
     "types": {
       "qmstart": "VM-Start",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3618,7 +3618,14 @@
     },
     "shared": {
       "detailTitle": "Migration task",
-      "startedBy": "Started by {name}"
+      "startedBy": "Started by {name}",
+      "cancelMigration": "Cancel migration",
+      "cancelConfirmTitle": "Cancel this migration?",
+      "cancelConfirmStop": "The migration stops immediately, even if it was started by another user.",
+      "cancelConfirmLeftovers": "Volumes already copied and a partially created VMID may remain on the target node. Clean them up manually if you do not need them.",
+      "cancelConfirmKeep": "Keep migrating",
+      "cancelling": "Cancelling...",
+      "cancelFailed": "Failed to cancel the migration"
     },
     "types": {
       "qmstart": "VM Start",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -3618,7 +3618,14 @@
     },
     "shared": {
       "detailTitle": "Tarea de migración",
-      "startedBy": "Iniciada por {name}"
+      "startedBy": "Iniciada por {name}",
+      "cancelMigration": "Cancelar migración",
+      "cancelConfirmTitle": "¿Cancelar esta migración?",
+      "cancelConfirmStop": "La migración se detiene de inmediato, incluso si la inició otro usuario.",
+      "cancelConfirmLeftovers": "Los volúmenes ya copiados y un VMID creado parcialmente pueden permanecer en el nodo de destino. Límpielos manualmente si no los necesita.",
+      "cancelConfirmKeep": "Seguir migrando",
+      "cancelling": "Cancelando...",
+      "cancelFailed": "No se pudo cancelar la migración"
     },
     "types": {
       "qmstart": "Inicio de VM",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -3618,7 +3618,14 @@
     },
     "shared": {
       "detailTitle": "Tâche de migration",
-      "startedBy": "Lancé par {name}"
+      "startedBy": "Lancé par {name}",
+      "cancelMigration": "Annuler la migration",
+      "cancelConfirmTitle": "Annuler cette migration ?",
+      "cancelConfirmStop": "La migration s'arrête immédiatement, même si elle a été lancée par un autre utilisateur.",
+      "cancelConfirmLeftovers": "Des volumes déjà copiés et un VMID partiellement créé peuvent rester sur le nœud cible. Nettoyez-les manuellement si vous n'en avez pas besoin.",
+      "cancelConfirmKeep": "Continuer la migration",
+      "cancelling": "Annulation...",
+      "cancelFailed": "Échec de l'annulation de la migration"
     },
     "types": {
       "qmstart": "Démarrage VM",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -3618,7 +3618,14 @@
     },
     "shared": {
       "detailTitle": "마이그레이션 작업",
-      "startedBy": "{name}이(가) 시작함"
+      "startedBy": "{name}이(가) 시작함",
+      "cancelMigration": "마이그레이션 취소",
+      "cancelConfirmTitle": "이 마이그레이션을 취소하시겠습니까?",
+      "cancelConfirmStop": "다른 사용자가 시작한 마이그레이션이라도 즉시 중지됩니다.",
+      "cancelConfirmLeftovers": "이미 복사된 볼륨과 부분적으로 생성된 VMID가 대상 노드에 남을 수 있습니다. 필요하지 않으면 수동으로 정리하십시오.",
+      "cancelConfirmKeep": "마이그레이션 계속하기",
+      "cancelling": "취소 중...",
+      "cancelFailed": "마이그레이션을 취소하지 못했습니다"
     },
     "types": {
       "qmstart": "VM 시작",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -3579,7 +3579,14 @@
     },
     "shared": {
       "detailTitle": "迁移任务",
-      "startedBy": "由 {name} 发起"
+      "startedBy": "由 {name} 发起",
+      "cancelMigration": "取消迁移",
+      "cancelConfirmTitle": "确定要取消此次迁移吗？",
+      "cancelConfirmStop": "迁移将立即停止，即使它是由其他用户发起的。",
+      "cancelConfirmLeftovers": "已复制的卷和部分创建的 VMID 可能会留在目标节点上。如果不需要，请手动清理。",
+      "cancelConfirmKeep": "继续迁移",
+      "cancelling": "正在取消...",
+      "cancelFailed": "取消迁移失败"
     },
     "types": {
       "qmstart": "VM 启动",


### PR DESCRIPTION
Closes #608

## The problem

A migration reported as "In progress" for 18 days. Its logs stopped mid-transfer on disk 2 of 4, no failure line, and the task survived page reloads and a product upgrade. Nothing in the UI could clear it, and because the default tenant sees the whole fleet, every user kept seeing it.

## Root cause

The migration pipeline runs inside an unsupervised `after()` continuation of `POST /api/v1/migrations`, and the terminal status is written **only** by that same continuation. If the process dies mid-transfer (container restart, redeploy, OOM), no `catch` and no `finally` ever runs, so the row stays non-terminal forever. There was no reaper, heartbeat, watchdog or startup sweep anywhere, and the shared-task query has no age bound on non-terminal rows, so the row came back on every poll, forever.

Cancel would have unstuck it, but it was unreachable: the only Cancel button lives in the migrate dialog and depends on React state that is reset on every open, so it disappears after a reload.

## What this changes

**1. Deterministic orphan detection.** New `owner_instance_id` column on `migration_jobs`, stamped at both creation sites. At boot, non-terminal rows are failed with a clear error and stay retryable:

- rows owned by this instance, unconditionally, since a row owned by our own previous incarnation cannot still be running;
- rows owned by nobody (created before this column) or by another instance, only once they have been silent for more than 12 hours.

The second branch matters more than it looks: `os.hostname()` is the container id on a single-node install, so an image upgrade renames the instance and turns its own leftover rows into foreign ones. Without that branch, the exact row from this issue would have stayed immortal.

**No timeout-based reaper on our own rows.** A healthy migration can legitimately write nothing for a long time, so an age-based sweep of live jobs would fail real migrations.

**2. A heartbeat, which is what makes the age bound safe.** Each of the four pipelines now touches its row every minute for the whole job, so silence genuinely means the writer is gone. The touch is an `updateMany` scoped to the row and to a non-terminal status, so a tick racing the terminal write is a strict no-op and can never resurrect a finished job. The timer is unref'd and stopped in the pipeline's `finally`.

**3. Eight hardened terminal writes.** Across the four pipelines the status write now comes first and a failing log append can no longer swallow it. `appendLog` is a read-modify-write of an unbounded JSONB column, so it is a realistic failure point. One case was worse than a stuck row: on the success path a throwing log append fell into the `catch`, which flipped a `completed` job to `failed` and then ran the cleanup that **destroys the migrated VM**.

**4. Cancel reachable from the task bar.** The task detail dialog now offers Cancel for any non-terminal migration, with a confirmation that warns about already-copied volumes and a partially created VMID left on the target node. No client-side permission gate, matching the other migration actions; the server enforces `vm.migrate` and its 403 is surfaced. Seven new i18n keys in all six locales.

## Deployment note

`PROXCENTER_INSTANCE_ID` is the instance identity. The single-node compose stacks set it to a fixed value so a job interrupted by an image upgrade is cleaned up at the next boot instead of waiting out the 12-hour bound. The HA stack deliberately leaves it unset: with host networking the container inherits the node hostname, which is already unique per node and stable across container recreation. Two instances sharing one database must never share a value, and `.env.example` says so.

`HOSTNAME` is deliberately not used: the image pins it to `0.0.0.0` for the standalone server, so every instance would answer the same identity and each boot would sweep its live peers' jobs. A regression test covers that.

## Verification

- Full suite: 296 files, 2882 tests, green.
- `eslint .`: 0 errors.
- `next build`: green, including the type check.
- New tests: startup sweep against a real Postgres (owned, ownerless, renamed instance, live peer untouched, terminal rows untouched, strict cutoff), heartbeat (interval, stop idempotence, non-terminal scoping, swallowed errors, unref), boot wiring, and the Cancel dialog (visibility rules, confirmation required, success revalidation, 403 surfaced).
