### PR TITLE
fix(migration): report warm progress during pre-zero and copy (#502, #606)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -4024,7 +4024,7 @@ return vm?.isCluster ?? false
                           )}
                           <Chip
                             size="small"
-                            label={vmMigJob.status === 'completed' ? t('inventoryPage.esxiMigration.completed') : vmMigJob.status === 'failed' ? t('inventoryPage.esxiMigration.failed') : vmMigJob.status === 'cancelled' ? t('inventoryPage.esxiMigration.cancelled') : vmMigJob.status === 'awaiting_cutover' ? t('inventoryPage.esxiMigration.awaitingCutover') : (vmMigJob.currentStep || vmMigJob.status).replaceAll("_", ' ')}
+                            label={vmMigJob.status === 'completed' ? t('inventoryPage.esxiMigration.completed') : vmMigJob.status === 'failed' ? t('inventoryPage.esxiMigration.failed') : vmMigJob.status === 'cancelled' ? t('inventoryPage.esxiMigration.cancelled') : vmMigJob.status === 'awaiting_cutover' ? t('inventoryPage.esxiMigration.awaitingCutover') : vmMigJob.status === 'preparing_disks' ? t('inventoryPage.esxiMigration.preparingDisks') : (vmMigJob.currentStep || vmMigJob.status).replaceAll("_", ' ')}
                             color={vmMigJob.status === 'completed' ? 'success' : vmMigJob.status === 'failed' ? 'error' : vmMigJob.status === 'awaiting_cutover' ? 'warning' : 'primary'}
                             sx={{ height: 20, fontSize: 10, fontWeight: 600 }}
                           />

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/MigrationDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/MigrationDashboard.tsx
@@ -452,7 +452,7 @@ export default function MigrationDashboard({ externalHypervisors, onHostClick }:
                 : 'ri-loader-4-line'
               const isActive = job.status === 'transferring' || job.status === 'preflight' || job.status === 'creating_vm' || job.status === 'configuring' || job.status === 'pending'
                 // Warm migration (CBT) phases
-                || job.status === 'planning' || job.status === 'enabling_cbt' || job.status === 'full_copy' || job.status === 'delta_sync' || job.status === 'cutover' || job.status === 'verify'
+                || job.status === 'planning' || job.status === 'enabling_cbt' || job.status === 'preparing_disks' || job.status === 'full_copy' || job.status === 'delta_sync' || job.status === 'awaiting_cutover' || job.status === 'cutover' || job.status === 'verify'
               const duration = job.startedAt && job.completedAt
                 ? Math.round((new Date(job.completedAt).getTime() - new Date(job.startedAt).getTime()) / 1000)
                 : null

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -3027,6 +3027,9 @@ return
                   <Button
                     color="error"
                     onClick={() => {
+                      // preparing_disks is deliberately absent: nothing has been
+                      // copied while the targets are still being allocated/zeroed,
+                      // so cancelling frees the volumes without a confirm (#612).
                       const hasCopiedData = ['full_copy', 'delta_sync', 'awaiting_cutover', 'cutover', 'verify'].includes(migJob.status)
                       if (hasCopiedData) {
                         setCancelMigConfirmOpen(true)

--- a/frontend/src/lib/migration/warm/dd-progress.test.ts
+++ b/frontend/src/lib/migration/warm/dd-progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { parseDdProgress } from "./dd-progress"
+import { parseDdProgress, createDdProgressAccumulator } from "./dd-progress"
 
 describe("parseDdProgress", () => {
   it("parses a single dd progress line into bytes, seconds and derived rate", () => {
@@ -43,5 +43,45 @@ describe("parseDdProgress", () => {
     const r = parseDdProgress("4194304 bytes (4.2 MB, 4.0 MiB) copied, 0 s, 0 B/s")
     expect(r!.bytes).toBe(4194304)
     expect(r!.bytesPerSec).toBe(0)
+  })
+})
+
+describe("createDdProgressAccumulator", () => {
+  it("passes a single dd's monotonic counter through unchanged", () => {
+    const acc = createDdProgressAccumulator()
+    expect(acc("104857600 bytes (105 MB, 100 MiB) copied, 1 s, 105 MB/s")!.bytes).toBe(104857600)
+    expect(acc("524288000 bytes (524 MB, 500 MiB) copied, 5 s, 105 MB/s")!.bytes).toBe(524288000)
+  })
+
+  it("folds the previous dd's total when the counter restarts (#502)", () => {
+    // The apply path runs one dd per extent, so the status=progress counter
+    // restarts at 0 for every extent — the customer log showed "copying 0.0 GB"
+    // at the start of each batch. A drop in the counter means a new dd started.
+    const acc = createDdProgressAccumulator()
+    acc("1073741824 bytes (1.1 GB, 1.0 GiB) copied, 10 s, 107 MB/s")
+    const r = acc("4194304 bytes (4.2 MB, 4.0 MiB) copied, 0.1 s, 42 MB/s")
+    expect(r!.bytes).toBe(1073741824 + 4194304)
+  })
+
+  it("folds every restart when one chunk carries several dd completions", () => {
+    const acc = createDdProgressAccumulator()
+    const r = acc("100 bytes copied, 1 s\n50 bytes copied, 1 s\n30 bytes copied, 1 s")
+    expect(r!.bytes).toBe(180)
+  })
+
+  it("returns null on a chunk without progress lines and keeps its running total", () => {
+    const acc = createDdProgressAccumulator()
+    acc("100 bytes copied, 1 s")
+    expect(acc("1024+0 records in\n1024+0 records out")).toBeNull()
+    expect(acc("50 bytes copied, 1 s")!.bytes).toBe(150)
+  })
+
+  it("reports the latest dd's own rate, not a cumulative one", () => {
+    const acc = createDdProgressAccumulator()
+    acc("1000 bytes copied, 1 s")
+    const r = acc("500 bytes copied, 5 s")
+    expect(r!.bytes).toBe(1500)
+    expect(r!.bytesPerSec).toBe(100)
+    expect(r!.seconds).toBe(5)
   })
 })

--- a/frontend/src/lib/migration/warm/dd-progress.ts
+++ b/frontend/src/lib/migration/warm/dd-progress.ts
@@ -35,3 +35,34 @@ export function parseDdProgress(text: string): DdProgress | null {
   const bytesPerSec = seconds > 0 ? bytes / seconds : 0
   return { bytes, seconds, bytesPerSec }
 }
+
+/**
+ * Cumulative byte counter over a stream that interleaves MANY dd invocations.
+ * The block-apply path runs one dd per extent, so the status=progress counter
+ * restarts at 0 for every extent — which is why the job log used to read
+ * "copying 0.0 GB" at the start of each batch (#502). Within one dd the counter
+ * only grows, so a drop means the previous dd finished: fold its last figure
+ * into the running total. A dd whose final figure never exceeds its successor's
+ * first printed one goes undetected and is under-counted; callers correct at
+ * exact per-disk/per-pass boundaries, so the estimate is conservative, never
+ * inflated. `seconds`/`bytesPerSec` are the latest dd's own (current
+ * throughput), only `bytes` is cumulative.
+ */
+export function createDdProgressAccumulator(): (chunk: string) => DdProgress | null {
+  let folded = 0   // totals of dd invocations known to have finished
+  let current = 0  // last counter of the dd currently printing
+  return (chunk: string): DdProgress | null => {
+    let last: RegExpExecArray | null = null
+    for (let m = PROGRESS_RE.exec(chunk); m !== null; m = PROGRESS_RE.exec(chunk)) {
+      const bytes = Number(m[1])
+      if (bytes < current) folded += current
+      current = bytes
+      last = m
+    }
+    PROGRESS_RE.lastIndex = 0
+    if (!last) return null
+    const seconds = Number(last[2])
+    const bytesPerSec = seconds > 0 ? current / seconds : 0
+    return { bytes: folded + current, seconds, bytesPerSec }
+  }
+}

--- a/frontend/src/lib/migration/warm/warm-pipeline.test.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { planPasses, buildThickZeroScript, markVolumesCopied, requestWarmCutover, __isCutoverRequestedForTest, __awaitOperatorCutoverForTest } from "./warm-pipeline"
+import { planPasses, buildThickZeroScript, scaleWarmProgress, ZERO_PARALLEL_CHUNKS, markVolumesCopied, requestWarmCutover, __isCutoverRequestedForTest, __awaitOperatorCutoverForTest } from "./warm-pipeline"
+import { parseDdProgress } from "./dd-progress"
 import { volumesToFree, volumesToKeep, type AllocatedVolume } from "../pvesm-alloc"
 import { prismaTest, truncate } from "../../../__tests__/setup/prisma-test"
 
@@ -39,11 +40,11 @@ describe("planPasses", () => {
 describe("buildThickZeroScript", () => {
   const dev = "/dev/vg-ld6-isp/vm-116-disk-1"
 
-  it("queries the exact device size and bounds the zero-fill to it", () => {
+  it("queries the exact device size and bounds every zero stream to its range (#445)", () => {
     const cmd = buildThickZeroScript(dev)
-    expect(cmd).toContain("blockdev --getsize64")
-    // the bound is the byte size read back from the device
-    expect(cmd).toContain('head -c "$sz" /dev/zero')
+    expect(cmd).toContain(`blockdev --getsize64 '${dev}'`)
+    // one bounded `head -c … | dd` per parallel range — never an unbounded dd
+    expect(cmd.match(/head -c /g)).toHaveLength(ZERO_PARALLEL_CHUNKS)
   })
 
   it("does NOT emit the unbounded dd that ENOSPCs past end-of-device (#445)", () => {
@@ -56,14 +57,66 @@ describe("buildThickZeroScript", () => {
 
   it("prefers blkdiscard -z and only streams zeros on its failure", () => {
     const cmd = buildThickZeroScript(dev)
-    expect(cmd).toContain(`blkdiscard -z '${dev}'`)
-    // blkdiscard || stream: the stream is the fallback, not the primary path
-    expect(cmd.indexOf("blkdiscard -z")).toBeLessThan(cmd.indexOf("|| head -c"))
+    expect(cmd).toContain(`blkdiscard -z '${dev}' 2>&1`)
+    // blkdiscard first; the parallel dd streams are the fallback, not the primary path
+    expect(cmd.indexOf("blkdiscard -z")).toBeLessThan(cmd.indexOf("head -c"))
   })
 
-  it("keeps O_DIRECT with full 4 MiB blocks reassembled across the pipe", () => {
+  it("surfaces WHY the offload was refused with a parseable marker (#606)", () => {
+    // Today the blkdiscard error is only visible when the whole script fails;
+    // when the fallback succeeds the reason for the slow path is silently lost.
     const cmd = buildThickZeroScript(dev)
-    expect(cmd).toContain("bs=4M iflag=fullblock oflag=direct")
+    expect(cmd).toContain('echo "blkdiscard-refused: $out"')
+  })
+
+  it("splits the device into equal 4 MiB-aligned ranges, remainder on the last (#606)", () => {
+    // Queue depth 1 is why the field run sustained only 359 MiB/s on an FC
+    // array that reaches 1.9 GB/s with concurrency: one dd per range, in parallel.
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain(`per=$((sz / ${ZERO_PARALLEL_CHUNKS} / 4194304 * 4194304))`)
+    for (let i = 0; i < ZERO_PARALLEL_CHUNKS - 1; i++) {
+      expect(cmd).toContain(`head -c "$per" /dev/zero | dd of='${dev}'`)
+      expect(cmd).toContain(`seek=$((${i} * per))`)
+      expect(cmd).toContain(`2>"$t/z${i}" & p${i}=$!`)
+      expect(cmd).toContain(`wait $p${i} || fail=1`)
+    }
+    // the last range takes the remainder, so the whole device is covered
+    const last = ZERO_PARALLEL_CHUNKS - 1
+    expect(cmd).toContain(`head -c "$((sz - ${last} * per))" /dev/zero`)
+    expect(cmd).toContain(`seek=$((${last} * per))`)
+    expect(cmd).toContain(`wait $p${last} || fail=1`)
+  })
+
+  it("honours a custom chunk count, remainder included", () => {
+    const cmd = buildThickZeroScript(dev, 2)
+    expect(cmd).toContain("per=$((sz / 2 / 4194304 * 4194304))")
+    expect(cmd).toContain('head -c "$per" /dev/zero')
+    expect(cmd).toContain('head -c "$((sz - 1 * per))" /dev/zero')
+    expect(cmd).not.toContain("$t/z2")
+  })
+
+  it("degenerates to one bounded full-device stream with a single chunk", () => {
+    const cmd = buildThickZeroScript(dev, 1)
+    expect(cmd.match(/head -c /g)).toHaveLength(1)
+    expect(cmd).toContain('head -c "$((sz - 0 * per))" /dev/zero')
+    expect(cmd).toContain("seek=$((0 * per))")
+  })
+
+  it("aggregates the per-range progress into ONE line in dd's own format", () => {
+    // The poller line must be consumable by parseDdProgress unchanged, so the
+    // caller gets live bytes for the progress bar and the SSH stream stays alive
+    // (feeding the same inactivity guard as the copy).
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain('echo "$b bytes copied, $(($(date +%s)-start)) s"')
+    const sample = 'echo "$b bytes copied, $(($(date +%s)-start)) s"'
+      .replace('$b', "3221225472").replace("$(($(date +%s)-start))", "120")
+      .replace(/^echo "/, "").replace(/"$/, "")
+    expect(parseDdProgress(sample)).toEqual({ bytes: 3221225472, seconds: 120, bytesPerSec: 3221225472 / 120 })
+  })
+
+  it("keeps O_DIRECT with full 4 MiB pipe blocks and byte-exact seeks", () => {
+    const cmd = buildThickZeroScript(dev)
+    expect(cmd).toContain("bs=4M iflag=fullblock oflag=seek_bytes,direct conv=notrunc status=progress")
   })
 
   it("single-quotes the device in every write/read position", () => {
@@ -76,6 +129,33 @@ describe("buildThickZeroScript", () => {
   it("escapes an embedded single quote in the device path", () => {
     const cmd = buildThickZeroScript("/dev/x'y")
     expect(cmd).toContain(`'/dev/x'\\''y'`)
+  })
+})
+
+describe("scaleWarmProgress", () => {
+  // Locked scale: preparing_disks 0→10, full_copy 10→80, deltas 80→95, cutover+ 95→100.
+  it("pins the phase boundaries of the locked scale", () => {
+    expect(scaleWarmProgress(0, 10, 0, 1000)).toBe(0)
+    expect(scaleWarmProgress(0, 10, 1000, 1000)).toBe(10)
+    expect(scaleWarmProgress(10, 80, 500, 1000)).toBe(45)
+  })
+
+  it("clamps an overshooting numerator to the top of the window", () => {
+    // aligned/merged extents can apply a few more bytes than the raw CBT sum
+    expect(scaleWarmProgress(10, 80, 2000, 1000)).toBe(80)
+  })
+
+  it("never goes below the bottom of the window", () => {
+    expect(scaleWarmProgress(80, 95, -5, 1000)).toBe(80)
+  })
+
+  it("treats an empty phase as already complete", () => {
+    // e.g. a delta pass with zero changed bytes
+    expect(scaleWarmProgress(80, 95, 0, 0)).toBe(95)
+  })
+
+  it("rounds to a whole percent (the job column is an Int)", () => {
+    expect(scaleWarmProgress(0, 10, 1, 3)).toBe(3)
   })
 })
 

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -24,16 +24,17 @@ import { initDiskState, recordPass, type DiskWarmState } from "./state"
 import { startVddkReader, stopVddkReader, type VddkReaderHandle } from "./vddk-reader"
 import type { VddkOpts } from "./vddk-cmd"
 import { buildApplyScripts } from "./block-applier"
-import { parseDdProgress } from "./dd-progress"
+import { parseDdProgress, createDdProgressAccumulator } from "./dd-progress"
 import { detectChangedExtentsByChecksum, scanBlockChecksums } from "./checksum-detector"
 import { checkVddkPreflight } from "./vddk-preflight"
 import { parseSha1Thumbprint } from "./thumbprint"
 import type { Extent } from "./extents"
 import { startSoapKeepAlive } from "./session-keepalive"
 import { startJobHeartbeat } from "../job-heartbeat"
+import { TERMINAL_STATUSES } from "@/lib/tasks/sharedTask"
 
 export type WarmStatus =
-  | "pending" | "planning" | "enabling_cbt" | "full_copy" | "delta_sync"
+  | "pending" | "planning" | "enabling_cbt" | "preparing_disks" | "full_copy" | "delta_sync"
   | "awaiting_cutover" | "cutover" | "verify" | "completed" | "failed" | "cancelled"
 
 export interface WarmMigrationConfig {
@@ -82,6 +83,20 @@ async function updateJob(id: string, status: WarmStatus, extra: Record<string, a
   })
 }
 
+/**
+ * Throttled live-progress write, fired from an SSH onData callback that is not
+ * awaited by the pipeline. updateMany scoped to a non-terminal status: a
+ * straggler flush racing the terminal write in the catch must never resurrect a
+ * completed/failed/cancelled row (#608 — same guard as the job heartbeat).
+ */
+async function updateJobLive(id: string, status: WarmStatus, extra: Record<string, any> = {}) {
+  const prisma = jobPrisma.get(id)
+  await prisma.migrationJob.updateMany({
+    where: { id, status: { notIn: [...TERMINAL_STATUSES] } },
+    data: { status, currentStep: status, ...extra },
+  })
+}
+
 async function appendLog(id: string, msg: string, level: LogEntry["level"] = "info") {
   const prisma = jobPrisma.get(id)
   const job = await prisma.migrationJob.findUnique({ where: { id }, select: { logs: true, progress: true } })
@@ -122,6 +137,12 @@ const SNAPSHOT_PREFIX = "proxcenter-warm"
 // Ping the SOAP session every 60 s to prevent idle-expiry during long dd copies (issue #394).
 const SOAP_KEEPALIVE_INTERVAL_MS = 60_000
 
+// Parallel ranges for the streamed zero fallback. One dd is queue depth 1: the
+// #606 field run sustained only 359 MiB/s on an FC array that reaches 1.9 GB/s
+// with concurrency, i.e. 2 h 30 min to zero 3.1 TiB. FC/iSCSI arrays scale with
+// outstanding I/O, so a handful of concurrent streams recovers most of it.
+export const ZERO_PARALLEL_CHUNKS = 4
+
 /**
  * Build the node-side command that zeroes a freshly-allocated *thick* block
  * device before the CBT copy. Unwritten regions on a thick LV are not
@@ -129,20 +150,87 @@ const SOAP_KEEPALIVE_INTERVAL_MS = 60_000
  * map, so any gap left un-zeroed would surface a previous tenant's bytes (a
  * correctness AND information-leak bug). We prefer `blkdiscard -z` (offloaded
  * write-zeroes where the array supports it) and fall back to streaming zeros.
+ * When the array refuses the offload, the script says so with a parseable
+ * `blkdiscard-refused: <reason>` line — previously that reason was only visible
+ * if the whole script failed, so the slow path ran with no explanation (#606).
  *
- * The fallback streams `head -c <size> /dev/zero | dd …` rather than the earlier
+ * The fallback streams `head -c <bytes> /dev/zero | dd …` rather than the earlier
  * `dd if=/dev/zero of=DEV` (no count): a bare unbounded dd fills the device and
  * then issues one write *past* end-of-device, which returns ENOSPC and makes dd
  * exit 1 — even though every block was already zeroed — so the thick-zero step
  * could never succeed (this is what broke #445's disk 1 after a full 45-min
- * zero). Bounding the stream to `blockdev --getsize64` writes exactly the device
- * and exits 0. `iflag=fullblock` reassembles 4 MiB blocks across the pipe so
- * O_DIRECT accepts every write, including a sub-4 MiB final block (still
- * logical-block aligned because a device size is always a sector multiple).
+ * zero). The device is split into `chunks` equal 4 MiB-aligned ranges (the last
+ * takes the remainder) and each range gets its own bounded stream, run in
+ * parallel and reaped with `wait` (#606). Every stream is still bounded to its
+ * exact range, so the #445 ENOSPC-past-EOF failure cannot come back.
+ * `iflag=fullblock` reassembles 4 MiB blocks across the pipe so O_DIRECT
+ * accepts every write, including a sub-4 MiB final block (still logical-block
+ * aligned because a device size is always a sector multiple).
+ *
+ * The step used to run `status=none` — hours of total silence on a multi-TB LV,
+ * indistinguishable from a hang (#606). Now each range dd writes
+ * `status=progress` to its own temp file and a background poller sums the last
+ * counter of every range every 10 s into ONE line in dd's own summary format
+ * (`<bytes> bytes copied, <s> s`), so parseDdProgress consumes it unchanged,
+ * the caller can drive the progress bar, and the SSH stream stays alive for the
+ * same inactivity guard as the copy. On a range failure the dd error text (kept
+ * in the temp files) is replayed to stdout so the caller surfaces the real cause.
  */
-export function buildThickZeroScript(dev: string): string {
+export function buildThickZeroScript(dev: string, chunks: number = ZERO_PARALLEL_CHUNKS): string {
   const d = shellEscape(dev)
-  return `sz=$(blockdev --getsize64 ${d}); blkdiscard -z ${d} 2>&1 || head -c "$sz" /dev/zero | dd of=${d} bs=4M iflag=fullblock oflag=direct status=none 2>&1`
+  const n = Math.max(1, Math.floor(chunks))
+  const lines = [
+    `sz=$(blockdev --getsize64 ${d})`,
+    `t=$(mktemp -d)`,
+    `start=$(date +%s)`,
+    `( while :; do sleep 10; b=0; for f in "$t"/z*; do [ -s "$f" ] || continue; v=$(tr '\\r' '\\n' < "$f" | awk '/ bytes /{n=$1} END{print n+0}'); b=$((b+v)); done; echo "$b bytes copied, $(($(date +%s)-start)) s"; done ) & poller=$!`,
+    `trap 'kill $poller 2>/dev/null; rm -rf "$t"' EXIT`,
+    `if out=$(blkdiscard -z ${d} 2>&1); then echo "$sz bytes copied, $(($(date +%s)-start)) s"; exit 0; fi`,
+    `echo "blkdiscard-refused: $out"`,
+    `per=$((sz / ${n} / 4194304 * 4194304))`,
+  ]
+  for (let i = 0; i < n; i++) {
+    const bound = i === n - 1 ? `"$((sz - ${i} * per))"` : `"$per"`
+    lines.push(`head -c ${bound} /dev/zero | dd of=${d} bs=4M iflag=fullblock oflag=seek_bytes,direct conv=notrunc status=progress seek=$((${i} * per)) 2>"$t/z${i}" & p${i}=$!`)
+  }
+  lines.push(`fail=0`)
+  for (let i = 0; i < n; i++) lines.push(`wait $p${i} || fail=1`)
+  lines.push(`if [ "$fail" -ne 0 ]; then for f in "$t"/z*; do tr '\\r' '\\n' < "$f" | grep -v ' bytes \\|records '; done; exit 1; fi`)
+  lines.push(`echo "$sz bytes copied, $(($(date +%s)-start)) s"`)
+  return lines.join("\n")
+}
+
+/**
+ * Map a phase's byte counter onto its window of the warm run's locked progress
+ * scale (#502/#606): preparing_disks 0→10, full_copy 10→80, delta passes 80→95,
+ * cutover/verify/attach 95→100. Monotonic across the run as long as callers hand
+ * it non-decreasing byte counts and contiguous windows. A total of zero means
+ * the phase has nothing to do, i.e. it is already complete.
+ */
+export function scaleWarmProgress(rangeStart: number, rangeEnd: number, doneBytes: number, totalBytes: number): number {
+  if (totalBytes <= 0) return Math.round(rangeEnd)
+  const fraction = Math.min(1, Math.max(0, doneBytes / totalBytes))
+  return Math.round(rangeStart + (rangeEnd - rangeStart) * fraction)
+}
+
+/** One copy pass's slot on the locked progress scale (see scaleWarmProgress). */
+interface PassWindow {
+  status: WarmStatus
+  /** Persisted with each live update so a throttled flush never clobbers a
+   *  finer-grained step label (e.g. `delta_2`). */
+  currentStep: string
+  rangeStart: number
+  rangeEnd: number
+}
+
+/** Live byte bookkeeping for one pass, shared across its disks. */
+interface PassProgress extends PassWindow {
+  /** Denominator: changed-extent bytes across ALL disks of the pass. */
+  totalBytes: number
+  /** Exact bytes from disks already fully applied (corrected per disk). */
+  doneBytes: number
+  /** Monotonic floor so a conservative estimate never moves the bar backwards. */
+  lastPct: number
 }
 
 const OPERATOR_GATE_TIMEOUT_MS = 2 * 60 * 60 * 1000 // 2h safety cap
@@ -307,7 +395,15 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     // after the highest existing disk number, or `pvesm alloc` collides on the name.
     const shellConf = await pveFetch<Record<string, any>>(pveConn as any, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`)
 
-    // Allocate a raw block volume per disk and resolve (+ map) its device path.
+    // ── preparing_disks: allocate a raw block volume per disk, zero the thick ones ──
+    // A dedicated phase, not enabling_cbt: on thick LVM the mandatory pre-zero
+    // below can run for hours, and the badge must say what the job is doing (#606).
+    // Progress covers 0→10 of the locked scale, weighted by bytes zeroed across
+    // all disks (they share the target storage, so it is all-thick or none).
+    await updateJob(jobId, "preparing_disks")
+    const zeroTotalBytes = vmConfig.disks.reduce((s, d) => s + d.capacityBytes, 0)
+    let zeroedBytes = 0
+    let lastZeroPct = 0
     for (let i = 0; i < vmConfig.disks.length; i++) {
       const disk = vmConfig.disks[i]
       const sizeKB = Math.ceil(disk.capacityBytes / 1024)
@@ -335,13 +431,49 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       if (preZeroed) {
         await executeSSH(config.targetConnectionId, nodeIp, `blkdiscard ${shellEscape(dev)} 2>/dev/null || true`)
       } else {
-        const z = await executeSSH(config.targetConnectionId, nodeIp, buildThickZeroScript(dev), APPLY_TIMEOUT_MS)
-        // Surface z.output first: the script merges stderr into stdout (2>&1), so
-        // the real cause (e.g. "No space left on device", an array I/O error)
-        // lands in output while error is just "Exit code N" on the ssh2 path.
+        // #606: this step used to be hours of total silence (no start line, no
+        // output, status stuck on enabling_cbt) — operators cancelled healthy
+        // runs. Announce it, stream the script's aggregated dd progress through
+        // the same inactivity guard as the copy, and surface why the blkdiscard
+        // offload was refused when the streamed slow path runs.
+        const capGB = (disk.capacityBytes / 1073741824).toFixed(1)
+        await appendLog(jobId, `Disk ${i}: zeroing thick target ${dev} (${capGB} GB) — mandatory on thick storage and can take a long time; live throughput follows`)
+        let headBuf = ""              // first KBs of output; carries the refusal marker
+        let refusalLogged = false
+        let lastFlush = 0
+        const onData = (chunk: string): void => {
+          if (!refusalLogged && headBuf.length < 8192) {
+            headBuf += chunk
+            const m = /blkdiscard-refused: ([^\r\n]*)/.exec(headBuf)
+            if (m) {
+              refusalLogged = true
+              void appendLog(jobId, `Disk ${i}: array refused the blkdiscard write-zeroes offload (${m[1].trim() || "no reason given"}) — streaming zeros in ${ZERO_PARALLEL_CHUNKS} parallel ranges instead`, "warn").catch(() => {})
+            }
+          }
+          const p = parseDdProgress(chunk)
+          if (!p) return
+          const now = Date.now()
+          if (now - lastFlush < PROGRESS_LOG_INTERVAL_MS) return
+          lastFlush = now
+          const diskBytes = Math.min(p.bytes, disk.capacityBytes)
+          const pct = Math.max(lastZeroPct, scaleWarmProgress(0, 10, zeroedBytes + diskBytes, zeroTotalBytes))
+          lastZeroPct = pct
+          // Progress first, then the log line — appendLog stamps each entry with
+          // the job's current progress, which is why the lines used to read 0 (#502).
+          void (async () => {
+            await updateJobLive(jobId, "preparing_disks", { progress: pct, transferSpeed: `Zeroing: ${(p.bytesPerSec / 1048576).toFixed(0)} MB/s` })
+            await appendLog(jobId, `Disk ${i}: zeroed ${(diskBytes / 1073741824).toFixed(1)} of ${capGB} GB`)
+          })().catch(() => {})
+        }
+        const z = await executeSSH(config.targetConnectionId, nodeIp, buildThickZeroScript(dev), APPLY_TIMEOUT_MS, { inactivityMs: APPLY_INACTIVITY_MS, onData })
+        // Surface z.output first: the script replays the range dd errors to
+        // stdout, so the real cause (e.g. "No space left on device", an array
+        // I/O error) lands in output while error is just "Exit code N" on the
+        // ssh2 path.
         if (!z.success) throw new Error(`Failed to zero thick target ${dev} before warm copy (unwritten regions would expose stale data): ${z.output || z.error}`)
         await appendLog(jobId, `Disk ${i}: zeroed thick target ${dev}`)
       }
+      zeroedBytes += disk.capacityBytes
       await appendLog(jobId, `Disk ${i}: target ${vol.volumeId} → ${dev} (${(disk.capacityBytes / 1073741824).toFixed(1)} GB)`)
     }
 
@@ -352,19 +484,32 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     // "EOF" (#445). We run the commands in order and stop on the first failure,
     // so the original abort-on-first-error (`set -e`) semantics hold across the
     // split. `label` distinguishes the delta/full path from the checksum path.
-    async function applyExtents(nbdDev: string, dev: string, extents: Extent[], capacityBytes: number, label: string, diskIndex: number): Promise<void> {
-      // Live progress: parse dd's status=progress lines off the stream and log the
-      // current throughput (throttled). Also feeds executeSSH's inactivity guard,
-      // which resets on every byte — so a moving copy is never cut off and a stalled
-      // one fails within APPLY_INACTIVITY_MS instead of hanging to the 12h cap.
-      let lastLog = 0
+    async function applyExtents(nbdDev: string, dev: string, extents: Extent[], capacityBytes: number, label: string, diskIndex: number, pass: PassProgress): Promise<void> {
+      // Live progress: accumulate dd's status=progress counters off the stream —
+      // the pass runs one dd per extent, so the raw counter restarts at 0 with
+      // every batch and the log read "copying 0.0 GB" for the whole run (#502).
+      // The cumulative figure drives the job's progress/bytesTransferred within
+      // the pass's window (throttled to one DB write per interval). Also feeds
+      // executeSSH's inactivity guard, which resets on every byte — so a moving
+      // copy is never cut off and a stalled one fails within APPLY_INACTIVITY_MS
+      // instead of hanging to the 12h cap.
+      const accumulate = createDdProgressAccumulator()
+      let lastFlush = 0
       const onData = (chunk: string): void => {
-        const p = parseDdProgress(chunk)
+        const p = accumulate(chunk)
         if (!p) return
         const now = Date.now()
-        if (now - lastLog < PROGRESS_LOG_INTERVAL_MS) return
-        lastLog = now
-        void appendLog(jobId, `Disk ${diskIndex}: copying ${(p.bytes / 1073741824).toFixed(1)} GB at ${(p.bytesPerSec / 1048576).toFixed(0)} MB/s`).catch(() => {})
+        if (now - lastFlush < PROGRESS_LOG_INTERVAL_MS) return
+        lastFlush = now
+        const passBytes = Math.min(pass.doneBytes + p.bytes, pass.totalBytes)
+        const pct = Math.max(pass.lastPct, scaleWarmProgress(pass.rangeStart, pass.rangeEnd, passBytes, pass.totalBytes))
+        pass.lastPct = pct
+        // Progress first, then the log line — appendLog stamps each entry with
+        // the job's current progress, which is why the lines used to read 0 (#502).
+        void (async () => {
+          await updateJobLive(jobId, pass.status, { currentStep: pass.currentStep, progress: pct, bytesTransferred: BigInt(passBytes), transferSpeed: `${(p.bytesPerSec / 1048576).toFixed(0)} MB/s` })
+          await appendLog(jobId, `Disk ${diskIndex}: copying ${(passBytes / 1073741824).toFixed(1)} GB at ${(p.bytesPerSec / 1048576).toFixed(0)} MB/s`)
+        })().catch(() => {})
       }
       for (const script of buildApplyScripts(nbdDev, dev, extents, capacityBytes)) {
         const res = await executeSSH(config.targetConnectionId, nodeIp, script, APPLY_TIMEOUT_MS, { inactivityMs: APPLY_INACTIVITY_MS, onData })
@@ -373,7 +518,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     }
 
     // Read one disk of a snapshot through VDDK and apply its extents to the target.
-    async function readAndApply(disk: EsxiDiskInfo, diskIndex: number, snapMor: string, extents: Extent[]): Promise<number> {
+    async function readAndApply(disk: EsxiDiskInfo, diskIndex: number, snapMor: string, extents: Extent[], pass: PassProgress): Promise<number> {
       const bytes = extents.reduce((s, e) => s + e.length, 0)
       if (extents.length === 0) return 0
       const sock = `/tmp/proxcenter-vddk-${jobId}-${disk.deviceKey}.sock`
@@ -382,7 +527,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       const reader = await startVddkReader(config.targetConnectionId, nodeIp, opts, password)
       activeReaders.push(reader)
       try {
-        await applyExtents(reader.nbdDev, targetDev.get(disk.deviceKey)!, extents, disk.capacityBytes, "block apply failed", diskIndex)
+        await applyExtents(reader.nbdDev, targetDev.get(disk.deviceKey)!, extents, disk.capacityBytes, "block apply failed", diskIndex, pass)
         return bytes
       } finally {
         await stopVddkReader(config.targetConnectionId, nodeIp, reader).catch(() => {})
@@ -392,17 +537,33 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     }
 
     // Run one CBT pass: snapshot, per-disk query+read+apply, record changeIds, remove the snapshot.
-    async function runCbtPass(label: string, baseline: (deviceKey: number) => string): Promise<number> {
+    async function runCbtPass(label: string, baseline: (deviceKey: number) => string, window: PassWindow): Promise<number> {
       const snapMor = await soapCreateSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-${label}`, "warm migration", false)
       if (!snapMor) throw new Error(`CreateSnapshot (${label}) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually`)
       ourSnapshots.push(snapMor)
       let bytes = 0
       try {
+        // Query every disk's changed areas up front so the pass has its byte
+        // denominator before the first dd runs (#502): the sum weights the
+        // progress window and is persisted as totalBytes for the transfer
+        // readout. bytesTransferred restarts at 0 with each pass, matching it.
+        const extentsByDisk = new Map<number, Extent[]>()
+        let passTotalBytes = 0
+        for (const disk of vmConfig.disks) {
+          if (isCancelled(jobId)) throw new Error("Migration cancelled")
+          const extents = await queryAllChangedAreas(soapSession!, config.sourceVmId, snapMor, disk.deviceKey, baseline(disk.deviceKey), disk.capacityBytes)
+          extentsByDisk.set(disk.deviceKey, extents)
+          passTotalBytes += extents.reduce((s, e) => s + e.length, 0)
+        }
+        const pass: PassProgress = { ...window, totalBytes: passTotalBytes, doneBytes: 0, lastPct: Math.round(window.rangeStart) }
+        await updateJob(jobId, window.status, { currentStep: window.currentStep, progress: pass.lastPct, totalBytes: BigInt(passTotalBytes), bytesTransferred: BigInt(0) })
         for (let i = 0; i < vmConfig.disks.length; i++) {
           if (isCancelled(jobId)) throw new Error("Migration cancelled")
           const disk = vmConfig.disks[i]
-          const extents = await queryAllChangedAreas(soapSession!, config.sourceVmId, snapMor, disk.deviceKey, baseline(disk.deviceKey), disk.capacityBytes)
-          bytes += await readAndApply(disk, i, snapMor, extents)
+          bytes += await readAndApply(disk, i, snapMor, extentsByDisk.get(disk.deviceKey)!, pass)
+          // Correct the estimate with the disk's exact extent total: the dd
+          // accumulator is conservative (see createDdProgressAccumulator).
+          pass.doneBytes = bytes
         }
         // Record this snapshot's per-disk changeId as the next pass's baseline.
         const cids = await soapGetSnapshotChangeIds(soapSession!, snapMor)
@@ -427,17 +588,18 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     }
 
     if (useCbt) {
-      // ── full_copy: pass 0 with the "*" baseline ──
-      await updateJob(jobId, "full_copy", { progress: 0 })
+      // ── full_copy: pass 0 with the "*" baseline (10→80 on the locked scale) ──
+      await updateJob(jobId, "full_copy", { progress: 10 })
       await appendLog(jobId, "Full copy (CBT allocated map)…")
       const t0 = Date.now()
-      const fullBytes = await runCbtPass("full", () => "*")
+      const fullBytes = await runCbtPass("full", () => "*", { status: "full_copy", currentStep: "full_copy", rangeStart: 10, rangeEnd: 80 })
       // The full pass applied a VMware-snapshot-consistent image of every disk:
       // from this point the target holds a bootable point-in-time copy worth hours
       // of transfer, so failure cleanup must keep these volumes, not free them (#612).
       markVolumesCopied(allocatedVolumes)
       const fullSec = Math.max(1, (Date.now() - t0) / 1000)
       let throughput = fullBytes / fullSec
+      await updateJob(jobId, "full_copy", { progress: 80, bytesTransferred: BigInt(fullBytes), transferSpeed: `${(throughput / 1048576).toFixed(0)} MB/s` })
       await appendLog(jobId, `Full copy done: ${(fullBytes / 1073741824).toFixed(2)} GB at ${(throughput / 1048576).toFixed(0)} MB/s`, "success")
 
       // ── delta_sync: converge by downtime budget ──
@@ -448,12 +610,18 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         if (isCutoverRequested(jobId)) { await appendLog(jobId, "Operator requested cutover — proceeding to final delta", "info"); break }
         const tk = Date.now()
         await updateJob(jobId, "delta_sync", { currentStep: `delta_${pass + 1}` })
-        const deltaBytes = await runCbtPass(`delta-${pass + 1}`, dk => diskState.get(dk)!.currentChangeId || "*")
+        // Each delta pass advances through an equal slice of the 80→95 delta
+        // window; a run that converges before maxPasses jumps to 95 at cutover.
+        const deltaWindow: PassWindow = {
+          status: "delta_sync", currentStep: `delta_${pass + 1}`,
+          rangeStart: 80 + (15 * pass) / maxPasses, rangeEnd: 80 + (15 * (pass + 1)) / maxPasses,
+        }
+        const deltaBytes = await runCbtPass(`delta-${pass + 1}`, dk => diskState.get(dk)!.currentChangeId || "*", deltaWindow)
         const dsec = Math.max(1, (Date.now() - tk) / 1000)
         throughput = deltaBytes > 0 ? deltaBytes / dsec : throughput
         await appendLog(jobId, `Delta pass ${pass + 1}: ${(deltaBytes / 1048576).toFixed(1)} MB`)
         const decision = decideNextPass(pass, { deltaBytes, throughputBytesPerSec: throughput }, cfg)
-        await updateJob(jobId, "delta_sync", { currentStep: `delta_${pass + 1}`, projectedDowntimeSec: decision.projectedDowntimeSec })
+        await updateJob(jobId, "delta_sync", { currentStep: `delta_${pass + 1}`, projectedDowntimeSec: decision.projectedDowntimeSec, progress: Math.round(deltaWindow.rangeEnd) })
         if (decision.action === "cutover") break
         if (decision.action === "operator-gate") {
           await awaitOperatorCutover(jobId, decision.projectedDowntimeSec, budget, maxPasses)
@@ -463,15 +631,15 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       }
 
       // ── cutover: confirmed power-off → final delta → verify → attach → boot ──
-      await updateJob(jobId, "cutover")
+      await updateJob(jobId, "cutover", { progress: 95 })
       await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId)
       await appendLog(jobId, "Source powered off (confirmed) — applying final delta", "success")
-      await runCbtPass("cutover", dk => diskState.get(dk)!.currentChangeId || "*")
+      await runCbtPass("cutover", dk => diskState.get(dk)!.currentChangeId || "*", { status: "cutover", currentStep: "cutover", rangeStart: 95, rangeEnd: 98 })
     } else {
       // ── checksum fallback: stop source, full block-diff vs the (zeroed) target ──
       await updateJob(jobId, "cutover")
       await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId)
-      await updateJob(jobId, "full_copy")
+      await updateJob(jobId, "full_copy", { progress: 10 })
       const snapMor = await soapCreateSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-checksum`, "warm migration", false)
       if (!snapMor) throw new Error("CreateSnapshot (checksum) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually")
       ourSnapshots.push(snapMor)
@@ -486,7 +654,16 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
           try {
             const dev = targetDev.get(disk.deviceKey)!
             const extents = await detectChangedExtentsByChecksum(config.targetConnectionId, nodeIp, reader.nbdDev, dev, 256 * 1024 * 1024, disk.capacityBytes)
-            await applyExtents(reader.nbdDev, dev, extents, disk.capacityBytes, "checksum apply failed", i)
+            // Per-disk progress window: unlike runCbtPass there is no upfront
+            // all-disk denominator here (the checksum scan needs each disk's
+            // reader), so each disk gets an equal slice of the 10→80 window.
+            const span = 70 / vmConfig.disks.length
+            await applyExtents(reader.nbdDev, dev, extents, disk.capacityBytes, "checksum apply failed", i, {
+              status: "full_copy", currentStep: "full_copy",
+              rangeStart: 10 + span * i, rangeEnd: 10 + span * (i + 1),
+              totalBytes: extents.reduce((s, e) => s + e.length, 0), doneBytes: 0,
+              lastPct: Math.round(10 + span * i),
+            })
           } finally {
             await stopVddkReader(config.targetConnectionId, nodeIp, reader).catch(() => {})
             const idx = activeReaders.indexOf(reader)
@@ -511,7 +688,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     // now powered off, so its current disk == the cutover state (no snapshot param).
     // A mismatch is a loud warning, never a hard failure; the authoritative full
     // cmp is the lab runbook.
-    await updateJob(jobId, "verify")
+    await updateJob(jobId, "verify", { progress: 98 })
     for (let i = 0; i < vmConfig.disks.length; i++) {
       const disk = vmConfig.disks[i]
       const dev = targetDev.get(disk.deviceKey)!

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2038,6 +2038,7 @@
       "estimatedDowntime": "Geschätzte Umschalt-Ausfallzeit",
       "estimatedDowntimeHint": "Zeit, in der die VM während der finalen Umschaltung offline ist, basierend auf dem letzten Delta-Durchlauf.",
       "awaitingCutover": "Wartet auf Umschaltung",
+      "preparingDisks": "Ziel-Festplatten werden vorbereitet",
       "cutoverNow": "Jetzt umschalten",
       "cutoverConfirmTitle": "Jetzt umschalten?",
       "cutoverConfirmBody": "Die Quell-VM wird heruntergefahren und die letzten Änderungen kopiert. Rechnen Sie mit etwa {mins} Min. Ausfallzeit. Fortfahren?",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2069,6 +2069,7 @@
       "estimatedDowntime": "Estimated cutover downtime",
       "estimatedDowntimeHint": "Time the VM will be offline during the final switchover, based on the last delta pass.",
       "awaitingCutover": "Waiting for cutover",
+      "preparingDisks": "Preparing target disks",
       "cutoverNow": "Cutover now",
       "cutoverConfirmTitle": "Cut over now?",
       "cutoverConfirmBody": "The source VM will be shut down and the final changes copied. Expect roughly {mins} min of downtime. Continue?",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2069,6 +2069,7 @@
       "estimatedDowntime": "Downtime de conmutación estimado",
       "estimatedDowntimeHint": "Tiempo que la VM estará fuera de línea durante la conmutación final, según la última pasada delta.",
       "awaitingCutover": "Esperando conmutación",
+      "preparingDisks": "Preparando los discos de destino",
       "cutoverNow": "Conmutar ahora",
       "cutoverConfirmTitle": "¿Conmutar ahora?",
       "cutoverConfirmBody": "La VM de origen se apagará y se copiarán los últimos cambios. Prevea unos {mins} min de inactividad. ¿Continuar?",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2069,6 +2069,7 @@
       "estimatedDowntime": "Downtime de bascule estimé",
       "estimatedDowntimeHint": "Durée d'indisponibilité de la VM pendant la bascule finale, d'après la dernière passe delta.",
       "awaitingCutover": "En attente de bascule",
+      "preparingDisks": "Préparation des disques cibles",
       "cutoverNow": "Basculer maintenant",
       "cutoverConfirmTitle": "Basculer maintenant ?",
       "cutoverConfirmBody": "La VM source va être arrêtée et les derniers changements copiés. Prévoyez environ {mins} min d'indisponibilité. Continuer ?",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2069,6 +2069,7 @@
       "estimatedDowntime": "예상 전환 다운타임",
       "estimatedDowntimeHint": "마지막 델타 패스를 기준으로, 최종 전환 중 VM이 오프라인 상태가 되는 시간입니다.",
       "awaitingCutover": "전환 대기 중",
+      "preparingDisks": "대상 디스크 준비 중",
       "cutoverNow": "지금 전환",
       "cutoverConfirmTitle": "지금 전환하시겠습니까?",
       "cutoverConfirmBody": "소스 VM이 종료되고 마지막 변경 사항이 복사됩니다. 약 {mins}분의 다운타임이 예상됩니다. 계속하시겠습니까?",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2038,6 +2038,7 @@
       "estimatedDowntime": "预计切换停机时间",
       "estimatedDowntimeHint": "根据最近一次增量同步估算的最终切换期间 VM 离线时长。",
       "awaitingCutover": "等待切换",
+      "preparingDisks": "正在准备目标磁盘",
       "cutoverNow": "立即切换",
       "cutoverConfirmTitle": "立即切换？",
       "cutoverConfirmBody": "源虚拟机将被关闭，并复制最后的变更。预计停机约 {mins} 分钟。是否继续？",


### PR DESCRIPTION
Closes #502. Closes #606.

A warm migration reported no progress at all between "planning" and "complete". The customer run on issue #587 (2026-07-29, a 3.1 TiB VM) makes it measurable: **639 of the 640 log lines carry `progress: 0`**, then it jumps to 100. Both issues share one root cause, so they share one fix: the warm pipeline never instrumented its `dd` invocations.

Where the 8 h 16 min actually went:

| Phase | Duration | Reported |
|---|---|---|
| pre-zeroing the 3.1 TiB thick LV | 2 h 49 min | nothing at all, phase badge said "enabling cbt" |
| full copy | 5 h 18 min, 3194 GB @ 171 MB/s | one line per 30 s, byte counter restarting at 0 each batch |
| delta 1 / delta 2 | 7 min 56 s / 16 s | per-pass summary only |
| cutover + verify + attach | 13 s | fine |

A third of the run was a phase that printed nothing, which is why the operator described waiting for the cutover line as taking "centuries".

## What changes

**A dedicated `preparing_disks` phase.** The allocate-and-zero loop no longer hides behind `enabling_cbt`, so the badge says what the job is doing. Labelled in all six locales.

**The pre-zero is instrumented and parallel.** It announces itself with the volume size and a warning that it is slow on thick storage. Each range `dd` now runs with `status=progress` into its own temp file, and a background poller sums those counters every 10 s into a single line in dd's own summary format, so `parseDdProgress` consumes it unchanged, the progress bar moves, and the step finally feeds the same inactivity guard as the copy instead of relying on the 12 h absolute cap. The device is split into 4 range-bounded streams: one `dd oflag=direct` is queue depth 1, which is why the field run sustained only 359 MiB/s on an array that reaches 1.9 GB/s with concurrency. Every stream stays bounded to its exact range, so the ENOSPC-past-end-of-device failure from #445 cannot come back.

**The blkdiscard refusal is no longer swallowed.** When the array rejects the write-zeroes offload the script emits a parseable marker and the job log says so, with the reason. Previously that reason was only visible if the whole script failed, so the slow path ran with no explanation.

**Cumulative copy progress.** Byte counts are accumulated across `dd` invocations and disks instead of restarting per extent, and `totalBytes` / `bytesTransferred` / `transferSpeed` are populated for warm jobs for the first time. Progress follows a single monotonic scale for the whole run: pre-zero 0 to 10, full copy 10 to 80, delta passes 80 to 95, cutover and verify 95 to 100.

`awaiting_cutover` also joins the dashboard's active-job predicate. That predicate gates the progress bar, so a job paused at the operator gate was showing none: the same blind spot, one word away.

## Deliberately out of scope

- **Skipping the pre-zero when `saferemove` is enabled** (#606, checklist item 4). Skipping it is an information-leak tradeoff, not a code decision: LVM extents that never belonged to a saferemove-deleted volume are not guaranteed to read as zero, and the CBT pass only writes the allocated map. It needs a product call and stays on #606.
- **Zeroing all volumes in parallel across disks** (#606, item 5). Splitting a single device already saturates the array, so cross-disk concurrency buys little and would restructure the allocation loop.

## Verification

Full suite on this branch: 298 files, 2906 tests, all passing. 17 new tests cover the chunked script shape, the range offsets and the remainder on the last chunk, the refusal marker, the aggregated progress line, the accumulator across restarting counters, and the progress scale. The generated shell script was additionally run against a real loop device: the whole device ends up zeroed including a non-4-MiB-aligned tail, a simulated offload refusal emits the marker, and a read-only device surfaces the real `dd` error with exit 1.
