### PR TITLE
fix(layout): keep content reachable when the tasks bar expands (#582)

### DIFF
--- a/frontend/src/@layouts/styles/shared/StyledMain.jsx
+++ b/frontend/src/@layouts/styles/shared/StyledMain.jsx
@@ -27,6 +27,11 @@ const StyledMain = styled.main`
   &:has(.${commonLayoutClasses.contentHeightFixed}) {
     overflow: hidden;
   }
+
+  /* No animation while the taskbar is being drag-resized (TasksFooter #582) */
+  html[data-taskbar-resizing] & {
+    transition: none;
+  }
 `
 
 export default StyledMain

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -2807,8 +2807,8 @@ return vm?.isCluster ?? false
               flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
-              height: '100%',
-              minHeight: 'calc(100vh - 200px)',
+              flex: 1,
+              minHeight: 0,
               opacity: 0.35,
               gap: 2
             }}
@@ -3203,7 +3203,7 @@ return vm?.isCluster ?? false
           {selection?.type === 'node' && data.status === 'crit' && (
             <Box sx={{
               display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-              gap: 2, height: '100%', minHeight: 'calc(100vh - 250px)',
+              gap: 2, flex: 1, minHeight: 0,
             }}>
               <img
                 src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'}
@@ -3666,10 +3666,10 @@ return vm?.isCluster ?? false
             const isNutanixHost = data.esxiHostInfo.hostType === 'nutanix'
             const extVmIcon = isNutanixHost ? '/images/nutanix-logo.svg' : isXcpng ? '/images/xcpng-logo.svg' : '/images/esxi-vm.svg'
             return (
-            <Card variant="outlined" sx={{ width: '100%', borderRadius: 2 }}>
-              <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
+            <Card variant="outlined" sx={{ width: '100%', borderRadius: 2, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
+              <CardContent sx={{ p: 0, '&:last-child': { pb: 0 }, flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
                 {data.esxiHostInfo.vms.length === 0 ? (
-                  <Box sx={{ p: 4, textAlign: 'center' }}>
+                  <Box sx={{ p: 4, textAlign: 'center', flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
                     <img src={extVmIcon} alt="" width={48} height={48} style={{ opacity: 0.3 }} />
                     <Typography variant="body2" sx={{ opacity: 0.5, mt: 1 }}>No virtual machines found on this host</Typography>
                   </Box>
@@ -3677,7 +3677,7 @@ return vm?.isCluster ?? false
                   <>
                   {/* Bulk migration toolbar */}
                   {bulkMigSelected.size > 0 && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 2, py: 1, bgcolor: theme.palette.mode === 'dark' ? 'rgba(var(--mui-palette-primary-mainChannel) / 0.08)' : 'rgba(var(--mui-palette-primary-mainChannel) / 0.06)', borderBottom: '1px solid', borderColor: 'divider' }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 2, py: 1, flexShrink: 0, bgcolor: theme.palette.mode === 'dark' ? 'rgba(var(--mui-palette-primary-mainChannel) / 0.08)' : 'rgba(var(--mui-palette-primary-mainChannel) / 0.06)', borderBottom: '1px solid', borderColor: 'divider' }}>
                       <Typography variant="body2" fontWeight={600} sx={{ fontSize: 12 }}>
                         {bulkMigSelected.size} VM{bulkMigSelected.size > 1 ? 's' : ''} {t('inventoryPage.esxiMigration.selected')}
                       </Typography>
@@ -3705,7 +3705,7 @@ return vm?.isCluster ?? false
                       </Button>
                     </Box>
                   )}
-                  <TableContainer sx={{ maxHeight: 'calc(100vh - 320px)' }}>
+                  <TableContainer sx={{ flex: 1, minHeight: 120, overflow: 'auto' }}>
                     <Table size="small" stickyHeader>
                       <TableHead>
                         <TableRow>
@@ -3901,7 +3901,9 @@ return vm?.isCluster ?? false
             const diskGB = vm.committed ? (vm.committed / 1073741824).toFixed(1) : '0'
 
             return (
-              <Stack spacing={2} sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+              /* The column scrolls as a whole when the fixed tasks bar (issue #582) shrinks the
+                 pane below the cards' combined min-height, so every card stays reachable. */
+              <Stack spacing={2} sx={{ flex: 1, minHeight: 0, overflow: 'auto', pr: 0.5 }}>
                 {/* VM Summary Bar + Migrate button */}
                 <Card variant="outlined" sx={{ borderRadius: 2 }}>
                   <CardContent sx={{ py: 1.5, px: 2, '&:last-child': { pb: 1.5 } }}>
@@ -4163,7 +4165,7 @@ return vm?.isCluster ?? false
                         </MuiTooltip>
                       )}
                     </Box>
-                    <Box ref={migLogsRef} sx={{ p: 1.5, bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.03)', fontFamily: '"JetBrains Mono", monospace', fontSize: 11, overflow: 'auto', borderRadius: '0 0 8px 8px', lineHeight: 1.8, flex: 1, minHeight: 80 }}>
+                    <Box ref={migLogsRef} sx={{ p: 1.5, bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.3)' : 'rgba(0,0,0,0.03)', fontFamily: '"JetBrains Mono", monospace', fontSize: 11, overflow: 'auto', borderRadius: '0 0 8px 8px', lineHeight: 1.8, flex: 1, minHeight: 220 }}>
                       {vmMigJob?.logs?.length > 0 ? (
                         vmMigJob.logs.map((log: any, i: number) => (
                           <Box key={i}>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/page.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/page.tsx
@@ -552,6 +552,9 @@ return () => setPageInfo('', '', '')
         overflow: 'hidden',
         transition: 'height 0.2s ease, max-height 0.2s ease',
 
+        // Pas d'animation pendant le drag-resize de la taskbar (TasksFooter #582)
+        'html[data-taskbar-resizing] &': { transition: 'none' },
+
         // Curseur de resize global pendant le drag
         cursor: isResizing ? 'col-resize' : 'default',
         userSelect: isResizing ? 'none' : 'auto',

--- a/frontend/src/app/api/v1/events/eventsDedup.test.ts
+++ b/frontend/src/app/api/v1/events/eventsDedup.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute, readJson } from "../../../../__tests__/setup/route-test"
+
+// Hoist mocks so they can be referenced in vi.mock factories
+const { globalFindMany, sessionFindMany, getInfraMock, getConnByIdMock, pveFetchMock } = vi.hoisted(() => ({
+  globalFindMany: vi.fn(),
+  sessionFindMany: vi.fn(),
+  getInfraMock: vi.fn(),
+  getConnByIdMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+}))
+
+// Keep REAL inventoryConnectionPlan + maskingScope; only mock getTenantInfrastructureScope
+vi.mock("@/lib/tenant/infraScope", async (orig) => ({
+  ...(await orig<typeof import("@/lib/tenant/infraScope")>()),
+  getTenantInfrastructureScope: (...a: any[]) => getInfraMock(...a),
+}))
+
+// Session prisma (tenant-scoped client)
+vi.mock("@/lib/tenant", () => ({
+  getSessionPrisma: async () => ({ connection: { findMany: sessionFindMany } }),
+  getCurrentTenantId: async () => "default",
+}))
+
+// Global prisma
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { connection: { findMany: globalFindMany } },
+}))
+
+// getConnectionById echoes the connection id so the pveFetch mock can key off it
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: (...a: any[]) => getConnByIdMock(...a),
+}))
+
+// PVE fetches served from per-connection fixtures (set per test)
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...a: any[]) => pveFetchMock(...a),
+}))
+
+// RBAC -- pass everything through
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: vi.fn().mockResolvedValue(null),
+  PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
+}))
+
+// Stub vdcVmids helper (not under test here)
+vi.mock("@/lib/alerts/vdcVmids", () => ({
+  getVdcVmidsByConnection: vi.fn().mockResolvedValue(null),
+}))
+
+// Stub task scope helper
+vi.mock("@/lib/tasks/scope", () => ({
+  extractTaskVmid: vi.fn().mockReturnValue(null),
+}))
+
+// ---- Fixtures ------------------------------------------------------------
+
+type EventsPayload = {
+  data: any[]
+  meta: { total: number; returned: number; connections: number }
+}
+
+const task = (upid: string, node: string, starttime: number, over: Record<string, unknown> = {}) => ({
+  upid,
+  node,
+  pid: 1234,
+  pstart: 1,
+  starttime,
+  endtime: starttime + 5, // finished tasks keep duration deterministic
+  type: "qmstart",
+  user: "root@pam",
+  status: "OK",
+  ...over,
+})
+
+const log = (uid: number, node: string, time: number, over: Record<string, unknown> = {}) => ({
+  uid,
+  time,
+  msg: `msg-${uid}`,
+  node,
+  pri: 6,
+  tag: "pvedaemon",
+  ...over,
+})
+
+/** Per-connection PVE API fixtures, keyed by connection id. */
+let clusterData: Record<string, { tasks?: any[]; logs?: any[] }>
+
+/** Connection id whose fetches are delayed, to force Promise.all ordering. */
+let delayedConnId: string | null
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clusterData = {}
+  delayedConnId = null
+
+  globalFindMany.mockResolvedValue([])
+  sessionFindMany.mockResolvedValue([])
+  getConnByIdMock.mockImplementation(async (id: string) => ({ id, baseUrl: "https://pve.test", apiToken: "t" }))
+  pveFetchMock.mockImplementation(async (connection: any, path: string) => {
+    if (connection.id === delayedConnId) {
+      await new Promise((r) => setTimeout(r, 15))
+    }
+    const d = clusterData[connection.id] || {}
+    if (path === "/cluster/tasks") return d.tasks ?? []
+    if (path.startsWith("/cluster/log")) return d.logs ?? []
+
+    return []
+  })
+})
+
+const twoConnsSameCluster = [
+  { id: "c1", name: "MSP Demo (GRA4)", type: "pve", tenantId: "msp-demo" },
+  { id: "c2", name: "PVE-STORE-GRA4", type: "pve", tenantId: "default" },
+]
+
+describe("GET /api/v1/events deduplication", () => {
+  it("emits a task once when two connections see the same cluster, and meta.total counts distinct events", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    const sharedTasks = [
+      task("UPID:store1:0001:0001:65F00001:qmstart:101:root@pam:", "store1", 1000),
+      task("UPID:store1:0002:0002:65F00002:vzdump:102:root@pam:", "store1", 2000),
+    ]
+    clusterData = { c1: { tasks: sharedTasks }, c2: { tasks: sharedTasks } }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "tasks" } })
+    expect(res.status).toBe(200)
+
+    const body = (await readJson<EventsPayload>(res))!
+    expect(body.data).toHaveLength(2)
+    expect(body.data.map((e) => e.id).sort()).toEqual([
+      "UPID:store1:0001:0001:65F00001:qmstart:101:root@pam:",
+      "UPID:store1:0002:0002:65F00002:vzdump:102:root@pam:",
+    ])
+    expect(body.meta.total).toBe(2)
+    expect(body.meta.returned).toBe(2)
+    // dedupKey is internal and must not leak into the payload
+    expect(body.data[0]).not.toHaveProperty("dedupKey")
+  })
+
+  it("does not let duplicates consume the limit", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    const sharedTasks = [
+      task("UPID:store1:0001:0001:65F00001:qmstart:101:root@pam:", "store1", 1000),
+      task("UPID:store1:0002:0002:65F00002:vzdump:102:root@pam:", "store1", 2000),
+      task("UPID:store1:0003:0003:65F00003:qmstop:103:root@pam:", "store1", 3000),
+    ]
+    clusterData = { c1: { tasks: sharedTasks }, c2: { tasks: sharedTasks } }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "tasks", limit: "2" } })
+    const body = (await readJson<EventsPayload>(res))!
+
+    // Pre-fix, limit=2 returned the newest task TWICE (once per connection).
+    // Now the 2 newest DISTINCT tasks come back. Each connection pre-slices
+    // its own list to `limit`, so meta.total counts distinct events that
+    // survived that pre-slice (2 here), not the raw duplicated 4.
+    expect(body.data).toHaveLength(2)
+    expect(body.data.map((e) => e.id)).toEqual([
+      "UPID:store1:0003:0003:65F00003:qmstop:103:root@pam:",
+      "UPID:store1:0002:0002:65F00002:vzdump:102:root@pam:",
+    ])
+    expect(body.meta.total).toBe(2)
+  })
+
+  it("keeps genuinely different tasks from two connections (no over-eager dedup)", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    clusterData = {
+      c1: { tasks: [task("UPID:nodeA:0001:0001:65F00001:qmstart:101:root@pam:", "nodeA", 1000)] },
+      c2: { tasks: [task("UPID:nodeB:0002:0002:65F00002:qmstop:202:root@pam:", "nodeB", 2000)] },
+    }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "tasks" } })
+    const body = (await readJson<EventsPayload>(res))!
+
+    expect(body.data).toHaveLength(2)
+    expect(body.data.map((e) => e.id).sort()).toEqual([
+      "UPID:nodeA:0001:0001:65F00001:qmstart:101:root@pam:",
+      "UPID:nodeB:0002:0002:65F00002:qmstop:202:root@pam:",
+    ])
+    expect(body.meta.total).toBe(2)
+  })
+
+  it("emits a cluster log line once when seen via two connections, keeping the id shape", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    const sharedLogs = [log(42, "store1", 1000)]
+    clusterData = { c1: { logs: sharedLogs }, c2: { logs: sharedLogs } }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "logs" } })
+    const body = (await readJson<EventsPayload>(res))!
+
+    expect(body.data).toHaveLength(1)
+    expect(body.meta.total).toBe(1)
+    // The emitted id keeps its existing `${connectionId}-log-${uid}` shape
+    expect(body.data[0].id).toBe("c1-log-42")
+  })
+
+  it("keeps log lines from DIFFERENT clusters that share the same uid (uid is only a per-cluster sequence)", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    // Two distinct clusters, each with its own log uid=42
+    clusterData = {
+      c1: { logs: [log(42, "gra4-node1", 1000)] },
+      c2: { logs: [log(42, "store-node1", 2000)] },
+    }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "logs" } })
+    const body = (await readJson<EventsPayload>(res))!
+
+    expect(body.data).toHaveLength(2)
+    expect(body.data.map((e) => e.id).sort()).toEqual(["c1-log-42", "c2-log-42"])
+    expect(body.meta.total).toBe(2)
+  })
+
+  it("is deterministic: same input yields identical payloads regardless of which connection responds first", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue(twoConnsSameCluster)
+
+    const sharedTasks = [
+      task("UPID:store1:0001:0001:65F00001:qmstart:101:root@pam:", "store1", 1000),
+      task("UPID:store1:0002:0002:65F00002:vzdump:102:root@pam:", "store1", 1000), // same ts on purpose
+    ]
+    clusterData = { c1: { tasks: sharedTasks }, c2: { tasks: sharedTasks } }
+
+    const { GET } = await import("./route")
+
+    // Run 1: c1 responds LAST (c2 pushes into allEvents first)
+    delayedConnId = "c1"
+    const body1 = (await readJson<EventsPayload>(
+      await callRoute(GET, { method: "GET", searchParams: { source: "tasks" } }),
+    ))!
+
+    // Run 2: c2 responds LAST (c1 pushes first)
+    delayedConnId = "c2"
+    const body2 = (await readJson<EventsPayload>(
+      await callRoute(GET, { method: "GET", searchParams: { source: "tasks" } }),
+    ))!
+
+    // Identical order and identical connection attribution both times
+    expect(body1.data).toEqual(body2.data)
+    // The deterministic tiebreak attributes shared events to the smallest connectionId
+    expect(body1.data.every((e) => e.connectionId === "c1")).toBe(true)
+  })
+
+  it("leaves a tenant-scoped (single-connection) request unaffected", async () => {
+    getInfraMock.mockResolvedValue({ kind: "msp", connectionIds: new Set(["c1"]) })
+    sessionFindMany.mockResolvedValue([{ id: "c1", name: "Tenant PVE", type: "pve", tenantId: "msp-demo" }])
+
+    clusterData = {
+      c1: {
+        tasks: [
+          task("UPID:nodeA:0001:0001:65F00001:qmstart:101:root@pam:", "nodeA", 1000),
+          task("UPID:nodeA:0002:0002:65F00002:qmstop:102:root@pam:", "nodeA", 2000),
+        ],
+      },
+    }
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { source: "tasks" } })
+    expect(res.status).toBe(200)
+
+    const body = (await readJson<EventsPayload>(res))!
+    expect(body.data).toHaveLength(2)
+    expect(body.meta.total).toBe(2)
+    expect(body.data.every((e) => e.connectionId === "c1")).toBe(true)
+    expect(globalFindMany).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/events/route.ts
+++ b/frontend/src/app/api/v1/events/route.ts
@@ -187,6 +187,10 @@ export async function GET(req: Request) {
               const vmName = task.id ? vmNameMap[task.id] || null : null
 
               allEvents.push({
+                // Dedup key: the UPID embeds node, pid, pstart and start
+                // time, so it uniquely identifies the physical task even
+                // when several connections point at the same cluster.
+                dedupKey: `task:${task.upid}`,
                 id: task.upid,
                 ts: new Date(task.starttime * 1000).toISOString(),
                 endTs: task.endtime ? new Date(task.endtime * 1000).toISOString() : null,
@@ -238,6 +242,12 @@ export async function GET(req: Request) {
 
             for (const log of logs) {
               allEvents.push({
+                // Dedup key must be connection-independent (two connections
+                // to one cluster must collapse) but `uid` alone is only a
+                // per-cluster sequence number, so node + uid + time is
+                // combined to avoid merging log lines from distinct
+                // clusters that happen to share a uid.
+                dedupKey: `log:${log.node}:${log.uid}:${log.time}`,
                 id: `${conn.id}-log-${log.uid}`,
                 ts: new Date(log.time * 1000).toISOString(),
                 level: getLogLevel(log.pri),
@@ -261,16 +271,37 @@ export async function GET(req: Request) {
       })
     )
 
-    // Trier par date décroissante
-    allEvents.sort((a, b) => new Date(b.ts).getTime() - new Date(a.ts).getTime())
+    // Trier par date décroissante. connectionId + id break ties so the
+    // order, and therefore which connection a shared cluster's event is
+    // attributed to after dedup below, is deterministic instead of
+    // depending on Promise.all completion order.
+    allEvents.sort((a, b) =>
+      new Date(b.ts).getTime() - new Date(a.ts).getTime() ||
+      String(a.connectionId).localeCompare(String(b.connectionId)) ||
+      String(a.id).localeCompare(String(b.id))
+    )
 
-    // Limiter le nombre de résultats
-    const limitedEvents = allEvents.slice(0, limit)
+    // Deduplicate: several connections may point at the same physical
+    // cluster (legitimate MSP setup), so /cluster/tasks and /cluster/log
+    // return the same events once per connection. Keep the first
+    // occurrence (deterministic thanks to the sort above); attributing a
+    // shared cluster's event to one connection is unavoidable without
+    // cluster-identity detection, but it is at least stable.
+    const seen = new Set<string>()
+    const dedupedEvents = allEvents.filter(e => {
+      if (seen.has(e.dedupKey)) return false
+      seen.add(e.dedupKey)
 
-    return NextResponse.json({ 
+      return true
+    })
+
+    // Limiter le nombre de résultats (dedupKey is internal, strip it)
+    const limitedEvents = dedupedEvents.slice(0, limit).map(({ dedupKey, ...event }) => event)
+
+    return NextResponse.json({
       data: limitedEvents,
       meta: {
-        total: allEvents.length,
+        total: dedupedEvents.length,
         returned: limitedEvents.length,
         connections: connections.length
       }

--- a/frontend/src/components/TasksFooter.test.tsx
+++ b/frontend/src/components/TasksFooter.test.tsx
@@ -1,0 +1,325 @@
+/**
+ * Component tests for the TasksFooter drag-resize feature (#582).
+ *
+ * jsdom has no layout engine, but the feature's observable contract is not
+ * geometry: it is the --taskbar-height CSS custom property published on
+ * document.documentElement, the tasksFooterPanelHeight localStorage key, and
+ * the drag-lifecycle side effects on document/body. Every assertion here
+ * targets that contract, never internal state.
+ *
+ * The pure clamp/drag math lives in taskbarHeight.ts and is fully covered by
+ * taskbarHeight.test.ts (node project); these tests cover the component
+ * wiring: publish effect, drag effect, keyboard handler, persistence effect
+ * and the window-resize re-clamp.
+ *
+ * Data hooks (useTaskEvents / useSharedTasks / useProxCenterTasks) and the
+ * DataGrid are mocked following the repo's existing patterns
+ * (FeatureGuard.test.tsx, InventoryDialogs.test.tsx) so no network fires and
+ * the grid does not dominate the test.
+ */
+
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+
+import TasksFooter from './TasksFooter'
+import {
+  TASKBAR_HEIGHT_VAR,
+  TASKBAR_HEADER_HEIGHT,
+  TASKBAR_MIN_PANEL_HEIGHT,
+  TASKBAR_MAX_PANEL_HEIGHT,
+  TASKBAR_DEFAULT_PANEL_HEIGHT,
+  TASKBAR_HEIGHT_STORAGE_KEY,
+  clampTaskbarPanelHeight,
+} from './taskbarHeight'
+
+// ------------------------------------------------------------------ //
+// Mocks
+// ------------------------------------------------------------------ //
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/contexts/ProxCenterTasksContext', () => ({
+  useProxCenterTasks: () => ({ tasks: [], clearDone: vi.fn(), restoreTask: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useSharedTasks', () => ({
+  useSharedTasks: () => ({ data: undefined }),
+}))
+
+vi.mock('@/hooks/useTaskEvents', () => ({
+  useTaskEvents: () => ({ data: { data: [] }, mutate: vi.fn(), isLoading: false }),
+}))
+
+vi.mock('@mui/x-data-grid', () => ({
+  DataGrid: () => <div data-testid="datagrid" />,
+}))
+
+vi.mock('./TaskDetailDialog', () => ({ default: () => null }))
+vi.mock('@/components/SharedTaskDetailDialog', () => ({ default: () => null }))
+
+// ------------------------------------------------------------------ //
+// Helpers
+// ------------------------------------------------------------------ //
+
+/**
+ * Tall enough that the 60%-of-viewport cap (1200px) sits above
+ * TASKBAR_MAX_PANEL_HEIGHT, so the plain [MIN, MAX] clamp applies.
+ */
+const VIEWPORT = 2000
+
+/** Keyboard resize step hardcoded in TasksFooter's handleResizeKeyDown. */
+const KEYBOARD_STEP = 24
+
+/** Always strictly inside [MIN, MAX] whatever the constants become. */
+const TARGET_PANEL = Math.round((TASKBAR_MIN_PANEL_HEIGHT + TASKBAR_MAX_PANEL_HEIGHT) / 2)
+
+function setViewportHeight(px: number) {
+  Object.defineProperty(window, 'innerHeight', { configurable: true, writable: true, value: px })
+}
+
+function publishedHeight(): string {
+  return document.documentElement.style.getPropertyValue(TASKBAR_HEIGHT_VAR)
+}
+
+function storedPanelHeight(): string | null {
+  return window.localStorage.getItem(TASKBAR_HEIGHT_STORAGE_KEY)
+}
+
+function renderExpanded() {
+  return render(<TasksFooter defaultExpanded />)
+}
+
+function getHandle() {
+  return screen.getByRole('separator')
+}
+
+/** clientY that panelHeightFromPointer maps to `panel` px for VIEWPORT. */
+function pointerYFor(panel: number): number {
+  return VIEWPORT - panel - TASKBAR_HEADER_HEIGHT
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  setViewportHeight(VIEWPORT)
+})
+
+// No automatic RTL cleanup is configured in this repo: unmount explicitly,
+// then scrub every global surface the component writes to, so no state leaks
+// into the next test.
+afterEach(() => {
+  cleanup()
+  document.documentElement.style.removeProperty(TASKBAR_HEIGHT_VAR)
+  document.documentElement.removeAttribute('data-taskbar-resizing')
+  document.body.style.userSelect = ''
+  document.body.style.cursor = ''
+  window.localStorage.clear()
+})
+
+// ------------------------------------------------------------------ //
+// Publish effect
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter --taskbar-height publishing', () => {
+  it('publishes the header height when collapsed', () => {
+    render(<TasksFooter />)
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT}px`)
+  })
+
+  it('publishes header + panel height when expanded', () => {
+    renderExpanded()
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_DEFAULT_PANEL_HEIGHT}px`)
+  })
+
+  it('publishes 0px when hidden', () => {
+    window.localStorage.setItem('tasksFooterHidden', 'true')
+    render(<TasksFooter />)
+    expect(publishedHeight()).toBe('0px')
+  })
+
+  it('removes the property on unmount so the CSS var() fallback applies', () => {
+    const { unmount } = renderExpanded()
+    expect(publishedHeight()).not.toBe('')
+    unmount()
+    expect(publishedHeight()).toBe('')
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Handle rendering
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter drag handle', () => {
+  it('is absent when collapsed', () => {
+    render(<TasksFooter />)
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument()
+  })
+
+  it('is present when expanded and exposes the clamp bounds via aria', () => {
+    renderExpanded()
+    const handle = getHandle()
+
+    expect(handle).toHaveAttribute('aria-orientation', 'horizontal')
+    expect(handle).toHaveAttribute('aria-valuenow', String(TASKBAR_DEFAULT_PANEL_HEIGHT))
+    expect(handle).toHaveAttribute('aria-valuemin', String(TASKBAR_MIN_PANEL_HEIGHT))
+    expect(handle).toHaveAttribute('aria-valuemax', String(TASKBAR_MAX_PANEL_HEIGHT))
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Mouse drag
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter mouse drag resize', () => {
+  it('resizes with document-level mousemove and keeps the height after release', () => {
+    renderExpanded()
+
+    fireEvent.mouseDown(getHandle(), { clientY: pointerYFor(TASKBAR_DEFAULT_PANEL_HEIGHT) })
+    fireEvent.mouseMove(document, { clientY: pointerYFor(TARGET_PANEL) })
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TARGET_PANEL}px`)
+
+    fireEvent.mouseUp(document)
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TARGET_PANEL}px`)
+  })
+
+  it('locks selection/cursor and flags the drag on <html>, restoring all on release', () => {
+    renderExpanded()
+
+    // Pre-existing values must be restored, not blindly cleared.
+    document.body.style.userSelect = 'text'
+    document.body.style.cursor = 'default'
+
+    fireEvent.mouseDown(getHandle())
+    expect(document.documentElement.hasAttribute('data-taskbar-resizing')).toBe(true)
+    expect(document.body.style.userSelect).toBe('none')
+    expect(document.body.style.cursor).toBe('ns-resize')
+
+    fireEvent.mouseUp(document)
+    expect(document.documentElement.hasAttribute('data-taskbar-resizing')).toBe(false)
+    expect(document.body.style.userSelect).toBe('text')
+    expect(document.body.style.cursor).toBe('default')
+  })
+
+  it('does not collapse the panel when the handle is pressed (header toggle must not fire)', () => {
+    renderExpanded()
+    const expandedHeight = `${TASKBAR_HEADER_HEIGHT + TASKBAR_DEFAULT_PANEL_HEIGHT}px`
+    expect(publishedHeight()).toBe(expandedHeight)
+
+    fireEvent.mouseDown(getHandle())
+    fireEvent.mouseUp(document)
+
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+    expect(publishedHeight()).toBe(expandedHeight)
+    expect(window.localStorage.getItem('tasksFooterExpanded')).toBe('true')
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Persistence
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter panel height persistence', () => {
+  it('writes the height on release only, never mid-drag', () => {
+    renderExpanded()
+
+    // The persistence effect runs once on mount with the initial height.
+    expect(storedPanelHeight()).toBe(String(TASKBAR_DEFAULT_PANEL_HEIGHT))
+
+    fireEvent.mouseDown(getHandle())
+    fireEvent.mouseMove(document, { clientY: pointerYFor(TARGET_PANEL) })
+
+    // Mid-drag: still the pre-drag value, not the live one.
+    expect(storedPanelHeight()).toBe(String(TASKBAR_DEFAULT_PANEL_HEIGHT))
+
+    fireEvent.mouseUp(document)
+    expect(storedPanelHeight()).toBe(String(TARGET_PANEL))
+  })
+
+  it('honours a stored height on mount', () => {
+    const stored = TASKBAR_MIN_PANEL_HEIGHT + 30
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(stored))
+
+    renderExpanded()
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + stored}px`)
+  })
+
+  it('clamps an oversized stored height to the maximum', () => {
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(TASKBAR_MAX_PANEL_HEIGHT * 10))
+
+    renderExpanded()
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_MAX_PANEL_HEIGHT}px`)
+  })
+
+  it('clamps an undersized stored height to the minimum', () => {
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, '1')
+
+    renderExpanded()
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_MIN_PANEL_HEIGHT}px`)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Keyboard
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter keyboard resize', () => {
+  it('grows on ArrowUp and shrinks on ArrowDown by one step', () => {
+    renderExpanded()
+    const handle = getHandle()
+
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    expect(publishedHeight()).toBe(
+      `${TASKBAR_HEADER_HEIGHT + TASKBAR_DEFAULT_PANEL_HEIGHT + KEYBOARD_STEP}px`
+    )
+
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_DEFAULT_PANEL_HEIGHT}px`)
+  })
+
+  it('clamps at the maximum', () => {
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(TASKBAR_MAX_PANEL_HEIGHT))
+    renderExpanded()
+
+    fireEvent.keyDown(getHandle(), { key: 'ArrowUp' })
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_MAX_PANEL_HEIGHT}px`)
+  })
+
+  it('clamps at the minimum', () => {
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(TASKBAR_MIN_PANEL_HEIGHT))
+    renderExpanded()
+
+    fireEvent.keyDown(getHandle(), { key: 'ArrowDown' })
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_MIN_PANEL_HEIGHT}px`)
+  })
+
+  it('ignores unrelated keys', () => {
+    renderExpanded()
+
+    fireEvent.keyDown(getHandle(), { key: 'Enter' })
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_DEFAULT_PANEL_HEIGHT}px`)
+  })
+})
+
+// ------------------------------------------------------------------ //
+// Window resize re-clamp
+// ------------------------------------------------------------------ //
+
+describe('TasksFooter window resize re-clamp', () => {
+  it('re-clamps the published height when the viewport shrinks (60% cap)', () => {
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(TASKBAR_MAX_PANEL_HEIGHT))
+    renderExpanded()
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + TASKBAR_MAX_PANEL_HEIGHT}px`)
+
+    const shortViewport = 500
+    const reclamped = clampTaskbarPanelHeight(TASKBAR_MAX_PANEL_HEIGHT, shortViewport)
+    expect(reclamped).toBeLessThan(TASKBAR_MAX_PANEL_HEIGHT) // the cap actually bites
+
+    setViewportHeight(shortViewport)
+    fireEvent(window, new Event('resize'))
+
+    expect(publishedHeight()).toBe(`${TASKBAR_HEADER_HEIGHT + reclamped}px`)
+  })
+})

--- a/frontend/src/components/TasksFooter.tsx
+++ b/frontend/src/components/TasksFooter.tsx
@@ -27,6 +27,17 @@ import { useSharedTasks } from '@/hooks/useSharedTasks'
 import { mergeSharedTasks, type MergedPCTask } from '@/lib/tasks/mergeSharedTasks'
 import TaskDetailDialog from './TaskDetailDialog'
 import SharedTaskDetailDialog from '@/components/SharedTaskDetailDialog'
+import {
+  TASKBAR_HEADER_HEIGHT,
+  TASKBAR_MIN_PANEL_HEIGHT,
+  TASKBAR_MAX_PANEL_HEIGHT,
+  clampTaskbarPanelHeight,
+  panelHeightFromPointer,
+  publishTaskbarHeight,
+  clearTaskbarHeight,
+  readStoredPanelHeight,
+  storePanelHeight
+} from './taskbarHeight'
 
 // ============================================
 // Types
@@ -97,33 +108,28 @@ const STATUS_LABEL_KEYS: Record<string, string> = {
   stopped: 'tasks.status.stopped',
 }
 
-function formatTime(dateStr: string | null, dateLocale: string): string {
-  if (!dateStr) return '—'
+// Full date + time: a task list spanning several days is unreadable when only
+// the time is shown, so the day/month/year is always spelled out. Accepts the
+// Date produced by the columns' valueGetter as well as a raw ISO string.
+function formatDateTime(value: Date | string | null, dateLocale: string): string {
+  if (!value) return '—'
 
   try {
-    const date = new Date(dateStr)
-    return date.toLocaleTimeString(dateLocale, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    const date = value instanceof Date ? value : new Date(value)
+
+    // toLocaleString would render "Invalid Date" instead of throwing.
+    if (Number.isNaN(date.getTime())) return String(value)
+
+    return date.toLocaleString(dateLocale, {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    })
   } catch {
-    return dateStr
-  }
-}
-
-function formatDateStr(dateStr: string | null, dateLocale: string): string {
-  if (!dateStr) return '—'
-
-  try {
-    const date = new Date(dateStr)
-    const today = new Date()
-    const isToday = date.toDateString() === today.toDateString()
-
-    if (isToday) {
-      return date.toLocaleTimeString(dateLocale, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-    }
-
-    return date.toLocaleDateString(dateLocale, { day: '2-digit', month: '2-digit' }) + ' ' +
-           date.toLocaleTimeString(dateLocale, { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return dateStr
+    return String(value)
   }
 }
 
@@ -170,23 +176,41 @@ export default function TasksFooter({
   // SWR hook for task events
   const { data: tasksRaw, mutate: mutateTasks, isLoading: loading } = useTaskEvents(50)
 
-  // Derive tasks from SWR data
-  const tasks: TaskEvent[] = (tasksRaw?.data || []).map((e: any) => ({
-    id: e.id,
-    upid: e.id,
-    type: e.type,
-    status: e.status,
-    startTime: e.ts,
-    endTime: e.endTs,
-    duration: e.duration,
-    node: e.node,
-    user: e.user,
-    description: e.typeLabel || e.message,
-    entity: e.entity || null,
-    entityName: e.entityName || null,
-    connectionId: e.connectionId,
-    connectionName: e.connectionName
-  }))
+  // Derive tasks from SWR data. Memoised so the DataGrid is not handed brand-new
+  // row objects on every render (it keys its internal state on row identity).
+  const tasks: TaskEvent[] = useMemo(
+    () =>
+      (tasksRaw?.data || []).map((e: any) => ({
+        id: e.id,
+        upid: e.id,
+        type: e.type,
+        status: e.status,
+        startTime: e.ts,
+        endTime: e.endTs,
+        duration: e.duration,
+        node: e.node,
+        user: e.user,
+        description: e.typeLabel || e.message,
+        entity: e.entity || null,
+        entityName: e.entityName || null,
+        connectionId: e.connectionId,
+        connectionName: e.connectionName
+      })),
+    [tasksRaw]
+  )
+
+  // Running tasks first; the grid's own sortModel takes precedence once the user
+  // clicks a header. Memoised for the same row-identity reason as above.
+  const sortedTasks: TaskEvent[] = useMemo(
+    () =>
+      [...tasks].sort((a, b) => {
+        const aRunning = a.status === 'running' ? 0 : 1
+        const bRunning = b.status === 'running' ? 0 : 1
+
+        return aRunning - bRunning
+      }),
+    [tasks]
+  )
 
   // State - initialize with defaults, then hydrate from localStorage
   const [expanded, setExpanded] = useState(defaultExpanded)
@@ -194,6 +218,15 @@ export default function TasksFooter({
   const [isHydrated, setIsHydrated] = useState(false)
   const [selectedTask, setSelectedTask] = useState<TaskEvent | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
+
+  // Panel height (resizable by dragging, #582). `maxHeight` stays the seed
+  // so the default appearance is unchanged for users who never drag.
+  const [panelHeight, setPanelHeight] = useState(() => {
+    if (typeof window === 'undefined') return clampTaskbarPanelHeight(maxHeight)
+
+    return clampTaskbarPanelHeight(readStoredPanelHeight() ?? maxHeight, window.innerHeight)
+  })
+  const [isResizing, setIsResizing] = useState(false)
 
   // Hydrate from localStorage after mount (client-side only)
   useEffect(() => {
@@ -214,16 +247,67 @@ export default function TasksFooter({
   // Communicate taskbar height to layout via CSS custom property
   useEffect(() => {
     if (!isHydrated) return
-    const headerHeight = 36
     let height = 0
     if (!hidden) {
-      height = expanded ? headerHeight + maxHeight : headerHeight
+      height = expanded ? TASKBAR_HEADER_HEIGHT + panelHeight : TASKBAR_HEADER_HEIGHT
     }
-    document.documentElement.style.setProperty('--taskbar-height', `${height}px`)
+    publishTaskbarHeight(height)
     return () => {
-      document.documentElement.style.setProperty('--taskbar-height', '0px')
+      clearTaskbarHeight()
     }
-  }, [hidden, expanded, maxHeight, isHydrated])
+  }, [hidden, expanded, panelHeight, isHydrated])
+
+  // Drag resize: document-level listeners only while a drag is in flight.
+  // Mirrors the inventory tree resizer (page.tsx), transposed to vertical.
+  useEffect(() => {
+    if (!isResizing) return
+
+    const handleMouseMove = (e: MouseEvent) => {
+      setPanelHeight(panelHeightFromPointer(e.clientY, window.innerHeight))
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+    }
+
+    // Lock selection + cursor for the whole drag, restoring previous values.
+    const prevUserSelect = document.body.style.userSelect
+    const prevCursor = document.body.style.cursor
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = 'ns-resize'
+
+    // Marker consumed by StyledMain and the inventory page to suppress their
+    // 0.2s taskbar-height transitions while dragging (they would lag the bar).
+    document.documentElement.setAttribute('data-taskbar-resizing', '')
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.userSelect = prevUserSelect
+      document.body.style.cursor = prevCursor
+      document.documentElement.removeAttribute('data-taskbar-resizing')
+    }
+  }, [isResizing])
+
+  // Persiste la hauteur du panneau. Écrit une fois par redimensionnement
+  // (au relâchement), pas à chaque mousemove.
+  useEffect(() => {
+    if (!isHydrated || isResizing) return
+    storePanelHeight(panelHeight)
+  }, [isResizing, panelHeight, isHydrated])
+
+  // Re-clamp when the window shrinks so the bar cannot swallow the screen.
+  useEffect(() => {
+    const handleWindowResize = () => {
+      setPanelHeight(prev => clampTaskbarPanelHeight(prev, window.innerHeight))
+    }
+
+    window.addEventListener('resize', handleWindowResize)
+    return () => window.removeEventListener('resize', handleWindowResize)
+  }, [])
 
   // Persist state
   useEffect(() => {
@@ -241,6 +325,22 @@ export default function TasksFooter({
   // Handlers
   const handleToggleExpand = () => {
     setExpanded(prev => !prev)
+  }
+
+  const handleResizeStart = (e: React.MouseEvent) => {
+    // stopPropagation: a drag on the handle must not toggle the header's
+    // onClick={handleToggleExpand} underneath.
+    e.preventDefault()
+    e.stopPropagation()
+    setIsResizing(true)
+  }
+
+  const handleResizeKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
+    e.preventDefault()
+    e.stopPropagation()
+    const delta = e.key === 'ArrowUp' ? 24 : -24
+    setPanelHeight(prev => clampTaskbarPanelHeight(prev + delta, window.innerHeight))
   }
 
   const handleHide = () => {
@@ -282,27 +382,41 @@ export default function TasksFooter({
     {
       field: 'startTime',
       headerName: t('tasks.columns.start'),
-      width: 110,
+      // Wide enough for the longest locale rendering without truncation: en-US
+      // adds AM/PM ("07/29/2026, 02:10:34 AM") and ko-KR uses double-width CJK
+      // ("2026. 7. 29. 오전 02:10:34").
+      width: 200,
+      // type + Date valueGetter: without them the grid treats the ISO string as
+      // text, so sorting is lexicographic and the filter panel offers "contains"
+      // against the raw ISO value instead of date operators.
+      type: 'dateTime',
+      valueGetter: (value) => (value ? new Date(value) : null),
       renderCell: (params) => (
-        <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-          {formatTime(params.value, dateLocale)}
+        <Typography variant="caption" noWrap>
+          {formatDateTime(params.value, dateLocale)}
         </Typography>
       )
     },
     {
       field: 'endTime',
       headerName: t('tasks.columns.end'),
-      width: 110,
+      width: 200,
+      type: 'dateTime',
+      valueGetter: (value) => (value ? new Date(value) : null),
       renderCell: (params) => (
-        <Typography variant="caption" sx={{ fontFamily: 'monospace' }}>
-          {formatTime(params.value, dateLocale)}
+        <Typography variant="caption" noWrap>
+          {formatDateTime(params.value, dateLocale)}
         </Typography>
       )
     },
     {
       field: 'node',
       headerName: t('tasks.columns.node'),
-      width: 180,
+      // Node names are uppercase hostnames, which are wider than the average
+      // glyph: "PROXMOX-STORE-GRA4" alone needs ~182px once the icon, gap and
+      // cell padding are counted. Sized for ~28 characters; anything longer
+      // still falls back to the title tooltip.
+      width: 240,
       renderCell: (params) => (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
           <img src="/images/proxmox-logo-dark.svg" alt="" style={{ width: 14, height: 14, opacity: 0.7, flexShrink: 0 }} />
@@ -315,8 +429,11 @@ export default function TasksFooter({
     {
       field: 'entity',
       headerName: t('tasks.columns.target'),
+      // Stays flexible: a VM name plus its vmid has no bounded length, so it
+      // absorbs leftover width instead of guessing. The floor is raised so it
+      // does not collapse to an unreadable sliver on a narrow viewport.
       flex: 1,
-      minWidth: 150,
+      minWidth: 220,
       renderCell: (params) => {
         const name = params.row.entityName
         const vmid = params.value
@@ -356,7 +473,10 @@ export default function TasksFooter({
     {
       field: 'status',
       headerName: t('tasks.columns.status'),
-      width: 120,
+      // A failed Proxmox task puts its whole error string here (e.g. "command
+      // 'apt-get update' failed: exit code 100"), which is unbounded, hence
+      // the title below, since no width fits every message.
+      width: 180,
       align: 'right',
       headerAlign: 'right',
       renderCell: (params) => {
@@ -368,6 +488,7 @@ export default function TasksFooter({
           <Chip
             size="small"
             label={getStatusLabel(status)}
+            title={getStatusLabel(status)}
             color={color}
             variant={isRunning ? 'outlined' : 'filled'}
             sx={{
@@ -462,6 +583,44 @@ export default function TasksFooter({
           colorScheme: 'dark',
         }}
       >
+        {/* Drag handle (#582): absolute overlay on the top edge, contributes
+            0px to the bar's height. Only rendered when expanded: a collapsed
+            bar has nothing to resize. */}
+        {expanded && (
+          <Box
+            onMouseDown={handleResizeStart}
+            onKeyDown={handleResizeKeyDown}
+            role="separator"
+            aria-orientation="horizontal"
+            aria-label={t('tasks.resizePanel')}
+            aria-valuenow={panelHeight}
+            aria-valuemin={TASKBAR_MIN_PANEL_HEIGHT}
+            aria-valuemax={TASKBAR_MAX_PANEL_HEIGHT}
+            tabIndex={0}
+            sx={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              height: 6,
+              zIndex: 1, // above the header row
+              cursor: 'ns-resize',
+              bgcolor: 'transparent',
+              transition: 'background-color 0.15s',
+              '&:hover': {
+                bgcolor: alpha(darkTaskbarTheme.palette.primary.main, 0.5)
+              },
+              '&:focus-visible': {
+                outline: 'none',
+                bgcolor: alpha(darkTaskbarTheme.palette.primary.main, 0.5)
+              },
+              ...(isResizing && {
+                bgcolor: alpha(darkTaskbarTheme.palette.primary.main, 0.7),
+                '&:hover': { bgcolor: alpha(darkTaskbarTheme.palette.primary.main, 0.7) }
+              })
+            }}
+          />
+        )}
         {/* Header */}
         <Box
           onClick={handleToggleExpand}
@@ -605,7 +764,7 @@ export default function TasksFooter({
         <Collapse in={expanded}>
           {/* ProxCenter tasks tab */}
           {activeTab === 'proxcenter' && (
-            <Box sx={{ height: maxHeight, overflow: 'auto', bgcolor: '#1e1e2d' }}>
+            <Box sx={{ height: panelHeight, overflow: 'auto', bgcolor: '#1e1e2d' }}>
               {mergedPcTasks.length === 0 ? (
                 <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', opacity: 0.4 }}>
                   <Typography variant="body2">No ProxCenter tasks</Typography>
@@ -695,7 +854,7 @@ export default function TasksFooter({
             </Box>
           )}
           {/* Proxmox tasks tab */}
-          <Box sx={{ height: maxHeight, display: activeTab === 'proxmox' ? 'block' : 'none', bgcolor: '#1e1e2d' }}>
+          <Box sx={{ height: panelHeight, display: activeTab === 'proxmox' ? 'block' : 'none', bgcolor: '#1e1e2d' }}>
             {loading ? (
               <Box sx={{ p: 2 }}>
                 {[...new Array(5)].map((_, i) => (
@@ -704,11 +863,7 @@ export default function TasksFooter({
               </Box>
             ) : (
               <DataGrid
-                rows={[...tasks].sort((a, b) => {
-                  const aRunning = a.status === 'running' ? 0 : 1
-                  const bRunning = b.status === 'running' ? 0 : 1
-                  return aRunning - bRunning
-                })}
+                rows={sortedTasks}
                 columns={columns}
                 density="compact"
                 disableRowSelectionOnClick

--- a/frontend/src/components/layout/vertical/Navigation.jsx
+++ b/frontend/src/components/layout/vertical/Navigation.jsx
@@ -39,10 +39,10 @@ const StyledBoxForShadow = styled('div')(({ theme }) => ({
 const HoverTriggerZone = styled('div')({
   position: 'fixed',
   left: 0,
-  // Keeps the strip below a fixed top banner; 0px when no banner is shown.
+  // Keeps the strip below a fixed top banner and above the fixed tasks bar; each var is 0px when hidden.
   top: 'var(--top-banner-height, 0px)',
   width: 12,
-  height: 'calc(100vh - var(--top-banner-height, 0px))',
+  height: 'calc(100vh - var(--top-banner-height, 0px) - var(--taskbar-height, 0px))',
   zIndex: 1300,
   cursor: 'pointer',
 })
@@ -172,9 +172,9 @@ const Navigation = props => {
         sx={{
           position: 'fixed',
           left: 0,
-          // Keeps the overlay below a fixed top banner; 0px when no banner is shown.
+          // Keeps the overlay below a fixed top banner and above the fixed tasks bar; each var is 0px when hidden.
           top: 'var(--top-banner-height, 0px)',
-          height: 'calc(100vh - var(--top-banner-height, 0px))',
+          height: 'calc(100vh - var(--top-banner-height, 0px) - var(--taskbar-height, 0px))',
           zIndex: 1300,
           boxShadow: '4px 0 24px rgba(0,0,0,0.25)',
         }}
@@ -183,9 +183,9 @@ const Navigation = props => {
           customStyles={{
             ...navigationCustomStyles(verticalNavOptions, theme),
             // The nav is a sibling of the padded content wrapper, so it must make
-            // room for a fixed top banner on its own. Zero when no banner is shown.
+            // room for a fixed top banner and the fixed tasks bar on its own. Zero when neither is shown.
             insetBlockStart: 'var(--top-banner-height, 0px)',
-            blockSize: 'calc(100dvh - var(--top-banner-height, 0px))',
+            blockSize: 'calc(100dvh - var(--top-banner-height, 0px) - var(--taskbar-height, 0px))',
           }}
           collapsedWidth={68}
           backgroundColor='var(--mui-palette-background-default)'
@@ -216,9 +216,9 @@ const Navigation = props => {
       customStyles={{
         ...navigationCustomStyles(verticalNavOptions, theme),
         // The nav is a sibling of the padded content wrapper, so it must make
-        // room for a fixed top banner on its own. Zero when no banner is shown.
+        // room for a fixed top banner and the fixed tasks bar on its own. Zero when neither is shown.
         insetBlockStart: 'var(--top-banner-height, 0px)',
-        blockSize: 'calc(100dvh - var(--top-banner-height, 0px))',
+        blockSize: 'calc(100dvh - var(--top-banner-height, 0px) - var(--taskbar-height, 0px))',
       }}
       collapsedWidth={68}
       backgroundColor='var(--mui-palette-background-default)'

--- a/frontend/src/components/taskbarHeight.test.ts
+++ b/frontend/src/components/taskbarHeight.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  TASKBAR_HEIGHT_VAR,
+  TASKBAR_HEADER_HEIGHT,
+  TASKBAR_MIN_PANEL_HEIGHT,
+  TASKBAR_MAX_PANEL_HEIGHT,
+  TASKBAR_DEFAULT_PANEL_HEIGHT,
+  TASKBAR_HEIGHT_STORAGE_KEY,
+  clampTaskbarPanelHeight,
+  panelHeightFromPointer,
+  publishTaskbarHeight,
+  clearTaskbarHeight,
+  readStoredPanelHeight,
+  storePanelHeight,
+} from './taskbarHeight'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makeStyleTarget() {
+  return { setProperty: vi.fn(), removeProperty: vi.fn() }
+}
+
+function makeStorage(initial: Record<string, string> = {}) {
+  const data = new Map(Object.entries(initial))
+
+  return {
+    getItem: (key: string) => (data.has(key) ? data.get(key)! : null),
+    setItem: (key: string, value: string) => {
+      data.set(key, value)
+    },
+    data,
+  }
+}
+
+describe('constants', () => {
+  it('exposes the documented custom property name and header height', () => {
+    expect(TASKBAR_HEIGHT_VAR).toBe('--taskbar-height')
+    expect(TASKBAR_HEADER_HEIGHT).toBe(36)
+  })
+
+  it('keeps the historical 250px default inside the clamp bounds', () => {
+    expect(TASKBAR_DEFAULT_PANEL_HEIGHT).toBe(250)
+    expect(TASKBAR_DEFAULT_PANEL_HEIGHT).toBeGreaterThanOrEqual(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(TASKBAR_DEFAULT_PANEL_HEIGHT).toBeLessThanOrEqual(TASKBAR_MAX_PANEL_HEIGHT)
+  })
+
+  it('names the storage key as a sibling of tasksFooterExpanded/Hidden', () => {
+    expect(TASKBAR_HEIGHT_STORAGE_KEY).toBe('tasksFooterPanelHeight')
+  })
+})
+
+describe('clampTaskbarPanelHeight', () => {
+  it('falls back to the default for non-numeric and non-finite input', () => {
+    expect(clampTaskbarPanelHeight(undefined)).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(null)).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight('garbage')).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight('')).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight('   ')).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight({})).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(Number.NaN)).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(Number.POSITIVE_INFINITY)).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(Number.NEGATIVE_INFINITY)).toBe(TASKBAR_DEFAULT_PANEL_HEIGHT)
+  })
+
+  it('coerces numeric strings (localStorage values)', () => {
+    expect(clampTaskbarPanelHeight('300')).toBe(300)
+  })
+
+  it('rounds fractional heights', () => {
+    expect(clampTaskbarPanelHeight(200.6)).toBe(201)
+  })
+
+  it('clamps to MIN for zero and negative input', () => {
+    expect(clampTaskbarPanelHeight(0)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(-50)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+  })
+
+  it('clamps to MAX for oversized input and is identity within bounds', () => {
+    expect(clampTaskbarPanelHeight(10_000)).toBe(TASKBAR_MAX_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(TASKBAR_MIN_PANEL_HEIGHT)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(TASKBAR_MAX_PANEL_HEIGHT)).toBe(TASKBAR_MAX_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(250)).toBe(250)
+  })
+
+  it('caps the maximum to 60% of the viewport when supplied', () => {
+    // floor(800 * 0.6) = 480 < 600
+    expect(clampTaskbarPanelHeight(TASKBAR_MAX_PANEL_HEIGHT, 800)).toBe(480)
+    expect(clampTaskbarPanelHeight(400, 800)).toBe(400)
+  })
+
+  it('never lets a tiny viewport push the upper bound below MIN', () => {
+    // floor(100 * 0.6) = 60 < MIN, so the cap must not invert the clamp.
+    expect(clampTaskbarPanelHeight(TASKBAR_MAX_PANEL_HEIGHT, 100)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(50, 100)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(clampTaskbarPanelHeight(TASKBAR_MAX_PANEL_HEIGHT, 0)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+  })
+
+  it('ignores a non-finite viewport height', () => {
+    expect(clampTaskbarPanelHeight(700, Number.NaN)).toBe(TASKBAR_MAX_PANEL_HEIGHT)
+  })
+})
+
+describe('panelHeightFromPointer', () => {
+  // Viewport of 1000px: 60% cap = 600 = TASKBAR_MAX_PANEL_HEIGHT.
+  it('grows the panel as the pointer moves toward the top of the viewport', () => {
+    expect(panelHeightFromPointer(0, 1000)).toBe(600)
+  })
+
+  it('returns viewport - clientY - header in the middle of the viewport', () => {
+    expect(panelHeightFromPointer(500, 1000)).toBe(1000 - 500 - TASKBAR_HEADER_HEIGHT)
+  })
+
+  it('clamps to MIN when the pointer reaches the bottom of the viewport', () => {
+    expect(panelHeightFromPointer(990, 1000)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+    expect(panelHeightFromPointer(1000, 1000)).toBe(TASKBAR_MIN_PANEL_HEIGHT)
+  })
+
+  it('applies the viewport cap on shorter screens', () => {
+    // floor(900 * 0.6) = 540
+    expect(panelHeightFromPointer(100, 900)).toBe(540)
+  })
+})
+
+describe('publishTaskbarHeight / clearTaskbarHeight', () => {
+  it('writes a pixel value on the injected target', () => {
+    const target = makeStyleTarget()
+
+    publishTaskbarHeight(286, target)
+    expect(target.setProperty).toHaveBeenCalledWith('--taskbar-height', '286px')
+  })
+
+  it('writes "0px" for the hidden state instead of clearing (historical contract)', () => {
+    const target = makeStyleTarget()
+
+    publishTaskbarHeight(0, target)
+    expect(target.setProperty).toHaveBeenCalledWith('--taskbar-height', '0px')
+    expect(target.removeProperty).not.toHaveBeenCalled()
+  })
+
+  it('clear removes the property so the CSS var() fallback applies', () => {
+    const target = makeStyleTarget()
+
+    clearTaskbarHeight(target)
+    expect(target.removeProperty).toHaveBeenCalledWith('--taskbar-height')
+    expect(target.setProperty).not.toHaveBeenCalled()
+  })
+
+  it('publish/clear round-trips on document.documentElement by default', () => {
+    const style = makeStyleTarget()
+
+    vi.stubGlobal('document', { documentElement: { style } })
+
+    publishTaskbarHeight(300)
+    expect(style.setProperty).toHaveBeenCalledWith('--taskbar-height', '300px')
+
+    clearTaskbarHeight()
+    expect(style.removeProperty).toHaveBeenCalledWith('--taskbar-height')
+  })
+
+  it('is a no-op without a document (SSR)', () => {
+    expect(typeof document).toBe('undefined')
+    expect(() => publishTaskbarHeight(300)).not.toThrow()
+    expect(() => clearTaskbarHeight()).not.toThrow()
+  })
+})
+
+describe('readStoredPanelHeight / storePanelHeight', () => {
+  it('returns null and does not throw without a window (SSR)', () => {
+    expect(typeof window).toBe('undefined')
+    expect(readStoredPanelHeight()).toBeNull()
+    expect(() => storePanelHeight(300)).not.toThrow()
+  })
+
+  it('round-trips a stored height through localStorage', () => {
+    const storage = makeStorage()
+
+    vi.stubGlobal('window', { localStorage: storage })
+
+    storePanelHeight(240)
+    expect(storage.data.get(TASKBAR_HEIGHT_STORAGE_KEY)).toBe('240')
+    expect(readStoredPanelHeight()).toBe(240)
+  })
+
+  it('returns null when nothing is stored', () => {
+    vi.stubGlobal('window', { localStorage: makeStorage() })
+    expect(readStoredPanelHeight()).toBeNull()
+  })
+
+  it('returns null for an unparsable stored value', () => {
+    vi.stubGlobal('window', {
+      localStorage: makeStorage({ [TASKBAR_HEIGHT_STORAGE_KEY]: 'garbage' }),
+    })
+    expect(readStoredPanelHeight()).toBeNull()
+  })
+
+  it('survives a throwing localStorage (private mode, quota)', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => {
+          throw new Error('denied')
+        },
+        setItem: () => {
+          throw new Error('quota')
+        },
+      },
+    })
+
+    expect(readStoredPanelHeight()).toBeNull()
+    expect(() => storePanelHeight(240)).not.toThrow()
+  })
+})

--- a/frontend/src/components/taskbarHeight.ts
+++ b/frontend/src/components/taskbarHeight.ts
@@ -1,0 +1,137 @@
+// src/components/taskbarHeight.ts
+//
+// Single writer for the --taskbar-height layout contract consumed by
+// StyledMain, the inventory page and the console layouts. Mirrors
+// src/components/broadcast/bannerHeight.ts: constants, clamp/drag math and
+// the CSS-var writer live here so TasksFooter stays the only publisher and
+// the geometry is unit-testable without layout (jsdom cannot measure).
+
+export const TASKBAR_HEIGHT_VAR = '--taskbar-height'
+
+/** Height of the collapsed taskbar header row (px). */
+export const TASKBAR_HEADER_HEIGHT = 36
+
+/** Keep a couple of task rows visible even at the smallest size. */
+export const TASKBAR_MIN_PANEL_HEIGHT = 120
+export const TASKBAR_MAX_PANEL_HEIGHT = 600
+
+/** Historical `maxHeight` prop default, preserves today's appearance. */
+export const TASKBAR_DEFAULT_PANEL_HEIGHT = 250
+
+/**
+ * A stored/dragged panel must never swallow a short screen: the effective
+ * maximum is also capped to this fraction of the viewport height.
+ */
+const TASKBAR_MAX_VIEWPORT_RATIO = 0.6
+
+/** Sibling of the existing tasksFooterExpanded / tasksFooterHidden keys. */
+export const TASKBAR_HEIGHT_STORAGE_KEY = 'tasksFooterPanelHeight'
+
+interface StyleTarget {
+  setProperty(name: string, value: string): void
+  removeProperty(name: string): void
+}
+
+/**
+ * Coerces any persisted/derived value into a valid panel height.
+ *
+ * Non-numeric and non-finite input falls back to the default. The result is
+ * clamped into [MIN, MAX], where MAX is additionally capped to 60% of the
+ * viewport when a viewport height is supplied. The viewport cap can never
+ * drop the upper bound below MIN (tiny viewports must not invert the clamp).
+ */
+export function clampTaskbarPanelHeight(value: unknown, viewportHeight?: number): number {
+  let candidate = Number.NaN
+
+  if (typeof value === 'number') {
+    candidate = value
+  } else if (typeof value === 'string' && value.trim() !== '') {
+    candidate = Number(value)
+  }
+
+  if (!Number.isFinite(candidate)) {
+    candidate = TASKBAR_DEFAULT_PANEL_HEIGHT
+  }
+
+  let max = TASKBAR_MAX_PANEL_HEIGHT
+
+  if (typeof viewportHeight === 'number' && Number.isFinite(viewportHeight)) {
+    max = Math.min(max, Math.floor(viewportHeight * TASKBAR_MAX_VIEWPORT_RATIO))
+  }
+
+  // Clamp order must not invert: the viewport cap never goes below MIN.
+  max = Math.max(max, TASKBAR_MIN_PANEL_HEIGHT)
+
+  return Math.min(max, Math.max(TASKBAR_MIN_PANEL_HEIGHT, Math.round(candidate)))
+}
+
+/**
+ * Panel height for a drag pointer at `clientY`.
+ *
+ * The bar is fixed to the viewport bottom and laid out as [header][panel];
+ * the drag handle is an absolutely-positioned overlay that adds nothing to
+ * the bar's height, so the panel simply fills the space between the pointer
+ * and the header. Already clamped against the same viewport.
+ */
+export function panelHeightFromPointer(clientY: number, viewportHeight: number): number {
+  return clampTaskbarPanelHeight(viewportHeight - clientY - TASKBAR_HEADER_HEIGHT, viewportHeight)
+}
+
+function resolveStyleTarget(target?: StyleTarget): StyleTarget | null {
+  if (target) return target
+  if (typeof document === 'undefined') return null
+
+  return document.documentElement.style
+}
+
+/**
+ * Writes the total bar height (header + panel, 0 when hidden) on the root
+ * element. Unlike bannerHeight, 0 is written as "0px" on purpose: that is
+ * the value TasksFooter has always published for the hidden state.
+ */
+export function publishTaskbarHeight(px: number, target?: StyleTarget): void {
+  const style = resolveStyleTarget(target)
+
+  if (!style) return
+  style.setProperty(TASKBAR_HEIGHT_VAR, `${px}px`)
+}
+
+/**
+ * Removes the property so the CSS fallback in `var(--taskbar-height, 0px)`
+ * applies, used on unmount, like bannerHeight's removeProperty path.
+ */
+export function clearTaskbarHeight(target?: StyleTarget): void {
+  const style = resolveStyleTarget(target)
+
+  if (!style) return
+  style.removeProperty(TASKBAR_HEIGHT_VAR)
+}
+
+/**
+ * Reads the persisted panel height. Returns null when unset, unparsable, or
+ * when localStorage is absent/throwing (SSR, private mode); callers fall
+ * back to their default and the render never crashes.
+ */
+export function readStoredPanelHeight(): number | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const raw = window.localStorage.getItem(TASKBAR_HEIGHT_STORAGE_KEY)
+
+    if (raw === null) return null
+    const parsed = Number(raw)
+
+    return Number.isFinite(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/** Persists the panel height; silently ignores quota/private-mode errors. */
+export function storePanelHeight(px: number): void {
+  try {
+    if (typeof window === 'undefined') return
+    window.localStorage.setItem(TASKBAR_HEIGHT_STORAGE_KEY, String(px))
+  } catch {
+    // Private mode / quota: the height simply stays in memory for the session.
+  }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -3558,6 +3558,7 @@
     "title": "Aufgaben",
     "showTasks": "Aufgaben anzeigen",
     "hideTasks": "Ausblenden",
+    "resizePanel": "Ziehen, um die Größe des Aufgabenbereichs zu ändern",
     "refresh": "Aktualisieren",
     "expand": "Erweitern",
     "collapse": "Einklappen",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3597,6 +3597,7 @@
     "title": "Tasks",
     "showTasks": "Show tasks",
     "hideTasks": "Hide",
+    "resizePanel": "Drag to resize the tasks panel",
     "refresh": "Refresh",
     "expand": "Expand",
     "collapse": "Collapse",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -3597,6 +3597,7 @@
     "title": "Tareas",
     "showTasks": "Mostrar tareas",
     "hideTasks": "Ocultar",
+    "resizePanel": "Arrastrar para cambiar el tamaño del panel de tareas",
     "refresh": "Actualizar",
     "expand": "Expandir",
     "collapse": "Contraer",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -3597,6 +3597,7 @@
     "title": "Tâches",
     "showTasks": "Afficher les tâches",
     "hideTasks": "Masquer",
+    "resizePanel": "Glisser pour redimensionner le panneau des tâches",
     "refresh": "Actualiser",
     "expand": "Agrandir",
     "collapse": "Réduire",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -3597,6 +3597,7 @@
     "title": "작업",
     "showTasks": "작업 표시",
     "hideTasks": "숨기기",
+    "resizePanel": "드래그하여 작업 패널 크기 조절",
     "refresh": "새로 고침",
     "expand": "펼치기",
     "collapse": "접기",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -3558,6 +3558,7 @@
     "title": "任务",
     "showTasks": "显示任务",
     "hideTasks": "隐藏",
+    "resizePanel": "拖动以调整任务面板大小",
     "refresh": "刷新",
     "expand": "展开",
     "collapse": "折叠",


### PR DESCRIPTION
Follow-up to #582. The originally reported clipping was fixed and shipped, but the reporter confirmed the same symptom reappears elsewhere: with the Tasks section expanded, the Migration Log becomes invisible and cannot be scrolled to. They also asked for a page scrollbar and for the Tasks section to be resizable.

## Root cause

The tasks bar grows from `36px` to `286px` when expanded (36 header + 250 panel) and publishes its height as `--taskbar-height`. Several containers sized themselves from viewport magic numbers instead of from their flex parent, so they did not shrink with it.

The inventory page is the **only** page in the app that opts out of page scrolling. It carries `contentHeightFixed`, which turns `<main>` into `overflow: hidden`. So on that page there is no page scrollbar to act as a safety net, and the excess is hard-clipped by four nested `overflow: hidden` ancestors. The content is rendered but unreachable. That also answers the "please make sure there is a scrollbar visible in the page" request: the fix is to make the right container scroll, not to force a page scrollbar onto a deliberately full-height two-pane layout.

The earlier fix on this issue made the log console `flex: 1`, which was correct but assumed the column had room. It never made the column itself scrollable, and three of the four sibling cards above the log cannot shrink (one has an explicit `flexShrink: 0`).

## Layout: the whole bug class, not just the reported instance

| Site | Was | Now |
|---|---|---|
| Migration panel column | `overflow: hidden`, never scrolled | scrolls as a whole; log console floor raised so it stays readable |
| External-host VM table | `maxHeight: calc(100vh - 320px)` | sizes from its flex parent |
| "No guests" empty state | `minHeight: calc(100vh - 200px)` | `flex: 1` |
| Offline-node placeholder | `minHeight: calc(100vh - 250px)` | `flex: 1` |
| Sidebar (4 spots) | subtracted only the top banner | also subtracts `--taskbar-height` |

A viewport-derived `minHeight` is the worst of the group: it *blocks* flex shrink, so overflow is guaranteed rather than merely possible.

The sidebar one affects **every page**, not just the inventory. The bar is `z-index: 1200` and the nav is below it, so the last menu entries could only ever be scrolled underneath the bar, which also swallowed their clicks.

Two entries from an earlier survey turned out not to belong: one sits inside a Dialog (modal z-index is above the bar, so it cannot be covered) and another already had a correct flex chain, making its `maxHeight` dead weight. Around ten further sites remain intentionally untouched: they live on normally-scrolling pages where `<main>` already reserves `--taskbar-height` as padding, so their content is always reachable by page scroll.

## Resizable tasks bar

Drag the bar's top edge. Implemented by hand, mirroring the existing inventory split resizer (clamped, document-level listeners under an `isResizing` guard, write-on-release persistence, `userSelect` lock) rather than pulling in a dependency for one strip.

- Clamp 120-600px, additionally capped to 60% of the viewport so a stored height cannot swallow a short screen; re-clamped on window resize.
- Height persisted; default appearance is unchanged for anyone who never drags.
- Keyboard accessible: the handle is a focusable `separator` with arrow-key resizing and aria value/min/max.
- `--taskbar-height` gains a single-writer module mirroring the existing `bannerHeight.ts` contract. The drag and clamp arithmetic lives there so it is unit-testable. jsdom has no layout engine, so this is the only way to cover it.
- The two 0.2s `--taskbar-height` transitions are suppressed during a drag, otherwise the bar visibly lags the pointer.

## Found while testing

Reported during review of the branch, same component, so folded in here.

- **Start/End showed only the clock**, which is unreadable on a list spanning days. They now show the full localised date and time, and are typed as `dateTime` with a `Date` valueGetter. As untyped columns the grid sorted the ISO strings lexicographically and offered *"contains"* text filters against the raw ISO value, so filtering on a displayed date could never match. That is why sorting and filtering appeared to do nothing.
- **Column widths**: Start/End/Node/Status sized for their real content, including the widest locale renderings (`en-US` adds AM/PM, `ko-KR` uses double-width CJK). Status gains the `title` it was missing, so a long Proxmox error string can be read on hover instead of being silently truncated. Note this raises the grid's minimum width, so the tasks grid will scroll horizontally below roughly 1470px.
- **Duplicated cluster events.** Several connections may legitimately point at the same physical cluster (a normal multi-tenant setup). The events route iterates every connection and calls `/cluster/tasks` on each, so every event was returned once per connection. Consequences: duplicate React keys (a console error storm), rows visually scrambling while scrolling, sorting corrupted by ambiguous row ids, and `limit=50` surfacing only ~25 distinct tasks. Events are now deduplicated by UPID for tasks and by node+uid+time for logs. `uid` alone is only a per-cluster sequence, so keying on it would wrongly merge lines from different clusters. Ordering breaks ties on connectionId then id, so the payload and the connection attributed to a shared cluster's event are deterministic. The emitted log `id` keeps its existing shape; the dedup key is internal.
- Rows are memoised so the grid is no longer handed brand-new row identities on every render.

## Tests

50 new tests: 25 on the taskbar height module (100% coverage), 18 on the footer's resize behaviour, 7 on event deduplication.

The resize tests assert on observable output (the published CSS variable, the storage key, the drag marker attribute) rather than geometry, since jsdom cannot compute layout. Dedup tests cover the over-eager case (genuinely different tasks are never dropped), the `uid` collision trap across distinct clusters, and determinism under forced response-order inversion.

Full suite: 303 files / 2994 tests green, up from 300 / 2944 on `main`, with the delta exactly accounted for. `next build` green, ESLint 0 errors.

## Review notes

Verification of the layout half is **visual only**: jsdom cannot compute layout, and reproducing the original report needs a live migration with the tasks bar expanded. Checked in a browser: migration log reachable with the bar expanded, sidebar menu entries clickable, drag smooth and persisted across reload, empty states centred.

Two deliberate appearance changes worth a look:
- On an external host with few VMs, the VM list card now fills the pane instead of sizing to its content, a consequence of the flex conversion.
- The log console floor moved from 80px to 220px, so on a very short viewport the migration column may show its scrollbar even with the bar collapsed. That is the trade-off for keeping the log readable rather than letting it collapse.

The drag handle occupies the top 6px of the header, which therefore no longer toggles collapse on click.

Refs #582
