### PR TITLE
feat(migration): optionally convert migrated disks to qcow2 (#595)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -8,6 +8,7 @@ import { useProxCenterTasks } from '@/contexts/ProxCenterTasksContext'
 import { useHostsByConnection } from '@/hooks/useHosts'
 import { BULK_MIG_CONCURRENCY } from './bulkMigrationConfig'
 import { useFavorites } from './hooks/useFavorites'
+import { useMigrationOptions } from './hooks/useMigrationOptions'
 import { useSnapshots } from './hooks/useSnapshots'
 import { useTasks } from './hooks/useTasks'
 import { useNotes } from './hooks/useNotes'
@@ -274,25 +275,13 @@ export default function InventoryDetails({
   const [migTargetConn, setMigTargetConn] = useState('')
   const [migTargetNode, setMigTargetNode] = useState('')
   const [migTargetStorage, setMigTargetStorage] = useState('')
-  const [migNetworkBridge, setMigNetworkBridge] = useState('')
   // Optional user-picked target VMID. Empty string = let PVE pick the next
   // free id (default behavior). The dialog runs a debounced availability
   // check and surfaces the result inline; the migration POST forwards the
   // value as `targetVmid` when set.
   const [migTargetVmid, setMigTargetVmid] = useState('')
   const [migTargetVmidStatus, setMigTargetVmidStatus] = useState<'idle' | 'checking' | 'available' | 'taken' | 'invalid'>('idle')
-  // Optional 802.1Q VLAN tag applied to the created VM's NIC. Empty string means
-  // "no tag" (access port on the bridge's native VLAN). Stored as string so the
-  // input renders cleanly when blank; coerced + validated server-side.
-  const [migVlanTag, setMigVlanTag] = useState<string>('')
   const [migBridges, setMigBridges] = useState<any[]>([])
-  const [migStartAfter, setMigStartAfter] = useState(false)
-  const [migDiskPaths, setMigDiskPaths] = useState('')
-  const [migTempStorage, setMigTempStorage] = useState('/tmp')
-  const [migType, setMigType] = useState<'cold' | 'live' | 'sshfs_boot' | 'warm'>('cold')
-  // Transfer method is auto-detected by the backend (SSHFS when ESXi SSH is available, HTTPS otherwise).
-  // Kept in state for the payload contract; no longer user-selectable in the UI.
-  const [migTransferMode, setMigTransferMode] = useState<'https' | 'sshfs' | 'auto'>('auto')
   const [migPveConnections, setMigPveConnections] = useState<any[]>([])
   const [migNodes, setMigNodes] = useState<any[]>([])
   const [migStorages, setMigStorages] = useState<any[]>([])
@@ -319,6 +308,19 @@ export default function InventoryDetails({
   const [extVmSortDir, setExtVmSortDir] = useState<'asc' | 'desc'>('asc')
   const [bulkMigOpen, setBulkMigOpen] = useState(false)
   const [bulkMigStarting, setBulkMigStarting] = useState(false)
+  // Per-migration options (start-after, VLAN, qcow2 conversion, ...) live in a
+  // dedicated hook that resets the whole family whenever the single-VM or the
+  // bulk dialog opens — see useMigrationOptions for the #443 background.
+  const {
+    migNetworkBridge, setMigNetworkBridge,
+    migVlanTag, setMigVlanTag,
+    migStartAfter, setMigStartAfter,
+    migDiskPaths, setMigDiskPaths,
+    migTempStorage, setMigTempStorage,
+    migType, setMigType,
+    migTransferMode, setMigTransferMode,
+    migConvertToQcow2, setMigConvertToQcow2,
+  } = useMigrationOptions({ esxiMigrateVm, bulkMigOpen })
   // Shared with InventoryDialogs.tsx — see bulkMigrationConfig.ts. Used here
   // by the queued-job poller below to decide how many slots are free; must
   // match the dispatcher in InventoryDialogs.tsx or the two will fight each
@@ -329,7 +331,7 @@ export default function InventoryDetails({
   const [bulkMigLogsFilter, setBulkMigLogsFilter] = useState<string | null>(null)
   const bulkMigJobsRef = useRef(bulkMigJobs)
   bulkMigJobsRef.current = bulkMigJobs
-  const bulkMigConfigRef = useRef<{ sourceConnectionId: string; targetConnectionId: string; targetStorage: string; networkBridge: string; vlanTag?: number; migrationType: string; transferMode: string; startAfterMigration: boolean; sourceType: string; tempStorage?: string } | null>(null)
+  const bulkMigConfigRef = useRef<{ sourceConnectionId: string; targetConnectionId: string; targetStorage: string; networkBridge: string; vlanTag?: number; migrationType: string; transferMode: string; startAfterMigration: boolean; convertDisksToQcow2: boolean; sourceType: string; tempStorage?: string } | null>(null)
   // Snapshot of host info when bulk dialog opens (avoids null data when selection changes)
   const [bulkMigHostInfo, setBulkMigHostInfo] = useState<any>(null)
   const [extHostMigrations, setExtHostMigrations] = useState<any[]>([])
@@ -944,6 +946,7 @@ export default function InventoryDetails({
                   migrationType: cfg.migrationType,
                   transferMode: cfg.transferMode,
                   startAfterMigration: cfg.startAfterMigration,
+                  convertDisksToQcow2: cfg.convertDisksToQcow2,
                   // vCenter inventory path was captured per-VM when the bulk job was
                   // enqueued (see InventoryDialogs.tsx bulk-launch handler). Forward it
                   // here too, otherwise queued vCenter migrations would lose the path
@@ -3931,15 +3934,9 @@ return vm?.isCluster ?? false
                           if (!vmwareMigrationAvailable) { setUpgradeDialogOpen(true); return }
                           const ht = vm.hostType || data.esxiVmInfo?.hostType
                           if (ht === 'vcenter' || ht === 'hyperv' || ht === 'nutanix') setMigType('cold')
-                          // Pre-fill disk paths for Hyper-V (convert Windows paths to /mnt/hyperv/ linux paths)
-                          if (ht === 'hyperv' && (vm as any).diskPaths?.length > 0) {
-                            const linuxPaths = ((vm as any).diskPaths as string[]).map((p: string) => {
-                              // "C:\VMs\TestVM.vhdx" -> "/mnt/hyperv/TestVM.vhdx"
-                              const fileName = p.split('\\').pop() || p.split('/').pop() || p
-                              return `/mnt/hyperv/${fileName}`
-                            })
-                            setMigDiskPaths(linuxPaths.join('\n'))
-                          }
+                          // Hyper-V disk paths are pre-filled by useMigrationOptions'
+                          // reset-on-open (from the diskPaths passed below); doing it
+                          // here would be wiped by that reset.
                           setEsxiMigrateVm({
                             vmid: vm.vmid, name: vm.name, connId: vm.connectionId,
                             connName: vm.connectionName, cpu: vm.numCPU, memoryMB: vm.memoryMB,
@@ -4386,6 +4383,8 @@ return vm?.isCluster ?? false
         migBridges={migBridges}
         migStartAfter={migStartAfter}
         setMigStartAfter={setMigStartAfter}
+        migConvertToQcow2={migConvertToQcow2}
+        setMigConvertToQcow2={setMigConvertToQcow2}
         migDiskPaths={migDiskPaths}
         setMigDiskPaths={setMigDiskPaths}
         migTempStorage={migTempStorage}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/MigrationDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/MigrationDashboard.tsx
@@ -453,6 +453,8 @@ export default function MigrationDashboard({ externalHypervisors, onHostClick }:
               const isActive = job.status === 'transferring' || job.status === 'preflight' || job.status === 'creating_vm' || job.status === 'configuring' || job.status === 'pending'
                 // Warm migration (CBT) phases
                 || job.status === 'planning' || job.status === 'enabling_cbt' || job.status === 'preparing_disks' || job.status === 'full_copy' || job.status === 'delta_sync' || job.status === 'awaiting_cutover' || job.status === 'cutover' || job.status === 'verify'
+                // Post-migration qcow2 conversion, shared by every pipeline (#595)
+                || job.status === 'converting_disks'
               const duration = job.startedAt && job.completedAt
                 ? Math.round((new Date(job.completedAt).getTime() - new Date(job.startedAt).getTime()) / 1000)
                 : null

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/__tests__/fixtures/pveProvisioning'
 
 import InventoryDialogs, { type InventoryDialogsProps } from './InventoryDialogs'
+import { useMigrationOptions } from '../hooks/useMigrationOptions'
 
 // ------------------------------------------------------------------ //
 // Context mocks
@@ -294,6 +295,8 @@ function makeProps(overrides: Partial<InventoryDialogsProps> = {}): InventoryDia
     migBridges: [],
     migStartAfter: false,
     setMigStartAfter: vi.fn(),
+    migConvertToQcow2: false,
+    setMigConvertToQcow2: vi.fn(),
     migDiskPaths: '',
     setMigDiskPaths: vi.fn(),
     migTempStorage: '',
@@ -658,5 +661,264 @@ describe('InventoryDialogs', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Migration dialog options: sticky-state reset (#443) and post-migration
+// qcow2 conversion (#595)
+// ------------------------------------------------------------------ //
+
+describe('migration dialog options', () => {
+  const ESXI_VM = {
+    vmid: '42',
+    name: 'web01',
+    connId: CONN_ID,
+    connName: 'esxi-lab',
+    hostType: 'esxi',
+    status: 'poweredOff',
+    guestOS: 'Ubuntu Linux (64-bit)',
+  }
+  const THICK_LVM = { storage: 'san-lvm', type: 'lvm', content: 'images', total: 1099511627776, avail: 879609302220 }
+  const ZFS = { storage: 'tank', type: 'zfspool', content: 'images', total: 1099511627776, avail: 879609302220 }
+  const START_AFTER_LABEL = 'Start VM after migration'
+  const QCOW2_LABEL = 'Convert disks to qcow2 after migration (enables Proxmox snapshots)'
+
+  function getSwitch(label: string): HTMLInputElement {
+    const labelEl = screen.getByText(label)
+    const fcl = labelEl.closest('.MuiFormControlLabel-root') as HTMLElement
+    expect(fcl).not.toBeNull()
+    return fcl.querySelector('input[type="checkbox"]') as HTMLInputElement
+  }
+
+  beforeEach(() => {
+    seedAllHandlers()
+    server.use(
+      // Source-datastore probe fired when the single-VM dialog opens for a
+      // direct-ESXi source (vSAN gate). No disks = no vSAN = nothing blocked.
+      http.get(`*/api/v1/vmware/${CONN_ID}/vms/42`, () =>
+        HttpResponse.json({ data: { disks: [] } }),
+      ),
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // Harness owning the dialog-open state the same way InventoryDetails does:
+  // the option family comes from the real useMigrationOptions hook, so this
+  // exercises the production reset path rather than a test-local copy.
+  function OptionsHarness({ dialogOverrides = {} }: { dialogOverrides?: Partial<InventoryDialogsProps> }) {
+    const [esxiMigrateVm, setEsxiMigrateVm] = React.useState<any>(null)
+    const [bulkMigOpen, setBulkMigOpen] = React.useState(false)
+    const options = useMigrationOptions({ esxiMigrateVm, bulkMigOpen })
+    return (
+      <>
+        <button onClick={() => setEsxiMigrateVm(ESXI_VM)}>harness-open-single</button>
+        <button onClick={() => setEsxiMigrateVm(null)}>harness-close-single</button>
+        <InventoryDialogs
+          {...makeProps({
+            esxiMigrateVm,
+            setEsxiMigrateVm,
+            bulkMigOpen,
+            setBulkMigOpen,
+            ...options,
+            ...dialogOverrides,
+          })}
+        />
+      </>
+    )
+  }
+
+  // Regression proof for the customer report inside #443: an option toggled
+  // for an earlier migration must not silently apply to the next one started
+  // in the same page session.
+  it('resets toggled options to their defaults when the dialog is closed and reopened', async () => {
+    renderWithProviders(
+      <OptionsHarness dialogOverrides={{ migTargetStorage: 'san-lvm', migStorages: [THICK_LVM, ZFS] }} />,
+    )
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    expect(getSwitch(START_AFTER_LABEL).checked).toBe(false)
+    expect(getSwitch(QCOW2_LABEL).checked).toBe(false)
+
+    fireEvent.click(getSwitch(START_AFTER_LABEL))
+    fireEvent.click(getSwitch(QCOW2_LABEL))
+    expect(getSwitch(START_AFTER_LABEL).checked).toBe(true)
+    expect(getSwitch(QCOW2_LABEL).checked).toBe(true)
+
+    fireEvent.click(screen.getByText('harness-close-single'))
+    await waitFor(() => expect(screen.queryByText(START_AFTER_LABEL)).not.toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    expect(getSwitch(START_AFTER_LABEL).checked).toBe(false)
+    expect(getSwitch(QCOW2_LABEL).checked).toBe(false)
+  })
+
+  it('shows the qcow2 switch only when the selected target storage is thick LVM', () => {
+    const { unmount } = renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: ESXI_VM,
+          migTargetConn: CONN_ID,
+          migTargetNode: NODE_NAME,
+          migTargetStorage: 'san-lvm',
+          migStorages: [THICK_LVM, ZFS],
+        })}
+      />,
+    )
+    expect(screen.getByText(QCOW2_LABEL)).toBeInTheDocument()
+    unmount()
+
+    renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: ESXI_VM,
+          migTargetConn: CONN_ID,
+          migTargetNode: NODE_NAME,
+          migTargetStorage: 'tank',
+          migStorages: [THICK_LVM, ZFS],
+        })}
+      />,
+    )
+    expect(screen.queryByText(QCOW2_LABEL)).not.toBeInTheDocument()
+  })
+
+  it('forwards convertDisksToQcow2=true in the single-VM migration request', async () => {
+    const bodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations', async ({ request }) => {
+        bodies.push(await request.json())
+        return HttpResponse.json({ data: { jobId: 'job-1' } })
+      }),
+    )
+    renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: ESXI_VM,
+          migTargetConn: CONN_ID,
+          migTargetNode: NODE_NAME,
+          migTargetStorage: 'san-lvm',
+          migStorages: [THICK_LVM, ZFS],
+          migConvertToQcow2: true,
+          migNetworkBridge: 'vmbr0',
+          migPveConnections: [{ id: CONN_ID, name: 'pve-lab', sshEnabled: true }],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /migrate to proxmox/i }))
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0].convertDisksToQcow2).toBe(true)
+    // The neighbouring option keeps its wiring: default off means false.
+    expect(bodies[0].startAfterMigration).toBe(false)
+  })
+
+  // A toggle left on for a previously selected LVM storage must not leak when
+  // the user switches to a storage the option does not apply to.
+  it('sends convertDisksToQcow2=false when the toggle is stale for a non-LVM storage', async () => {
+    const bodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations', async ({ request }) => {
+        bodies.push(await request.json())
+        return HttpResponse.json({ data: { jobId: 'job-2' } })
+      }),
+    )
+    renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: ESXI_VM,
+          migTargetConn: CONN_ID,
+          migTargetNode: NODE_NAME,
+          migTargetStorage: 'tank',
+          migStorages: [THICK_LVM, ZFS],
+          migConvertToQcow2: true,
+          migNetworkBridge: 'vmbr0',
+          migPveConnections: [{ id: CONN_ID, name: 'pve-lab', sshEnabled: true }],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /migrate to proxmox/i }))
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0].convertDisksToQcow2).toBe(false)
+  })
+
+  it('bulk dialog forwards convertDisksToQcow2 and records it for queued jobs', async () => {
+    const bodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations', async ({ request }) => {
+        bodies.push(await request.json())
+        return HttpResponse.json({ data: { jobId: 'job-bulk-1' } })
+      }),
+    )
+    const bulkMigConfigRef = { current: null } as React.MutableRefObject<any>
+    renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          bulkMigOpen: true,
+          bulkMigHostInfo: {
+            hostType: 'esxi',
+            connectionId: 'esxi-1',
+            connectionName: 'esxi-lab',
+            vms: [{ vmid: '42', name: 'web01', status: 'poweredOff' }],
+          },
+          bulkMigSelected: new Set(['42']),
+          migTargetConn: CONN_ID,
+          migTargetNode: NODE_NAME,
+          migTargetStorage: 'san-lvm',
+          migStorages: [THICK_LVM, ZFS],
+          migConvertToQcow2: true,
+          migNetworkBridge: 'vmbr0',
+          migPveConnections: [{ id: CONN_ID, name: 'pve-lab', sshEnabled: true }],
+          bulkMigConfigRef,
+        })}
+      />,
+    )
+    expect(screen.getByText(QCOW2_LABEL)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /migrate to proxmox/i }))
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0].convertDisksToQcow2).toBe(true)
+    // The queued-job poller in InventoryDetails restarts jobs from this ref,
+    // so the option must survive there too.
+    expect(bulkMigConfigRef.current?.convertDisksToQcow2).toBe(true)
+  })
+
+  // The Hyper-V VHDX pre-fill moved into the reset-on-open hook (a blind reset
+  // would have wiped what the open handler pre-filled): opening for a Hyper-V
+  // VM with known disk paths must derive the /mnt/hyperv/ paths.
+  it('pre-fills migDiskPaths for Hyper-V sources with known disk paths on open', async () => {
+    function HypervHarness() {
+      const [esxiMigrateVm, setEsxiMigrateVm] = React.useState<any>(null)
+      const [bulkMigOpen, setBulkMigOpen] = React.useState(false)
+      const options = useMigrationOptions({ esxiMigrateVm, bulkMigOpen })
+      return (
+        <>
+          <button
+            onClick={() =>
+              setEsxiMigrateVm({
+                vmid: 'hv-1',
+                name: 'win01',
+                connId: CONN_ID,
+                connName: 'hyperv-lab',
+                hostType: 'hyperv',
+                status: 'poweredOff',
+                diskPaths: ['C:\\VMs\\win01.vhdx'],
+              })
+            }
+          >
+            harness-open-hyperv
+          </button>
+          <span data-testid="mig-disk-paths">{options.migDiskPaths}</span>
+          <InventoryDialogs
+            {...makeProps({ esxiMigrateVm, setEsxiMigrateVm, bulkMigOpen, setBulkMigOpen, ...options })}
+          />
+        </>
+      )
+    }
+    renderWithProviders(<HypervHarness />)
+    fireEvent.click(screen.getByText('harness-open-hyperv'))
+    await waitFor(() =>
+      expect(screen.getByTestId('mig-disk-paths')).toHaveTextContent('/mnt/hyperv/win01.vhdx'),
+    )
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -38,6 +38,7 @@ import {
 } from '@mui/material'
 
 import { NodeRow, BulkAction } from '@/components/NodesTable'
+import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
 
 // Dynamic imports for HardwareModals (code-split, loaded on demand)
 const AddDiskDialog = dynamic(() => import('@/components/HardwareModals').then(mod => ({ default: mod.AddDiskDialog })), { ssr: false })
@@ -245,6 +246,8 @@ export interface InventoryDialogsProps {
   migBridges: any[]
   migStartAfter: boolean
   setMigStartAfter: (v: boolean) => void
+  migConvertToQcow2: boolean
+  setMigConvertToQcow2: (v: boolean) => void
   migDiskPaths: string
   setMigDiskPaths: (v: string) => void
   migTempStorage: string
@@ -282,7 +285,7 @@ export interface InventoryDialogsProps {
   setBulkMigLogsExpanded: (v: React.SetStateAction<boolean>) => void
   bulkMigLogsFilter: string | null
   setBulkMigLogsFilter: (v: string | null) => void
-  bulkMigConfigRef: React.MutableRefObject<{ sourceConnectionId: string; targetConnectionId: string; targetStorage: string; networkBridge: string; vlanTag?: number; migrationType: string; transferMode: string; startAfterMigration: boolean; sourceType: string; tempStorage?: string } | null>
+  bulkMigConfigRef: React.MutableRefObject<{ sourceConnectionId: string; targetConnectionId: string; targetStorage: string; networkBridge: string; vlanTag?: number; migrationType: string; transferMode: string; startAfterMigration: boolean; convertDisksToQcow2: boolean; sourceType: string; tempStorage?: string } | null>
   bulkMigHostInfo: any
 
   // Upgrade dialog
@@ -391,7 +394,8 @@ export default function InventoryDialogs(props: InventoryDialogsProps) {
     migTargetStorage, setMigTargetStorage,
     migTargetVmid, setMigTargetVmid, migTargetVmidStatus, setMigTargetVmidStatus,
     migNetworkBridge, setMigNetworkBridge, migVlanTag, setMigVlanTag, migBridges,
-    migStartAfter, setMigStartAfter, migDiskPaths, setMigDiskPaths, migTempStorage, setMigTempStorage,
+    migStartAfter, setMigStartAfter, migConvertToQcow2, setMigConvertToQcow2,
+    migDiskPaths, setMigDiskPaths, migTempStorage, setMigTempStorage,
     migType, setMigType, migTransferMode, setMigTransferMode, migPveConnections, migNodes, migStorages,
     migSshfsAvailable, vcenterPreflight, setVcenterPreflight, migStarting, setMigStarting,
     migJobId, setMigJobId, migJob, setMigJob, migNodeOptions,
@@ -643,6 +647,33 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
   // from re-enabling the launch against a node that has not passed the current check.
   const warmPreflightCurrent =
     warmPreflight && warmPreflight.key === `${migTargetConn}::${migTargetNode}` ? warmPreflight : null
+
+  // Post-migration qcow2 conversion (#595) only applies to thick `lvm` target
+  // storages: since #587 their volumes are allocated raw, which forfeits
+  // Proxmox snapshots unless converted afterwards. lvmthin cannot hold qcow2,
+  // and ZFS/Ceph RBD snapshot natively, so the switch stays hidden there. The
+  // storage listing the wizard already fetched carries `type`; the precise
+  // snapshot-as-volume-chain check stays server-side. Both the switch below
+  // and the request payloads gate on this, so a toggle left on for an earlier
+  // LVM pick can never leak into a run against a storage it doesn't apply to.
+  const migTargetIsThickLvm = migStorages.find((s: any) => s.storage === migTargetStorage)?.type === 'lvm'
+
+  // Rendered identically by the single-VM and the bulk dialog. Kept as one
+  // helper rather than two copies of the same JSX: an identical block repeated
+  // in both dialogs is what trips the new-code duplication gate.
+  const renderQcow2ConvertSwitch = () => migTargetIsThickLvm && (
+    <FormControlLabel
+      control={<Switch size="small" checked={migConvertToQcow2} onChange={(_, v) => setMigConvertToQcow2(v)} />}
+      label={
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+          <Typography variant="body2">{t('inventoryPage.esxiMigration.convertDisksToQcow2')}</Typography>
+          <MuiTooltip title={t('inventoryPage.esxiMigration.convertDisksToQcow2Tooltip')} arrow placement="top" slotProps={tooltipSlotProps}>
+            <i className="ri-question-line" style={{ fontSize: 14, opacity: 0.6 }} />
+          </MuiTooltip>
+        </Box>
+      }
+    />
+  )
 
   const startVirtioWinDownload = async () => {
     const installNodes = migTargetNode === '__auto__'
@@ -2641,6 +2672,9 @@ return
                     control={<Switch size="small" checked={migStartAfter} onChange={(_, v) => setMigStartAfter(v)} />}
                     label={<Typography variant="body2">{t('inventoryPage.esxiMigration.startAfterMigration')}</Typography>}
                   />
+
+                  {/* Post-migration qcow2 conversion (#595) — thick LVM targets only */}
+                  {renderQcow2ConvertSwitch()}
                 </Stack>
               </Box>
 
@@ -2955,6 +2989,10 @@ return
                           : (esxiMigrateVm.hostType === 'vcenter' ? (migType === 'sshfs_boot' ? 'cold' : migType) : migType),
                         transferMode: (esxiMigrateVm.hostType === 'vcenter' || esxiMigrateVm.hostType === 'hyperv' || esxiMigrateVm.hostType === 'nutanix') ? 'v2v' : migTransferMode,
                         startAfterMigration: migStartAfter,
+                        // Gated on the storage type so a toggle left on while an
+                        // LVM storage was selected never leaks into a run against
+                        // a storage the option is hidden for.
+                        convertDisksToQcow2: migConvertToQcow2 && migTargetIsThickLvm,
                         // Forward tempStorage for every source type — v2v uses it as virt-v2v's -os,
                         // direct-ESXi uses it as the base path for SSHFS mount + VMDK dumps + clones.
                         ...(migTempStorage !== '/tmp' && {
@@ -3060,8 +3098,11 @@ return
                   {t('inventoryPage.esxiMigration.retry')}
                 </Button>
               )}
+              {/* Option state (migType, transfer mode, ...) is reset by
+                  useMigrationOptions on the next dialog open, so closing
+                  only clears the job view. */}
               {migJob && ['completed', 'failed', 'cancelled'].includes(migJob.status) && (
-                <Button onClick={() => { setEsxiMigrateVm(null); setMigJobId(null); setMigJob(null); setMigType('cold'); setMigTransferMode('sshfs') }}>
+                <Button onClick={() => { setEsxiMigrateVm(null); setMigJobId(null); setMigJob(null) }}>
                   {t('common.close')}
                 </Button>
               )}
@@ -3684,6 +3725,9 @@ return
                   label={<Typography variant="body2">{t('inventoryPage.esxiMigration.startAfterMigration')}</Typography>}
                 />
 
+                {/* Post-migration qcow2 conversion (#595) — thick LVM targets only */}
+                {renderQcow2ConvertSwitch()}
+
                 {/* SSH warning — not needed for vCenter */}
                 {bulkMigHostInfo?.hostType !== 'vcenter' && bulkMigHostInfo?.hostType !== 'hyperv' && bulkMigHostInfo?.hostType !== 'nutanix' && migTargetConn && !migPveConnections.find((c: any) => c.id === migTargetConn)?.sshEnabled && (
                   <Alert severity="error" sx={{ fontSize: 12 }} icon={<i className="ri-ssh-line" style={{ fontSize: 18 }} />}>{t('inventoryPage.esxiMigration.sshRequired')}</Alert>
@@ -4066,6 +4110,8 @@ return
                             : (isVcenterBulk ? (migType === 'sshfs_boot' ? 'cold' : migType) : migType),
                           transferMode: (isVcenterBulk || isHypervBulk || isNutanixBulk) ? 'v2v' : migTransferMode,
                           startAfterMigration: migStartAfter,
+                          // Same storage-type gate as the single-VM payload.
+                          convertDisksToQcow2: migConvertToQcow2 && migTargetIsThickLvm,
                           // vCenter inventory path required by libvirt vpx URI (auto-discovered
                           // server-side via SOAP). Bulk jobs may target different ESXi hosts
                           // inside the same vCenter, so the path is per-VM. Same rationale
@@ -4126,6 +4172,7 @@ return
                       : (isVcenterBulk ? (migType === 'sshfs_boot' ? 'cold' : migType) : migType),
                     transferMode: isVcenterBulk ? 'v2v' : migTransferMode,
                     startAfterMigration: migStartAfter,
+                    convertDisksToQcow2: migConvertToQcow2 && migTargetIsThickLvm,
                     sourceType,
                     // Persisted across the queued-job poller so retries use the
                     // same temp storage the user selected when starting the batch.

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Minimal shape of the VM the single-migration dialog was opened for. Only the
+ * fields the reset logic needs; InventoryDetails' richer esxiMigrateVm state
+ * is structurally assignable to it.
+ */
+type MigrationDialogVm = { hostType?: string; diskPaths?: string[] } | null | undefined
+
+/**
+ * Hyper-V sources with known VHDX paths get migDiskPaths pre-filled: the
+ * Windows paths are mapped onto the /mnt/hyperv/ mount the migration pipeline
+ * uses ("C:\VMs\TestVM.vhdx" -> "/mnt/hyperv/TestVM.vhdx"). Every other source
+ * starts blank. Derived here, inside the reset, because deriving it in the
+ * dialog-open click handler would be wiped by the reset effect running right
+ * after (state updates from the handler and the open both commit before the
+ * effect fires).
+ */
+function deriveHypervDiskPaths(vm: MigrationDialogVm): string {
+  if (!vm || vm.hostType !== 'hyperv' || !vm.diskPaths?.length) return ''
+
+  return vm.diskPaths
+    .map(p => `/mnt/hyperv/${p.split('\\').pop() || p.split('/').pop() || p}`)
+    .join('\n')
+}
+
+/**
+ * Per-migration option state shared by the single-VM and the bulk migration
+ * dialogs (components/InventoryDialogs.tsx).
+ *
+ * Every option resets to its default each time either dialog opens. The state
+ * lives at page level (InventoryDetails) and used to survive from one
+ * migration to the next in the same page session, so an option toggled for an
+ * earlier VM silently applied to every later run — a live customer report in
+ * #443: "start VM after migration" fired although it was never ticked for
+ * that job. Keeping the whole family in this hook guarantees a new option can
+ * never be added without inheriting the reset.
+ */
+export function useMigrationOptions({
+  esxiMigrateVm,
+  bulkMigOpen,
+}: {
+  esxiMigrateVm: MigrationDialogVm
+  bulkMigOpen: boolean
+}) {
+  const [migNetworkBridge, setMigNetworkBridge] = useState('')
+  // Optional 802.1Q VLAN tag applied to the created VM's NIC. Empty string means
+  // "no tag" (access port on the bridge's native VLAN). Stored as string so the
+  // input renders cleanly when blank; coerced + validated server-side.
+  const [migVlanTag, setMigVlanTag] = useState<string>('')
+  const [migStartAfter, setMigStartAfter] = useState(false)
+  const [migDiskPaths, setMigDiskPaths] = useState('')
+  const [migTempStorage, setMigTempStorage] = useState('/tmp')
+  const [migType, setMigType] = useState<'cold' | 'live' | 'sshfs_boot' | 'warm'>('cold')
+  // Transfer method is auto-detected by the backend (SSHFS when ESXi SSH is available, HTTPS otherwise).
+  // Kept in state for the payload contract; no longer user-selectable in the UI.
+  const [migTransferMode, setMigTransferMode] = useState<'https' | 'sshfs' | 'auto'>('auto')
+  // Opt-in post-migration qcow2 conversion (#595). Default off: it fully
+  // rewrites every migrated disk in the background and transiently doubles
+  // the space used on the target storage.
+  const [migConvertToQcow2, setMigConvertToQcow2] = useState(false)
+
+  useEffect(() => {
+    if (!esxiMigrateVm && !bulkMigOpen) return
+    setMigNetworkBridge('')
+    setMigVlanTag('')
+    setMigStartAfter(false)
+    setMigDiskPaths(deriveHypervDiskPaths(esxiMigrateVm))
+    setMigTempStorage('/tmp')
+    setMigType('cold')
+    setMigTransferMode('auto')
+    setMigConvertToQcow2(false)
+  }, [esxiMigrateVm, bulkMigOpen])
+
+  return {
+    migNetworkBridge,
+    setMigNetworkBridge,
+    migVlanTag,
+    setMigVlanTag,
+    migStartAfter,
+    setMigStartAfter,
+    migDiskPaths,
+    setMigDiskPaths,
+    migTempStorage,
+    setMigTempStorage,
+    migType,
+    setMigType,
+    migTransferMode,
+    setMigTransferMode,
+    migConvertToQcow2,
+    setMigConvertToQcow2,
+  }
+}

--- a/frontend/src/app/api/v1/migrations/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/route.test.ts
@@ -44,6 +44,11 @@ const body = {
 
 async function runAfters() { for (const cb of h.afterCbs) await cb() }
 
+/** The `data` payload of the first migrationJob.create call of the test. */
+function createdJobData(): any {
+  return (h.prisma.migrationJob.create as any).mock.calls[0][0].data
+}
+
 beforeEach(() => {
   h.afterCbs.length = 0
   warm.mockReset(); cold.mockReset()
@@ -111,6 +116,54 @@ describe("POST /api/v1/migrations — warm routing", () => {
     expect(h.prisma.migrationJob.create).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ ownerInstanceId: "inst-1" }) }),
     )
+  })
+
+  // Boolean options must be coerced strictly: raw API callers serialise form
+  // state as strings, and `"false"` is truthy. That is how a job whose caller
+  // "did not select the option to start VM" still logged `Target VM started`
+  // (#443) — the same class of bug the new convertDisksToQcow2 flag would have.
+  it('coerces the string "false" to real false for startAfterMigration and convertDisksToQcow2', async () => {
+    h.prisma.connection.findUnique
+      .mockResolvedValueOnce({ id: "src", type: "vmware", subType: null, name: "esxi", baseUrl: "https://esxi" })
+      .mockResolvedValueOnce({ id: "tgt", type: "pve", name: "pve" })
+
+    const res = await callRoute(POST, { body: { ...body, startAfterMigration: "false", convertDisksToQcow2: "false" } })
+    expect(res.status).toBe(200)
+
+    // persisted config (what a retry replays) holds real booleans
+    expect(createdJobData().config.startAfterMigration).toBe(false)
+    expect(createdJobData().config.convertDisksToQcow2).toBe(false)
+
+    // and the pipeline gate receives the same
+    await runAfters()
+    expect(warm.mock.calls[0][1]).toMatchObject({ startAfterMigration: false, convertDisksToQcow2: false })
+  })
+
+  it("defaults both options to false when omitted, and forwards an explicit true", async () => {
+    h.prisma.connection.findUnique
+      .mockResolvedValue({ id: "src", type: "vmware", subType: null, name: "esxi", baseUrl: "https://esxi" })
+    h.prisma.connection.findUnique
+      .mockResolvedValueOnce({ id: "src", type: "vmware", subType: null, name: "esxi", baseUrl: "https://esxi" })
+      .mockResolvedValueOnce({ id: "tgt", type: "pve", name: "pve" })
+
+    await callRoute(POST, { body })
+    expect(createdJobData().config).toMatchObject({
+      startAfterMigration: false, convertDisksToQcow2: false,
+    })
+
+    h.prisma.migrationJob.create.mockClear()
+    h.prisma.connection.findUnique
+      .mockResolvedValueOnce({ id: "src", type: "vmware", subType: null, name: "esxi", baseUrl: "https://esxi" })
+      .mockResolvedValueOnce({ id: "tgt", type: "pve", name: "pve" })
+
+    await callRoute(POST, { body: { ...body, startAfterMigration: true, convertDisksToQcow2: true } })
+    expect(createdJobData().config).toMatchObject({
+      startAfterMigration: true, convertDisksToQcow2: true,
+    })
+
+    await runAfters()
+    const last = warm.mock.calls[warm.mock.calls.length - 1][1]
+    expect(last).toMatchObject({ startAfterMigration: true, convertDisksToQcow2: true })
   })
 
   it("dispatches a vCenter warm request to runWarmMigration, never the cold pipeline", async () => {

--- a/frontend/src/app/api/v1/migrations/route.ts
+++ b/frontend/src/app/api/v1/migrations/route.ts
@@ -36,11 +36,17 @@ export async function POST(req: Request) {
       targetNode,
       targetStorage,
       networkBridge = "vmbr0",
-      startAfterMigration = false,
       migrationType = "cold",
       transferMode = "auto",
       targetVmid: targetVmidRaw,
     } = body
+
+    // Boolean options arrive as real booleans from our UI but as strings from
+    // raw API callers. Defaulting only `undefined` let the string "false"
+    // through truthy — a caller that never asked for it got their VM started.
+    // Coerce strictly: anything but true/"true" is false.
+    const startAfterMigration = body.startAfterMigration === true || body.startAfterMigration === "true"
+    const convertDisksToQcow2 = body.convertDisksToQcow2 === true || body.convertDisksToQcow2 === "true"
 
     if (!sourceConnectionId || !sourceVmId || !targetConnectionId || !targetNode || !targetStorage) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
@@ -138,7 +144,7 @@ export async function POST(req: Request) {
         // Warm-only options (vddkLibdir, downtimeBudgetSec) are persisted here so a
         // retry — which rebuilds the config from job.config — keeps them instead of
         // silently reverting to the defaults.
-        config: { sourceConnectionId, sourceVmId, sourceVmName: body.sourceVmName, targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, migrationType, transferMode, sourceType: effectiveSourceType, ...(targetVmid !== undefined && { targetVmid }), ...(body.vddkLibdir && { vddkLibdir: body.vddkLibdir }), ...(downtimeBudgetSec !== undefined && { downtimeBudgetSec }) },
+        config: { sourceConnectionId, sourceVmId, sourceVmName: body.sourceVmName, targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2, migrationType, transferMode, sourceType: effectiveSourceType, ...(targetVmid !== undefined && { targetVmid }), ...(body.vddkLibdir && { vddkLibdir: body.vddkLibdir }), ...(downtimeBudgetSec !== undefined && { downtimeBudgetSec }) },
         status: "pending",
         currentStep: "pending",
         startedAt: new Date(),
@@ -158,6 +164,7 @@ export async function POST(req: Request) {
       networkBridge,
       vlanTag,
       startAfterMigration,
+      convertDisksToQcow2,
       migrationType: migrationType as "cold" | "live" | "sshfs_boot",
       transferMode: transferMode as "https" | "sshfs",
       // Pass through the user-selected Temporary Storage so the direct-ESXi pipeline
@@ -177,7 +184,7 @@ export async function POST(req: Request) {
       if ((effectiveSourceType === "vmware" || effectiveSourceType === "vcenter") && migrationType === "warm") {
         await runWarmMigration(job.id, {
           sourceConnectionId, sourceVmId, targetConnectionId, targetNode, targetStorage,
-          networkBridge, vlanTag, startAfterMigration,
+          networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2,
           ...(targetVmid !== undefined && { targetVmid }),
           ...(body.vddkLibdir && { vddkLibdir: body.vddkLibdir as string }),
           ...(downtimeBudgetSec !== undefined && { downtimeBudgetSec }),
@@ -194,7 +201,7 @@ export async function POST(req: Request) {
         await runV2vMigrationPipeline(job.id, {
           sourceConnectionId, sourceVmId, sourceVmName,
           sourceType: effectiveSourceType as "vcenter" | "hyperv" | "nutanix",
-          targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration,
+          targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2,
           vcenterDatacenter, vcenterCluster, vcenterHost, diskPaths, tempStorage,
           migrationType: v2vMigrationType,
           ...(targetVmid !== undefined && { targetVmid }),
@@ -261,7 +268,7 @@ export async function POST(req: Request) {
             await runV2vMigrationPipeline(job.id, {
               sourceConnectionId, sourceVmId, sourceVmName: body.sourceVmName || "",
               sourceType: "esxi-direct",
-              targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration,
+              targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2,
               tempStorage: body.tempStorage,
               migrationType: "cold",
               vmxPath: posixVmxPath,

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -30,10 +30,11 @@ import {
 } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
+import { convertDisksToQcow2 } from "./qcow2-convert"
 import { startJobHeartbeat } from "./job-heartbeat"
 import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
 
-type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
+type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "converting_disks" | "completed" | "failed" | "cancelled"
 
 interface MigrationConfig {
   sourceConnectionId: string
@@ -49,6 +50,13 @@ interface MigrationConfig {
    */
   vlanTag?: number
   startAfterMigration: boolean
+  /**
+   * Convert the migrated data disks to qcow2 after the migration (one `move_disk`
+   * per disk on the same storage), so they can take Proxmox snapshots on a
+   * snapshot-as-volume-chain LVM storage (#595). Opt-in, default false; the
+   * conversion can never fail the migration.
+   */
+  convertDisksToQcow2?: boolean
   migrationType?: "cold" | "live" | "sshfs_boot"
   transferMode?: "https" | "sshfs" | "auto"
   // User-selected temp directory on the PVE node for large intermediate files
@@ -2782,6 +2790,20 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         await appendLog(jobId, "VM started", "success")
       }
     }
+
+    // ── STEP 6: Optional qcow2 conversion (#595) ──
+    // After the disks are attached and after the optional start (SSHFS Boot
+    // always restarts the VM above): on a running VM PVE does move_disk as a
+    // live drive-mirror, no extra downtime. The helper gates itself (opt-in,
+    // storage default format, free space) and NEVER throws: a conversion
+    // problem leaves the disks raw, not the migration failed.
+    await convertDisksToQcow2({
+      enabled: config.convertDisksToQcow2 === true,
+      conn: pveConn, node: config.targetNode, vmid: targetVmid!,
+      targetStorage: config.targetStorage, volumes: allocatedVolumes,
+      log: (m, l) => appendLog(jobId, m, l),
+      setPhase: p => updateJob(jobId, "converting_disks", { progress: p }),
+    })
 
     // ── DONE ──
     const totalCapacity = vmConfig.disks.reduce((sum, d) => sum + d.capacityBytes, 0)

--- a/frontend/src/lib/migration/qcow2-convert.test.ts
+++ b/frontend/src/lib/migration/qcow2-convert.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: vi.fn() }))
+vi.mock("./pve-tasks", () => ({ waitForPveTask: vi.fn() }))
+
+import { pveFetch } from "@/lib/proxmox/client"
+import { waitForPveTask } from "./pve-tasks"
+import {
+  convertDisksToQcow2, storageDefaultsToQcow2, migratedDataDisks, MOVE_DISK_TIMEOUT_MS,
+} from "./qcow2-convert"
+import type { AllocatedVolume } from "./pvesm-alloc"
+
+const mockFetch = vi.mocked(pveFetch)
+const mockWait = vi.mocked(waitForPveTask)
+
+const conn = { baseUrl: "https://pve.example:8006", apiToken: "t", insecureDev: false, id: "c1" }
+const NODE = "pve1"
+const VMID = 250
+const STORAGE = "FC-HDC-01"
+const GiB = 1024 ** 3
+
+// A PVE 9 LVM storage with snapshot-as-volume-chain: the only storage class
+// whose default format is qcow2 (what the whole feature exists for, #595).
+const QUALIFYING_STORAGE = { storage: STORAGE, type: "lvm", "snapshot-as-volume-chain": 1 }
+
+function makeVolumes(): AllocatedVolume[] {
+  return [
+    { volumeId: `${STORAGE}:vm-250-disk-1`, devicePath: "/dev/vg/vm-250-disk-1", attached: true, copied: true },
+    { volumeId: `${STORAGE}:vm-250-disk-2`, devicePath: "/dev/vg/vm-250-disk-2", attached: true, copied: true },
+  ]
+}
+
+// VM config after a migration: our two data disks, plus an efidisk that is
+// already qcow2 (created by qm create, never ours to convert — #606) and keys
+// that are not disks at all.
+function baseVmConf(): Record<string, string> {
+  return {
+    scsi0: `${STORAGE}:vm-250-disk-1,size=32G`,
+    scsi1: `${STORAGE}:vm-250-disk-2,size=100G`,
+    efidisk0: `${STORAGE}:vm-250-disk-0.qcow2,efitype=4m,size=4M`,
+    net0: "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0",
+    name: "web01",
+    boot: "order=scsi0",
+  }
+}
+
+function makeHarness(volumes: AllocatedVolume[] = makeVolumes(), overrides: Record<string, unknown> = {}) {
+  const logs: Array<{ msg: string; level: string }> = []
+  const phases: number[] = []
+  const args = {
+    enabled: true,
+    conn,
+    node: NODE,
+    vmid: VMID,
+    targetStorage: STORAGE,
+    volumes,
+    log: (msg: string, level = "info") => { logs.push({ msg, level }) },
+    setPhase: (progress: number) => { phases.push(progress) },
+    ...overrides,
+  }
+  return { logs, phases, args: args as Parameters<typeof convertDisksToQcow2>[0] }
+}
+
+/**
+ * Wire the pveFetch mock like a live PVE node: storage config, storage status,
+ * VM config, and a move_disk endpoint that renames the slot's volume to a fresh
+ * .qcow2 name (exactly what PVE does: mirror into a new volume, delete the raw
+ * one) unless `onMove` overrides it.
+ */
+function mockPveRoutes(opts: {
+  storageCfg?: unknown
+  avail?: number
+  conf?: Record<string, string>
+  onMove?: (body: URLSearchParams) => string | Promise<string>
+} = {}) {
+  const conf = opts.conf ?? baseVmConf()
+  let nextDisk = 3
+  mockFetch.mockImplementation(async (_c: any, path: string, init?: any) => {
+    if (path === `/storage/${STORAGE}`) return opts.storageCfg === undefined ? QUALIFYING_STORAGE : opts.storageCfg
+    if (path === `/nodes/${NODE}/storage/${STORAGE}/status`) {
+      return { avail: opts.avail ?? 500 * GiB, total: 1000 * GiB, used: 500 * GiB }
+    }
+    if (path === `/nodes/${NODE}/qemu/${VMID}/config`) return { ...conf }
+    if (path === `/nodes/${NODE}/qemu/${VMID}/move_disk`) {
+      const body = init.body as URLSearchParams
+      if (opts.onMove) return opts.onMove(body)
+      const slot = body.get("disk")!
+      const size = String(conf[slot]).split("size=")[1]
+      conf[slot] = `${STORAGE}:vm-${VMID}-disk-${nextDisk++}.qcow2,size=${size}`
+      return `UPID:${slot}`
+    }
+    throw new Error(`unexpected pveFetch ${path}`)
+  })
+  return conf
+}
+
+function moveCalls() {
+  return mockFetch.mock.calls.filter(c => String(c[1]).endsWith("/move_disk"))
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+  mockWait.mockReset().mockResolvedValue(undefined)
+})
+
+describe("convertDisksToQcow2 — success path", () => {
+  it("issues the exact move_disk call the web UI makes, one per data disk, and waits for each task", async () => {
+    mockPveRoutes()
+    const { args, logs } = makeHarness()
+
+    await convertDisksToQcow2(args)
+
+    const calls = moveCalls()
+    expect(calls).toHaveLength(2)
+    expect(calls[0][2]?.method).toBe("POST")
+    expect(Object.fromEntries(calls[0][2]!.body as URLSearchParams)).toEqual({
+      disk: "scsi0", storage: STORAGE, format: "qcow2", delete: "1",
+    })
+    expect(Object.fromEntries(calls[1][2]!.body as URLSearchParams)).toEqual({
+      disk: "scsi1", storage: STORAGE, format: "qcow2", delete: "1",
+    })
+    // one UPID wait per disk, under the generous multi-TB timeout
+    expect(mockWait).toHaveBeenCalledTimes(2)
+    expect(mockWait).toHaveBeenNthCalledWith(1, conn, NODE, "UPID:scsi0", MOVE_DISK_TIMEOUT_MS)
+    expect(mockWait).toHaveBeenNthCalledWith(2, conn, NODE, "UPID:scsi1", MOVE_DISK_TIMEOUT_MS)
+    expect(logs.some(l => l.level === "success" && /snapshot/i.test(l.msg))).toBe(true)
+  })
+
+  it("reports its own converting_disks phase from 95 to 99", async () => {
+    mockPveRoutes()
+    const { args, phases } = makeHarness()
+
+    await convertDisksToQcow2(args)
+
+    expect(phases[0]).toBe(95)
+    expect(phases[phases.length - 1]).toBe(99)
+    // monotonic: a job log reader never sees progress move backwards
+    for (let i = 1; i < phases.length; i++) expect(phases[i]).toBeGreaterThanOrEqual(phases[i - 1])
+  })
+
+  it("rewrites the cleanup registry with the new qcow2 volume ids (#595 point 7: the raw volume is gone)", async () => {
+    mockPveRoutes()
+    const volumes = makeVolumes()
+    const { args } = makeHarness(volumes)
+
+    await convertDisksToQcow2(args)
+
+    // PVE mirrored into a fresh volume and deleted the raw one: a later cleanup
+    // freeing the old name would hit a volume that no longer exists.
+    expect(volumes[0].volumeId).toBe(`${STORAGE}:vm-250-disk-3.qcow2`)
+    expect(volumes[1].volumeId).toBe(`${STORAGE}:vm-250-disk-4.qcow2`)
+    // the raw LV's device path died with it
+    expect(volumes[0].devicePath).toBe("")
+    expect(volumes[0].attached).toBe(true)
+  })
+
+  it("only converts the disks this migration created — never the efidisk, never someone else's disk", async () => {
+    const conf = baseVmConf()
+    conf.scsi2 = `${STORAGE}:vm-250-disk-9,size=10G` // attached by an operator, not ours
+    mockPveRoutes({ conf })
+    const { args } = makeHarness()
+
+    await convertDisksToQcow2(args)
+
+    const slots = moveCalls().map(c => (c[2]!.body as URLSearchParams).get("disk"))
+    expect(slots).toEqual(["scsi0", "scsi1"])
+  })
+})
+
+describe("convertDisksToQcow2 — skip paths (each with an explanatory log line)", () => {
+  it("does nothing at all when the option is off", async () => {
+    const { args, logs, phases } = makeHarness(makeVolumes(), { enabled: false })
+
+    await convertDisksToQcow2(args)
+
+    expect(mockFetch).not.toHaveBeenCalled()
+    expect(phases).toEqual([])
+    // Silent: every pipeline calls the helper unconditionally, so a skip line
+    // here would pollute the log of every migration that never opted in.
+    expect(logs).toEqual([])
+  })
+
+  it.each([
+    ["lvm without snapshot-as-volume-chain", { type: "lvm" }],
+    ["lvmthin (qcow2-on-lvmthin is not a thing)", { type: "lvmthin", "snapshot-as-volume-chain": 1 }],
+    ["zfspool (snapshots natively, raw is right)", { type: "zfspool" }],
+  ])("skips when the storage does not default to qcow2: %s", async (_label, storageCfg) => {
+    mockPveRoutes({ storageCfg: { storage: STORAGE, ...storageCfg } })
+    const { args, logs, phases } = makeHarness()
+
+    await convertDisksToQcow2(args)
+
+    expect(moveCalls()).toHaveLength(0)
+    expect(phases).toEqual([])
+    expect(logs.some(l => l.msg.includes(STORAGE))).toBe(true)
+  })
+
+  it("skips when free space is below the largest disk (the mirror transiently needs a second full copy)", async () => {
+    mockPveRoutes({ avail: 50 * GiB }) // largest disk is 100G
+    const { args, logs } = makeHarness()
+
+    await convertDisksToQcow2(args)
+
+    expect(moveCalls()).toHaveLength(0)
+    expect(logs.some(l => l.level === "warn" && /free space/i.test(l.msg))).toBe(true)
+  })
+
+  it("skips when none of our volumes is attached to the VM (nothing to convert)", async () => {
+    mockPveRoutes()
+    const volumes: AllocatedVolume[] = [{ volumeId: `${STORAGE}:vm-250-disk-7`, devicePath: "/dev/vg/x" }]
+    const { args, logs } = makeHarness(volumes)
+
+    await convertDisksToQcow2(args)
+
+    expect(moveCalls()).toHaveLength(0)
+    expect(logs.length).toBeGreaterThan(0)
+  })
+})
+
+describe("convertDisksToQcow2 — can never fail the migration (#595 design point 3)", () => {
+  // Resolving (never rejecting) is the property that lets every pipeline's very
+  // next statement — updateJob(jobId, "completed") — run whatever happened here.
+  const warnAbout = (logs: Array<{ msg: string; level: string }>) =>
+    logs.filter(l => l.level === "warn").map(l => l.msg).join("\n")
+
+  it("a move_disk refusal (API error) resolves, warns, and stops converting", async () => {
+    mockPveRoutes({ onMove: () => { throw new Error("400 Parameter verification failed") } })
+    const { args, logs } = makeHarness()
+
+    await expect(convertDisksToQcow2(args)).resolves.toBeUndefined()
+
+    expect(moveCalls()).toHaveLength(1) // first disk refused -> do not hammer the second
+    expect(warnAbout(logs)).toMatch(/migrated and usable/i)
+    expect(warnAbout(logs)).toMatch(/still raw/i)
+  })
+
+  it("a failed PVE task resolves, warns, and leaves the bookkeeping untouched", async () => {
+    mockPveRoutes()
+    mockWait.mockRejectedValue(new Error("PVE task failed: lvcreate 'vg/vm-250-disk-3.qcow2' error: not enough extents"))
+    const volumes = makeVolumes()
+    const { args, logs } = makeHarness(volumes)
+
+    await expect(convertDisksToQcow2(args)).resolves.toBeUndefined()
+
+    expect(warnAbout(logs)).toMatch(/still raw/i)
+    // the move failed: the raw volume is still the attached one, keep its id
+    expect(volumes[0].volumeId).toBe(`${STORAGE}:vm-250-disk-1`)
+  })
+
+  it("a task timeout resolves and warns", async () => {
+    mockPveRoutes()
+    mockWait.mockRejectedValue(new Error("PVE task timed out after 86400s"))
+    const { args, logs } = makeHarness()
+
+    await expect(convertDisksToQcow2(args)).resolves.toBeUndefined()
+    expect(warnAbout(logs)).toMatch(/still raw/i)
+  })
+
+  it("even the server-side gate blowing up resolves and warns", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"))
+    const { args, logs } = makeHarness()
+
+    await expect(convertDisksToQcow2(args)).resolves.toBeUndefined()
+    expect(warnAbout(logs)).toMatch(/still raw/i)
+  })
+
+  it("a throwing log callback still resolves (nothing may reach the pipeline's catch)", async () => {
+    mockPveRoutes({ onMove: () => { throw new Error("boom") } })
+    const { args } = makeHarness(makeVolumes(), {
+      log: () => { throw new Error("logs JSONB write failed") },
+    })
+
+    await expect(convertDisksToQcow2(args)).resolves.toBeUndefined()
+  })
+})
+
+describe("storageDefaultsToQcow2", () => {
+  it("accepts an lvm storage with snapshot-as-volume-chain (number or string flag)", () => {
+    expect(storageDefaultsToQcow2({ type: "lvm", "snapshot-as-volume-chain": 1 })).toBe(true)
+    expect(storageDefaultsToQcow2({ type: "lvm", "snapshot-as-volume-chain": "1" })).toBe(true)
+  })
+
+  it("rejects everything else", () => {
+    expect(storageDefaultsToQcow2({ type: "lvm" })).toBe(false)
+    expect(storageDefaultsToQcow2({ type: "lvm", "snapshot-as-volume-chain": 0 })).toBe(false)
+    expect(storageDefaultsToQcow2({ type: "lvmthin", "snapshot-as-volume-chain": 1 })).toBe(false)
+    expect(storageDefaultsToQcow2({ type: "zfspool" })).toBe(false)
+    expect(storageDefaultsToQcow2({ type: "rbd" })).toBe(false)
+    expect(storageDefaultsToQcow2(null)).toBe(false)
+    expect(storageDefaultsToQcow2(undefined)).toBe(false)
+  })
+})
+
+describe("migratedDataDisks", () => {
+  const ours = [{ volumeId: `${STORAGE}:vm-250-disk-1` }, { volumeId: `${STORAGE}:vm-250-disk-2` }]
+
+  it("maps our attached volumes to their slots with byte sizes parsed from the config value", () => {
+    expect(migratedDataDisks(baseVmConf(), ours)).toEqual([
+      { slot: "scsi0", volumeId: `${STORAGE}:vm-250-disk-1`, sizeBytes: 32 * GiB },
+      { slot: "scsi1", volumeId: `${STORAGE}:vm-250-disk-2`, sizeBytes: 100 * GiB },
+    ])
+  })
+
+  it("understands M/T suffixes and plain byte counts", () => {
+    const conf = {
+      scsi0: `${STORAGE}:vm-250-disk-1,size=4400M`,
+      virtio1: `${STORAGE}:vm-250-disk-2,size=1T`,
+      sata2: `${STORAGE}:vm-250-disk-3,size=10737418240`,
+    }
+    const vols = [...ours, { volumeId: `${STORAGE}:vm-250-disk-3` }]
+    // natural slot order: sata2 < scsi0 < virtio1
+    expect(migratedDataDisks(conf, vols).map(d => d.sizeBytes)).toEqual([
+      10737418240, 4400 * 1024 ** 2, 1024 ** 4,
+    ])
+  })
+
+  it("never returns the efidisk, unused slots, or volumes we did not create", () => {
+    const conf = {
+      ...baseVmConf(),
+      tpmstate0: `${STORAGE}:vm-250-disk-5,size=4M`,
+      unused0: `${STORAGE}:vm-250-disk-1`,
+      scsi3: `other-storage:vm-250-disk-1,size=5G`,
+    }
+    const slots = migratedDataDisks(conf, ours).map(d => d.slot)
+    expect(slots).toEqual(["scsi0", "scsi1"])
+  })
+
+  it("skips a volume that is already qcow2 (idempotent after a partial conversion)", () => {
+    const conf = {
+      scsi0: `${STORAGE}:vm-250-disk-3.qcow2,size=32G`,
+      scsi1: `${STORAGE}:vm-250-disk-2,size=100G`,
+    }
+    const vols = [{ volumeId: `${STORAGE}:vm-250-disk-3.qcow2` }, { volumeId: `${STORAGE}:vm-250-disk-2` }]
+    expect(migratedDataDisks(conf, vols).map(d => d.slot)).toEqual(["scsi1"])
+  })
+
+  it("orders slots naturally so scsi10 converts after scsi2", () => {
+    const conf = {
+      scsi10: `${STORAGE}:vm-250-disk-1,size=1G`,
+      scsi2: `${STORAGE}:vm-250-disk-2,size=1G`,
+    }
+    expect(migratedDataDisks(conf, ours).map(d => d.slot)).toEqual(["scsi2", "scsi10"])
+  })
+
+  it("handles an empty or missing config", () => {
+    expect(migratedDataDisks(null, ours)).toEqual([])
+    expect(migratedDataDisks({}, [])).toEqual([])
+  })
+})

--- a/frontend/src/lib/migration/qcow2-convert.ts
+++ b/frontend/src/lib/migration/qcow2-convert.ts
@@ -1,0 +1,235 @@
+import { pveFetch } from "@/lib/proxmox/client"
+
+import { waitForPveTask } from "./pve-tasks"
+import type { AllocatedVolume } from "./pvesm-alloc"
+
+type PveConn = { baseUrl: string; apiToken: string; insecureDev: boolean; id: string }
+
+/**
+ * Timeout for one `move_disk` task. The conversion rewrites every byte of the
+ * disk: PVE mirrors the raw volume into a fresh qcow2 volume, then deletes the
+ * raw one. On the customer array that motivated this (#587/#606), sequential
+ * throughput lands between 359 MiB/s (QD1 worst case) and 1.9 GiB/s, so a
+ * multi-TB disk is legitimately *hours* of work — nowhere near waitForPveTask's
+ * 5-minute default. 24 h covers a 10+ TB disk on a slow array with margin.
+ */
+export const MOVE_DISK_TIMEOUT_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Does this storage allocate qcow2 volumes by default?
+ *
+ * That is exactly one storage class today: PVE 9 LVM with
+ * `snapshot-as-volume-chain` — the configuration whose snapshots depend on the
+ * qcow2 volume chain, and therefore the only one where converting a migrated
+ * raw disk buys the operator anything (#595). Everything else is deliberately
+ * out: lvmthin/ZFS/Ceph snapshot natively on raw, and file-based storages get
+ * their disks imported as qcow2 files in the first place. PVE serialises the
+ * flag as 0/1 (sometimes a string), so accept both spellings.
+ *
+ * This is the server-side re-check of the UI gate: the dialog only shows the
+ * option on an lvm storage, but a raw API caller bypasses the dialog.
+ */
+export function storageDefaultsToQcow2(
+  cfg: { type?: string; "snapshot-as-volume-chain"?: number | string | boolean } | null | undefined,
+): boolean {
+  if (!cfg || cfg.type !== "lvm") return false
+  const flag = cfg["snapshot-as-volume-chain"]
+  return flag === 1 || flag === "1" || flag === true
+}
+
+export interface MigratedDataDisk {
+  /** VM config slot the disk is attached to (`scsi0`, `virtio1`, ...). */
+  slot: string
+  volumeId: string
+  /** Virtual size parsed from the config value's `size=` option (0 if absent). */
+  sizeBytes: number
+}
+
+// Bus slots that can hold a data disk. efidisk0/tpmstate0 deliberately do NOT
+// match: PVE creates them itself at `qm create` time and the efidisk is already
+// qcow2 on a volume-chain storage (#606: `efidisk0: FC-HDC-01:vm-169-disk-0.qcow2`).
+// `unusedN` does not match either — an unused volume is not attached, so a live
+// mirror is impossible and it is not a disk this migration handed to the VM.
+const DATA_DISK_SLOT_RE = /^(?:scsi|sata|virtio|ide)\d+$/
+
+// `size=32G` in a VM config value. PVE prints the largest exact binary unit,
+// or plain bytes when nothing divides evenly.
+const PVE_SIZE_UNIT: Record<string, number> = { K: 1024, M: 1024 ** 2, G: 1024 ** 3, T: 1024 ** 4, P: 1024 ** 5 }
+
+function parsePveSize(value: string): number {
+  const m = /(?:^|,)size=(\d+)([KMGTP])?(?:,|$)/.exec(value)
+  if (!m) return 0
+  return Number(m[1]) * (m[2] ? PVE_SIZE_UNIT[m[2]] : 1)
+}
+
+/**
+ * The attached data disks THIS migration created, resolved against the live VM
+ * config. Matching by volume ID (not by remembering slots) means a disk whose
+ * attach failed with a warning simply never shows up, and a volume that is
+ * already qcow2 — a re-run after a partially completed conversion — is skipped
+ * instead of being rewritten a second time. Sorted naturally by slot so scsi10
+ * converts after scsi2 and the job log reads in order.
+ */
+export function migratedDataDisks(
+  vmConf: Record<string, unknown> | null | undefined,
+  volumes: ReadonlyArray<Pick<AllocatedVolume, "volumeId">>,
+): MigratedDataDisk[] {
+  const ours = new Set(volumes.map(v => v.volumeId).filter(Boolean))
+  const disks: MigratedDataDisk[] = []
+  for (const [slot, value] of Object.entries(vmConf || {})) {
+    if (!DATA_DISK_SLOT_RE.test(slot) || typeof value !== "string") continue
+    const volumeId = value.split(",")[0]
+    if (!ours.has(volumeId) || volumeId.endsWith(".qcow2")) continue
+    disks.push({ slot, volumeId, sizeBytes: parsePveSize(value) })
+  }
+  return disks.sort((a, b) => a.slot.localeCompare(b.slot, undefined, { numeric: true }))
+}
+
+export interface ConvertDisksToQcow2Args {
+  /** `config.convertDisksToQcow2` — pass it through, the helper owns the skip log. */
+  enabled: boolean
+  conn: PveConn
+  node: string
+  vmid: number | string
+  targetStorage: string
+  /**
+   * The pipeline's cleanup registry (or any list of the volume IDs this
+   * migration created). Mutated on success: PVE deletes the raw volume and
+   * mirrors into a fresh `.qcow2` name, so the recorded IDs are rewritten to
+   * the new ones — a later cleanup must never try to free a name that no
+   * longer exists.
+   */
+  volumes: AllocatedVolume[]
+  /** Job-log writer (the pipeline's appendLog bound to its jobId). */
+  log: (msg: string, level?: "info" | "success" | "warn" | "error") => Promise<void> | void
+  /** Persist the `converting_disks` phase with the given progress (95 → 99). */
+  setPhase: (progress: number) => Promise<void> | void
+  /** Override for tests; defaults to MOVE_DISK_TIMEOUT_MS. */
+  moveTimeoutMs?: number
+}
+
+/**
+ * Post-migration qcow2 conversion (#595): one `move_disk` per data disk against
+ * the same storage with `format=qcow2, delete=1` — exactly the call the web UI
+ * "Move disk" makes, i.e. the operation the reporter already runs by hand after
+ * every migration to get snapshot-capable disks back. On a running VM PVE
+ * performs it as a live drive-mirror, so run it after the disks are attached
+ * and after the optional start.
+ *
+ * CONTRACT: this function can never fail the migration. By the time it runs the
+ * VM is migrated, bootable and possibly already serving — a conversion problem
+ * must degrade to "the disks are still raw", never to a failed job. Every exit
+ * path, including a throwing log callback, resolves.
+ */
+export async function convertDisksToQcow2(args: ConvertDisksToQcow2Args): Promise<void> {
+  try {
+    await runConversion(args)
+  } catch (err: any) {
+    // Never rethrow: the pipeline's next statement is the terminal "completed"
+    // write, and nothing that happens here may keep the job from reaching it.
+    try {
+      await args.log(
+        `qcow2 conversion did not complete: ${err?.message || err}. The migration itself succeeded — ` +
+        `the VM is migrated and usable, its disks are simply still raw. Convert them manually with ` +
+        `"Move disk" (same storage, format qcow2) if you need snapshots.`,
+        "warn",
+      )
+    } catch {
+      // Even a failing job-log write must not surface: swallowing it here is
+      // what keeps the "cannot fail the migration" contract absolute.
+    }
+  }
+}
+
+async function runConversion(args: ConvertDisksToQcow2Args): Promise<void> {
+  const { enabled, conn, node, vmid, targetStorage, volumes, log, setPhase } = args
+
+  // Silently: every pipeline calls this unconditionally, so logging a skip here
+  // would add a line about an opt-in feature to the log of every migration that
+  // never asked for it. The gates below DO log, because there the operator did
+  // ask and needs to know why it did not happen.
+  if (!enabled) return
+
+  // Server-side re-check of the UI gate: only a snapshot-as-volume-chain LVM
+  // storage defaults to qcow2, and only there does the conversion buy snapshots.
+  const storageCfg = await pveFetch<any>(conn, `/storage/${encodeURIComponent(targetStorage)}`)
+  if (!storageDefaultsToQcow2(storageCfg)) {
+    await log(
+      `Skipping qcow2 conversion: storage "${targetStorage}" (${storageCfg?.type || "unknown"}) does not ` +
+      `default to qcow2 (requires an LVM storage with snapshot-as-volume-chain). Disks keep their native format.`,
+    )
+    return
+  }
+
+  const vmConf = await pveFetch<Record<string, unknown>>(
+    conn, `/nodes/${encodeURIComponent(node)}/qemu/${vmid}/config`,
+  )
+  const disks = migratedDataDisks(vmConf, volumes)
+  if (disks.length === 0) {
+    await log(`Skipping qcow2 conversion: no raw data disks from this migration are attached to VM ${vmid}.`)
+    return
+  }
+
+  // The mirror transiently doubles the disk: source raw volume and target qcow2
+  // volume coexist until the copy completes and `delete=1` frees the raw one.
+  // Disks convert one at a time, so the requirement is the LARGEST disk, not
+  // the sum. `avail` comes from the node's live storage status, not the config.
+  const storageStatus = await pveFetch<any>(
+    conn, `/nodes/${encodeURIComponent(node)}/storage/${encodeURIComponent(targetStorage)}/status`,
+  )
+  const avail = Number(storageStatus?.avail ?? 0)
+  const largest = Math.max(...disks.map(d => d.sizeBytes))
+  if (!Number.isFinite(avail) || avail < largest) {
+    const gib = (n: number) => (n / 1024 ** 3).toFixed(1)
+    await log(
+      `Skipping qcow2 conversion: free space on "${targetStorage}" (${gib(avail)} GiB) is below the largest ` +
+      `disk to convert (${gib(largest)} GiB) — the conversion transiently needs a second full copy of the disk. ` +
+      `Free up space and convert manually with "Move disk" if you need snapshots.`,
+      "warn",
+    )
+    return
+  }
+
+  await setPhase(95)
+  await log(
+    `Converting ${disks.length} disk(s) to qcow2 on "${targetStorage}" so they can take Proxmox snapshots. ` +
+    `This rewrites every byte in the background (hours on multi-TB disks); a running VM stays available.`,
+  )
+
+  for (let i = 0; i < disks.length; i++) {
+    const disk = disks[i]
+    try {
+      const upid = await pveFetch<string>(
+        conn, `/nodes/${encodeURIComponent(node)}/qemu/${vmid}/move_disk`,
+        {
+          method: "POST",
+          body: new URLSearchParams({ disk: disk.slot, storage: targetStorage, format: "qcow2", delete: "1" }),
+        },
+      )
+      if (!upid) throw new Error("move_disk returned no task id")
+      await waitForPveTask(conn, node, String(upid), args.moveTimeoutMs ?? MOVE_DISK_TIMEOUT_MS)
+    } catch (e: any) {
+      // One refusal (feature/space/lock) very likely applies to the remaining
+      // disks too — do not hammer the storage for hours per disk. Re-throwing
+      // hands the whole batch to the outer never-fails handler.
+      throw new Error(`disk ${disk.slot} (${disk.volumeId}): ${e?.message || e}`)
+    }
+
+    // The move deleted the raw volume and attached a fresh `.qcow2` one: read
+    // the slot back for the authoritative new ID and rewrite the cleanup
+    // registry, so no later code path can free a name that no longer exists.
+    const confAfter = await pveFetch<Record<string, unknown>>(
+      conn, `/nodes/${encodeURIComponent(node)}/qemu/${vmid}/config`,
+    )
+    const newVolumeId = String(confAfter?.[disk.slot] || "").split(",")[0]
+    const entry = volumes.find(v => v.volumeId === disk.volumeId)
+    if (entry && newVolumeId) {
+      entry.volumeId = newVolumeId
+      entry.devicePath = "" // the raw LV's device node died with the volume
+    }
+    await log(`Disk ${disk.slot}: converted to qcow2 → ${newVolumeId || "(new volume)"}`, "success")
+    await setPhase(95 + Math.round(((i + 1) / disks.length) * 4))
+  }
+
+  await log(`qcow2 conversion complete: ${disks.length} disk(s) now support Proxmox snapshots.`, "success")
+}

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -24,7 +24,8 @@ import { getNodeIp } from "@/lib/ssh/node-ip"
 import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
 import { parseV2vXml, buildPveCreateParams } from "./v2vConfigMapper"
 import type { V2vVmConfig } from "./v2vConfigMapper"
-import { allocateAndMapBlockVolume, nextFreeDiskName } from "./pvesm-alloc"
+import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
+import { convertDisksToQcow2 } from "./qcow2-convert"
 // SOAP imports for the NFC (HttpNfcLease) transport path used when the source VM
 // has any disk on a vSAN datastore. vpx://+HTTPS /folder/ download is broken for
 // vSAN because vSAN VMDK descriptors reference vsan:// URIs that only ESXi's
@@ -50,7 +51,7 @@ import type { SoapSession, NfcLeaseDeviceUrl, EsxiVmConfig } from "@/lib/vmware/
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { startJobHeartbeat } from "./job-heartbeat"
 
-type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
+type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "converting_disks" | "completed" | "failed" | "cancelled"
 
 export interface V2vMigrationConfig {
   sourceConnectionId: string
@@ -69,6 +70,13 @@ export interface V2vMigrationConfig {
    */
   vlanTag?: number
   startAfterMigration: boolean
+  /**
+   * Convert the migrated data disks to qcow2 after the migration (one `move_disk`
+   * per disk on the same storage), so they can take Proxmox snapshots on a
+   * snapshot-as-volume-chain LVM storage (#595). Opt-in, default false; the
+   * conversion can never fail the migration.
+   */
+  convertDisksToQcow2?: boolean
   /** vCenter datacenter name (libvirt vpx URI: vpx://VC/{datacenter}/...). Required for vcenter source. */
   vcenterDatacenter?: string
   /**
@@ -2373,6 +2381,12 @@ export async function runV2vMigrationPipeline(
     // Track the highest disk number used (EFI VMs may have disk-0 for efidisk0)
     let nextDiskNum = isEfi ? 1 : 0
 
+    // Block volumes created by THIS migration, for the optional post-migration
+    // qcow2 conversion (#595). Unlike the other pipelines, v2v has no cleanup
+    // registry, so this list exists only to tell the conversion which attached
+    // disks are ours — it must never convert a disk an operator attached.
+    const blockVolumes: AllocatedVolume[] = []
+
     // When virt-v2v can't inject virtio-scsi (`--block-driver` missing), it falls
     // back to virtio-blk (viostor.sys) as the boot-critical driver on Windows.
     // Attaching on scsi0 in that case yields INACCESSIBLE_BOOT_DEVICE (0x7B) at
@@ -2499,6 +2513,7 @@ export async function runV2vMigrationPipeline(
           connectionId: config.targetConnectionId, nodeIp,
           targetStorage: config.targetStorage, targetVmid, volName, sizeKB,
         })
+        blockVolumes.push(vol)
         const volumeId = vol.volumeId
         const devicePath = vol.devicePath
         const rbdMapped = vol.rbdMapped
@@ -2588,6 +2603,21 @@ export async function runV2vMigrationPipeline(
       )
       await appendLog(jobId, "VM started", "success")
     }
+
+    // Optional qcow2 conversion (#595): after the disks are attached and after
+    // the optional start — on a running VM PVE does move_disk as a live
+    // drive-mirror, no extra downtime. The helper gates itself (opt-in, storage
+    // default format, free space) and NEVER throws: a conversion problem leaves
+    // the disks raw, not the migration failed. File-based imports skip
+    // naturally: their storage does not default to qcow2 the LVM way, and `qm
+    // disk import --format qcow2` already produced qcow2 files.
+    await convertDisksToQcow2({
+      enabled: config.convertDisksToQcow2 === true,
+      conn: pveConn, node: config.targetNode, vmid: targetVmid!,
+      targetStorage: config.targetStorage, volumes: blockVolumes,
+      log: (m, l) => appendLog(jobId, m, l),
+      setPhase: p => updateJob(jobId, "converting_disks", { progress: p }),
+    })
 
     await updateJob(jobId, "completed", { progress: 100 })
     // Non-fatal: a failing log append after the terminal write must not throw

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -19,6 +19,7 @@ import {
 } from "../pvesm-alloc"
 import { pveSetVmConfig } from "../pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "../pve-tasks"
+import { convertDisksToQcow2 } from "../qcow2-convert"
 import { decideNextPass, type PassStat, type ConvergenceConfig, type ConvergenceDecision } from "./convergence"
 import { initDiskState, recordPass, type DiskWarmState } from "./state"
 import { startVddkReader, stopVddkReader, type VddkReaderHandle } from "./vddk-reader"
@@ -35,7 +36,8 @@ import { TERMINAL_STATUSES } from "@/lib/tasks/sharedTask"
 
 export type WarmStatus =
   | "pending" | "planning" | "enabling_cbt" | "preparing_disks" | "full_copy" | "delta_sync"
-  | "awaiting_cutover" | "cutover" | "verify" | "completed" | "failed" | "cancelled"
+  | "awaiting_cutover" | "cutover" | "verify" | "converting_disks"
+  | "completed" | "failed" | "cancelled"
 
 export interface WarmMigrationConfig {
   sourceConnectionId: string
@@ -46,6 +48,13 @@ export interface WarmMigrationConfig {
   networkBridge: string
   vlanTag?: number
   startAfterMigration: boolean
+  /**
+   * Convert the migrated data disks to qcow2 after the cutover (one `move_disk`
+   * per disk on the same storage), so they can take Proxmox snapshots on a
+   * snapshot-as-volume-chain LVM storage (#595). Opt-in, default false; the
+   * conversion can never fail the migration.
+   */
+  convertDisksToQcow2?: boolean
   targetVmid?: number
   /** Extracted VDDK distribution dir on the PVE node (libdir=). */
   vddkLibdir?: string
@@ -737,6 +746,19 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       await pveFetch<any>(pveConn as any, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/status/start`, { method: "POST" })
       await appendLog(jobId, "Target VM started", "success")
     }
+
+    // Post-cutover qcow2 conversion (#595): runs after the disks are attached
+    // and after the optional start — on a running VM PVE does move_disk as a
+    // live drive-mirror, no extra downtime. The helper gates itself (opt-in,
+    // storage default format, free space) and NEVER throws: a conversion
+    // problem leaves the disks raw, not the migration failed.
+    await convertDisksToQcow2({
+      enabled: config.convertDisksToQcow2 === true,
+      conn: pveConn as any, node: config.targetNode, vmid: targetVmid,
+      targetStorage: config.targetStorage, volumes: allocatedVolumes,
+      log: (m, l) => appendLog(jobId, m, l),
+      setPhase: p => updateJob(jobId, "converting_disks", { progress: p }),
+    })
 
     await updateJob(jobId, "completed", { progress: 100 })
     // Non-fatal: a failing log append after the terminal write must not throw

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -34,9 +34,10 @@ import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
+import { convertDisksToQcow2 } from "./qcow2-convert"
 import { startJobHeartbeat } from "./job-heartbeat"
 
-type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "completed" | "failed" | "cancelled"
+type MigrationStatus = "pending" | "preflight" | "creating_vm" | "transferring" | "configuring" | "converting_disks" | "completed" | "failed" | "cancelled"
 
 interface MigrationConfig {
   sourceConnectionId: string
@@ -52,6 +53,13 @@ interface MigrationConfig {
    */
   vlanTag?: number
   startAfterMigration: boolean
+  /**
+   * Convert the migrated data disks to qcow2 after the migration (one `move_disk`
+   * per disk on the same storage), so they can take Proxmox snapshots on a
+   * snapshot-as-volume-chain LVM storage (#595). Opt-in, default false; the
+   * conversion can never fail the migration.
+   */
+  convertDisksToQcow2?: boolean
   migrationType?: "cold" | "live"
   // User-selected scratch directory on the PVE node for VHD download +
   // qemu-img conversion. When set, overrides the default heuristic that picks
@@ -806,6 +814,20 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       )
       await appendLog(jobId, "VM started", "success")
     }
+
+    // ── STEP 6: Optional qcow2 conversion (#595) ──
+    // After the disks are attached and after the optional start: on a running
+    // VM PVE does move_disk as a live drive-mirror, no extra downtime. The
+    // helper gates itself (opt-in, storage default format, free space) and
+    // NEVER throws: a conversion problem leaves the disks raw, not the
+    // migration failed.
+    await convertDisksToQcow2({
+      enabled: config.convertDisksToQcow2 === true,
+      conn: pveConn, node: config.targetNode, vmid: targetVmid!,
+      targetStorage: config.targetStorage, volumes: allocatedVolumes,
+      log: (m, l) => appendLog(jobId, m, l),
+      setPhase: p => updateJob(jobId, "converting_disks", { progress: p }),
+    })
 
     // ── DONE ──
     await updateJob(jobId, "completed", {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2022,6 +2022,8 @@
       "vlanTagPlaceholder": "keiner",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "Start VM after Migration",
+      "convertDisksToQcow2": "Festplatten nach der Migration in qcow2 konvertieren (aktiviert Proxmox-Snapshots)",
+      "convertDisksToQcow2Tooltip": "Nach Abschluss der Migration wird jede Festplatte im Hintergrund vollständig nach qcow2 umgeschrieben. Das kann bei Multi-TB-Festplatten Stunden dauern und belegt vorübergehend den doppelten Platz auf dem Zielspeicher. Keine Ausfallzeit: Die Konvertierung läuft live, während die VM läuft.",
       "coldMigrationInfo": "Kaltmigration: Die VM wird heruntergefahren. VMDK-Disks werden in QCOW2/RAW konvertiert und die Hardwarekonfiguration wird automatisch zugeordnet.",
       "coldMigrationRunningVms": "Die folgenden VMs laufen derzeit und müssen vor einer Kaltmigration heruntergefahren werden:",
       "startMigration": "Nach Proxmox migrieren",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2053,6 +2053,8 @@
       "vlanTagPlaceholder": "none",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "Start VM after migration",
+      "convertDisksToQcow2": "Convert disks to qcow2 after migration (enables Proxmox snapshots)",
+      "convertDisksToQcow2Tooltip": "After the migration completes, each disk is fully rewritten to qcow2 in the background. This can take hours on a multi-TB disk and temporarily uses double the space on the target storage. No downtime: the conversion runs live while the VM is running.",
       "coldMigrationInfo": "Cold migration: VM will be powered off. VMDK disks are converted to QCOW2/RAW and hardware config is mapped automatically.",
       "coldMigrationRunningVms": "The following VMs are currently running and must be powered off before starting a cold migration:",
       "startMigration": "Migrate to Proxmox",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2053,6 +2053,8 @@
       "vlanTagPlaceholder": "ninguna",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "Iniciar VM después de la migración",
+      "convertDisksToQcow2": "Convertir los discos a qcow2 después de la migración (habilita snapshots de Proxmox)",
+      "convertDisksToQcow2Tooltip": "Al completarse la migración, cada disco se reescribe por completo a qcow2 en segundo plano. Esto puede tardar horas en un disco de varios TB y usa temporalmente el doble de espacio en el almacenamiento de destino. Sin tiempo de inactividad: la conversión se realiza en caliente mientras la VM está en ejecución.",
       "coldMigrationInfo": "Migración en frío: la VM se apagará. Los discos VMDK se convierten a QCOW2/RAW y la configuración de hardware se asigna automáticamente.",
       "coldMigrationRunningVms": "Las siguientes VMs están en ejecución y deben apagarse antes de iniciar una migración en frío:",
       "startMigration": "Migrar a Proxmox",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2053,6 +2053,8 @@
       "vlanTagPlaceholder": "aucun",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "Démarrer la VM après la migration",
+      "convertDisksToQcow2": "Convertir les disques en qcow2 après la migration (active les snapshots Proxmox)",
+      "convertDisksToQcow2Tooltip": "Une fois la migration terminée, chaque disque est entièrement réécrit en qcow2 en arrière-plan. Cela peut prendre des heures pour un disque de plusieurs To et double temporairement l'espace utilisé sur le stockage cible. Aucune interruption : la conversion s'effectue à chaud pendant que la VM tourne.",
       "coldMigrationInfo": "Migration à froid : la VM sera éteinte. Les disques VMDK sont convertis en QCOW2/RAW et la configuration matérielle est mappée automatiquement.",
       "coldMigrationRunningVms": "Les VM suivantes sont actuellement en cours d'exécution et doivent être éteintes avant de lancer une migration à froid :",
       "startMigration": "Migrer vers Proxmox",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2053,6 +2053,8 @@
       "vlanTagPlaceholder": "없음",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "마이그레이션 후 VM 시작",
+      "convertDisksToQcow2": "마이그레이션 후 디스크를 qcow2로 변환 (Proxmox 스냅샷 사용 가능)",
+      "convertDisksToQcow2Tooltip": "마이그레이션이 완료되면 각 디스크가 백그라운드에서 qcow2로 완전히 다시 기록됩니다. 수 TB 디스크는 몇 시간이 걸릴 수 있으며 변환 중에는 대상 스토리지 공간을 일시적으로 두 배로 사용합니다. VM이 실행 중이어도 중단 시간은 없습니다.",
       "coldMigrationInfo": "콜드 마이그레이션: VM 전원이 꺼집니다. VMDK 디스크는 QCOW2/RAW로 변환되고 하드웨어 구성은 자동으로 매핑됩니다.",
       "coldMigrationRunningVms": "다음 VM은 현재 실행 중이며 콜드 마이그레이션을 시작하기 전에 전원을 꺼야 합니다:",
       "startMigration": "Proxmox로 마이그레이션",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2022,6 +2022,8 @@
       "vlanTagPlaceholder": "无",
       "vlanTagInvalid": "1-4094",
       "startAfterMigration": "迁移后启动虚拟机",
+      "convertDisksToQcow2": "迁移后将磁盘转换为 qcow2（启用 Proxmox 快照）",
+      "convertDisksToQcow2Tooltip": "迁移完成后，每个磁盘会在后台完整重写为 qcow2。数 TB 的磁盘可能需要数小时，转换期间目标存储会暂时占用双倍空间。虚拟机运行时转换在线进行，不会产生停机。",
       "coldMigrationInfo": "冷迁移：虚拟机将关机。VMDK 磁盘将转换为 QCOW2/RAW，硬件配置将自动映射。",
       "coldMigrationRunningVms": "以下虚拟机当前正在运行，在开始冷迁移前必须关机：",
       "startMigration": "迁移到 Proxmox",


### PR DESCRIPTION
Closes #595.

Since #587 every block volume is allocated `--format raw`, deliberately: formatting a 3.1 TiB volume as qcow2 is exactly what used to fail with "exit code 17" on a `snapshot-as-volume-chain` LVM storage. The side effect, confirmed again by the reporter on 2026-07-29, is that migrated disks cannot take Proxmox snapshots on such a storage, so they convert every disk by hand after every migration with the web UI's "Move disk".

This adds that conversion as an opt-in step, using the design agreed on the issue.

## How it works

Nothing changes in the copy paths. Disks are still allocated and written raw, which is fast and proven. After a successful migration, one `move_disk` per data disk runs against the same storage with `format=qcow2, delete=1` — the exact call the web UI makes. On a running VM Proxmox performs it as a live drive-mirror, so it costs **no additional downtime**; it runs after the disks are attached and after the optional start for that reason.

The step is shared by all four pipelines (warm, cold, v2v, xcp-ng), because all four allocate raw through the same helper and therefore all four leave raw disks behind.

**It can never fail a migration.** By the time it runs the VM is migrated, bootable and possibly already serving traffic, so every failure path degrades to "the disks are still raw" with a warning that tells the operator how to convert them by hand. That includes a throwing job-log callback. It skips, with an explanation in the log, when the option was not requested, when the target storage does not default to qcow2 (re-checked server-side, the UI gate is not trusted), and when free space is below the largest disk to convert, since the mirror transiently needs a second full copy.

The recorded volume IDs are rewritten after each conversion: PVE deletes the raw volume and mirrors into a fresh `.qcow2` one, so a later cleanup must not try to free a name that no longer exists.

## UI

A per-migration switch, default off, in both the single-VM and the bulk migration dialog, shown only when the target storage is a thick `lvm` storage. `lvmthin` cannot hold qcow2, and ZFS and Ceph RBD snapshot natively on raw, so the option would be meaningless there. The tooltip states the cost: a full background rewrite of every disk, hours on a multi-TB disk, transient double space, no downtime while the VM runs. The request payload re-applies the storage gate, so a switch left on for an earlier LVM target cannot leak into a run against a storage where the option is hidden.

## Sticky migration options, fixed as a class

Adding an eighth option to the migration dialog surfaced a live bug: the dialog-open effect resets the connection, node, storage and VMID, but none of the option state, and that state lives at page level shared by both dialogs. One toggle survived into every later migration in the same page session. This is what a user reported inside #443: they had not ticked "start VM after migration", yet the job started the VM, because an earlier run had left it on.

Shipping a new option into that family would have shipped a known bug, so the whole family now resets on dialog open — network bridge, VLAN tag, start-after, disk paths, temp storage, migration type, transfer mode and the new option. The state moved into a `useMigrationOptions` hook so the reset is testable and so a future option inherits it by construction. A regression test toggles options, closes and reopens, and asserts the defaults are back.

Two related gaps closed while in the same code: the API now coerces `convertDisksToQcow2` and `startAfterMigration` strictly, where previously only `undefined` was defaulted so a caller sending the string `"false"` got a VM started; and `converting_disks` joins the dashboard's active-job predicate, which gates the progress bar, alongside the warm phases #621 added there.

## Verification

Full suite on this branch after rebasing onto #621: 299 files, 2937 tests, all passing, and a complete `next build`. Plus 23 tests on the conversion helper covering the three skip paths, the `move_disk` body shape, the phase progression, the volume-ID bookkeeping and every never-fails path, and 6 new dialog tests including the sticky regression, verified by mutation: disabling the reset makes the test fail.
