### PR TITLE
fix(dashboard): keep widget filters reachable when they empty the view (#611)

### DIFF
--- a/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
@@ -244,7 +244,11 @@ return json.data || {}
     )
   }
 
-  if (!trendsData || trendsData.length === 0) {
+  const isEmpty = !trendsData || trendsData.length === 0
+
+  // Nothing to plot and no connection filter to blame: there is no control the
+  // user could act on, so the bare empty state is still the right answer.
+  if (isEmpty && selectedConnections.length === 0) {
     return (
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4, opacity: 0.65 }}>
         <Typography variant="caption">{t('common.noData')}</Typography>
@@ -286,8 +290,19 @@ return json.data || {}
         )}
       </Box>
 
-      {/* Chart */}
+      {/* Chart — an active connection filter can empty it, so the empty state
+          stays here and never replaces the controls above (#611). */}
       <Box sx={{ flex: 1, minHeight: 100, width: '100%' }}>
+        {isEmpty ? (
+          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 0.75 }}>
+            <Typography variant="caption" sx={{ opacity: 0.65 }}>{t('common.noResults')}</Typography>
+            <Box onClick={() => handleFilterChange([])} sx={{
+              px: 1, py: 0.25, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: 600,
+              color: c.textMuted, bgcolor: c.borderLight,
+              '&:hover': { bgcolor: c.surfaceSubtle, color: '#fff' },
+            }}>{t('common.reset')}</Box>
+          </Box>
+        ) : (
         <ChartContainer>
           <AreaChart data={trendsData} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
             <defs>
@@ -329,6 +344,7 @@ return (
             })}
           </AreaChart>
         </ChartContainer>
+        )}
       </Box>
 
     </Box>

--- a/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.test.tsx
+++ b/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen, waitFor } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import InfraGlobalChartWidget from './InfraGlobalChartWidget'
+
+/**
+ * Same bug class as #611: the connection filter is persisted in the widget
+ * settings, so an empty chart used to replace the controls permanently — a
+ * page reload restored the filter and landed straight back on "No data".
+ */
+
+// This project does not enable Vitest globals, so RTL's auto-cleanup is off.
+afterEach(cleanup)
+
+const data = {
+  clusters: [{ id: 'c1', name: 'cluster-1' }, { id: 'c2', name: 'cluster-2' }],
+  nodes: [
+    { name: 'pve-01', node: 'pve-01', connectionId: 'c1' },
+    { name: 'pve-02', node: 'pve-02', connectionId: 'c2' },
+  ],
+}
+
+// The widget fetches one trends endpoint per selected connection.
+const respondWith = (payload: unknown) =>
+  server.use(
+    http.post('/api/v1/connections/:connId/nodes/trends', () => HttpResponse.json({ data: payload })),
+  )
+
+const render = (settings: Record<string, unknown>) =>
+  renderWithProviders(
+    <InfraGlobalChartWidget
+      data={data}
+      loading={false}
+      timeRange="1h"
+      config={{ settings }}
+      onUpdateSettings={() => {}}
+    />,
+  )
+
+describe('InfraGlobalChartWidget empty states', () => {
+  it('keeps its controls when the selected connection has no trend data', async () => {
+    respondWith({})
+    render({ selectedConnections: ['c2'] })
+
+    expect(await screen.findByText('No results')).toBeInTheDocument()
+
+    // The bug: the metric toggle and the connection filter used to vanish,
+    // leaving no way to widen the selection back out.
+    expect(screen.getByText('CPU')).toBeInTheDocument()
+    expect(screen.getByText('RAM')).toBeInTheDocument()
+    expect(screen.getByText('Reset')).toBeInTheDocument()
+  })
+
+  it('falls back to the plain no-data card when no filter is responsible', async () => {
+    respondWith({})
+    render({})
+
+    expect(await screen.findByText('No data')).toBeInTheDocument()
+    expect(screen.queryByText('Reset')).not.toBeInTheDocument()
+  })
+
+  it('renders the chart when the selected connection returns points', async () => {
+    respondWith({ 'node:pve-02': [{ ts: 1, t: '10:00', cpu: 12, ram: 34 }] })
+    render({ selectedConnections: ['c2'] })
+
+    // Wait for the controls to actually mount: the widget paints a spinner
+    // first, so asserting an absence here would pass before anything renders.
+    expect(await screen.findByText('CPU')).toBeInTheDocument()
+    expect(screen.queryByText('No results')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/dashboard/widgets/VmHeatmapWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/VmHeatmapWidget.jsx
@@ -198,6 +198,14 @@ return (a.name || '').localeCompare(b.name || '')
     return filtered
   }, [data?.vmList, data?.lxcList, selectedConnections, mode, minThreshold])
 
+  // Guest count before any filter (connection, mode or threshold). Tells an
+  // empty grid caused by the user's own filters apart from one caused by
+  // there being nothing to show at all.
+  const totalGuests = useMemo(
+    () => [...(data?.vmList || []), ...(data?.lxcList || [])].filter(g => !g.template).length,
+    [data?.vmList, data?.lxcList],
+  )
+
   // Group by node
   const nodeGroups = useMemo(() => {
     const groups = {}
@@ -228,6 +236,14 @@ return { total: guests.length, avg: Math.round(vals.reduce((s, v) => s + v, 0) /
   const handleClick = useCallback((vm) => { router.push(`/infrastructure/inventory?vmid=${vm.vmid}&connId=${vm.connId}&node=${vm.node}&type=${vm.type}`) }, [router])
   const cycleThreshold = () => setMinThreshold(prev => prev === 0 ? 20 : prev === 20 ? 50 : 0)
 
+  // 'status' with no threshold and no connection filter shows every guest, so
+  // it is the one combination guaranteed to bring the grid back.
+  const resetFilters = () => {
+    setMode('status')
+    setMinThreshold(0)
+    if (selectedConnections.length > 0) handleFilterChange([])
+  }
+
   // Tile color based on mode
   const getTileColor = (vm) => {
     if (mode === 'status') return getStatusColor(vm.status)
@@ -254,9 +270,13 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
     return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>Loading...</Typography></Box>
   }
 
-  if (guests.length === 0) {
+  // Nothing to show and no filter to blame: the widget has no controls worth
+  // keeping on screen, so the bare empty card is still the right answer.
+  if (totalGuests === 0) {
     return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>{t('common.noData')}</Typography></Box>
   }
+
+  const isEmpty = guests.length === 0
 
   return (
     <Box sx={{ height: '100%', ...darkCard, display: 'flex', flexDirection: 'column' }}>
@@ -308,9 +328,24 @@ return mode === 'cpu' ? vm.cpuPct : vm.ramPct
         </Box>
       </Box>
 
-      {/* Grid by node */}
-      <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
-        {nodeGroups.map((group) => (
+      {/* Grid by node — the empty state lives here, never in place of the
+          header, so the filters that emptied it stay reachable. */}
+      <Box sx={{
+        flex: 1, overflow: 'auto', minHeight: 0,
+        ...(isEmpty && { display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 0.75 }),
+      }}>
+        {isEmpty && (
+          <>
+            <Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>{t('common.noResults')}</Typography>
+            {/* Guests exist but a filter hid them all, so a reset always applies. */}
+            <Box onClick={resetFilters} sx={{
+              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: 600,
+              color: c.textMuted, bgcolor: c.borderLight,
+              '&:hover': { bgcolor: c.surfaceSubtle, color: '#fff' },
+            }}>{t('common.reset')}</Box>
+          </>
+        )}
+        {!isEmpty && nodeGroups.map((group) => (
           <Box key={group.node} sx={{ mb: 1 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.4 }}>
               <Box sx={{ position: 'relative', width: 14, height: 14, flexShrink: 0 }}>

--- a/frontend/src/components/dashboard/widgets/VmHeatmapWidget.test.tsx
+++ b/frontend/src/components/dashboard/widgets/VmHeatmapWidget.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen, fireEvent } from '@/__tests__/setup/renderWithProviders'
+
+import VmHeatmapWidget from './VmHeatmapWidget'
+
+/**
+ * Regression cover for #611: applying a filter that matches no guest used to
+ * replace the whole widget with a bare "No data" card, taking the mode toggle
+ * and the threshold button down with it. The user was then stuck until a full
+ * page reload, because that state lives in the component.
+ */
+
+// This project does not enable Vitest globals, so RTL's auto-cleanup is off.
+afterEach(cleanup)
+
+type Guest = Record<string, unknown>
+
+const guest = (over: Guest = {}): Guest => ({
+  id: 'qemu/100', vmid: 100, name: 'web-01', node: 'obsidian-host', connId: 'c1',
+  type: 'qemu', status: 'running', cpu: 0.01, mem: 1024, maxmem: 4096, template: false,
+  ...over,
+})
+
+// Three near-idle running guests, as in the reported dashboard (1%, 0%, 0%).
+const idleData = {
+  clusters: [{ id: 'c1', name: 'cluster-1' }],
+  vmList: [
+    guest(),
+    guest({ id: 'qemu/101', vmid: 101, name: 'web-02', cpu: 0 }),
+    guest({ id: 'qemu/102', vmid: 102, name: 'db-01', cpu: 0 }),
+  ],
+  lxcList: [],
+}
+
+const render = (data: unknown) =>
+  renderWithProviders(
+    <VmHeatmapWidget data={data} loading={false} config={{}} onUpdateSettings={() => {}} />,
+  )
+
+// 'Status' is the one mode label that never doubles as a legend caption, and
+// it is the toggle that always widens the view back out to every guest.
+const expectEscapeHatch = () => expect(screen.getByText('Status')).toBeInTheDocument()
+
+describe('VmHeatmapWidget empty states', () => {
+  it('renders the guests grouped by node by default', () => {
+    render(idleData)
+    expect(screen.getByText('obsidian-host')).toBeInTheDocument()
+    expect(screen.getByText('(3)')).toBeInTheDocument()
+  })
+
+  it('keeps its controls when the threshold filters every guest out', () => {
+    render(idleData)
+
+    // Cycles the threshold from "all" to ">20%" — no guest reaches 20%.
+    fireEvent.click(screen.getByText('All'))
+
+    expect(screen.getByText('No results')).toBeInTheDocument()
+    expect(screen.queryByText('obsidian-host')).not.toBeInTheDocument()
+
+    // The bug: these used to vanish along with the grid, stranding the user.
+    expectEscapeHatch()
+    expect(screen.getByText('>20%')).toBeInTheDocument()
+    expect(screen.getByText('Reset')).toBeInTheDocument()
+  })
+
+  it('restores the guests when the reset affordance is used', () => {
+    render(idleData)
+    fireEvent.click(screen.getByText('All'))
+    expect(screen.getByText('No results')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Reset'))
+
+    expect(screen.queryByText('No results')).not.toBeInTheDocument()
+    expect(screen.getByText('obsidian-host')).toBeInTheDocument()
+  })
+
+  it('keeps its controls when a mode filters every guest out', () => {
+    // CPU and RAM modes only ever show running guests.
+    render({ ...idleData, vmList: idleData.vmList.map(g => ({ ...g, status: 'stopped' })) })
+
+    expect(screen.getByText('No results')).toBeInTheDocument()
+    expectEscapeHatch()
+
+    // Recovers in place — no page reload, which was the only way out before.
+    fireEvent.click(screen.getByText('Status'))
+    expect(screen.getByText('obsidian-host')).toBeInTheDocument()
+  })
+
+  it('falls back to the plain no-data card when there is genuinely nothing', () => {
+    render({ clusters: [], vmList: [], lxcList: [] })
+
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    expect(screen.queryByText('Status')).not.toBeInTheDocument()
+  })
+
+  it('does not offer a reset when no filter is responsible', () => {
+    // Templates are always excluded, so the grid is empty with no filter on.
+    render({ ...idleData, vmList: [guest({ template: true })] })
+
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    expect(screen.queryByText('Reset')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -87,6 +87,8 @@
     "with": "mit",
     "by": "von",
     "no_data": "Keine Daten",
+    "noData": "Keine Daten",
+    "noResults": "Keine Ergebnisse",
     "empty": "Leer",
     "overview": "Übersicht",
     "configuration": "Konfiguration",


### PR DESCRIPTION
Fixes #611.

## Problem

The Guest Heatmap rendered its empty state as an early return, in place of the header that holds the mode toggle, the threshold button and the connection filter. Any filter combination matching no guest therefore removed the very controls needed to undo it: the widget went blank and the only way out was a full page reload.

The reporter's dashboard makes it concrete. Their three guests sit at 1%, 0% and 0% CPU, so one click on the threshold button (labelled `All`, which actually applies `>20%`) emptied the grid. A reload appeared to "fix" it only because `mode` and `minThreshold` are local component state.

## Scope

A sweep of every dashboard widget found the same defect in a second one, and there it is worse. `InfraGlobalChartWidget` can be emptied by its connection filter, which is persisted in the widget settings, so a reload restored the filter and landed straight back on the empty state. That one had no escape at all.

Both are fixed here. `NodesGaugesWidget` already had the correct shape and was used as the reference: test the raw list, never the filtered one.

## Change

- The empty state moves into the content area, so the header always renders and the filters that emptied the view stay reachable.
- A reset returns to the one combination guaranteed to show every guest (status mode, no threshold, no connection filter).
- The bare no-data card is kept for when there is genuinely nothing to show, where no control would help anyway.
- Adds the German `common.noData` and `common.noResults` keys the widgets rely on, which were missing from that locale.

## Verification

- 9 new tests, of which 4 fail without the fix (verified by restoring the widgets from `main`).
- `npm run build`: exit 0.
- ESLint: 0 errors on the touched files.
- 100% of the new executable lines covered (29/29 and 15/15).

## Notes for the reviewer

Two pre-existing issues surfaced while working on this, both untouched here:

- The German locale is missing 28 `common` keys and carries 25 more under snake_case names (`no_data` rather than `noData`). Only the two keys this change depends on were added.
- The full jsdom vitest suite is already unstable on `main`: the set of failing files differs between runs on a clean tree, while each of those files passes in isolation. Likely the shared MSW server with `onUnhandledRequest: 'error'` catching requests still in flight from a previous file.
