### PR TITLE
fix(alerts): keep batch actions available on header select-all (#568)

### DIFF
--- a/frontend/src/app/(dashboard)/operations/alerts/page.tsx
+++ b/frontend/src/app/(dashboard)/operations/alerts/page.tsx
@@ -46,6 +46,7 @@ import { Features, useLicense } from '@/contexts/LicenseContext'
 import { useToast } from '@/contexts/ToastContext'
 import { useOrchestratorAlerts, useAlertsSummary, useAlertRules } from '@/hooks/useAlerts'
 import { useConnections } from '@/hooks/useConnections'
+import { resolveSelectedRowIds } from '@/utils/gridSelection'
 import EmptyState from '@/components/EmptyState'
 import { CardsSkeleton, TableSkeleton } from '@/components/skeletons'
 
@@ -312,9 +313,9 @@ export default function AlertsPage() {
   const [severityFilter, setSeverityFilter] = useState('all')
   const [statusFilter, setStatusFilter] = useState('active')
 
-  // Selection for bulk actions
+  // Selection for bulk actions. The concrete id list is derived below, once
+  // filteredAlerts (the grid's row set) exists.
   const [selectionModel, setSelectionModel] = useState<GridRowSelectionModel>({ type: 'include', ids: new Set() })
-  const selectedAlertIds = Array.from(selectionModel.ids) as string[]
 
   // Mute popover
   const [muteAnchorEl, setMuteAnchorEl] = useState<null | HTMLElement>(null)
@@ -397,6 +398,13 @@ return () => setPageInfo('', '', '')
 return true
     })
   }, [alerts, search, severityFilter, statusFilter])
+
+  // The header "select all" checkbox emits an "exclude" model instead of the
+  // selected rows, so the id list has to be resolved against the grid's rows (#568).
+  const selectedAlertIds = useMemo(
+    () => resolveSelectedRowIds(selectionModel, filteredAlerts),
+    [selectionModel, filteredAlerts]
+  )
 
   const handleClearAll = () => {
     if (!isEnterprise) return

--- a/frontend/src/utils/gridSelection.test.ts
+++ b/frontend/src/utils/gridSelection.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { resolveSelectedRowIds } from './gridSelection'
+
+const rows = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+
+describe('resolveSelectedRowIds', () => {
+  it('returns the ids of a manual multi-select', () => {
+    const ids = resolveSelectedRowIds({ type: 'include', ids: new Set(['a', 'c']) }, rows)
+
+    expect(ids).toEqual(['a', 'c'])
+  })
+
+  it('returns an empty list when nothing is selected', () => {
+    expect(resolveSelectedRowIds({ type: 'include', ids: new Set() }, rows)).toEqual([])
+  })
+
+  it('expands a "select all" model into every row id', () => {
+    const ids = resolveSelectedRowIds({ type: 'exclude', ids: new Set() }, rows)
+
+    expect(ids).toEqual(['a', 'b', 'c'])
+  })
+
+  it('excludes the rows unchecked after a "select all"', () => {
+    const ids = resolveSelectedRowIds({ type: 'exclude', ids: new Set(['b']) }, rows)
+
+    expect(ids).toEqual(['a', 'c'])
+  })
+
+  it('returns an empty list when every row was unchecked after a "select all"', () => {
+    const ids = resolveSelectedRowIds({ type: 'exclude', ids: new Set(['a', 'b', 'c']) }, rows)
+
+    expect(ids).toEqual([])
+  })
+
+  it('never reports rows filtered out of the grid', () => {
+    const visible = [{ id: 'b' }]
+
+    expect(resolveSelectedRowIds({ type: 'exclude', ids: new Set() }, visible)).toEqual(['b'])
+  })
+
+  it('handles numeric row ids in an include model', () => {
+    expect(resolveSelectedRowIds({ type: 'include', ids: new Set([1, 2]) }, rows)).toEqual(['1', '2'])
+  })
+})

--- a/frontend/src/utils/gridSelection.ts
+++ b/frontend/src/utils/gridSelection.ts
@@ -1,0 +1,24 @@
+import type { GridRowSelectionModel } from '@mui/x-data-grid'
+
+/**
+ * Resolve a DataGrid selection model into the concrete list of selected row ids.
+ *
+ * The header "select all" checkbox does not emit the selected rows: it emits
+ * `{ type: 'exclude', ids: <deselected rows> }`, i.e. "every row except these".
+ * Reading `model.ids` directly therefore yields an EMPTY list on select-all,
+ * which silently disables any batch action gated on that list (#568).
+ *
+ * `rows` must be the very array handed to the grid's `rows` prop, so that
+ * "every row" means the same thing here as it does inside the grid (filters
+ * included).
+ */
+export function resolveSelectedRowIds<T extends { id: string }>(
+  model: GridRowSelectionModel,
+  rows: readonly T[]
+): string[] {
+  if (model.type === 'exclude') {
+    return rows.filter(row => !model.ids.has(row.id)).map(row => row.id)
+  }
+
+  return Array.from(model.ids).map(String)
+}


### PR DESCRIPTION
## Problem

Reported on #568 after the initial fix shipped: the batch action bar on the alerts page shows up when rows are ticked one by one, but not when the header "select all" checkbox is used. With every row visibly selected, no action is offered.

## Root cause

The DataGrid header checkbox does not emit the selected rows. It emits an inverted model:

```
{ type: 'exclude', ids: <rows the user unticked> }
```

meaning "every row except these". The page read `selectionModel.ids` directly, so on select-all the derived id list was empty, `selectedAlertIds.length > 0` stayed false and the action bar never rendered. Manual multi-select emits `{ type: 'include', ids: <selected rows> }`, which is why it appeared to work.

## Fix

`resolveSelectedRowIds(model, rows)` resolves both shapes of the model, and is given the exact array handed to the grid's `rows` prop. So "every row" means the same thing on both sides, and alerts hidden by the severity/status/search filters are never acted upon.

The helper is shared rather than inlined: the alerts grid is the only `checkboxSelection` grid today, but the inverted model is a standing trap for the next one.

Selection is already reset after each batch action, so an `exclude` model cannot leak into the refreshed row set.

## Tests

`src/utils/gridSelection.test.ts` covers the include model, the empty selection, select-all, select-all minus some rows, everything unticked after a select-all, a filtered grid, and numeric row ids.

## Verification

- targeted unit tests: 7 passed
- full test suite and production build: green
- lint: clean on the changed files

Fixes #568
