### PR TITLE
fix(ui): let numeric fields be cleared instead of snapping back to a default

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
@@ -18,6 +18,7 @@ import {
   screen,
   waitFor,
   fireEvent,
+  userEvent,
 } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
@@ -709,5 +710,130 @@ describe('CreateLxcDialog - Template tab', () => {
       name: /ubuntu-22\.04-standard_22\.04-1_amd64\.tar\.gz/,
     })
     expect(ubuntuOption).toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 11. Numeric fields must be clearable (discussion #634)
+//
+// Every numeric field here used to be written as
+//   value={n} onChange={e => setN(Number.parseInt(e.target.value) || fallback)}
+// Deleting the last digit yields '', parseInt('') is NaN and `|| fallback`
+// wrote the default straight back, so the input could never be empty and the
+// next keystroke was appended to the number that had just snapped back
+// (type 20 over a 1 and you get 120). They now use NumericTextField, which
+// keeps its own string buffer and only ever hands the parent a finite number.
+// ------------------------------------------------------------------ //
+
+describe('CreateLxcDialog - clearable numeric fields', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  /** Switch tab and wait until it is actually the selected one. */
+  async function goToTab(name: string) {
+    fireEvent.click(screen.getByRole('tab', { name }))
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name }).getAttribute('aria-selected')).toBe('true')
+    })
+  }
+
+  it('the disk size can be emptied, and a retyped size replaces it instead of gluing the old digit in front (discussion #634)', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('Disks')
+
+    const diskSize = screen.getByLabelText('Disk size (GiB)') as HTMLInputElement
+    expect(diskSize.value).toBe('8')
+
+    await userEvent.clear(diskSize)
+    // The reported symptom: with the old coercion this was already '1' again.
+    expect(diskSize.value).toBe('')
+
+    await userEvent.type(diskSize, '20')
+    expect(diskSize.value).toBe('20')
+
+    // The rootfs chip renders `${rootSize} GiB` from the committed state, so it
+    // proves the parent got 20 -- not 120 (old digit glued in front) and not 820.
+    expect(screen.getByText('20 GiB')).toBeInTheDocument()
+    expect(screen.queryByText('120 GiB')).not.toBeInTheDocument()
+    expect(screen.queryByText('820 GiB')).not.toBeInTheDocument()
+  })
+
+  it('a disk size left empty commits the fallback on blur, so the create payload can never carry an empty size', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('Disks')
+
+    const diskSize = screen.getByLabelText('Disk size (GiB)') as HTMLInputElement
+
+    await userEvent.clear(diskSize)
+    expect(diskSize.value).toBe('')
+
+    // Blur (tabbing out, or clicking Create) commits the fallback the old
+    // `|| 1` coercion used, so `rootfs: ${rootStorage}:${rootSize}` always
+    // interpolates a number.
+    await userEvent.tab()
+    expect(diskSize.value).toBe('1')
+    expect(screen.getByText('1 GiB')).toBeInTheDocument()
+  })
+
+  // Cores / Memory / Swap carried exactly the same defect. The committed value
+  // is asserted through the heading that mirrors it, so the test fails if the
+  // parent state kept the old number.
+  const clearableFields = [
+    { tab: 'CPU', label: 'Cores', initial: '1', typed: '4', committed: /Cores: 4/ },
+    { tab: 'Memory', label: 'Memory (MiB)', initial: '512', typed: '2048', committed: /Memory \(MiB\): 2 GiB/ },
+    { tab: 'Memory', label: 'Swap (MiB)', initial: '512', typed: '256', committed: /Swap \(MiB\): 256 MiB/ },
+  ]
+
+  it.each(clearableFields)(
+    '$label can be cleared and retyped without the old value gluing itself in front',
+    async ({ tab, label, initial, typed, committed }) => {
+      renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+      await waitForDataLoad()
+      await goToTab(tab)
+
+      const input = screen.getByLabelText(label) as HTMLInputElement
+      expect(input.value).toBe(initial)
+
+      await userEvent.clear(input)
+      expect(input.value).toBe('')
+
+      await userEvent.type(input, typed)
+      expect(input.value).toBe(typed)
+      expect(screen.getByText(committed)).toBeInTheDocument()
+    },
+  )
+
+  it('the advanced CPU limit and CPU units fields are clearable too', async () => {
+    renderWithProviders(<CreateLxcDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('CPU')
+
+    // Both fields live behind the collapsed "Advanced Options" header.
+    fireEvent.click(screen.getByText('Advanced Options'))
+
+    const cpuLimit = screen.getByLabelText('CPU limit') as HTMLInputElement
+    // 0 means "unlimited": format() renders it blank so the placeholder shows.
+    expect(cpuLimit.value).toBe('')
+
+    await userEvent.type(cpuLimit, '1')
+    expect(cpuLimit.value).toBe('1')
+
+    await userEvent.clear(cpuLimit)
+    expect(cpuLimit.value).toBe('')
+    // Blurring an empty CPU limit means unlimited again -- still blank, not '0'.
+    await userEvent.tab()
+    expect(cpuLimit.value).toBe('')
+
+    const cpuUnits = screen.getByLabelText('CPU units') as HTMLInputElement
+    expect(cpuUnits.value).toBe('1024')
+
+    await userEvent.clear(cpuUnits)
+    expect(cpuUnits.value).toBe('')
+
+    await userEvent.type(cpuUnits, '2048')
+    expect(cpuUnits.value).toBe('2048')
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
@@ -36,6 +36,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { AllVmItem } from './InventoryTree'
 
 function CreateLxcDialog({
@@ -1018,10 +1019,13 @@ return
                     ))}
                   </Select>
                 </FormControl>
-                <TextField
+                <NumericTextField
                   label={t('inventory.createLxc.diskSizeGib')}
                   value={rootSize}
-                  onChange={(e) => setRootSize(Number.parseInt(e.target.value) || 1)}
+                  onChange={setRootSize}
+                  fallback={1}
+                  min={1}
+                  max={1000}
                   size="small"
                   type="number"
                   inputProps={{ min: 1, max: 1000 }}
@@ -1054,10 +1058,13 @@ return
                 </Box>
               </Box>
 
-              <TextField
+              <NumericTextField
                 label={t('inventory.createLxc.cores')}
                 value={cpuCores}
-                onChange={(e) => setCpuCores(Number.parseInt(e.target.value) || 1)}
+                onChange={setCpuCores}
+                fallback={1}
+                min={1}
+                max={128}
                 size="small"
                 type="number"
                 inputProps={{ min: 1, max: 128 }}
@@ -1075,19 +1082,25 @@ return
                 </Box>
                 <Collapse in={cpuAdvancedExpanded}>
                   <Box sx={{ px: 2, pb: 2, pt: 0.5, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1.5 }}>
-                    <TextField
+                    <NumericTextField
                       label={t('inventory.createLxc.cpuLimit')}
-                      value={cpuLimit === 0 ? '' : cpuLimit}
-                      onChange={(e) => setCpuLimit(Number.parseFloat(e.target.value) || 0)}
+                      value={cpuLimit}
+                      onChange={setCpuLimit}
+                      fallback={0}
+                      parse={Number.parseFloat}
+                      format={(n) => (n === 0 ? '' : String(n))}
+                      min={0}
+                      max={cpuCores}
                       size="small"
                       type="number"
                       placeholder={t('inventory.createLxc.unlimited')}
                       inputProps={{ min: 0, max: cpuCores, step: 0.1 }}
                     />
-                    <TextField
+                    <NumericTextField
                       label={t('inventory.createLxc.cpuUnits')}
                       value={cpuUnits}
-                      onChange={(e) => setCpuUnits(Number.parseInt(e.target.value) || 1024)}
+                      onChange={setCpuUnits}
+                      fallback={1024}
                       size="small"
                       type="number"
                     />
@@ -1152,10 +1165,12 @@ return
                 />
               </Box>
 
-              <TextField
+              <NumericTextField
                 label={t('inventory.createLxc.memoryMib')}
                 value={memorySize}
-                onChange={(e) => setMemorySize(Number.parseInt(e.target.value) || 128)}
+                onChange={setMemorySize}
+                fallback={128}
+                min={16}
                 size="small"
                 type="number"
                 inputProps={{ min: 16, step: 32 }}
@@ -1184,10 +1199,12 @@ return
                 </Box>
               </Box>
 
-              <TextField
+              <NumericTextField
                 label={t('inventory.createLxc.swapMib')}
                 value={swapSize}
-                onChange={(e) => setSwapSize(Number.parseInt(e.target.value) || 0)}
+                onChange={setSwapSize}
+                fallback={0}
+                min={0}
                 size="small"
                 type="number"
                 inputProps={{ min: 0, step: 32 }}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
@@ -24,6 +24,7 @@ import {
   screen,
   waitFor,
   fireEvent,
+  userEvent,
 } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
@@ -699,5 +700,88 @@ describe('CreateVmDialog - System tab', () => {
     await waitFor(() => {
       expect(screen.getByText(/UEFI requires a q35 machine type/i)).toBeInTheDocument()
     })
+  })
+})
+
+// ------------------------------------------------------------------ //
+// 9. Numeric fields must be clearable (discussion #634)
+//
+// This dialog used to carry its own private copy of the buffered numeric
+// input; it now imports the shared @/components/ui/NumericTextField, and the
+// last two raw fields (disk size, CPU limit) were converted to it. These tests
+// pin the user-visible contract of that swap: the field can be emptied, and
+// what you type next replaces the old value instead of being appended to it.
+// ------------------------------------------------------------------ //
+
+describe('CreateVmDialog - clearable numeric fields', () => {
+  beforeEach(() => {
+    seedAllHandlers()
+  })
+
+  /** Switch tab and wait until it is actually the selected one. */
+  async function goToTab(name: string) {
+    fireEvent.click(screen.getByRole('tab', { name }))
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name }).getAttribute('aria-selected')).toBe('true')
+    })
+  }
+
+  it('Cores can be emptied and retyped without the old digit gluing itself in front', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('CPU')
+
+    const cores = screen.getByLabelText('Cores') as HTMLInputElement
+    expect(cores.value).toBe('1')
+
+    await userEvent.clear(cores)
+    expect(cores.value).toBe('')
+
+    await userEvent.type(cores, '8')
+    expect(cores.value).toBe('8')
+    // Total cores = sockets x cores, read from the committed state: 8, not 18.
+    expect(screen.getByText(/Total cores: 8/i)).toBeInTheDocument()
+  })
+
+  it('the disk size can be emptied and retyped, and the disk header follows the committed value', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('Disks')
+
+    // The first disk card is expanded by default (expandedDisks = {0}).
+    const diskSize = screen.getByLabelText('Disk size (GiB)') as HTMLInputElement
+    expect(diskSize.value).toBe('32')
+
+    await userEvent.clear(diskSize)
+    expect(diskSize.value).toBe('')
+
+    await userEvent.type(diskSize, '64')
+    expect(diskSize.value).toBe('64')
+    expect(screen.getByText('64 GiB')).toBeInTheDocument()
+    expect(screen.queryByText('3264 GiB')).not.toBeInTheDocument()
+  })
+
+  it('the CPU limit keeps its "unlimited" sentinel while staying clearable', async () => {
+    renderWithProviders(<CreateVmDialog {...makeProps()} />)
+    await waitForDataLoad()
+    await goToTab('CPU')
+
+    // The CPU limit lives behind the collapsed "Advanced Options" header.
+    fireEvent.click(screen.getByText('Advanced Options'))
+
+    const cpuLimit = screen.getByLabelText('CPU limit') as HTMLInputElement
+    // 0 is displayed as the word 'unlimited' (unchanged from before the swap).
+    expect(cpuLimit.value).toBe('unlimited')
+
+    await userEvent.clear(cpuLimit)
+    expect(cpuLimit.value).toBe('')
+
+    await userEvent.type(cpuLimit, '2')
+    expect(cpuLimit.value).toBe('2')
+
+    // Emptying it again and blurring means unlimited: back to the sentinel.
+    await userEvent.clear(cpuLimit)
+    await userEvent.tab()
+    expect(cpuLimit.value).toBe('unlimited')
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -41,6 +41,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 import QuotaDonut from '@/components/mydc/QuotaDonut'
 import { formatBytes } from '@/utils/format'
 import { AllVmItem } from './InventoryTree'
@@ -102,55 +103,6 @@ const createDefaultNic = (): NicConfig => ({
   rateLimit: '',
   mtu: '1500',
 })
-
-function NumericTextField({
-  value,
-  onChange,
-  fallback,
-  parse = Number.parseInt,
-  ...rest
-}: Omit<React.ComponentProps<typeof TextField>, 'value' | 'onChange'> & {
-  value: number
-  onChange: (v: number) => void
-  fallback: number
-  parse?: (s: string) => number
-}) {
-  const [raw, setRaw] = useState<string>(String(value))
-
-  useEffect(() => {
-    setRaw(String(value))
-  }, [value])
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const text = e.target.value
-
-    setRaw(text)
-
-    if (text === '' || text === '-') return
-
-    const num = parse(text)
-
-    if (Number.isFinite(num)) onChange(num)
-  }
-
-  const handleBlur = () => {
-    if (raw === '' || raw === '-') {
-      onChange(fallback)
-      setRaw(String(fallback))
-
-      return
-    }
-
-    const num = parse(raw)
-
-    if (!Number.isFinite(num)) {
-      onChange(fallback)
-      setRaw(String(fallback))
-    }
-  }
-
-  return <TextField value={raw} onChange={handleChange} onBlur={handleBlur} {...rest} />
-}
 
 function CreateVmDialog({
   open,
@@ -1582,13 +1534,12 @@ return
                               </FormHelperText>
                             )}
                           </FormControl>
-                          <TextField
+                          <NumericTextField
                             label={t('inventory.createVm.diskSizeGib')}
-                            value={disk.size === 0 ? '' : disk.size}
-                            onChange={(e) => {
-                              const n = Number.parseInt(e.target.value, 10)
-                              updateDisk(diskIdx, { size: Number.isFinite(n) ? n : 0 })
-                            }}
+                            value={disk.size}
+                            onChange={(n) => updateDisk(diskIdx, { size: n })}
+                            fallback={0}
+                            format={(n) => (n === 0 ? '' : String(n))}
                             size="small"
                             type="number"
                           />
@@ -1752,10 +1703,13 @@ return
                       size="small"
                       type="number"
                     />
-                    <TextField
+                    <NumericTextField
                       label={t('inventory.createVm.cpuLimit')}
-                      value={cpuLimit === 0 ? 'unlimited' : cpuLimit}
-                      onChange={(e) => setCpuLimit(e.target.value === 'unlimited' ? 0 : Number.parseFloat(e.target.value) || 0)}
+                      value={cpuLimit}
+                      onChange={setCpuLimit}
+                      fallback={0}
+                      parse={Number.parseFloat}
+                      format={(n) => (n === 0 ? 'unlimited' : String(n))}
                       size="small"
                       placeholder="unlimited"
                     />

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -30,6 +30,7 @@ import {
   waitFor,
   fireEvent,
   within,
+  userEvent,
 } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
@@ -529,6 +530,55 @@ describe('InventoryDialogs', () => {
     fireEvent.click(noneOption)
     // 'none' is not in MEMORY_CAPABLE, so buildValue('none', undefined, '') = 'none'
     expect(setEditOptionValue).toHaveBeenCalledWith('none')
+  })
+
+  // 8b. editOptionDialog - vga display memory can be emptied
+  it('editOptionDialog vga: display memory can be cleared and retyped without the old digits sticking', async () => {
+    // The field is controlled by editOptionValue (a VGA string), so the retype
+    // path only exercises the bug when the parent really owns that string: a
+    // vi.fn() spy would freeze the value and hide the buffer's behaviour.
+    const baseProps = makeProps({
+      editOptionDialog: {
+        key: 'vga',
+        label: 'Display',
+        value: 'std,memory=32',
+        type: 'vga',
+        options: [{ value: 'std', label: 'Standard (std)' }],
+      },
+    })
+
+    function Harness() {
+      const [editOptionValue, setEditOptionValue] = React.useState('std,memory=32')
+
+      return (
+        <InventoryDialogs
+          {...baseProps}
+          editOptionValue={editOptionValue}
+          setEditOptionValue={setEditOptionValue}
+        />
+      )
+    }
+
+    renderWithProviders(<Harness />)
+
+    const input = screen.getByRole('spinbutton', { name: 'Memory' }) as HTMLInputElement
+    expect(input.value).toBe('32')
+
+    await userEvent.clear(input)
+    // Before the fix the controlled value snapped straight back to '32'.
+    expect(input.value).toBe('')
+
+    await userEvent.type(input, '64')
+    expect(input.value).toBe('64')
+
+    fireEvent.blur(input)
+    expect(input.value).toBe('64')
+
+    // Emptying it again and leaving the field commits the 16 MB PVE default,
+    // and buildValue drops the redundant `memory=16` segment.
+    await userEvent.clear(input)
+    fireEvent.blur(input)
+    expect(input.value).toBe('16')
   })
 
   // 9. createBackupDialog

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -38,6 +38,7 @@ import {
 } from '@mui/material'
 
 import { NodeRow, BulkAction } from '@/components/NodesTable'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
 
 // Dynamic imports for HardwareModals (code-split, loaded on demand)
@@ -1383,7 +1384,7 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
                   </FormControl>
                   {memoryCapable && (
                     <>
-                      <TextField
+                      <NumericTextField
                         fullWidth
                         size="small"
                         type="number"
@@ -1391,16 +1392,11 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
                         helperText={t('inventory.displayMemoryHelper')}
                         inputProps={{ min: 4, max: 512, step: 1 }}
                         InputProps={{ endAdornment: <InputAdornment position="end">MB</InputAdornment> }}
-                        value={memoryValue ?? ''}
-                        onChange={(e) => {
-                          const n = Number.parseInt(e.target.value, 10)
-                          if (Number.isFinite(n)) setEditOptionValue(buildValue(vgaType, n, clipboard))
-                        }}
-                        onBlur={(e) => {
-                          const n = Number.parseInt(e.target.value, 10)
-                          const clamped = Number.isFinite(n) ? Math.max(4, Math.min(512, n)) : 16
-                          setEditOptionValue(buildValue(vgaType, clamped, clipboard))
-                        }}
+                        value={memoryValue ?? 16}
+                        onChange={(n) => setEditOptionValue(buildValue(vgaType, n, clipboard))}
+                        fallback={16}
+                        min={4}
+                        max={512}
                       />
                       <FormControl fullWidth size="small">
                         <InputLabel>{t('inventory.displayClipboard')}</InputLabel>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
@@ -73,6 +73,7 @@ import HaRuleDialog from '../HaRuleDialog'
 import EntityTagManager from '../components/EntityTagManager'
 import CephTopology from '../components/CephTopology'
 import { AddIcon } from '../components/IconWrappers'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { useLicense, Features } from '@/contexts/LicenseContext'
 import { useToast } from '@/contexts/ToastContext'
 import { useRollingUpdates } from '@/contexts/RollingUpdateContext'
@@ -1773,21 +1774,23 @@ export default function ClusterTabs(props: any) {
                                       </FormControl>
                                     )}
 
-                                    <TextField
+                                    <NumericTextField
                                       size="small"
                                       type="number"
                                       label="Max Restart"
                                       value={autoHaSettings.max_restart ?? 1}
-                                      onChange={(e) => setAutoHaSettings((prev: any) => ({ ...prev, max_restart: Number.parseInt(e.target.value) || 0 }))}
+                                      onChange={(n) => setAutoHaSettings((prev: any) => ({ ...prev, max_restart: n }))}
+                                      fallback={0}
                                       inputProps={{ min: 0, max: 10 }}
                                       sx={{ flex: 1 }}
                                     />
-                                    <TextField
+                                    <NumericTextField
                                       size="small"
                                       type="number"
                                       label="Max Relocate"
                                       value={autoHaSettings.max_relocate ?? 1}
-                                      onChange={(e) => setAutoHaSettings((prev: any) => ({ ...prev, max_relocate: Number.parseInt(e.target.value) || 0 }))}
+                                      onChange={(n) => setAutoHaSettings((prev: any) => ({ ...prev, max_relocate: n }))}
+                                      fallback={0}
                                       inputProps={{ min: 0, max: 10 }}
                                       sx={{ flex: 1 }}
                                     />
@@ -4396,14 +4399,14 @@ export default function ClusterTabs(props: any) {
                 </Select>
               </FormControl>
               <Box sx={{ display: 'flex', gap: 2 }}>
-                <TextField
+                <NumericTextField
                   fullWidth size="small" type="number" label={t('cluster.maxRestart')}
-                  value={addHaMaxRestart} onChange={(e) => setAddHaMaxRestart(Number(e.target.value))}
+                  value={addHaMaxRestart} onChange={setAddHaMaxRestart} fallback={0}
                   inputProps={{ min: 0, max: 10 }}
                 />
-                <TextField
+                <NumericTextField
                   fullWidth size="small" type="number" label={t('cluster.maxRelocate')}
-                  value={addHaMaxRelocate} onChange={(e) => setAddHaMaxRelocate(Number(e.target.value))}
+                  value={addHaMaxRelocate} onChange={setAddHaMaxRelocate} fallback={0}
                   inputProps={{ min: 0, max: 10 }}
                 />
               </Box>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -82,60 +82,7 @@ import { AreaPctChart, AreaBpsChart2 } from '../components/RrdCharts'
 import InventorySummary from '../components/InventorySummary'
 import { SaveIcon, AddIcon, CloseIcon } from '../components/IconWrappers'
 import VdcQuotaBanner from '@/components/inventory/VdcQuotaBanner'
-
-function BufferedNumberField({
-  value,
-  onCommit,
-  display,
-  parse,
-  fallback,
-  ...rest
-}: Omit<React.ComponentProps<typeof TextField>, 'value' | 'onChange'> & {
-  value: number
-  onCommit: (n: number) => void
-  display?: (n: number) => string
-  parse?: (s: string) => number
-  fallback: number
-}) {
-  const fmt = display || ((n: number) => String(n))
-  const prs = parse || ((s: string) => Number(s))
-  const [raw, setRaw] = useState<string>(fmt(value))
-
-  useEffect(() => {
-    setRaw(fmt(value))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value])
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const text = e.target.value
-
-    setRaw(text)
-
-    if (text === '' || text === '-' || text === '.') return
-
-    const n = prs(text)
-
-    if (Number.isFinite(n)) onCommit(n)
-  }
-
-  const handleBlur = () => {
-    if (raw === '' || raw === '-' || raw === '.') {
-      onCommit(fallback)
-      setRaw(fmt(fallback))
-
-      return
-    }
-
-    const n = prs(raw)
-
-    if (!Number.isFinite(n)) {
-      onCommit(fallback)
-      setRaw(fmt(fallback))
-    }
-  }
-
-  return <TextField value={raw} onChange={handleChange} onBlur={handleBlur} {...rest} />
-}
+import NumericTextField from '@/components/ui/NumericTextField'
 
 export default function VmDetailTabs(props: any) {
   const t = useTranslations()
@@ -942,11 +889,11 @@ export default function VmDetailTabs(props: any) {
                             <Box>
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                                 <Typography variant="body2" fontWeight={600}>{t('inventory.sockets')}</Typography>
-                                <BufferedNumberField
+                                <NumericTextField
                                   size="small"
                                   type="number"
                                   value={cpuSockets}
-                                  onCommit={setCpuSockets}
+                                  onChange={setCpuSockets}
                                   fallback={1}
                                   sx={{ width: 70 }}
                                   inputProps={{ min: 1, max: maxSockets }}
@@ -968,11 +915,11 @@ export default function VmDetailTabs(props: any) {
                             <Box>
                               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                                 <Typography variant="body2" fontWeight={600}>{t('inventory.coresPerSocket')}</Typography>
-                                <BufferedNumberField
+                                <NumericTextField
                                   size="small"
                                   type="number"
                                   value={cpuCores}
-                                  onCommit={setCpuCores}
+                                  onChange={setCpuCores}
                                   fallback={1}
                                   sx={{ width: 70 }}
                                   inputProps={{ min: 1 }}
@@ -1124,11 +1071,13 @@ export default function VmDetailTabs(props: any) {
                               <Box sx={{ mt: 2 }}>
                                 <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
                                   <Typography variant="body2" fontWeight={600}>{t('inventory.cpuLimit')}</Typography>
-                                  <TextField
+                                  <NumericTextField
                                     size="small"
                                     type="number"
                                     value={cpuLimit}
-                                    onChange={(e) => setCpuLimit(Number(e.target.value))}
+                                    onChange={setCpuLimit}
+                                    fallback={0}
+                                    parse={Number.parseFloat}
                                     sx={{ width: 100 }}
                                     inputProps={{ min: 0, max: 128, step: 0.5 }}
                                   />
@@ -1300,19 +1249,25 @@ export default function VmDetailTabs(props: any) {
                           <Box sx={{ mb: 3 }}>
                             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                               <Typography variant="body2" fontWeight={600}>{t('inventoryPage.memory')}</Typography>
-                              <BufferedNumberField
+                              {/* The field shows GB, the state holds MB: format divides, parse
+                                  multiplies, so `min` is expressed in MB like `memory`. parse uses
+                                  parseFloat, not Number, because Number('') is 0 and would commit
+                                  0 MB on blur instead of falling back to 1 GB. The 512 MB floor
+                                  lives in `min` (applied on blur) rather than in onChange: a
+                                  parent that re-clamped mid-keystroke would rewrite the buffer
+                                  under the user's fingers. */}
+                              <NumericTextField
                                 size="small"
                                 type="number"
                                 value={memory}
-                                display={(v) => String(Math.round(v / 1024))}
-                                parse={(s) => Number(s) * 1024}
-                                onCommit={(newMem) => {
-                                  const clamped = Math.max(512, newMem)
-
-                                  setMemory(clamped)
-                                  if (balloonEnabled && balloon > clamped) setBalloon(clamped)
+                                format={(v) => String(Math.round(v / 1024))}
+                                parse={(s) => Number.parseFloat(s) * 1024}
+                                onChange={(newMem) => {
+                                  setMemory(newMem)
+                                  if (balloonEnabled && balloon > newMem) setBalloon(newMem)
                                 }}
                                 fallback={1024}
+                                min={512}
                                 InputProps={{
                                   endAdornment: <InputAdornment position="end">GB</InputAdornment>,
                                 }}
@@ -1365,11 +1320,21 @@ export default function VmDetailTabs(props: any) {
                               <Box sx={{ mt: 2 }}>
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
                                   <Typography variant="body2" fontWeight={600}>{t('inventory.minMemoryBalloon')}</Typography>
-                                  <TextField
+                                  {/* The field shows GB, the state holds MB: format divides, parse
+                                      multiplies, so min/max are expressed in MB like `balloon`.
+                                      The "never above the VM's memory" ceiling is `max` (applied on
+                                      blur) instead of a Math.min in onChange: clamping in the
+                                      parent would rewrite the buffer on every keystroke. */}
+                                  <NumericTextField
                                     size="small"
                                     type="number"
-                                    value={(balloon / 1024).toFixed(0)}
-                                    onChange={(e) => setBalloon(Math.min(Number(e.target.value) * 1024, memory))}
+                                    value={balloon}
+                                    format={(v) => (v / 1024).toFixed(0)}
+                                    parse={(s) => Number.parseFloat(s) * 1024}
+                                    onChange={setBalloon}
+                                    fallback={0}
+                                    min={0}
+                                    max={memory}
                                     InputProps={{
                                       endAdornment: <InputAdornment position="end">GB</InputAdornment>,
                                     }}
@@ -1410,11 +1375,13 @@ export default function VmDetailTabs(props: any) {
                                 <i className="ri-swap-line" style={{ marginRight: 4 }} />
                                 {t('inventory.swap')}
                               </Typography>
-                              <TextField
+                              <NumericTextField
                                 size="small"
                                 type="number"
                                 value={swap}
-                                onChange={(e) => setSwap(Math.max(0, Number(e.target.value)))}
+                                onChange={setSwap}
+                                fallback={0}
+                                min={0}
                                 InputProps={{
                                   endAdornment: <InputAdornment position="end">MB</InputAdornment>,
                                 }}
@@ -4500,20 +4467,22 @@ return (
                                   </Select>
                                 </FormControl>
 
-                                <TextField
+                                <NumericTextField
                                   label={t('cluster.maxRestart')}
                                   type="number"
                                   size="small"
                                   value={haMaxRestart}
-                                  onChange={(e) => setHaMaxRestart(Number.parseInt(e.target.value) || 0)}
+                                  onChange={setHaMaxRestart}
+                                  fallback={0}
                                   inputProps={{ min: 0, max: 10 }}
                                 />
-                                <TextField
+                                <NumericTextField
                                   label={t('cluster.maxRelocate')}
                                   type="number"
                                   size="small"
                                   value={haMaxRelocate}
-                                  onChange={(e) => setHaMaxRelocate(Number.parseInt(e.target.value) || 0)}
+                                  onChange={setHaMaxRelocate}
+                                  fallback={0}
                                   inputProps={{ min: 0, max: 10 }}
                                 />
 

--- a/frontend/src/app/(dashboard)/operations/backups/BackupJobsSection.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/BackupJobsSection.jsx
@@ -36,6 +36,8 @@ import {
 import { DataGrid } from '@mui/x-data-grid'
 import { useTranslations } from 'next-intl'
 
+import NumericTextField from '@/components/ui/NumericTextField'
+
 /* -----------------------------
   BackupJobsSection Component
 ------------------------------ */
@@ -698,12 +700,14 @@ export default function BackupJobsSection({ pveConnections = [] }) {
                 placeholder={t('backups.jobDescription')}
               />
 
-              <TextField
+              <NumericTextField
                 size="small"
                 label={t('backups.retentionBackupCount')}
                 type="number"
                 value={formData.maxfiles}
-                onChange={(e) => setFormData(prev => ({ ...prev, maxfiles: Number.parseInt(e.target.value) || 1 }))}
+                onChange={(v) => setFormData(prev => ({ ...prev, maxfiles: v }))}
+                fallback={1}
+                min={1}
                 inputProps={{ min: 1 }}
               />
             </Box>

--- a/frontend/src/app/(dashboard)/operations/backups/BackupJobsTabs.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/BackupJobsTabs.jsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from 'next-intl'
 
 import { getDateLocale } from '@/lib/i18n/date'
 import { useTenant } from '@/contexts/TenantContext'
+import NumericTextField from '@/components/ui/NumericTextField'
 import BackupSchedulePicker from './BackupSchedulePicker'
 
 import {
@@ -804,12 +805,14 @@ return '—'
                 value={formData.comment}
                 onChange={(e) => setFormData(prev => ({ ...prev, comment: e.target.value }))}
               />
-              <TextField
+              <NumericTextField
                 size="small"
                 label={t('backups.retention')}
                 type="number"
                 value={formData.maxfiles}
-                onChange={(e) => setFormData(prev => ({ ...prev, maxfiles: Number.parseInt(e.target.value) || 1 }))}
+                onChange={(v) => setFormData(prev => ({ ...prev, maxfiles: v }))}
+                fallback={1}
+                min={1}
                 inputProps={{ min: 1 }}
               />
               <TextField
@@ -1553,12 +1556,14 @@ function PbsJobsTab({ pbsConnections = [], isVdcTenant = false }) {
                   }
                   label={t('backups.ignoreVerified')}
                 />
-                <TextField
+                <NumericTextField
                   size="small"
                   label={t('backups.reVerifyAfter')}
                   type="number"
                   value={formData.outdatedAfter}
-                  onChange={(e) => setFormData(prev => ({ ...prev, outdatedAfter: Number.parseInt(e.target.value) || 30 }))}
+                  onChange={(v) => setFormData(prev => ({ ...prev, outdatedAfter: v }))}
+                  fallback={30}
+                  min={1}
                   inputProps={{ min: 1 }}
                 />
               </>
@@ -1570,44 +1575,54 @@ function PbsJobsTab({ pbsConnections = [], isVdcTenant = false }) {
                 <Divider />
                 <Typography variant="subtitle2" fontWeight={600}>{t('backups.retentionPolicy')}</Typography>
                 <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 2 }}>
-                  <TextField
+                  <NumericTextField
                     size="small"
                     label={t('backups.keepLast')}
                     type="number"
                     value={formData.keepLast}
-                    onChange={(e) => setFormData(prev => ({ ...prev, keepLast: Number.parseInt(e.target.value) || 0 }))}
+                    onChange={(v) => setFormData(prev => ({ ...prev, keepLast: v }))}
+                    fallback={0}
+                    min={0}
                     inputProps={{ min: 0 }}
                   />
-                  <TextField
+                  <NumericTextField
                     size="small"
                     label={t('backups.keepDaily')}
                     type="number"
                     value={formData.keepDaily}
-                    onChange={(e) => setFormData(prev => ({ ...prev, keepDaily: Number.parseInt(e.target.value) || 0 }))}
+                    onChange={(v) => setFormData(prev => ({ ...prev, keepDaily: v }))}
+                    fallback={0}
+                    min={0}
                     inputProps={{ min: 0 }}
                   />
-                  <TextField
+                  <NumericTextField
                     size="small"
                     label={t('backups.keepWeekly')}
                     type="number"
                     value={formData.keepWeekly}
-                    onChange={(e) => setFormData(prev => ({ ...prev, keepWeekly: Number.parseInt(e.target.value) || 0 }))}
+                    onChange={(v) => setFormData(prev => ({ ...prev, keepWeekly: v }))}
+                    fallback={0}
+                    min={0}
                     inputProps={{ min: 0 }}
                   />
-                  <TextField
+                  <NumericTextField
                     size="small"
                     label={t('backups.keepMonthly')}
                     type="number"
                     value={formData.keepMonthly}
-                    onChange={(e) => setFormData(prev => ({ ...prev, keepMonthly: Number.parseInt(e.target.value) || 0 }))}
+                    onChange={(v) => setFormData(prev => ({ ...prev, keepMonthly: v }))}
+                    fallback={0}
+                    min={0}
                     inputProps={{ min: 0 }}
                   />
-                  <TextField
+                  <NumericTextField
                     size="small"
                     label={t('backups.keepYearly')}
                     type="number"
                     value={formData.keepYearly}
-                    onChange={(e) => setFormData(prev => ({ ...prev, keepYearly: Number.parseInt(e.target.value) || 0 }))}
+                    onChange={(v) => setFormData(prev => ({ ...prev, keepYearly: v }))}
+                    fallback={0}
+                    min={0}
                     inputProps={{ min: 0 }}
                   />
                 </Box>

--- a/frontend/src/app/(dashboard)/operations/backups/BackupSchedulePicker.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/BackupSchedulePicker.jsx
@@ -33,6 +33,8 @@ import {
   Typography,
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
+
 const WEEKDAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
 
 // PVE accepts both `daily HH:MM` and bare `HH:MM` for the daily case.
@@ -225,16 +227,18 @@ export default function BackupSchedulePicker({ value, onChange, disabled = false
       )}
 
       {frequency === 'monthly' && (
-        <TextField
+        <NumericTextField
           size="small"
           type="number"
           label={t('backups.scheduleDayOfMonth')}
           value={dayOfMonth}
-          onChange={(e) => {
-            const v = Math.max(1, Math.min(31, Number.parseInt(e.target.value, 10) || 1))
+          onChange={(v) => {
             setDayOfMonth(v)
             emit({ dayOfMonth: v })
           }}
+          fallback={1}
+          min={1}
+          max={31}
           inputProps={{ min: 1, max: 31 }}
           disabled={disabled}
           sx={{ maxWidth: 200 }}

--- a/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
+++ b/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
@@ -37,6 +37,7 @@ import {
 } from '@mui/material'
 
 import { formatBytes } from '@/utils/format'
+import NumericTextField from '@/components/ui/NumericTextField'
 import dynamic from 'next/dynamic'
 
 const SankeyChart = dynamic(() => import('./SankeyChart'), { ssr: false })
@@ -1140,13 +1141,15 @@ export default function FlowsTab() {
             InputProps={{ sx: { fontFamily: 'monospace' } }}
             sx={{ mb: 2 }}
           />
-          <TextField
+          <NumericTextField
             fullWidth
             size="small"
             type="number"
             label="Sampling Rate"
             value={samplingRate}
-            onChange={(e) => setSamplingRate(Math.max(1, Number.parseInt(e.target.value) || 512))}
+            onChange={setSamplingRate}
+            fallback={512}
+            min={1}
             InputProps={{ sx: { fontFamily: 'monospace' } }}
           />
           <Box sx={{ mt: 1, p: 1.5, borderRadius: 1, bgcolor: 'action.hover' }}>

--- a/frontend/src/app/(dashboard)/security/compliance/page.tsx
+++ b/frontend/src/app/(dashboard)/security/compliance/page.tsx
@@ -14,6 +14,7 @@ import { usePageTitle } from '@/contexts/PageTitleContext'
 import EnterpriseGuard from '@/components/guards/EnterpriseGuard'
 import { Features } from '@/contexts/LicenseContext'
 import { CardsSkeleton, TableSkeleton } from '@/components/skeletons'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { usePVEConnections } from '@/hooks/useConnections'
 import {
   useHardeningChecks, useSecurityPolicies,
@@ -1045,11 +1046,13 @@ function PoliciesTab() {
               </Box>
               <Divider sx={{ mb: 2 }} />
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.minLength')}
                   value={form.password_min_length}
-                  onChange={(e) => handleChange('password_min_length', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('password_min_length', v)}
+                  fallback={0}
+                  max={128}
                   size="small"
                   inputProps={{ min: 1, max: 128 }}
                 />
@@ -1084,20 +1087,24 @@ function PoliciesTab() {
               </Box>
               <Divider sx={{ mb: 2 }} />
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.sessionTimeout')}
                   value={form.session_timeout_minutes}
-                  onChange={(e) => handleChange('session_timeout_minutes', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('session_timeout_minutes', v)}
+                  fallback={0}
+                  min={0}
                   size="small"
                   helperText={t('compliance.sessionTimeoutHelper')}
                   inputProps={{ min: 0 }}
                 />
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.maxConcurrentSessions')}
                   value={form.session_max_concurrent}
-                  onChange={(e) => handleChange('session_max_concurrent', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('session_max_concurrent', v)}
+                  fallback={0}
+                  min={0}
                   size="small"
                   helperText={t('compliance.maxConcurrentHelper')}
                   inputProps={{ min: 0 }}
@@ -1117,20 +1124,24 @@ function PoliciesTab() {
               </Box>
               <Divider sx={{ mb: 2 }} />
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.maxFailedAttempts')}
                   value={form.login_max_failed_attempts}
-                  onChange={(e) => handleChange('login_max_failed_attempts', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('login_max_failed_attempts', v)}
+                  fallback={0}
+                  min={0}
                   size="small"
                   helperText={t('compliance.maxFailedHelper')}
                   inputProps={{ min: 0 }}
                 />
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.lockoutDuration')}
                   value={form.login_lockout_duration_minutes}
-                  onChange={(e) => handleChange('login_lockout_duration_minutes', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('login_lockout_duration_minutes', v)}
+                  fallback={0}
+                  min={0}
                   size="small"
                   helperText={t('compliance.lockoutHelper')}
                   inputProps={{ min: 0 }}
@@ -1150,11 +1161,12 @@ function PoliciesTab() {
               </Box>
               <Divider sx={{ mb: 2 }} />
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <TextField
+                <NumericTextField
                   type="number"
                   label={t('compliance.retentionDays')}
                   value={form.audit_retention_days}
-                  onChange={(e) => handleChange('audit_retention_days', Number.parseInt(e.target.value) || 0)}
+                  onChange={(v) => handleChange('audit_retention_days', v)}
+                  fallback={0}
                   size="small"
                   helperText={t('compliance.retentionHelper')}
                   inputProps={{ min: 1 }}

--- a/frontend/src/components/MicrosegmentationTab.test.tsx
+++ b/frontend/src/components/MicrosegmentationTab.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Component tests for the custom gateway-offset field of MicrosegmentationTab
+ * (discussion #634).
+ *
+ * The offset used to be coerced with `Number.parseInt(v) || 1` inside onChange,
+ * so deleting the last digit wrote 1 straight back and the field could never be
+ * emptied. It is now buffered, with its 1..254 bound applied on blur.
+ *
+ * Committing a new offset re-runs the analysis fetch, because the offset is a
+ * dependency of loadAnalysis. The tab used to swap its whole subtree for a
+ * spinner while that request was in flight, which unmounted the config dialog
+ * and threw away the field mid-word: only the first digit ever landed. The
+ * spinner is now gated on there being no analysis yet, so a refetch leaves the
+ * dialog standing — hence the multi-digit test below, which is the one that
+ * would have failed before.
+ */
+
+import { beforeEach, describe, expect, it, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import MicrosegmentationTab from './MicrosegmentationTab'
+
+afterEach(cleanup)
+
+const CONNECTION_ID = 'conn-microseg'
+
+const ANALYSIS = {
+  networks: [
+    { name: 'vmbr0', cidr: '10.0.0.0/24', comment: '', gateway: '10.0.0.254', has_gateway: true, has_base_sg: true },
+  ],
+  gateway_aliases: ['gw_vmbr0'],
+  base_sgs: ['sg_vmbr0'],
+  missing_gateways: [],
+  missing_base_sgs: [],
+  total_vms: 2,
+  isolated_vms: 2,
+  unprotected_vms: 0,
+  segmentation_ready: true,
+}
+
+const VM_LIST = { vms: [], total_vms: 2, isolated_vms: 2, unprotected_vms: 0 }
+
+beforeEach(() => {
+  // The tab seeds its config from localStorage; start each test from a known
+  // state with 'custom' already selected so the offset field is enabled.
+  localStorage.setItem(`microseg-config-${CONNECTION_ID}`, JSON.stringify({
+    gatewayMode: 'custom',
+    customOffset: 254,
+    createGateways: true,
+    createBaseSGs: true,
+    excludePatterns: ['ceph'],
+    showExcluded: true,
+  }))
+
+  server.use(
+    http.get(`*/api/v1/firewall/microseg/${CONNECTION_ID}/analyze`, () => HttpResponse.json(ANALYSIS)),
+    http.get(`*/api/v1/firewall/microseg/${CONNECTION_ID}/vms`, () => HttpResponse.json(VM_LIST)),
+  )
+})
+
+const offset = () => screen.getByRole('spinbutton') as HTMLInputElement
+
+async function openConfigDialog() {
+  renderWithProviders(<MicrosegmentationTab connectionId={CONNECTION_ID} />)
+  await userEvent.click(await screen.findByRole('button', { name: 'Configuration' }))
+  await screen.findByText('Micro-segmentation Configuration')
+}
+
+describe('MicrosegmentationTab custom gateway offset', () => {
+  it('shows the offset held in the configuration', async () => {
+    await openConfigDialog()
+    expect(offset().value).toBe('254')
+    expect(offset()).not.toBeDisabled()
+  })
+
+  it('lets the offset be cleared without snapping back to 1', async () => {
+    await openConfigDialog()
+    await userEvent.clear(offset())
+    expect(offset().value).toBe('')
+  })
+
+  it('keeps every digit while the committed offset refetches the analysis', async () => {
+    await openConfigDialog()
+    await userEvent.clear(offset())
+    await userEvent.type(offset(), '10')
+
+    // Before the spinner was gated on `!analysis`, the first digit re-ran
+    // loadAnalysis, unmounted the dialog and left this reading '1'.
+    expect(offset().value).toBe('10')
+  })
+
+  it('commits the fallback of 1 when the offset is left empty', async () => {
+    await openConfigDialog()
+    await userEvent.clear(offset())
+    await userEvent.click(screen.getByText('Micro-segmentation Configuration'))
+    await waitFor(() => expect(offset().value).toBe('1'))
+  })
+})

--- a/frontend/src/components/MicrosegmentationTab.tsx
+++ b/frontend/src/components/MicrosegmentationTab.tsx
@@ -45,6 +45,7 @@ import {
   useTheme,
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
 import VMIsolationPanel from './VMIsolationPanel'
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -308,7 +309,12 @@ return config.excludePatterns.some(pattern =>
     })
   }
   
-  if (loading) {
+  // Only take over the whole tab while there is nothing to show yet. The gateway
+  // offset is a dependency of loadAnalysis, so committing a digit re-runs the
+  // fetch; swapping the subtree for a spinner on every refetch unmounted the
+  // config dialog and destroyed the field being typed into, which cost the user
+  // every keystroke after the first (discussion #634).
+  if (loading && !analysis) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
         <CircularProgress />
@@ -755,11 +761,14 @@ IN  DROP   -source net-dmz-k8s     # Bloquer VLAN entrant`}
                     label={
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                         <Typography variant="body2" sx={{ fontWeight: 500 }}>{t('microseg.configDialog.custom')}</Typography>
-                        <TextField
+                        <NumericTextField
                           size="small"
                           type="number"
                           value={config.customOffset}
-                          onChange={(e) => setConfig({ ...config, customOffset: Number.parseInt(e.target.value) || 1 })}
+                          onChange={(customOffset) => setConfig({ ...config, customOffset })}
+                          fallback={1}
+                          min={1}
+                          max={254}
                           disabled={config.gatewayMode !== 'custom'}
                           sx={{ width: 80 }}
                           inputProps={{ min: 1, max: 254 }}

--- a/frontend/src/components/RollingUpdateWizard.test.tsx
+++ b/frontend/src/components/RollingUpdateWizard.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Component tests for the three advanced numeric settings of
+ * RollingUpdateWizard (discussion #634).
+ *
+ * They used to be coerced with `Number.parseInt(v) || <default>` inside
+ * onChange, so deleting the last digit wrote the default straight back into the
+ * config object and the old digits stayed glued in front of the new ones. The
+ * fields are now buffered and clamp on blur, and the patch shape they write
+ * (a partial merge into the config) must be unchanged.
+ *
+ * The wizard is rendered with no nodes, which short-circuits the per-node
+ * network fetches; only the connection lookup is seeded.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import RollingUpdateWizard from './RollingUpdateWizard'
+
+afterEach(cleanup)
+
+async function renderWizard() {
+  server.use(
+    http.get('*/api/v1/connections/conn-1', () => HttpResponse.json({ data: { sshEnabled: true } })),
+  )
+
+  renderWithProviders(
+    <RollingUpdateWizard
+      open
+      onClose={vi.fn()}
+      connectionId="conn-1"
+      nodes={[]}
+      nodeUpdates={{}}
+    />,
+  )
+
+  // The three fields live behind the collapsed "Advanced options" panel.
+  await userEvent.click(screen.getByRole('button', { name: /Advanced options/ }))
+}
+
+const field = (label: string | RegExp) => screen.getByLabelText(label) as HTMLInputElement
+
+describe('RollingUpdateWizard advanced numeric settings', () => {
+  it('shows the default configuration values', async () => {
+    await renderWizard()
+    expect(field('Migration timeout (seconds)').value).toBe('600')
+    expect(field('Reboot timeout (seconds)').value).toBe('300')
+    expect(field('Minimum healthy nodes').value).toBe('2')
+  })
+
+  it('lets the migration timeout be cleared and retyped', async () => {
+    await renderWizard()
+    const input = field('Migration timeout (seconds)')
+
+    await userEvent.clear(input)
+    expect(input.value).toBe('')
+    await userEvent.type(input, '900')
+    expect(input.value).toBe('900')
+    // The sibling settings in the same config object are untouched.
+    expect(field('Reboot timeout (seconds)').value).toBe('300')
+    expect(field('Minimum healthy nodes').value).toBe('2')
+  })
+
+  it('commits the migration timeout fallback of 600 when left empty', async () => {
+    await renderWizard()
+    const input = field('Migration timeout (seconds)')
+
+    await userEvent.clear(input)
+    await userEvent.tab()
+    expect(input.value).toBe('600')
+  })
+
+  it('lets the reboot timeout be cleared and retyped', async () => {
+    await renderWizard()
+    const input = field('Reboot timeout (seconds)')
+
+    await userEvent.clear(input)
+    expect(input.value).toBe('')
+    await userEvent.type(input, '120')
+    expect(input.value).toBe('120')
+  })
+
+  it('commits the reboot timeout fallback of 300 when left empty', async () => {
+    await renderWizard()
+    const input = field('Reboot timeout (seconds)')
+
+    await userEvent.clear(input)
+    await userEvent.tab()
+    expect(input.value).toBe('300')
+  })
+
+  it('lets the minimum healthy nodes be cleared and retyped, then clamps on blur', async () => {
+    await renderWizard()
+    const input = field('Minimum healthy nodes')
+
+    await userEvent.clear(input)
+    expect(input.value).toBe('')
+    await userEvent.type(input, '99')
+    expect(input.value).toBe('99')
+    await userEvent.tab()
+    expect(input.value).toBe('10')
+  })
+
+  it('commits the minimum healthy nodes fallback of 2 when left empty', async () => {
+    await renderWizard()
+    const input = field('Minimum healthy nodes')
+
+    await userEvent.clear(input)
+    await userEvent.tab()
+    expect(input.value).toBe('2')
+  })
+})

--- a/frontend/src/components/RollingUpdateWizard.tsx
+++ b/frontend/src/components/RollingUpdateWizard.tsx
@@ -43,6 +43,9 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material'
+
+import NumericTextField from '@/components/ui/NumericTextField'
+
 // RemixIcon replacements for @mui/icons-material
 const CheckCircleIcon = (props: any) => <i className="ri-checkbox-circle-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
 const ErrorIcon = (props: any) => <i className="ri-error-warning-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
@@ -927,30 +930,39 @@ export default function RollingUpdateWizard({
                         />
                       </Box>
                       
-                      <TextField
+                      <NumericTextField
                         label={t('updates.migrationTimeout')}
                         type="number"
                         size="small"
                         value={config.migration_timeout}
-                        onChange={(e) => setConfig(c => ({ ...c, migration_timeout: Number.parseInt(e.target.value) || 600 }))}
+                        onChange={(migration_timeout) => setConfig(c => ({ ...c, migration_timeout }))}
+                        fallback={600}
+                        min={60}
+                        max={3600}
                         InputProps={{ inputProps: { min: 60, max: 3600 } }}
                       />
-                      
-                      <TextField
+
+                      <NumericTextField
                         label={t('updates.rebootTimeoutSeconds')}
                         type="number"
                         size="small"
                         value={config.reboot_timeout}
-                        onChange={(e) => setConfig(c => ({ ...c, reboot_timeout: Number.parseInt(e.target.value) || 300 }))}
+                        onChange={(reboot_timeout) => setConfig(c => ({ ...c, reboot_timeout }))}
+                        fallback={300}
+                        min={60}
+                        max={1800}
                         InputProps={{ inputProps: { min: 60, max: 1800 } }}
                       />
-                      
-                      <TextField
+
+                      <NumericTextField
                         label={t('updates.minHealthyNodes')}
                         type="number"
                         size="small"
                         value={config.min_healthy_nodes}
-                        onChange={(e) => setConfig(c => ({ ...c, min_healthy_nodes: Number.parseInt(e.target.value) || 2 }))}
+                        onChange={(min_healthy_nodes) => setConfig(c => ({ ...c, min_healthy_nodes }))}
+                        fallback={2}
+                        min={1}
+                        max={10}
                         InputProps={{ inputProps: { min: 1, max: 10 } }}
                         helperText={t('updates.minHealthyNodesHelper')}
                       />

--- a/frontend/src/components/VmConfigEditor.tsx
+++ b/frontend/src/components/VmConfigEditor.tsx
@@ -256,6 +256,29 @@ function SliderWithInput({
 /* Parse helpers                                                       */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Read a numeric setting out of the config for display, keeping a real 0.
+ *
+ * The old `config.shares || 1000` idiom laundered 0 into the default, which
+ * made the field impossible to set to 0: typing the digit fed 0 back through
+ * `||`, the value prop jumped to the default and SliderWithInput repainted the
+ * box with it (discussion #634).
+ *
+ * A plain `?? fallback` is not enough either. The GET route hands PVE's config
+ * through verbatim and `config` starts life as `{}`, so a field may be absent
+ * or a string — PVE reports `memory` as "current=8192,max=32768" on virtio-mem
+ * guests, and older releases stringify plain integers. Those must not reach
+ * SliderWithInput, whose Slider needs a number. So parse, and fall back only
+ * when there is genuinely no number to show. Display only: `config` itself is
+ * untouched, so handleSave still diffs the original value and writes nothing
+ * for a field the user never edited.
+ */
+function numOr(value: unknown, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''))
+
+  return Number.isFinite(n) ? n : fallback
+}
+
 function parseNetworkConfig(netStr: string): Partial<NetworkInfo> {
   // Format: "virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,firewall=1,tag=100"
   const parts = netStr.split(',')
@@ -623,7 +646,7 @@ return
               <Stack spacing={3}>
                 <SliderWithInput
                   label={t('vmConfig.cpuCores')}
-                  value={config.cores || 1}
+                  value={numOr(config.cores, 1)}
                   onChange={(val) => updateConfig('cores', val)}
                   min={1}
                   max={Math.min(maxCores, 128)}
@@ -632,7 +655,7 @@ return
                 
                 <SliderWithInput
                   label={t('vmConfig.sockets')}
-                  value={config.sockets || 1}
+                  value={numOr(config.sockets, 1)}
                   onChange={(val) => updateConfig('sockets', val)}
                   min={1}
                   max={4}
@@ -677,7 +700,7 @@ return
                 
                 <SliderWithInput
                   label={t('vmConfig.cpuLimit')}
-                  value={config.cpulimit || 0}
+                  value={numOr(config.cpulimit, 0)}
                   onChange={(val) => updateConfig('cpulimit', val)}
                   min={0}
                   max={(config.cores || 1) * (config.sockets || 1)}
@@ -687,7 +710,7 @@ return
                 
                 <SliderWithInput
                   label={t('vmConfig.cpuUnits')}
-                  value={config.cpuunits || 1024}
+                  value={numOr(config.cpuunits, 1024)}
                   onChange={(val) => updateConfig('cpuunits', val)}
                   min={2}
                   max={262144}
@@ -712,7 +735,7 @@ return
               <Stack spacing={3}>
                 <SliderWithInput
                   label={t('vmConfig.memoryRam')}
-                  value={config.memory || 512}
+                  value={numOr(config.memory, 512)}
                   onChange={(val) => updateConfig('memory', val)}
                   min={64}
                   max={Math.min(maxMemory, 512 * 1024)}
@@ -727,7 +750,7 @@ return
                 
                 <SliderWithInput
                   label={t('vmConfig.balloonMin')}
-                  value={config.balloon || 0}
+                  value={numOr(config.balloon, 0)}
                   onChange={(val) => updateConfig('balloon', val)}
                   min={0}
                   max={config.memory || 512}
@@ -744,7 +767,7 @@ return
                 
                 <SliderWithInput
                   label={t('vmConfig.memoryShares')}
-                  value={config.shares || 1000}
+                  value={numOr(config.shares, 1000)}
                   onChange={(val) => updateConfig('shares', val)}
                   min={0}
                   max={50000}

--- a/frontend/src/components/automation/site-recovery/BandwidthWindowsEditor.test.tsx
+++ b/frontend/src/components/automation/site-recovery/BandwidthWindowsEditor.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Component tests for the per-row rate field of BandwidthWindowsEditor
+ * (discussion #634).
+ *
+ * The rate used to be coerced with `Math.max(0, Number(v) || 0)` inside
+ * onChange, so deleting the last digit wrote 0 straight back and the old digit
+ * stayed glued in front of whatever was typed next. The field is now buffered
+ * and the bound applies on blur.
+ *
+ * Because the field lives inside a list, the tests also pin the two list-specific
+ * hazards: each input must stay bound to its own row index, and editing one row
+ * must not remount (and therefore wipe) a sibling row's input.
+ */
+
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { fireEvent, renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import type { BandwidthWindow } from '@/lib/orchestrator/site-recovery.types'
+
+import BandwidthWindowsEditor from './BandwidthWindowsEditor'
+
+afterEach(cleanup)
+
+function windowAt(rate: number, start = 8, end = 18): BandwidthWindow {
+  return { days: [1, 2, 3, 4, 5], start_hour: start, end_hour: end, rate_limit_mbps: rate }
+}
+
+function Harness({ initial }: { initial: BandwidthWindow[] }) {
+  const [value, setValue] = useState<BandwidthWindow[]>(initial)
+
+  return (
+    <>
+      <BandwidthWindowsEditor value={value} onChange={setValue} staticRateMbps={100} />
+      <span data-testid="windows">{JSON.stringify(value.map(w => w.rate_limit_mbps))}</span>
+      <button type="button">elsewhere</button>
+    </>
+  )
+}
+
+const rates = () => JSON.parse(screen.getByTestId('windows').textContent as string) as number[]
+const rateInputs = () => screen.getAllByRole('spinbutton') as HTMLInputElement[]
+const blur = () => userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+
+describe('BandwidthWindowsEditor rate field', () => {
+  it('shows the rate of each window', () => {
+    renderWithProviders(<Harness initial={[windowAt(50), windowAt(20)]} />)
+    expect(rateInputs().map(i => i.value)).toEqual(['50', '20'])
+  })
+
+  it('lets the rate be cleared without snapping back to 0', async () => {
+    renderWithProviders(<Harness initial={[windowAt(50)]} />)
+    await userEvent.clear(rateInputs()[0])
+    expect(rateInputs()[0].value).toBe('')
+    // The row still holds the last good number; only the display is empty.
+    expect(rates()).toEqual([50])
+  })
+
+  it('replaces the rate instead of gluing the old digit in front', async () => {
+    renderWithProviders(<Harness initial={[windowAt(50)]} />)
+    await userEvent.clear(rateInputs()[0])
+    await userEvent.type(rateInputs()[0], '10')
+    expect(rateInputs()[0].value).toBe('10')
+    expect(rates()).toEqual([10])
+  })
+
+  it('commits 0 (unlimited) when the rate is left empty', async () => {
+    renderWithProviders(<Harness initial={[windowAt(50)]} />)
+    await userEvent.clear(rateInputs()[0])
+    await blur()
+    expect(rateInputs()[0].value).toBe('0')
+    expect(rates()).toEqual([0])
+    expect(screen.getByText(/unlimited/)).toBeInTheDocument()
+  })
+
+  it('keeps each input bound to its own row and leaves siblings untouched', async () => {
+    renderWithProviders(<Harness initial={[windowAt(50), windowAt(20), windowAt(5)]} />)
+
+    await userEvent.clear(rateInputs()[1])
+    await userEvent.type(rateInputs()[1], '75')
+
+    expect(rates()).toEqual([50, 75, 5])
+    // Editing row 1 must not remount rows 0 and 2 (that would drop their buffer).
+    expect(rateInputs().map(i => i.value)).toEqual(['50', '75', '5'])
+  })
+
+  it('does not lose a half-typed buffer when a sibling row re-renders', async () => {
+    renderWithProviders(<Harness initial={[windowAt(50), windowAt(20)]} />)
+
+    // Empty row 0 without committing, then change row 1 through the DOM so the
+    // parent rebuilds the array while focus never leaves row 0. Row 0 must keep
+    // its empty buffer: a remount (bad keying) would repaint it with '50'.
+    await userEvent.clear(rateInputs()[0])
+    fireEvent.change(rateInputs()[1], { target: { value: '30' } })
+
+    expect(rateInputs()[0].value).toBe('')
+    expect(rates()).toEqual([50, 30])
+  })
+})

--- a/frontend/src/components/automation/site-recovery/BandwidthWindowsEditor.tsx
+++ b/frontend/src/components/automation/site-recovery/BandwidthWindowsEditor.tsx
@@ -2,9 +2,10 @@
 
 import { useTranslations } from 'next-intl'
 import {
-  Box, Button, IconButton, MenuItem, Select, Stack, TextField, Tooltip, Typography,
+  Box, Button, IconButton, MenuItem, Select, Stack, Tooltip, Typography,
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
 import type { BandwidthWindow } from '@/lib/orchestrator/site-recovery.types'
 
 interface Props {
@@ -131,11 +132,13 @@ export default function BandwidthWindowsEditor({ value, onChange, staticRateMbps
                   <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block' }}>
                     {t('siteRecovery.bandwidth.rate')}
                   </Typography>
-                  <TextField
+                  <NumericTextField
                     type='number'
                     size='small'
                     value={w.rate_limit_mbps}
-                    onChange={e => updateAt(idx, { rate_limit_mbps: Math.max(0, Number(e.target.value) || 0) })}
+                    onChange={rate_limit_mbps => updateAt(idx, { rate_limit_mbps })}
+                    fallback={0}
+                    min={0}
                     InputProps={{ endAdornment: <Typography variant='caption' sx={{ color: 'text.secondary' }}>Mbps</Typography> }}
                     fullWidth
                   />

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Component tests for CreateJobDialog's VMID-prefix field (discussion #634).
+ *
+ * The field is a sentinel-blank one: 0 means "no prefix" and must display as an
+ * empty box. It used to do that with `value={vmidPrefix || ''}` on the way in
+ * plus `Number(v) || 0` on the way out — a round trip that made the box
+ * impossible to correct, since the JSX rewrote whatever the parent recomputed.
+ * The blank now comes from `format`, so the buffer is the user's to edit.
+ *
+ * The dialog is rendered with no connections and no VMs: every fetch it owns is
+ * keyed off a selected cluster, so nothing hits the network here.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+
+import CreateJobDialog from './CreateJobDialog'
+
+afterEach(cleanup)
+
+function renderDialog() {
+  renderWithProviders(
+    <CreateJobDialog open onClose={vi.fn()} onSubmit={vi.fn()} connections={[]} allVMs={[]} />,
+  )
+}
+
+// No bandwidth window and no cluster selected, so the VMID prefix is the only
+// number input on the dialog.
+const prefix = () => screen.getByRole('spinbutton') as HTMLInputElement
+const blur = () => userEvent.click(screen.getByText('VMID Prefix'))
+
+describe('CreateJobDialog VMID prefix', () => {
+  it('renders blank rather than 0 when no prefix is set', () => {
+    renderDialog()
+    expect(prefix().value).toBe('')
+  })
+
+  it('accepts a typed prefix', async () => {
+    renderDialog()
+    await userEvent.type(prefix(), '9')
+    expect(prefix().value).toBe('9')
+  })
+
+  it('can be corrected without gluing the old digit in front', async () => {
+    renderDialog()
+    await userEvent.type(prefix(), '9')
+    await userEvent.clear(prefix())
+    expect(prefix().value).toBe('')
+    await userEvent.type(prefix(), '12')
+    expect(prefix().value).toBe('12')
+  })
+
+  it('falls back to blank (0) when left empty', async () => {
+    renderDialog()
+    await userEvent.type(prefix(), '9')
+    await userEvent.clear(prefix())
+    await blur()
+    expect(prefix().value).toBe('')
+  })
+})

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
@@ -15,6 +15,7 @@ import type { BandwidthWindow, CreateReplicationJobRequest } from '@/lib/orchest
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
+import NumericTextField from '@/components/ui/NumericTextField'
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -717,10 +718,12 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
           {/* VMID Prefix */}
           <Box>
             <Typography variant='subtitle2' sx={{ mb: 0.5 }}>{t('siteRecovery.createJob.vmidPrefix')}</Typography>
-            <TextField
+            <NumericTextField
               type='number'
-              value={vmidPrefix || ''}
-              onChange={e => setVmidPrefix(Number(e.target.value) || 0)}
+              value={vmidPrefix}
+              onChange={setVmidPrefix}
+              fallback={0}
+              format={n => (n === 0 ? '' : String(n))}
               size='small'
               fullWidth
               placeholder='0'

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Component tests for EditJobDialog's rate-limit field (discussion #634).
+ *
+ * The rate limit used to be coerced with `Math.max(0, Number(v) || 0)` inside
+ * onChange, so the field could never be emptied. It is now buffered, with the
+ * lower bound applied on blur, and the value it submits must follow what the
+ * user actually typed.
+ *
+ * The dialog renders standalone: it takes the job as a prop and its only child
+ * that talks to the network (none) means no fixtures are needed.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import type { ReplicationJob } from '@/lib/orchestrator/site-recovery.types'
+
+import EditJobDialog from './EditJobDialog'
+
+afterEach(cleanup)
+
+function job(overrides: Partial<ReplicationJob> = {}): ReplicationJob {
+  return {
+    id: 'job-1',
+    name: 'nightly',
+    vm_ids: [100],
+    vm_names: ['web-01'],
+    tags: [],
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    target_pool: 'rbd',
+    vmid_prefix: 0,
+    status: 'idle' as ReplicationJob['status'],
+    schedule: '',
+    schedule_spec: null,
+    timezone: 'UTC',
+    rpo_target: 900,
+    retry_count: 0,
+    throughput_bps: 0,
+    rate_limit_mbps: 200,
+    bandwidth_windows: [],
+    network_mapping: {},
+    progress_percent: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderDialog(overrides: Partial<ReplicationJob> = {}) {
+  const onSubmit = vi.fn().mockResolvedValue(undefined)
+
+  renderWithProviders(
+    <EditJobDialog open job={job(overrides)} onClose={vi.fn()} onSubmit={onSubmit} connections={[]} />,
+  )
+
+  return { onSubmit }
+}
+
+// The rate limit is the only spinbutton on the dialog while no bandwidth
+// window exists, so role alone identifies it.
+const rateLimit = () => screen.getAllByRole('spinbutton')[0] as HTMLInputElement
+const save = () => screen.getByRole('button', { name: 'Save changes' })
+
+describe('EditJobDialog rate limit', () => {
+  it('shows the job rate limit', () => {
+    renderDialog()
+    expect(rateLimit().value).toBe('200')
+  })
+
+  it('lets the rate limit be cleared without snapping back to 0', async () => {
+    renderDialog()
+    await userEvent.clear(rateLimit())
+    expect(rateLimit().value).toBe('')
+  })
+
+  it('submits the retyped rate limit, not the old digit glued in front', async () => {
+    const { onSubmit } = renderDialog()
+
+    await userEvent.clear(rateLimit())
+    await userEvent.type(rateLimit(), '50')
+    expect(rateLimit().value).toBe('50')
+
+    await userEvent.click(save())
+    expect(onSubmit).toHaveBeenCalledWith('job-1', expect.objectContaining({ rate_limit_mbps: 50 }))
+  })
+
+  it('commits the fallback of 0 when the rate limit is left empty', async () => {
+    const { onSubmit } = renderDialog()
+
+    await userEvent.clear(rateLimit())
+    await userEvent.click(save())
+    expect(rateLimit().value).toBe('0')
+    expect(onSubmit).toHaveBeenCalledWith('job-1', expect.objectContaining({ rate_limit_mbps: 0 }))
+  })
+})

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
@@ -9,6 +9,7 @@ import {
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
+import NumericTextField from '@/components/ui/NumericTextField'
 import type { BandwidthWindow, ReplicationJob, UpdateReplicationJobRequest } from '@/lib/orchestrator/site-recovery.types'
 
 interface Connection {
@@ -134,10 +135,12 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
             <Typography variant='subtitle2' sx={{ mb: 0.5 }}>
               {t('siteRecovery.createJob.rateLimit')}
             </Typography>
-            <TextField
+            <NumericTextField
               type='number' size='small' fullWidth
               value={rateLimit}
-              onChange={e => setRateLimit(Math.max(0, Number(e.target.value) || 0))}
+              onChange={setRateLimit}
+              fallback={0}
+              min={0}
               helperText={t('siteRecovery.editJob.rateLimitHelp')}
             />
           </Box>

--- a/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
+++ b/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * Component tests for FrequencyPicker's numeric hour fields (discussion #634).
+ *
+ * The three hourly-mode fields used to clamp inside onChange
+ * (`Math.max(1, Math.min(24, Number(v) || 1))`), which made them impossible to
+ * clear: deleting the last digit wrote the bound straight back into state. The
+ * clamp now lives on blur, so the tests drive a real parent and check both the
+ * intermediate (empty) display state and the committed spec.
+ */
+
+import { useState } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+
+import FrequencyPicker from './FrequencyPicker'
+import type { ScheduleSpec } from './types'
+
+afterEach(cleanup)
+
+function Harness({ initial }: { initial: ScheduleSpec }) {
+  const [value, setValue] = useState<ScheduleSpec>(initial)
+
+  return (
+    <>
+      <FrequencyPicker value={value} onChange={setValue} />
+      <span data-testid="spec">{JSON.stringify(value)}</span>
+      <button type="button">elsewhere</button>
+    </>
+  )
+}
+
+const hourly = (everyHours = 2): ScheduleSpec => ({ mode: 'hourly', everyHours })
+
+const spec = () => JSON.parse(screen.getByTestId('spec').textContent as string)
+const everyHours = () => screen.getByRole('spinbutton') as HTMLInputElement
+const hourField = (label: string) => screen.getByLabelText(label) as HTMLInputElement
+const blur = () => userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+
+// The hour window is opt-in; enabling it seeds windowStart=20 / windowEnd=6.
+async function enableWindow() {
+  await userEvent.click(screen.getByRole('checkbox'))
+}
+
+describe('FrequencyPicker numeric fields', () => {
+  it('shows the interval it is given', () => {
+    renderWithProviders(<Harness initial={hourly(6)} />)
+    expect(everyHours().value).toBe('6')
+  })
+
+  it('lets the interval be cleared without snapping back to 1', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await userEvent.clear(everyHours())
+    expect(everyHours().value).toBe('')
+    // The parent still owns the last good number; only the display is empty.
+    expect(spec().everyHours).toBe(2)
+  })
+
+  it('replaces the interval instead of gluing the old digit in front', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await userEvent.clear(everyHours())
+    await userEvent.type(everyHours(), '12')
+    expect(everyHours().value).toBe('12')
+    expect(spec().everyHours).toBe(12)
+  })
+
+  it('clamps the interval to 24 on blur, not while typing', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await userEvent.clear(everyHours())
+    await userEvent.type(everyHours(), '99')
+    expect(everyHours().value).toBe('99')
+    await blur()
+    expect(everyHours().value).toBe('24')
+    expect(spec().everyHours).toBe(24)
+  })
+
+  it('clamps the interval up to 1 on blur', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await userEvent.clear(everyHours())
+    await userEvent.type(everyHours(), '0')
+    await blur()
+    expect(spec().everyHours).toBe(1)
+  })
+
+  it('commits the fallback of 1 when the interval is left empty', async () => {
+    renderWithProviders(<Harness initial={hourly(6)} />)
+    await userEvent.clear(everyHours())
+    await blur()
+    expect(everyHours().value).toBe('1')
+    expect(spec().everyHours).toBe(1)
+  })
+
+  it('lets the start hour be cleared and retyped', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await enableWindow()
+    expect(hourField('Start hour').value).toBe('20')
+
+    await userEvent.clear(hourField('Start hour'))
+    expect(hourField('Start hour').value).toBe('')
+    expect(spec().windowStart).toBe(20)
+
+    await userEvent.type(hourField('Start hour'), '7')
+    expect(spec().windowStart).toBe(7)
+    // The sibling field must not have been disturbed.
+    expect(spec().windowEnd).toBe(6)
+  })
+
+  it('clamps the end hour to 23 on blur', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await enableWindow()
+    await userEvent.clear(hourField('End hour'))
+    await userEvent.type(hourField('End hour'), '48')
+    await blur()
+    expect(hourField('End hour').value).toBe('23')
+    expect(spec().windowEnd).toBe(23)
+  })
+
+  it('commits the fallback of 0 when an hour bound is left empty', async () => {
+    renderWithProviders(<Harness initial={hourly(2)} />)
+    await enableWindow()
+    await userEvent.clear(hourField('Start hour'))
+    await blur()
+    expect(hourField('Start hour').value).toBe('0')
+    expect(spec().windowStart).toBe(0)
+  })
+})

--- a/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.tsx
+++ b/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl'
 import {
   Box, Checkbox, FormControlLabel, IconButton, MenuItem, Select, Stack, Tab, Tabs, TextField, Typography
 } from '@mui/material'
+import NumericTextField from '@/components/ui/NumericTextField'
 import type { ScheduleSpec } from './types'
 
 interface Props {
@@ -43,11 +44,14 @@ export default function FrequencyPicker({ value, onChange, disabled }: Props) {
         <Stack spacing={1.5}>
           <Box>
             <Typography variant='caption'>{t('siteRecovery.schedule.everyNHours')}</Typography>
-            <TextField
+            <NumericTextField
               type='number' size='small' fullWidth
               inputProps={{ min: 1, max: 24 }}
               value={value.everyHours}
-              onChange={e => onChange({ ...value, everyHours: Math.max(1, Math.min(24, Number(e.target.value) || 1)) })}
+              onChange={everyHours => onChange({ ...value, everyHours })}
+              fallback={1}
+              min={1}
+              max={24}
               disabled={disabled}
             />
           </Box>
@@ -68,18 +72,24 @@ export default function FrequencyPicker({ value, onChange, disabled }: Props) {
           />
           {value.windowStart !== undefined && value.windowEnd !== undefined && (
             <Stack direction='row' spacing={1}>
-              <TextField
+              <NumericTextField
                 type='number' label={t('siteRecovery.schedule.startHour')} size='small'
                 inputProps={{ min: 0, max: 23 }}
                 value={value.windowStart}
-                onChange={e => onChange({ ...value, windowStart: Math.max(0, Math.min(23, Number(e.target.value))) })}
+                onChange={windowStart => onChange({ ...value, windowStart })}
+                fallback={0}
+                min={0}
+                max={23}
                 disabled={disabled}
               />
-              <TextField
+              <NumericTextField
                 type='number' label={t('siteRecovery.schedule.endHour')} size='small'
                 inputProps={{ min: 0, max: 23 }}
                 value={value.windowEnd}
-                onChange={e => onChange({ ...value, windowEnd: Math.max(0, Math.min(23, Number(e.target.value))) })}
+                onChange={windowEnd => onChange({ ...value, windowEnd })}
+                fallback={0}
+                min={0}
+                max={23}
                 disabled={disabled}
               />
             </Stack>

--- a/frontend/src/components/hardware/AddDiskDialog.test.tsx
+++ b/frontend/src/components/hardware/AddDiskDialog.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Component tests for AddDiskDialog.tsx — numeric fields must be clearable.
+ *
+ * Focus: the two fields converted to NumericTextField (discussion #634).
+ *   - "Disk size (GiB)" (fallback 1, min 1) — same defect class as the LXC
+ *     root-disk field that was reported: with `parseInt(v) || 1` the field
+ *     could never be emptied, so typing 20 over 32 produced 320.
+ *   - the unlabeled bus-index field next to Bus/Device (fallback 0, min 0/max 30).
+ *
+ * The dialog fetches storages on open; MSW seeds that one endpoint, and the
+ * first returned storage is auto-selected, which is what enables Add.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  userEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { AddDiskDialog } from './AddDiskDialog'
+
+const CONN_ID = 'conn-1'
+const NODE_NAME = 'pve1'
+
+const diskStorages = [
+  {
+    storage: 'local',
+    content: 'rootdir,images,vztmpl',
+    type: 'dir',
+    avail: 50 * 1024 * 1024 * 1024,
+    total: 100 * 1024 * 1024 * 1024,
+  },
+]
+
+function seedHandlers() {
+  server.use(
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storages`, () =>
+      HttpResponse.json({ data: diskStorages }),
+    ),
+  )
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    connId: CONN_ID,
+    node: NODE_NAME,
+    vmid: '100',
+    existingDisks: [] as string[],
+    ...overrides,
+  }
+}
+
+const sizeField = () => screen.getByLabelText('Disk size (GiB)') as HTMLInputElement
+
+// The bus-index field carries no label. Both numeric inputs are type="number",
+// so they expose the spinbutton role; bus index comes first in the DOM.
+const busIndexField = () => screen.getAllByRole('spinbutton')[0] as HTMLInputElement
+
+const addButton = () => screen.getByRole('button', { name: 'Add' })
+
+describe('AddDiskDialog — clearable numeric fields', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    seedHandlers()
+  })
+
+  it('shows the default disk size', () => {
+    renderWithProviders(<AddDiskDialog {...makeProps()} />)
+    expect(sizeField().value).toBe('32')
+  })
+
+  it('replaces the disk size instead of gluing the old digits in front (discussion #634)', async () => {
+    renderWithProviders(<AddDiskDialog {...makeProps()} />)
+
+    await userEvent.clear(sizeField())
+    expect(sizeField().value).toBe('')
+
+    await userEvent.type(sizeField(), '20')
+    expect(sizeField().value).toBe('20')
+  })
+
+  it('commits the fallback size when the field is left empty', async () => {
+    renderWithProviders(<AddDiskDialog {...makeProps()} />)
+
+    await userEvent.clear(sizeField())
+    await userEvent.tab()
+    expect(sizeField().value).toBe('1')
+  })
+
+  it('clamps a below-minimum disk size on blur', async () => {
+    renderWithProviders(<AddDiskDialog {...makeProps()} />)
+
+    await userEvent.clear(sizeField())
+    await userEvent.type(sizeField(), '0')
+    await userEvent.tab()
+    expect(sizeField().value).toBe('1')
+  })
+
+  it('lets the bus index be emptied and falls back to 0 on blur', async () => {
+    renderWithProviders(<AddDiskDialog {...makeProps()} />)
+
+    await userEvent.clear(busIndexField())
+    expect(busIndexField().value).toBe('')
+
+    await userEvent.tab()
+    expect(busIndexField().value).toBe('0')
+  })
+
+  it('saves the retyped bus index and disk size', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<AddDiskDialog {...props} />)
+
+    // Add stays disabled until the storages fetch auto-selects the first storage.
+    await waitFor(() => expect(addButton()).not.toBeDisabled())
+
+    await userEvent.clear(busIndexField())
+    await userEvent.type(busIndexField(), '2')
+    await userEvent.clear(sizeField())
+    await userEvent.type(sizeField(), '20')
+
+    await userEvent.click(addButton())
+
+    await waitFor(() => expect(props.onSave).toHaveBeenCalledWith({ scsi2: 'local:20' }))
+  })
+})

--- a/frontend/src/components/hardware/AddDiskDialog.tsx
+++ b/frontend/src/components/hardware/AddDiskDialog.tsx
@@ -28,6 +28,7 @@ import {
 
 import { formatBytes } from '@/utils/format'
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 import type { Storage } from './utils'
 
 // ==================== ADD DISK DIALOG ====================
@@ -376,11 +377,14 @@ return match ? Number.parseInt(match[1]) : -1
                   <MenuItem value="ide">IDE</MenuItem>
                 </Select>
               </FormControl>
-              <TextField
+              <NumericTextField
                 size="small"
                 type="number"
                 value={busIndex}
-                onChange={(e) => setBusIndex(Number.parseInt(e.target.value) || 0)}
+                onChange={setBusIndex}
+                fallback={0}
+                min={0}
+                max={30}
                 sx={{ width: 80 }}
                 inputProps={{ min: 0, max: 30 }}
               />
@@ -466,12 +470,14 @@ return match ? Number.parseInt(match[1]) : -1
             {deviceType === 'disk' && <>
             {/* Disk Size & Format */}
             <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-              <TextField
+              <NumericTextField
                 size="small"
                 label="Disk size (GiB)"
                 type="number"
                 value={diskSize}
-                onChange={(e) => setDiskSize(Number.parseInt(e.target.value) || 1)}
+                onChange={setDiskSize}
+                fallback={1}
+                min={1}
                 inputProps={{ min: 1 }}
               />
               <FormControl fullWidth size="small">

--- a/frontend/src/components/hardware/AddOtherHardwareDialog.test.tsx
+++ b/frontend/src/components/hardware/AddOtherHardwareDialog.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Component tests for AddOtherHardwareDialog.tsx — clearable RNG fields.
+ *
+ * The dialog opens on the USB type, so each test switches the Type select to
+ * VirtIO RNG to reach the two converted fields. MSW seeds the storages and USB
+ * device endpoints the dialog fires on open (unhandled requests error loudly).
+ *
+ * Both fields keep fallback 0 on purpose: the payload builder omits
+ * max_bytes / period when they are 0, which is what the old `Number('')`
+ * coercion already committed on an empty field.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  userEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { AddOtherHardwareDialog } from './AddOtherHardwareDialog'
+
+const CONN_ID = 'conn-1'
+const NODE_NAME = 'pve1'
+
+function seedHandlers() {
+  server.use(
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storages`, () =>
+      HttpResponse.json({ data: [] }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/hardware/usb`, () =>
+      HttpResponse.json({ data: [] }),
+    ),
+  )
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    connId: CONN_ID,
+    node: NODE_NAME,
+    vmid: '100',
+    existingHardware: [] as string[],
+    ...overrides,
+  }
+}
+
+/**
+ * Switch the hardware Type select to VirtIO RNG.
+ * MUI Select aria naming does not resolve under jsdom, so the Type select is
+ * reached by position: it is the first combobox in the dialog.
+ */
+async function selectRngType() {
+  fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+  fireEvent.click(await screen.findByRole('option', { name: /VirtIO RNG/i }))
+}
+
+const maxBytesField = () => screen.getByLabelText('Max Bytes per Period') as HTMLInputElement
+const periodField = () => screen.getByLabelText('Period (ms)') as HTMLInputElement
+
+describe('AddOtherHardwareDialog — clearable RNG fields', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    seedHandlers()
+  })
+
+  it('shows the RNG defaults once the RNG type is selected', async () => {
+    renderWithProviders(<AddOtherHardwareDialog {...makeProps()} />)
+    await selectRngType()
+
+    expect(maxBytesField().value).toBe('1024')
+    expect(periodField().value).toBe('1000')
+  })
+
+  it('replaces max bytes instead of gluing the old digits in front', async () => {
+    renderWithProviders(<AddOtherHardwareDialog {...makeProps()} />)
+    await selectRngType()
+
+    await userEvent.clear(maxBytesField())
+    expect(maxBytesField().value).toBe('')
+
+    await userEvent.type(maxBytesField(), '2048')
+    expect(maxBytesField().value).toBe('2048')
+  })
+
+  it('replaces the period instead of gluing the old digits in front', async () => {
+    renderWithProviders(<AddOtherHardwareDialog {...makeProps()} />)
+    await selectRngType()
+
+    await userEvent.clear(periodField())
+    await userEvent.type(periodField(), '500')
+    expect(periodField().value).toBe('500')
+  })
+
+  it('adds the RNG device with the retyped values', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<AddOtherHardwareDialog {...props} />)
+    await selectRngType()
+
+    await userEvent.clear(maxBytesField())
+    await userEvent.type(maxBytesField(), '2048')
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    expect(props.onSave).toHaveBeenCalledWith({
+      rng0: 'source=/dev/urandom,max_bytes=2048,period=1000',
+    })
+  })
+
+  it('falls back to 0 on blur, which drops the limit from the payload', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<AddOtherHardwareDialog {...props} />)
+    await selectRngType()
+
+    await userEvent.clear(periodField())
+    await userEvent.tab()
+    expect(periodField().value).toBe('0')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(props.onSave).toHaveBeenCalledWith({
+      rng0: 'source=/dev/urandom,max_bytes=1024',
+    })
+  })
+})

--- a/frontend/src/components/hardware/AddOtherHardwareDialog.tsx
+++ b/frontend/src/components/hardware/AddOtherHardwareDialog.tsx
@@ -24,6 +24,7 @@ import {
 
 import { formatBytes } from '@/utils/format'
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 import type { Storage } from './utils'
 
 type HardwareType = 'usb' | 'pci' | 'serial' | 'cloudinit' | 'audio' | 'rng'
@@ -458,22 +459,24 @@ export function AddOtherHardwareDialog({
                 onChange={e => setRngSource(e.target.value)}
                 helperText="/dev/urandom (default) or /dev/random (blocking)"
               />
-              <TextField
+              <NumericTextField
                 fullWidth
                 size="small"
                 label="Max Bytes per Period"
                 type="number"
                 value={rngMaxBytes}
-                onChange={e => setRngMaxBytes(Number(e.target.value))}
+                onChange={setRngMaxBytes}
+                fallback={0}
                 helperText="Maximum bytes of entropy injected per period (0 = unlimited)"
               />
-              <TextField
+              <NumericTextField
                 fullWidth
                 size="small"
                 label="Period (ms)"
                 type="number"
                 value={rngPeriod}
-                onChange={e => setRngPeriod(Number(e.target.value))}
+                onChange={setRngPeriod}
+                fallback={0}
                 helperText="Time interval in milliseconds for rate-limiting entropy"
               />
               <Alert severity="info" sx={{ fontSize: 13 }}>

--- a/frontend/src/components/hardware/EditDiskDialog.test.tsx
+++ b/frontend/src/components/hardware/EditDiskDialog.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Component tests for EditDiskDialog.tsx — clearable bus-index field.
+ *
+ * Only the unused-disk branch is exercised: that is where the converted
+ * numeric field lives (the reassign bus slot, fallback 0 / min 0 / max 30).
+ * Passing an unused disk and no connId/node keeps the dialog offline — the
+ * storage and ISO fetches are all guarded on isCdrom / connId / node.
+ *
+ * The Options and Bandwidth tabs of the regular-disk branch keep raw string
+ * state and were deliberately left untouched, so they are not covered here.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+} from '@/__tests__/setup/renderWithProviders'
+
+import { EditDiskDialog } from './EditDiskDialog'
+
+const unusedDisk = {
+  id: 'unused0',
+  size: '8G',
+  storage: 'local',
+  isUnused: true,
+  rawValue: 'local:vm-100-disk-1',
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    disk: unusedDisk,
+    ...overrides,
+  }
+}
+
+// The reassign index is the only numeric input in the unused-disk branch.
+const indexField = () => screen.getByRole('spinbutton') as HTMLInputElement
+
+describe('EditDiskDialog — clearable reassign index', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  it('replaces the index instead of gluing the old digit in front', async () => {
+    renderWithProviders(<EditDiskDialog {...makeProps()} />)
+    expect(indexField().value).toBe('0')
+
+    await userEvent.clear(indexField())
+    expect(indexField().value).toBe('')
+
+    await userEvent.type(indexField(), '3')
+    expect(indexField().value).toBe('3')
+
+    // The preview caption proves the number reached the parent state.
+    expect(screen.getByText(/scsi3/)).toBeInTheDocument()
+  })
+
+  it('commits the fallback index when the field is left empty', async () => {
+    renderWithProviders(<EditDiskDialog {...makeProps()} />)
+
+    await userEvent.clear(indexField())
+    await userEvent.tab()
+    expect(indexField().value).toBe('0')
+    expect(screen.getByText(/scsi0/)).toBeInTheDocument()
+  })
+
+  it('reassigns to the retyped bus slot', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<EditDiskDialog {...props} />)
+
+    await userEvent.clear(indexField())
+    await userEvent.type(indexField(), '5')
+    await userEvent.click(screen.getByRole('button', { name: 'Reassign' }))
+
+    expect(props.onSave).toHaveBeenCalledWith({ scsi5: unusedDisk.rawValue })
+  })
+})

--- a/frontend/src/components/hardware/EditDiskDialog.tsx
+++ b/frontend/src/components/hardware/EditDiskDialog.tsx
@@ -31,6 +31,7 @@ import {
 
 import { formatBytes } from '@/utils/format'
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { DetachConfirmDialog } from './DetachConfirmDialog'
 
 // Storage types that support multiple disk image formats (file-based storages)
@@ -660,11 +661,14 @@ return
                 <MenuItem value="ide">IDE</MenuItem>
               </Select>
             </FormControl>
-            <TextField
+            <NumericTextField
               size="small"
               type="number"
               value={reassignIndex}
-              onChange={(e) => setReassignIndex(Number.parseInt(e.target.value) || 0)}
+              onChange={setReassignIndex}
+              fallback={0}
+              min={0}
+              max={30}
               sx={{ width: 80 }}
               inputProps={{ min: 0, max: 30 }}
             />

--- a/frontend/src/components/hardware/EditOtherHardwareDialog.test.tsx
+++ b/frontend/src/components/hardware/EditOtherHardwareDialog.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Component tests for EditOtherHardwareDialog.tsx — clearable RNG fields.
+ *
+ * A VirtIO RNG item is passed straight in, so the RNG branch renders with no
+ * network at all (only the pci/usb branches fetch host devices).
+ *
+ * Both fields keep fallback 0 on purpose: 0 is a meaningful value here — the
+ * payload builder omits max_bytes / period when they are 0, which is exactly
+ * what the old `Number('') === 0` coercion committed.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+} from '@/__tests__/setup/renderWithProviders'
+
+import { EditOtherHardwareDialog, type OtherHardwareItem } from './EditOtherHardwareDialog'
+
+const rngHardware: OtherHardwareItem = {
+  id: 'rng0',
+  type: 'rng',
+  rawValue: 'source=/dev/urandom,max_bytes=1024,period=1000',
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(undefined),
+    onDelete: vi.fn().mockResolvedValue(undefined),
+    connId: 'conn-1',
+    node: 'pve1',
+    hardware: rngHardware,
+    ...overrides,
+  }
+}
+
+const maxBytesField = () => screen.getByLabelText('Max Bytes per Period') as HTMLInputElement
+const periodField = () => screen.getByLabelText('Period (ms)') as HTMLInputElement
+
+describe('EditOtherHardwareDialog — clearable RNG fields', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  it('seeds both fields from the raw config value', () => {
+    renderWithProviders(<EditOtherHardwareDialog {...makeProps()} />)
+    expect(maxBytesField().value).toBe('1024')
+    expect(periodField().value).toBe('1000')
+  })
+
+  it('replaces max bytes instead of gluing the old digits in front', async () => {
+    renderWithProviders(<EditOtherHardwareDialog {...makeProps()} />)
+
+    await userEvent.clear(maxBytesField())
+    expect(maxBytesField().value).toBe('')
+
+    await userEvent.type(maxBytesField(), '2048')
+    expect(maxBytesField().value).toBe('2048')
+  })
+
+  it('replaces the period instead of gluing the old digits in front', async () => {
+    renderWithProviders(<EditOtherHardwareDialog {...makeProps()} />)
+
+    await userEvent.clear(periodField())
+    await userEvent.type(periodField(), '500')
+    expect(periodField().value).toBe('500')
+  })
+
+  it('saves the retyped values', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<EditOtherHardwareDialog {...props} />)
+
+    await userEvent.clear(maxBytesField())
+    await userEvent.type(maxBytesField(), '2048')
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(props.onSave).toHaveBeenCalledWith({
+      rng0: 'source=/dev/urandom,max_bytes=2048,period=1000',
+    })
+  })
+
+  it('falls back to 0 on blur, which drops the limit from the payload', async () => {
+    const props = makeProps()
+
+    renderWithProviders(<EditOtherHardwareDialog {...props} />)
+
+    await userEvent.clear(maxBytesField())
+    await userEvent.tab()
+    expect(maxBytesField().value).toBe('0')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(props.onSave).toHaveBeenCalledWith({
+      rng0: 'source=/dev/urandom,period=1000',
+    })
+  })
+})

--- a/frontend/src/components/hardware/EditOtherHardwareDialog.tsx
+++ b/frontend/src/components/hardware/EditOtherHardwareDialog.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/material'
 
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import NumericTextField from '@/components/ui/NumericTextField'
 
 export type OtherHardwareItem = {
   id: string
@@ -386,22 +387,24 @@ export function EditOtherHardwareDialog({
                   onChange={e => setRngSource(e.target.value)}
                   helperText={t('hardware.rngSourceHelper')}
                 />
-                <TextField
+                <NumericTextField
                   fullWidth
                   size="small"
                   label={t('hardware.rngMaxBytes')}
                   type="number"
                   value={rngMaxBytes}
-                  onChange={e => setRngMaxBytes(Number(e.target.value))}
+                  onChange={setRngMaxBytes}
+                  fallback={0}
                   helperText={t('hardware.rngMaxBytesHelper')}
                 />
-                <TextField
+                <NumericTextField
                   fullWidth
                   size="small"
                   label={t('hardware.rngPeriod')}
                   type="number"
                   value={rngPeriod}
-                  onChange={e => setRngPeriod(Number(e.target.value))}
+                  onChange={setRngPeriod}
+                  fallback={0}
                   helperText={t('hardware.rngPeriodHelper')}
                 />
               </Stack>

--- a/frontend/src/components/settings/AlertThresholdsTab.jsx
+++ b/frontend/src/components/settings/AlertThresholdsTab.jsx
@@ -13,9 +13,10 @@ import {
   Slider,
   Snackbar,
   Switch,
-  TextField,
   Typography,
 } from '@mui/material'
+
+import NumericTextField from '@/components/ui/NumericTextField'
 
 const DEFAULTS = {
   cpu_warning: 80,
@@ -157,11 +158,17 @@ export default function AlertThresholdsTab() {
             <Typography variant='caption' color='text.secondary'>{t('alerts.snapshotAgeDesc')}</Typography>
             {thresholds.snapshot_max_age_days > 0 ? (
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 2 }}>
-                <TextField
+                {/* The Math.max stays on the commit: this whole field is only
+                    rendered while snapshot_max_age_days > 0, so writing a 0
+                    mid-keystroke would unmount the input under the cursor and
+                    flip the Switch off. min={1} still clamps on blur. */}
+                <NumericTextField
                   type='number'
                   size='small'
                   value={thresholds.snapshot_max_age_days}
-                  onChange={(e) => setThresholds(th => ({ ...th, snapshot_max_age_days: Math.max(1, Number.parseInt(e.target.value) || 1) }))}
+                  onChange={(days) => setThresholds(th => ({ ...th, snapshot_max_age_days: Math.max(1, days) }))}
+                  fallback={1}
+                  min={1}
                   slotProps={{ htmlInput: { min: 1, max: 365 } }}
                   sx={{ width: 80 }}
                 />

--- a/frontend/src/components/settings/ConnectionDialog.tsx
+++ b/frontend/src/components/settings/ConnectionDialog.tsx
@@ -39,6 +39,7 @@ import {
 
 import { COUNTRIES, findCountry } from '@/lib/utils/countries'
 import { CountryFlag } from '@/components/ui/CountryFlag'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { useTenant } from '@/contexts/TenantContext'
 import { useCopyToClipboard } from '@/lib/clipboard'
 
@@ -986,11 +987,14 @@ export default function ConnectionDialog({
         <Collapse in={form.sshEnabled}>
           <Box sx={{ mt: 2, pl: 2, borderLeft: '2px solid', borderColor: 'divider' }}>
             <Box sx={{ display: 'flex', gap: 2 }}>
-              <TextField
+              <NumericTextField
                 label={t('settings.sshPort')}
                 type="number"
                 value={form.sshPort}
-                onChange={e => handleChange('sshPort', Number.parseInt(e.target.value) || 22)}
+                onChange={port => handleChange('sshPort', port)}
+                fallback={22}
+                min={1}
+                max={65535}
                 sx={{ width: 120 }}
                 InputProps={{
                   inputProps: { min: 1, max: 65535 }

--- a/frontend/src/components/settings/NotificationsTab.jsx
+++ b/frontend/src/components/settings/NotificationsTab.jsx
@@ -26,6 +26,8 @@ import {
   Typography
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
+
 async function fetchJson(url, init) {
   const r = await fetch(url, init)
   const text = await r.text()
@@ -288,15 +290,18 @@ return
               }}
             />
 
-            <TextField
+            {/* ?? and not ||: with || a committed 0 is laundered back to 587 on
+                the way in, and the field snaps to 587 under the cursor. */}
+            <NumericTextField
               fullWidth
               type='number'
               label={t('notifications.smtp.port')}
-              value={settings.email?.smtp_port || 587}
-              onChange={e => setSettings(s => ({
+              value={settings.email?.smtp_port ?? 587}
+              onChange={port => setSettings(s => ({
                 ...s,
-                email: { ...s.email, smtp_port: Number.parseInt(e.target.value) || 587 }
+                email: { ...s.email, smtp_port: port }
               }))}
+              fallback={587}
               helperText={t('notifications.smtp.portHelper')}
             />
 
@@ -610,12 +615,15 @@ return
               </Select>
             </FormControl>
 
-            <TextField
+            {/* ?? and not ||: see the SMTP port field — || would launder a
+                committed 0 back to 100 while the user is still typing. */}
+            <NumericTextField
               fullWidth
               type='number'
               label={t('notifications.rateLimit')}
-              value={settings.rate_limit_per_hour || 100}
-              onChange={e => setSettings(s => ({ ...s, rate_limit_per_hour: Number.parseInt(e.target.value) || 100 }))}
+              value={settings.rate_limit_per_hour ?? 100}
+              onChange={limit => setSettings(s => ({ ...s, rate_limit_per_hour: limit }))}
+              fallback={100}
               InputProps={{
                 endAdornment: <InputAdornment position='end'>emails/h</InputAdornment>
               }}

--- a/frontend/src/components/settings/green/DatacenterDialog.tsx
+++ b/frontend/src/components/settings/green/DatacenterDialog.tsx
@@ -8,6 +8,7 @@ import {
   Stack, TextField, MenuItem, FormControlLabel, Switch, Box, Typography, Alert,
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
 import DatacenterAssignmentTree, { type AssignmentState } from './DatacenterAssignmentTree'
 
 export interface DatacenterValues {
@@ -247,22 +248,28 @@ export default function DatacenterDialog({ open, initial, onClose, onSaved }: Pr
             <Typography variant="overline" color="text.secondary">{t('settings.green.dc.energySection')}</Typography>
           </Box>
           <Stack direction="row" spacing={2}>
-            <TextField
+            <NumericTextField
               label={t('settings.green.dc.pue')}
               type="number"
               value={form.pue}
-              onChange={e => setForm(s => ({ ...s, pue: Number(e.target.value) }))}
+              onChange={pue => setForm(s => ({ ...s, pue }))}
+              fallback={1}
+              min={1}
+              parse={Number.parseFloat}
               size="small"
               fullWidth
               required
               inputProps={{ step: 0.01, min: 1.0, max: 3.0 }}
               helperText="1.0 = perfect; typical 1.2–1.6"
             />
-            <TextField
+            <NumericTextField
               label={t('settings.green.dc.electricityPrice')}
               type="number"
               value={form.electricityPrice}
-              onChange={e => setForm(s => ({ ...s, electricityPrice: Number(e.target.value) }))}
+              onChange={electricityPrice => setForm(s => ({ ...s, electricityPrice }))}
+              fallback={0}
+              min={0}
+              parse={Number.parseFloat}
               size="small"
               fullWidth
               required
@@ -299,15 +306,18 @@ export default function DatacenterDialog({ open, initial, onClose, onSaved }: Pr
                 </MenuItem>
               ))}
             </TextField>
-            <TextField
+            <NumericTextField
               label={t('settings.green.dc.co2Factor')}
               type="number"
               value={form.co2Factor}
-              onChange={e => setForm(s => ({
+              onChange={co2Factor => setForm(s => ({
                 ...s,
-                co2Factor: Number(e.target.value),
+                co2Factor,
                 co2CountryPreset: 'custom',
               }))}
+              fallback={0}
+              min={0}
+              parse={Number.parseFloat}
               size="small"
               fullWidth
               required

--- a/frontend/src/components/templates/CreateBlueprintDialog.tsx
+++ b/frontend/src/components/templates/CreateBlueprintDialog.tsx
@@ -29,6 +29,7 @@ import type { CatalogImage } from '@/lib/templates/blueprintImages'
 import { splitCatalogImages, hasMeaningfulCloudInit } from '@/lib/templates/blueprintImages'
 import { buildDeployIpconfig0, parseIpconfig0 } from '@/lib/templates/deployIpconfig'
 import type { NetworkOption } from '@/lib/templates/networkOptions'
+import NumericTextField from '@/components/ui/NumericTextField'
 import { useToast } from '@/contexts/ToastContext'
 import { useTenant } from '@/contexts/TenantContext'
 import VendorLogo from './VendorLogo'
@@ -249,7 +250,14 @@ export default function CreateBlueprintDialog({ open, onClose, blueprint }: Crea
   }, [name, description, imageSlug, hardware, cloudInit, tags, isPublic, blueprint, onClose, showToast, t, useDhcp, ipCidrValid])
 
   // Disk size as integer GB
-  const diskGb = Number.parseInt(hardware.diskSize) || 20
+  const parsedDiskGb = Number.parseInt(hardware.diskSize)
+  const diskGb = parsedDiskGb || 20
+  // The manual input needs the parsed size without that `|| 20`: a committed
+  // '0G' would otherwise bounce back as 20 and the sync effect would rewrite
+  // the buffer mid-keystroke ('0' → '20' → '208' on the next keypress). Only
+  // an unparseable size (malformed blueprint JSON) falls back, and to the
+  // same 1 the field commits on blur.
+  const diskGbInput = Number.isNaN(parsedDiskGb) ? 1 : parsedDiskGb
 
   return (
     <Dialog open={open} onClose={() => onClose()} maxWidth="sm" fullWidth>
@@ -336,11 +344,14 @@ export default function CreateBlueprintDialog({ open, onClose, blueprint }: Crea
                   onChange={(_, v) => setHardware(h => ({ ...h, cores: v as number }))}
                   sx={{ flex: 1 }}
                 />
-                <TextField
+                <NumericTextField
                   type="number"
                   size="small"
                   value={hardware.cores}
-                  onChange={e => setHardware(h => ({ ...h, cores: Number.parseInt(e.target.value) || 1 }))}
+                  onChange={n => setHardware(h => ({ ...h, cores: n }))}
+                  fallback={1}
+                  min={1}
+                  max={128}
                   sx={{ width: 92 }}
                   slotProps={{ htmlInput: { min: 1, max: 128 } }}
                 />
@@ -364,11 +375,13 @@ export default function CreateBlueprintDialog({ open, onClose, blueprint }: Crea
                   valueLabelFormat={(v) => `${v / 1024} GB`}
                   sx={{ flex: 1 }}
                 />
-                <TextField
+                <NumericTextField
                   type="number"
                   size="small"
                   value={hardware.memory}
-                  onChange={e => setHardware(h => ({ ...h, memory: Number.parseInt(e.target.value) || 128 }))}
+                  onChange={n => setHardware(h => ({ ...h, memory: n }))}
+                  fallback={128}
+                  min={128}
                   sx={{ width: 92 }}
                   helperText="MB"
                   slotProps={{ htmlInput: { min: 128, step: 256 } }}
@@ -391,14 +404,13 @@ export default function CreateBlueprintDialog({ open, onClose, blueprint }: Crea
                   onChange={(_, v) => setHardware(h => ({ ...h, diskSize: `${v as number}G` }))}
                   sx={{ flex: 1 }}
                 />
-                <TextField
+                <NumericTextField
                   type="number"
                   size="small"
-                  value={diskGb}
-                  onChange={e => {
-                    const gb = Number.parseInt(e.target.value) || 1
-                    setHardware(h => ({ ...h, diskSize: `${gb}G` }))
-                  }}
+                  value={diskGbInput}
+                  onChange={gb => setHardware(h => ({ ...h, diskSize: `${gb}G` }))}
+                  fallback={1}
+                  min={1}
                   sx={{ width: 92 }}
                   helperText="GB"
                   slotProps={{ htmlInput: { min: 1 } }}

--- a/frontend/src/components/templates/CustomImageDialog.test.tsx
+++ b/frontend/src/components/templates/CustomImageDialog.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import CustomImageDialog from './CustomImageDialog'
+
+// The hardware spec inputs are the ones discussion #634 is about: they used to
+// coerce every keystroke with `parseInt(e.target.value) || <default>`, so the
+// field could never be emptied and a retyped value landed glued behind the old
+// default ('4' over '1' gave '14'). Nothing else in the dialog needs stubbing:
+// the volume browser only fetches in "PVE volume" mode, which is provider-only
+// and off by default, and `useTenant()` falls back to its own default context.
+const open = () => renderWithProviders(<CustomImageDialog open onClose={() => {}} />)
+
+const field = (label: string) => screen.getByLabelText(label) as HTMLInputElement
+
+describe('CustomImageDialog hardware spec fields', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  it('lets min cores be cleared and retyped', async () => {
+    open()
+
+    const minCores = field('Min Cores')
+
+    expect(minCores.value).toBe('1')
+
+    await userEvent.clear(minCores)
+    expect(minCores.value).toBe('')
+
+    await userEvent.type(minCores, '4')
+    expect(minCores.value).toBe('4')
+  })
+
+  it('lets min memory be cleared and retyped', async () => {
+    open()
+
+    const minMemory = field('Min Memory')
+
+    expect(minMemory.value).toBe('512')
+
+    await userEvent.clear(minMemory)
+    expect(minMemory.value).toBe('')
+
+    await userEvent.type(minMemory, '1024')
+    expect(minMemory.value).toBe('1024')
+  })
+
+  it('restores the default when min memory is left empty', async () => {
+    open()
+
+    const minMemory = field('Min Memory')
+
+    await userEvent.clear(minMemory)
+    await userEvent.tab()
+
+    expect(minMemory.value).toBe('512')
+  })
+})

--- a/frontend/src/components/templates/CustomImageDialog.tsx
+++ b/frontend/src/components/templates/CustomImageDialog.tsx
@@ -24,6 +24,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import NumericTextField from '@/components/ui/NumericTextField'
 import { useTenant } from '@/contexts/TenantContext'
 
 interface CustomImageDialogProps {
@@ -452,37 +453,45 @@ export default function CustomImageDialog({ open, onClose, editData }: CustomIma
               onChange={e => setDefaultDiskSize(e.target.value)}
               placeholder="20G"
             />
-            <TextField
+            <NumericTextField
               size="small"
               label={t('templates.catalog.minCores')}
               type="number"
               value={minCores}
-              onChange={e => setMinCores(Number.parseInt(e.target.value) || 1)}
+              onChange={setMinCores}
+              fallback={1}
+              min={1}
               slotProps={{ htmlInput: { min: 1 } }}
             />
-            <TextField
+            <NumericTextField
               size="small"
               label={t('templates.catalog.recCores')}
               type="number"
               value={recommendedCores}
-              onChange={e => setRecommendedCores(Number.parseInt(e.target.value) || 2)}
+              onChange={setRecommendedCores}
+              fallback={2}
+              min={1}
               slotProps={{ htmlInput: { min: 1 } }}
             />
-            <TextField
+            <NumericTextField
               size="small"
               label={t('templates.catalog.minMem')}
               type="number"
               value={minMemory}
-              onChange={e => setMinMemory(Number.parseInt(e.target.value) || 512)}
+              onChange={setMinMemory}
+              fallback={512}
+              min={128}
               helperText="MB"
               slotProps={{ htmlInput: { min: 128, step: 256 } }}
             />
-            <TextField
+            <NumericTextField
               size="small"
               label={t('templates.catalog.recMem')}
               type="number"
               value={recommendedMemory}
-              onChange={e => setRecommendedMemory(Number.parseInt(e.target.value) || 2048)}
+              onChange={setRecommendedMemory}
+              fallback={2048}
+              min={128}
               helperText="MB"
               slotProps={{ htmlInput: { min: 128, step: 256 } }}
             />

--- a/frontend/src/components/templates/DeployWizard.tsx
+++ b/frontend/src/components/templates/DeployWizard.tsx
@@ -35,6 +35,7 @@ import {
 import type { CloudImage } from '@/lib/templates/cloudImages'
 import { buildDeployIpconfig0, parseIpconfig0 } from '@/lib/templates/deployIpconfig'
 import { supportsVmDisks } from '@/lib/proxmox/storage'
+import NumericTextField from '@/components/ui/NumericTextField'
 import DeploymentProgress from './DeploymentProgress'
 import VendorLogo from './VendorLogo'
 import IsoNetworkReservation from './IsoNetworkReservation'
@@ -932,12 +933,14 @@ export default function DeployWizard({ open, onClose, image, prefillBlueprint, r
       {isoBlocker}
 
       <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 2 }}>
-        <TextField
+        <NumericTextField
           size="small"
           label={t('templates.deploy.target.vmid')}
           type="number"
           value={vmid}
-          onChange={e => setVmid(Number.parseInt(e.target.value) || 100)}
+          onChange={setVmid}
+          fallback={100}
+          min={100}
           required
           slotProps={{ htmlInput: { min: 100 } }}
         />
@@ -1020,11 +1023,14 @@ export default function DeployWizard({ open, onClose, image, prefillBlueprint, r
                   sx={{ '& .MuiSlider-markLabel': { fontSize: '0.7rem' } }}
                 />
               </Box>
-              <TextField
+              <NumericTextField
                 size="small"
                 type="number"
                 value={cores}
-                onChange={e => setCores(Math.max(1, Number.parseInt(e.target.value) || 1))}
+                onChange={setCores}
+                fallback={1}
+                min={1}
+                max={128}
                 slotProps={{ htmlInput: { min: 1, max: 128 } }}
                 sx={{ width: 120 }}
               />
@@ -1083,11 +1089,13 @@ export default function DeployWizard({ open, onClose, image, prefillBlueprint, r
                   sx={{ '& .MuiSlider-markLabel': { fontSize: '0.65rem' } }}
                 />
               </Box>
-              <TextField
+              <NumericTextField
                 size="small"
                 type="number"
                 value={memory}
-                onChange={e => setMemory(Math.max(128, Number.parseInt(e.target.value) || 128))}
+                onChange={setMemory}
+                fallback={128}
+                min={128}
                 slotProps={{
                   htmlInput: { min: 128, step: 128 },
                   input: { endAdornment: <InputAdornment position="end" sx={{ '& p': { fontSize: 11, opacity: 0.6 } }}>MB</InputAdornment> },
@@ -1103,7 +1111,15 @@ export default function DeployWizard({ open, onClose, image, prefillBlueprint, r
         // existing payload + parseDiskSizeMb keeps working unchanged.
         // Slider operates in GiB ints; conversions are trivial.
         const diskMarks = [10, 20, 50, 100, 250, 500, 1000]
-        const diskGiB = Math.max(diskMarks[0], Number.parseInt(String(diskSize).replace(/G$/i, ''), 10) || diskMarks[0])
+        const parsedDiskGiB = Number.parseInt(String(diskSize).replace(/G$/i, ''), 10)
+        const diskGiB = Math.max(diskMarks[0], parsedDiskGiB || diskMarks[0])
+        // The manual input binds to the parsed size, not to the slider-floored
+        // value and not through a `||` fallback: every number the field can
+        // commit — 0 included — has to survive the round-trip, or the sync
+        // effect rewrites the buffer mid-keystroke ('5' → 10 → '10', or
+        // '0' → 1 → '18' on the next keypress). Only an unparseable size
+        // falls back, and to the same 1 the field commits on blur.
+        const diskGiBTyped = Number.isNaN(parsedDiskGiB) ? 1 : parsedDiskGiB
         const diskGiBToSlider = (gib: number) => {
           for (let i = diskMarks.length - 1; i >= 0; i--) {
             if (gib >= diskMarks[i]) {
@@ -1148,11 +1164,13 @@ export default function DeployWizard({ open, onClose, image, prefillBlueprint, r
                   sx={{ '& .MuiSlider-markLabel': { fontSize: '0.65rem' } }}
                 />
               </Box>
-              <TextField
+              <NumericTextField
                 size="small"
                 type="number"
-                value={diskGiB}
-                onChange={e => setDiskSize(`${Math.max(1, Number.parseInt(e.target.value) || 1)}G`)}
+                value={diskGiBTyped}
+                onChange={n => setDiskSize(`${n}G`)}
+                fallback={1}
+                min={1}
                 slotProps={{
                   htmlInput: { min: 1, step: 1 },
                   input: { endAdornment: <InputAdornment position="end" sx={{ '& p': { fontSize: 11, opacity: 0.6 } }}>GB</InputAdornment> },

--- a/frontend/src/components/ui/NumericTextField.test.tsx
+++ b/frontend/src/components/ui/NumericTextField.test.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import NumericTextField from './NumericTextField'
+
+type HarnessProps = Omit<React.ComponentProps<typeof NumericTextField>, 'value' | 'onChange'> & {
+  initial: number
+  onValue?: (v: number) => void
+}
+
+// The component is controlled, so every test drives it through a real parent.
+function Harness({ initial, onValue, ...rest }: HarnessProps) {
+  const [value, setValue] = useState(initial)
+
+  return (
+    <>
+      <NumericTextField
+        {...rest}
+        value={value}
+        onChange={v => {
+          setValue(v)
+          onValue?.(v)
+        }}
+      />
+      <span data-testid="committed">{String(value)}</span>
+      <button type="button">elsewhere</button>
+    </>
+  )
+}
+
+const field = () => screen.getByLabelText('Size') as HTMLInputElement
+const committed = () => screen.getByTestId('committed').textContent
+
+describe('NumericTextField', () => {
+  // This suite renders repeatedly; RTL is not auto-cleaned up in this repo.
+  afterEach(cleanup)
+
+  it('shows the value it is given', () => {
+    renderWithProviders(<Harness initial={8} fallback={1} label="Size" />)
+    expect(field().value).toBe('8')
+  })
+
+  it('can be cleared, and does not snap back to the fallback while typing', async () => {
+    renderWithProviders(<Harness initial={8} fallback={1} label="Size" />)
+    await userEvent.clear(field())
+    expect(field().value).toBe('')
+    // The parent keeps the last good number; only the display is empty.
+    expect(committed()).toBe('8')
+  })
+
+  it('replaces the value instead of gluing the old digit in front (discussion #634)', async () => {
+    const onValue = vi.fn()
+
+    renderWithProviders(<Harness initial={1} fallback={1} label="Size" onValue={onValue} />)
+    await userEvent.clear(field())
+    await userEvent.type(field(), '20')
+    expect(field().value).toBe('20')
+    expect(committed()).toBe('20')
+    expect(onValue).not.toHaveBeenCalledWith(1)
+  })
+
+  it('commits the fallback when the field is left empty', async () => {
+    renderWithProviders(<Harness initial={8} fallback={1} label="Size" />)
+    await userEvent.clear(field())
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(field().value).toBe('1')
+    expect(committed()).toBe('1')
+  })
+
+  it('clamps to min and max on blur', async () => {
+    const { unmount } = renderWithProviders(<Harness initial={8} fallback={1} label="Size" min={2} max={64} />)
+
+    await userEvent.clear(field())
+    await userEvent.type(field(), '999')
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(committed()).toBe('64')
+    unmount()
+
+    renderWithProviders(<Harness initial={8} fallback={4} label="Size" min={2} max={64} />)
+    await userEvent.clear(field())
+    await userEvent.type(field(), '1')
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(committed()).toBe('2')
+  })
+
+  it('lets a decimal be typed through its half-written states', async () => {
+    renderWithProviders(
+      <Harness initial={0} fallback={0} label="Size" parse={Number.parseFloat} />,
+    )
+    await userEvent.clear(field())
+    await userEvent.type(field(), '0.')
+    expect(field().value).toBe('0.')
+    await userEvent.type(field(), '5')
+    expect(field().value).toBe('0.5')
+    expect(committed()).toBe('0.5')
+  })
+
+  it('accepts a negative number through its leading minus sign', async () => {
+    renderWithProviders(<Harness initial={0} fallback={0} label="Size" />)
+    await userEvent.clear(field())
+    await userEvent.type(field(), '-')
+    expect(field().value).toBe('-')
+    expect(committed()).toBe('0')
+    await userEvent.type(field(), '5')
+    expect(committed()).toBe('-5')
+  })
+
+  it('follows the value when the parent changes it behind the input', async () => {
+    function PresetHarness() {
+      const [value, setValue] = useState(512)
+
+      return (
+        <>
+          <NumericTextField value={value} onChange={setValue} fallback={128} label="Size" />
+          <button type="button" onClick={() => setValue(2048)}>preset</button>
+        </>
+      )
+    }
+
+    renderWithProviders(<PresetHarness />)
+    await userEvent.clear(field())
+    await userEvent.click(screen.getByRole('button', { name: 'preset' }))
+    expect(field().value).toBe('2048')
+  })
+
+  it('uses format for display, so a sentinel value can render blank', async () => {
+    renderWithProviders(
+      <Harness initial={0} fallback={0} label="Size" format={n => (n === 0 ? '' : String(n))} />,
+    )
+    expect(field().value).toBe('')
+    await userEvent.type(field(), '4')
+    expect(committed()).toBe('4')
+  })
+
+  it('does not commit a lossy format back into state on a bare focus and blur', async () => {
+    const onValue = vi.fn()
+
+    // State in MiB, field shown in whole GiB: 3000 MiB has no exact GiB display.
+    renderWithProviders(
+      <Harness
+        initial={3000}
+        fallback={1024}
+        label="Size"
+        onValue={onValue}
+        format={n => String(Math.round(n / 1024))}
+        parse={s => Number.parseFloat(s) * 1024}
+      />,
+    )
+    expect(field().value).toBe('3')
+    await userEvent.click(field())
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(onValue).not.toHaveBeenCalled()
+    expect(committed()).toBe('3000')
+
+    // Editing it still commits through the lossy conversion, as it must.
+    await userEvent.clear(field())
+    await userEvent.type(field(), '4')
+    expect(committed()).toBe('4096')
+  })
+
+  it('does not fire onChange on blur when the value is unchanged', async () => {
+    const onValue = vi.fn()
+
+    renderWithProviders(<Harness initial={8} fallback={1} label="Size" onValue={onValue} />)
+    await userEvent.click(field())
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(onValue).not.toHaveBeenCalled()
+  })
+
+  it('still forwards a caller-supplied onBlur', async () => {
+    const onBlur = vi.fn()
+
+    renderWithProviders(<Harness initial={8} fallback={1} label="Size" onBlur={onBlur} />)
+    await userEvent.click(field())
+    await userEvent.click(screen.getByRole('button', { name: 'elsewhere' }))
+    expect(onBlur).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/ui/NumericTextField.tsx
+++ b/frontend/src/components/ui/NumericTextField.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import React, { useEffect, useRef, useState } from 'react'
+import { TextField } from '@mui/material'
+
+type NumericTextFieldProps = Omit<React.ComponentProps<typeof TextField>, 'value' | 'onChange'> & {
+  value: number
+  onChange: (value: number) => void
+  fallback: number
+  parse?: (raw: string) => number
+  format?: (value: number) => string
+  min?: number
+  max?: number
+}
+
+/**
+ * A numeric TextField that can actually be emptied.
+ *
+ * Binding `value={num}` to an onChange that coerces with `parseInt(x) || 1` makes
+ * the field impossible to clear: deleting the last digit yields '', which parses
+ * to NaN and snaps the state straight back to the default, so the old digit stays
+ * glued in front of whatever the user types next.
+ *
+ * Here the input keeps its own string buffer, so an empty (or half-typed) field is
+ * a valid display state. The parent only ever receives a finite number, and the
+ * fallback is committed on blur, so no caller has to handle a null value.
+ */
+export default function NumericTextField({
+  value,
+  onChange,
+  fallback,
+  parse = Number.parseInt,
+  format = String,
+  min,
+  max,
+  onBlur,
+  ...rest
+}: NumericTextFieldProps) {
+  const [raw, setRaw] = useState<string>(() => format(value))
+
+  // Whether the buffer holds something the user typed. Blur must not commit
+  // anything for a field that was only focused and left: with a lossy `format`
+  // (state in MiB, field shown in GiB) that would write the rounding back into
+  // state, turning 3000 MiB into 3072 and dirtying the form on a stray click.
+  const editedRef = useRef(false)
+
+  // Read through refs so the sync effect never re-runs just because a caller
+  // passed an inline arrow: re-running it mid-keystroke would wipe the buffer.
+  const parseRef = useRef(parse)
+  const formatRef = useRef(format)
+
+  // Declared before the sync effect below so the refs are already current when
+  // it runs in the same commit. Written here rather than during render because
+  // a render-phase ref write is unsafe under concurrent rendering.
+  useEffect(() => {
+    parseRef.current = parse
+    formatRef.current = format
+  })
+
+  const clamp = (n: number) => {
+    if (typeof min === 'number' && n < min) return min
+    if (typeof max === 'number' && n > max) return max
+
+    return n
+  }
+
+  // Follow the value the parent owns (preset chips, sliders, a reset on reopen)
+  // without normalising what is currently being typed: '2.' and '1.50' both
+  // already agree with the committed number and must survive as-is.
+  useEffect(() => {
+    setRaw(prev => {
+      const prevNum = parseRef.current(prev)
+
+      if (Number.isFinite(prevNum) && prevNum === value) return prev
+
+      // The parent overrode what was in the box, so it is no longer an edit.
+      editedRef.current = false
+
+      return formatRef.current(value)
+    })
+  }, [value])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const text = e.target.value
+
+    editedRef.current = true
+    setRaw(text)
+
+    // Intermediate states on the way to a number: commit nothing, keep showing them.
+    if (text === '' || text === '-' || text === '.' || text === '-.') return
+
+    const num = parseRef.current(text)
+
+    if (Number.isFinite(num)) onChange(num)
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (!editedRef.current) {
+      onBlur?.(e)
+
+      return
+    }
+
+    const num = parseRef.current(raw)
+    const next = Number.isFinite(num) ? clamp(num) : fallback
+
+    if (next !== value) onChange(next)
+    setRaw(formatRef.current(next))
+    editedRef.current = false
+
+    onBlur?.(e)
+  }
+
+  return <TextField {...rest} value={raw} onChange={handleChange} onBlur={handleBlur} />
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -53,6 +53,15 @@ export default defineConfig({
           environment: 'jsdom',
           include: ['src/**/*.test.tsx'],
           setupFiles: ['./src/__tests__/setup/jsdom-setup.ts'],
+          // Vitest's 5s default is not a budget these tests were written
+          // against, it is just the default — and under `--coverage` on a
+          // loaded machine it starts failing whole files that pass in
+          // isolation, including synchronous ones (a sync test can only
+          // "time out" when its worker is starved of CPU). Measured on this
+          // suite: 15 such failures at 5s, 0 at 20s, with the wall time
+          // unchanged at ~240s. Raising it removes that false-red class
+          // without hiding a genuinely hung test, which still fails.
+          testTimeout: 20_000,
         },
       },
     ],


### PR DESCRIPTION
Closes the glitch reported in discussion #634.

## The bug

Every controlled numeric field in the app was written like this:

```tsx
value={rootSize}
onChange={e => setRootSize(Number.parseInt(e.target.value) || 1)}
```

Deleting the last digit makes the input report `''`, which parses to `NaN`, so the `|| 1` wrote the default straight back into state. The field could never be emptied, and the old digit stayed glued in front of whatever was typed next: clearing `1` and typing `20` produced `120`.

It was reported on the LXC disk size, but the same pattern was repeated **72 times across 32 files**: CPU and memory in both guest wizards, backup retention tiers, the compliance policy form, site recovery, the rolling update wizard, HA restart limits, SSH and SMTP ports, hardware dialogs.

## The fix

A shared `NumericTextField` keeps its own string buffer, so an empty or half-typed field is a valid *display* state while the parent state stays a finite number. Callers never have to handle `null`: the fallback is committed on blur, and `min`/`max` clamp on blur only, never mid-keystroke. Three near-identical local implementations already existed in the codebase and are folded into it.

Seven fields were worse than the rest: they clamped inside the handler (`Math.max(128, …)`), which made the value impossible to overwrite at all, not merely impossible to clear. Typing `512` over `1024` never worked.

## Variants a plain conversion would not have cured

- **Feeding a laundered value back in.** Where the `value` expression itself routes through `|| default` or `Math.max`, the parent recomputes a different number and the sync effect rewrites the buffer, reproducing the bug in a new costume. Fixed on the template disk sizes, the SMTP and rate-limit ports, and the seven config-editor sliders, where `shares` could not be set to `0` at all even though PVE accepts it.
- **Lossy display formats.** Where the state is in MiB and the field shows GiB, a bare focus-and-leave used to commit the rounding back into state, turning 3000 MiB into 3072 and lighting up Save without the user typing anything.
- **A field destroyed mid-typing.** The microsegmentation gateway offset stayed unusable after conversion: committing a digit triggers a refetch that unmounted the entire subtree, so the field lost focus after the first character.

Fields that were already clearable by design are deliberately untouched: raw-string state, explicit `=== '' ? ''` branches, and `number | null` fields where empty is a meaningful value.

## Test timeout

This PR also raises the jsdom `testTimeout` to 20s. That is not cosmetic: Vitest's 5s default starts failing whole files that pass in isolation once the suite runs under `--coverage`, including **synchronous** tests, which can only time out when their worker is starved of CPU. Measured on this suite: 15 such failures at 5s, 0 at 20s, with the wall time unchanged at ~240s. Without it CI would go red on a 2-vCPU runner.

## Verification

- Full suite with coverage: **376/376 files, 3717/3717 tests** green (78 new tests in 13 new files).
- `npm run build`: green.
- New-code coverage on the lines Sonar measures: **50/50 = 100%**.
- The regression test was proved genuine by restoring the old handler: it fails with the exact reported symptom (`expected '1' to be ''`).