### PR TITLE
Revocable server-side sessions, session management UI, and secure cookie flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,18 @@ NEXTAUTH_URL=https://proxcenter.example.com
 APP_URL=https://proxcenter.example.com
 
 # ========================================
+# Optional - Session timeouts
+# ========================================
+# How long a browser session may live, in seconds. The database session row
+# is authoritative — it is what actually revokes access — and the session
+# cookie's own lifetime is derived from SESSION_ABSOLUTE_TIMEOUT so it can
+# never outlive that row.
+# SESSION_IDLE_TIMEOUT: time without activity before a session expires. Default: 43200 (12 hours)
+# SESSION_ABSOLUTE_TIMEOUT: max session lifetime regardless of activity. Default: 604800 (7 days)
+# SESSION_IDLE_TIMEOUT=43200
+# SESSION_ABSOLUTE_TIMEOUT=604800
+
+# ========================================
 # Database (Postgres)
 # ========================================
 # Postgres credentials for the bundled `postgres` compose service.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -14,6 +14,15 @@ APP_SECRET="your-app-secret-here"
 NEXTAUTH_SECRET="your-nextauth-secret-here"
 NEXTAUTH_URL="http://localhost:3000"
 
+# Session timeouts, in seconds. The database session row is authoritative —
+# it is what actually revokes a session — and the session cookie's own
+# lifetime is derived from SESSION_ABSOLUTE_TIMEOUT so it can never outlive
+# that row.
+# SESSION_IDLE_TIMEOUT: time without activity before a session expires. Default: 43200 (12 hours)
+# SESSION_ABSOLUTE_TIMEOUT: max session lifetime regardless of activity. Default: 604800 (7 days)
+# SESSION_IDLE_TIMEOUT="43200"
+# SESSION_ABSOLUTE_TIMEOUT="604800"
+
 # Orchestrator Backend URL
 ORCHESTRATOR_URL="http://localhost:8080"
 

--- a/frontend/prisma/migrations/20260803000000_session_store/migration.sql
+++ b/frontend/prisma/migrations/20260803000000_session_store/migration.sql
@@ -3,12 +3,21 @@
 -- 20260504144606_init_postgres in NextAuth-adapter shape and never read or
 -- written by any code, so it is empty in every deployment; dropping columns
 -- and adding NOT NULL columns without a default are both safe here.
+-- The DELETE below is a deliberate guard, not dead code: this migration runs
+-- unattended via docker-entrypoint.sh -> scripts/migrate-with-lock.js before
+-- the app boots, so a NOT NULL ADD COLUMN with no DEFAULT would fail the
+-- container start on any deployment that somehow has rows (hand-inserted, or
+-- a brief historical use of the NextAuth adapter). Any such row is unusable
+-- anyway, since it is keyed by the `token` column dropped right below, and
+-- no code has ever read it. Do not remove this DELETE as redundant.
 DROP INDEX "sessions_token_key";
 DROP INDEX "sessions_token_idx";
 DROP INDEX "sessions_expires_at_idx";
 
 ALTER TABLE "sessions" DROP COLUMN "token";
 ALTER TABLE "sessions" DROP COLUMN "expires_at";
+
+DELETE FROM "sessions";
 
 ALTER TABLE "sessions" ADD COLUMN "last_seen_at" TIMESTAMP(3) NOT NULL;
 ALTER TABLE "sessions" ADD COLUMN "revoked_at" TIMESTAMP(3);

--- a/frontend/prisma/migrations/20260803000000_session_store/migration.sql
+++ b/frontend/prisma/migrations/20260803000000_session_store/migration.sql
@@ -1,0 +1,16 @@
+-- Repurpose the never-used `sessions` table as the real session store:
+-- revocation, idle timeout and absolute cap. Created by
+-- 20260504144606_init_postgres in NextAuth-adapter shape and never read or
+-- written by any code, so it is empty in every deployment; dropping columns
+-- and adding NOT NULL columns without a default are both safe here.
+DROP INDEX "sessions_token_key";
+DROP INDEX "sessions_token_idx";
+DROP INDEX "sessions_expires_at_idx";
+
+ALTER TABLE "sessions" DROP COLUMN "token";
+ALTER TABLE "sessions" DROP COLUMN "expires_at";
+
+ALTER TABLE "sessions" ADD COLUMN "last_seen_at" TIMESTAMP(3) NOT NULL;
+ALTER TABLE "sessions" ADD COLUMN "revoked_at" TIMESTAMP(3);
+
+CREATE INDEX "sessions_last_seen_at_idx" ON "sessions"("last_seen_at");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -346,19 +346,23 @@ model UserTotpRecoveryCode {
   @@map("user_totp_recovery_codes")
 }
 
+// Server-side session store. The cookie stays a NextAuth JWT; it carries this
+// row's id as `sid`. Presence + revokedAt + lastSeenAt + createdAt are what
+// make a JWT session revocable and time-bounded. No expiresAt column on
+// purpose: both deadlines are derived from the CURRENT configuration, so
+// changing a timeout applies to sessions already open.
 model Session {
-  id        String   @id
-  userId    String   @map("user_id")
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  token     String   @unique
-  expiresAt DateTime @map("expires_at")
-  createdAt DateTime @map("created_at")
-  ipAddress String?  @map("ip_address")
-  userAgent String?  @map("user_agent")
+  id         String    @id
+  userId     String    @map("user_id")
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt  DateTime  @map("created_at")
+  lastSeenAt DateTime  @map("last_seen_at")
+  revokedAt  DateTime? @map("revoked_at")
+  ipAddress  String?   @map("ip_address")
+  userAgent  String?   @map("user_agent")
 
   @@index([userId])
-  @@index([token])
-  @@index([expiresAt])
+  @@index([lastSeenAt])
   @@map("sessions")
 }
 

--- a/frontend/src/app/(dashboard)/layout.jsx
+++ b/frontend/src/app/(dashboard)/layout.jsx
@@ -20,6 +20,7 @@ import Navbar from '@components/layout/vertical/Navbar'
 import ScrollToTop from '@core/components/scroll-to-top'
 import TasksFooter from '@components/TasksFooter'
 import OnboardingGuard from '@components/OnboardingGuard'
+import SessionExpiryGuard from '@components/SessionExpiryGuard'
 import TopBannerStack from '@components/broadcast/TopBannerStack'
 import DemoInterceptor from '@components/DemoInterceptor'
 import { ProxCenterTasksProvider } from '@/contexts/ProxCenterTasksContext'
@@ -62,12 +63,16 @@ const Layout = async props => {
         systemMode={systemMode}
         verticalLayout={
           <VerticalLayout navigation={<Navigation mode={mode} />} navbar={<Navbar />}>
-            <OnboardingGuard>{children}</OnboardingGuard>
+            <SessionExpiryGuard>
+              <OnboardingGuard>{children}</OnboardingGuard>
+            </SessionExpiryGuard>
           </VerticalLayout>
         }
         horizontalLayout={
           <HorizontalLayout header={<Header />}>
-            <OnboardingGuard>{children}</OnboardingGuard>
+            <SessionExpiryGuard>
+              <OnboardingGuard>{children}</OnboardingGuard>
+            </SessionExpiryGuard>
           </HorizontalLayout>
         }
       />

--- a/frontend/src/app/(dashboard)/profile/page.jsx
+++ b/frontend/src/app/(dashboard)/profile/page.jsx
@@ -24,6 +24,7 @@ import { usePageTitle } from '@/contexts/PageTitleContext'
 import { useRBAC } from '@/contexts/RBACContext'
 import TwoFactorCard from '@/components/profile/TwoFactorCard'
 import SessionsCard from '@/components/profile/SessionsCard'
+import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
 
 
 // Fonction pour obtenir les initiales
@@ -143,9 +144,12 @@ return
 return
       }
 
-      setPasswordSuccess(t('common.success'))
-      setNewPassword('')
-      setConfirmPassword('')
+      // Changing your own password revokes every session of the account,
+      // including the one this tab is on (users/[id] PATCH →
+      // revokeAllSessions with no exception, by design). A success message
+      // here would be one the dead session cannot back — every next call
+      // 401s. Go to /login now; the user signs back in with the new password.
+      redirectToLoginOnce()
     } catch (e) {
       setPasswordError(t('settings.connectionError'))
     } finally {

--- a/frontend/src/app/(dashboard)/profile/page.jsx
+++ b/frontend/src/app/(dashboard)/profile/page.jsx
@@ -23,6 +23,7 @@ import {
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import { useRBAC } from '@/contexts/RBACContext'
 import TwoFactorCard from '@/components/profile/TwoFactorCard'
+import SessionsCard from '@/components/profile/SessionsCard'
 
 
 // Fonction pour obtenir les initiales
@@ -333,6 +334,9 @@ return
 
       {/* Two-factor authentication */}
       <TwoFactorCard />
+
+      {/* Active sessions */}
+      <SessionsCard />
     </Box>
   )
 }

--- a/frontend/src/app/(dashboard)/security/users/RevokeSessionsDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/security/users/RevokeSessionsDialog.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { RevokeSessionsDialog } from './page'
+
+// Translate stub: return the key unchanged. The dialog receives `t` as a prop
+// (not the next-intl hook), matching how page.jsx passes it down — see
+// RoleDefaultScopeEditor.test.tsx for the same convention.
+const t = (k: string) => k
+
+const targetUser = { id: 'u1', email: 'target@example.com' }
+const SESSIONS_URL = '*/api/v1/admin/users/u1/sessions'
+
+describe('RevokeSessionsDialog', () => {
+  afterEach(() => cleanup())
+
+  it('issues DELETE /api/v1/admin/users/<id>/sessions and calls onSuccess(user.id) then onClose()', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+    let deleteCalls = 0
+
+    server.use(
+      http.delete(SESSIONS_URL, () => {
+        deleteCalls += 1
+        return HttpResponse.json({ data: { revoked: 2 } })
+      }),
+    )
+
+    renderWithProviders(
+      <RevokeSessionsDialog open user={targetUser} onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(deleteCalls).toBe(1))
+    expect(onSuccess).toHaveBeenCalledWith('u1')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces errors.connectionError on a network failure and does not close', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSIONS_URL, () => HttpResponse.error()),
+    )
+
+    renderWithProviders(
+      <RevokeSessionsDialog open user={targetUser} onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    expect(await screen.findByText('errors.connectionError')).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('disables the confirm button while the request is in flight', async () => {
+    const user = userEvent.setup()
+    let resolveDelete: (() => void) | null = null
+
+    server.use(
+      http.delete(
+        SESSIONS_URL,
+        () =>
+          new Promise(resolve => {
+            resolveDelete = () => resolve(HttpResponse.json({ data: { revoked: 1 } }))
+          }),
+      ),
+    )
+
+    renderWithProviders(
+      <RevokeSessionsDialog open user={targetUser} onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    const confirmBtn = screen.getByRole('button', { name: 'common.confirm' })
+    expect(confirmBtn).not.toBeDisabled()
+
+    await user.click(confirmBtn)
+
+    await waitFor(() => expect(confirmBtn).toBeDisabled())
+
+    // Let the in-flight request resolve so it doesn't leak into the next test.
+    resolveDelete?.()
+  })
+})

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -38,10 +38,13 @@ import { DataGrid } from '@mui/x-data-grid'
 
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import { useLicense, Features } from '@/contexts/LicenseContext'
-import { useUsers, useRbacRoles, useRbacAssignments, useTenants } from '@/hooks/useUsers'
+import { useRBAC } from '@/contexts/RBACContext'
+import { useUsers, useRbacRoles, useRbacAssignments, useTenants, useAdminSessions } from '@/hooks/useUsers'
 import EmptyState from '@/components/EmptyState'
 import { TableSkeleton } from '@/components/skeletons'
 import RevokeSessionsDialog from '@/components/security/RevokeSessionsDialog'
+import RevokeSingleSessionDialog from '@/components/security/RevokeSingleSessionDialog'
+import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
 
 /* --------------------------------
    Helpers
@@ -765,6 +768,177 @@ function Require2FADialog({ open, mode, onClose, user, onSuccess, t }) {
 }
 
 /* --------------------------------
+   Admin Sessions Tab (super-admin only)
+
+   Every live session in the installation, across every tenant — a
+   deliberate reversal of the "count only" boundary the sibling
+   admin/users/[id]/sessions route still documents. Gated purely by the
+   parent only mounting this when useRBAC().isAdmin is true; the API route
+   re-checks with requireSuperAdminCaller() regardless.
+-------------------------------- */
+
+function AdminSessionsTab({ t }) {
+  const { data, error: fetchError, isLoading, mutate } = useAdminSessions(true)
+  const sessions = data?.data || []
+  const loadError = fetchError ? t('errors.connectionError') : ''
+
+  const [revokeDialogOpen, setRevokeDialogOpen] = useState(false)
+  const [sessionToRevoke, setSessionToRevoke] = useState(null)
+
+  const handleRevoke = (row) => {
+    setSessionToRevoke(row)
+    setRevokeDialogOpen(true)
+  }
+
+  const handleRevoked = useCallback((sessionId) => {
+    // Optimistically drop the row without a full network round-trip.
+    // mutate() will reconcile on next SWR revalidation.
+    mutate(prev => {
+      if (!prev?.data) return prev
+      return { ...prev, data: prev.data.filter(s => s.id !== sessionId) }
+    }, false)
+  }, [mutate])
+
+  const columns = useMemo(
+    () => [
+      {
+        field: 'userEmail',
+        headerName: t('sessions.userHeader'),
+        flex: 1,
+        minWidth: 200,
+        renderCell: params => (
+          <Typography variant='body2' noWrap sx={{ fontWeight: 600 }}>{params.row.userEmail}</Typography>
+        ),
+      },
+      {
+        field: 'tenantName',
+        headerName: t('sessions.tenantHeader'),
+        width: 160,
+        renderCell: params => (
+          <Typography variant='body2' noWrap>{params.row.tenantName}</Typography>
+        ),
+      },
+      {
+        field: 'createdAt',
+        headerName: t('sessions.signedInLabel'),
+        width: 160,
+        renderCell: params => (
+          <Typography variant='body2' sx={{ opacity: 0.7 }}>
+            {new Date(params.row.createdAt).toLocaleString()}
+          </Typography>
+        ),
+      },
+      {
+        field: 'lastSeenAt',
+        headerName: t('sessions.lastActiveLabel'),
+        width: 150,
+        renderCell: params => (
+          <Typography variant='body2' sx={{ opacity: 0.7 }}>
+            {timeAgo(params.row.lastSeenAt, t)}
+          </Typography>
+        ),
+      },
+      {
+        field: 'ipAddress',
+        headerName: t('sessions.ipLabel'),
+        width: 140,
+        renderCell: params => (
+          // No monospace on the IP — project-wide convention.
+          <Typography variant='body2'>{params.row.ipAddress || t('common.unknown')}</Typography>
+        ),
+      },
+      {
+        field: 'device',
+        headerName: t('sessions.deviceHeader'),
+        width: 170,
+        sortable: false,
+        renderCell: params => {
+          const parts = [params.row.browser, params.row.os].filter(Boolean)
+          const label = parts.length > 0 ? parts.join(' · ') : t('common.unknown')
+          return (
+            <Tooltip title={params.row.userAgent || t('common.unknown')} slotProps={tooltipSlotProps}>
+              {/* No monospace on the device label — project-wide convention. */}
+              <Typography variant='body2' noWrap>{label}</Typography>
+            </Tooltip>
+          )
+        },
+      },
+      {
+        field: 'actions',
+        headerName: t('common.actions'),
+        width: 90,
+        sortable: false,
+        renderCell: params => (
+          <Tooltip title={t('sessions.adminRevokeOneMenu')}>
+            <IconButton
+              size='small'
+              color='warning'
+              onClick={() => handleRevoke(params.row)}
+            >
+              <i className='ri-logout-box-line' />
+            </IconButton>
+          </Tooltip>
+        ),
+      },
+    ],
+    [t]
+  )
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant='body2' sx={{ opacity: 0.6 }}>
+          {sessions.length} {t('sessions.columnHeader').toLowerCase()}
+        </Typography>
+      </Box>
+
+      {loadError && <Alert severity='error' sx={{ mb: 2 }}>{loadError}</Alert>}
+
+      <Box sx={{ flex: 1, minHeight: 400 }}>
+        {!isLoading && sessions.length === 0 && !loadError ? (
+          <EmptyState
+            icon='ri-device-line'
+            title={t('sessions.adminAllEmptyTitle')}
+            description={t('sessions.adminAllEmptyDesc')}
+            size='large'
+          />
+        ) : (
+          <DataGrid
+            rows={sessions}
+            columns={columns}
+            loading={isLoading}
+            pageSizeOptions={[10, 25, 50]}
+            disableRowSelectionOnClick
+            rowHeight={52}
+            columnHeaderHeight={40}
+            sx={{
+              border: 'none',
+              '& .MuiDataGrid-cell': {
+                display: 'flex',
+                alignItems: 'center',
+                overflow: 'hidden',
+              },
+              '& .MuiDataGrid-columnHeaders': {
+                borderBottom: '1px solid',
+                borderColor: 'divider',
+              },
+            }}
+          />
+        )}
+      </Box>
+
+      <RevokeSingleSessionDialog
+        open={revokeDialogOpen}
+        onClose={() => setRevokeDialogOpen(false)}
+        session={sessionToRevoke}
+        onSuccess={handleRevoked}
+        t={t}
+      />
+    </>
+  )
+}
+
+/* --------------------------------
    Main Page
 -------------------------------- */
 
@@ -772,6 +946,7 @@ export default function UsersPage() {
   const { data: session } = useSession()
   const t = useTranslations()
   const { hasFeature } = useLicense()
+  const { isAdmin } = useRBAC()
   const showRbac = hasFeature(Features.RBAC)
   const showTenants = hasFeature(Features.MULTI_TENANCY)
   // Cross-tenant management (list every user, edit memberships from the
@@ -781,6 +956,14 @@ export default function UsersPage() {
   const isInDefaultTenant = (session?.user?.tenantId || 'default') === 'default'
   const enableTenantMgmt = showTenants && isInDefaultTenant
   const [activeTab, setActiveTab] = useState(0)
+
+  // The Sessions tab (index 1) only exists for super admins. Derived rather
+  // than reset via an effect (a synchronous setState in a bare useEffect
+  // triggers react-hooks/set-state-in-effect and an extra render): if
+  // isAdmin is false — on load before RBAC resolves, or because the flag
+  // flips while that tab is active — this renders tab 0 immediately,
+  // without ever landing on a blank card for tab 1.
+  const effectiveTab = isAdmin ? activeTab : 0
 
   const { setPageInfo } = usePageTitle()
 
@@ -1193,12 +1376,15 @@ return () => setPageInfo('', '', '')
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, flex: 1 }}>
       <Card variant='outlined' sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-        <Tabs value={activeTab} onChange={(e, v) => setActiveTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs value={effectiveTab} onChange={(e, v) => setActiveTab(v)} sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <Tab label={t('navigation.users')} icon={<i className='ri-user-line' />} iconPosition='start' />
+          {isAdmin && (
+            <Tab label={t('sessions.adminAllTab')} icon={<i className='ri-device-line' />} iconPosition='start' />
+          )}
         </Tabs>
 
         <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-          {activeTab === 0 && (
+          {effectiveTab === 0 && (
             <>
               <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
                 <Typography variant='body2' sx={{ opacity: 0.6 }}>
@@ -1251,6 +1437,7 @@ return () => setPageInfo('', '', '')
               </Box>
             </>
           )}
+          {effectiveTab === 1 && <AdminSessionsTab t={t} />}
         </CardContent>
       </Card>
 

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -41,6 +41,7 @@ import { useLicense, Features } from '@/contexts/LicenseContext'
 import { useUsers, useRbacRoles, useRbacAssignments, useTenants } from '@/hooks/useUsers'
 import EmptyState from '@/components/EmptyState'
 import { TableSkeleton } from '@/components/skeletons'
+import RevokeSessionsDialog from '@/components/security/RevokeSessionsDialog'
 
 /* --------------------------------
    Helpers
@@ -747,67 +748,6 @@ function Require2FADialog({ open, mode, onClose, user, onSuccess, t }) {
       <DialogContent sx={{ pt: '20px !important' }}>
         {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
         <Typography>{t(bodyKey)}</Typography>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose}>{t('common.cancel')}</Button>
-        <Button
-          variant='contained'
-          onClick={handleConfirm}
-          disabled={loading}
-          startIcon={loading ? <CircularProgress size={16} /> : null}
-        >
-          {t('common.confirm')}
-        </Button>
-      </DialogActions>
-    </Dialog>
-  )
-}
-
-/* --------------------------------
-   Revoke Sessions Confirm Dialog
-   (non-destructive — simple confirm, recoverable by signing back in)
--------------------------------- */
-
-export function RevokeSessionsDialog({ open, onClose, user, onSuccess, t }) {
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-
-  const handleConfirm = async () => {
-    setLoading(true)
-    setError('')
-    try {
-      const res = await fetch(`/api/v1/admin/users/${user.id}/sessions`, {
-        method: 'DELETE',
-      })
-      if (res.ok) {
-        onSuccess(user.id)
-        onClose()
-        return
-      }
-      let data = {}
-      try { data = await res.json() } catch (_) {}
-      setError(data.error || t('common.error'))
-    } catch (_) {
-      setError(t('errors.connectionError'))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleClose = () => {
-    setError('')
-    onClose()
-  }
-
-  return (
-    <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth>
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <i className='ri-logout-box-line' />
-        {t('sessions.adminRevokeConfirmTitle', { email: user?.email || '' })}
-      </DialogTitle>
-      <DialogContent sx={{ pt: '20px !important' }}>
-        {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
-        <Typography>{t('sessions.adminRevokeConfirmBody')}</Typography>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>{t('common.cancel')}</Button>

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -764,6 +764,67 @@ function Require2FADialog({ open, mode, onClose, user, onSuccess, t }) {
 }
 
 /* --------------------------------
+   Revoke Sessions Confirm Dialog
+   (non-destructive — simple confirm, recoverable by signing back in)
+-------------------------------- */
+
+export function RevokeSessionsDialog({ open, onClose, user, onSuccess, t }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/v1/admin/users/${user.id}/sessions`, {
+        method: 'DELETE',
+      })
+      if (res.ok) {
+        onSuccess(user.id)
+        onClose()
+        return
+      }
+      let data = {}
+      try { data = await res.json() } catch (_) {}
+      setError(data.error || t('common.error'))
+    } catch (_) {
+      setError(t('errors.connectionError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setError('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <i className='ri-logout-box-line' />
+        {t('sessions.adminRevokeConfirmTitle', { email: user?.email || '' })}
+      </DialogTitle>
+      <DialogContent sx={{ pt: '20px !important' }}>
+        {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        <Typography>{t('sessions.adminRevokeConfirmBody')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{t('common.cancel')}</Button>
+        <Button
+          variant='contained'
+          onClick={handleConfirm}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {t('common.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+/* --------------------------------
    Main Page
 -------------------------------- */
 
@@ -893,6 +954,26 @@ return () => setPageInfo('', '', '')
       return {
         ...prev,
         data: prev.data.map(u => u.id === userId ? { ...u, require_2fa_enrollment: isRequired } : u),
+      }
+    }, false)
+  }, [mutateUsers])
+
+  const [revokeSessionsDialogOpen, setRevokeSessionsDialogOpen] = useState(false)
+  const [userToRevokeSessions, setUserToRevokeSessions] = useState(null)
+
+  const handleRevokeSessions = (user) => {
+    setUserToRevokeSessions(user)
+    setRevokeSessionsDialogOpen(true)
+  }
+
+  const handleSessionsRevoked = useCallback((userId) => {
+    // Optimistically zero the count for the row without a full network
+    // round-trip. mutateUsers() will reconcile on next SWR revalidation.
+    mutateUsers(prev => {
+      if (!prev?.data) return prev
+      return {
+        ...prev,
+        data: prev.data.map(u => u.id === userId ? { ...u, active_session_count: 0 } : u),
       }
     }, false)
   }, [mutateUsers])
@@ -1076,6 +1157,20 @@ return () => setPageInfo('', '', '')
         ),
       },
       {
+        field: 'active_session_count',
+        headerName: t('sessions.columnHeader'),
+        width: 90,
+        sortable: true,
+        renderCell: params => (
+          <Typography
+            variant='body2'
+            sx={{ textAlign: 'center', width: '100%', opacity: params.row.active_session_count ? 0.85 : 0.35 }}
+          >
+            {params.row.active_session_count ?? 0}
+          </Typography>
+        ),
+      },
+      {
         field: 'actions',
         headerName: t('common.actions'),
         width: 120,
@@ -1123,6 +1218,19 @@ return () => setPageInfo('', '', '')
                 </IconButton>
               </Tooltip>
             )}
+            {/* Revoke sessions: hidden on your own row — revoking here would log the admin
+                out mid-task; they already have the profile card's session card for that. */}
+            {params.row.id !== session?.user?.id && (
+              <Tooltip title={t('sessions.adminRevokeMenu')}>
+                <IconButton
+                  size='small'
+                  color='warning'
+                  onClick={() => handleRevokeSessions(params.row)}
+                >
+                  <i className='ri-logout-box-line' />
+                </IconButton>
+              </Tooltip>
+            )}
             {/* Hide delete on your own row — self-delete is refused by the backend */}
             {params.row.id !== session?.user?.id && (
               <Tooltip title={t('common.delete')}>
@@ -1139,7 +1247,7 @@ return () => setPageInfo('', '', '')
         ),
       },
     ],
-    [t, showRbac, showTenants, session?.user?.id, handleDisable2FA, handleRequire2FA, handleClearRequire2FA]
+    [t, showRbac, showTenants, session?.user?.id, handleDisable2FA, handleRequire2FA, handleClearRequire2FA, handleRevokeSessions]
   )
 
   return (
@@ -1244,6 +1352,14 @@ return () => setPageInfo('', '', '')
         onClose={() => setRequire2FADialogOpen(false)}
         user={userToRequire2FA}
         onSuccess={handle2FARequirementChanged}
+        t={t}
+      />
+
+      <RevokeSessionsDialog
+        open={revokeSessionsDialogOpen}
+        onClose={() => setRevokeSessionsDialogOpen(false)}
+        user={userToRevokeSessions}
+        onSuccess={handleSessionsRevoked}
         t={t}
       />
     </Box>

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -44,6 +44,7 @@ import EmptyState from '@/components/EmptyState'
 import { TableSkeleton } from '@/components/skeletons'
 import RevokeSessionsDialog from '@/components/security/RevokeSessionsDialog'
 import RevokeSingleSessionDialog from '@/components/security/RevokeSingleSessionDialog'
+import RevokeEverySessionDialog from '@/components/security/RevokeEverySessionDialog'
 import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
 import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
 
@@ -834,6 +835,17 @@ function AdminSessionsTab({ t }) {
     }, false)
   }, [mutate])
 
+  const [revokeEveryDialogOpen, setRevokeEveryDialogOpen] = useState(false)
+
+  const handleEveryRevoked = useCallback(() => {
+    // The server kept only the caller's session; reflect that without a
+    // network round-trip. mutate() will reconcile on next SWR revalidation.
+    mutate(prev => {
+      if (!prev?.data) return prev
+      return { ...prev, data: prev.data.filter(s => s.current) }
+    }, false)
+  }, [mutate])
+
   const columns = useMemo(
     () => [
       {
@@ -946,6 +958,20 @@ function AdminSessionsTab({ t }) {
         <Typography variant='body2' sx={{ opacity: 0.6 }}>
           {sessions.length} {t('sessions.columnHeader').toLowerCase()}
         </Typography>
+        {/* Same visibility rule as the profile card's revoke-all: pointless
+            when the only live session is the caller's own (the DELETE keeps
+            it by design). */}
+        {sessions.some(s => !s.current) && (
+          <Button
+            variant='outlined'
+            color='error'
+            size='small'
+            startIcon={<i className='ri-logout-box-line' />}
+            onClick={() => setRevokeEveryDialogOpen(true)}
+          >
+            {t('sessions.adminRevokeEveryButton')}
+          </Button>
+        )}
       </Box>
 
       {loadError && <Alert severity='error' sx={{ mb: 2 }}>{loadError}</Alert>}
@@ -998,6 +1024,13 @@ function AdminSessionsTab({ t }) {
         user={userToRevokeAll}
         onSuccess={handleAllRevoked}
         currentUserId={session?.user?.id}
+        t={t}
+      />
+
+      <RevokeEverySessionDialog
+        open={revokeEveryDialogOpen}
+        onClose={() => setRevokeEveryDialogOpen(false)}
+        onSuccess={handleEveryRevoked}
         t={t}
       />
     </>

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -45,6 +45,7 @@ import { TableSkeleton } from '@/components/skeletons'
 import RevokeSessionsDialog from '@/components/security/RevokeSessionsDialog'
 import RevokeSingleSessionDialog from '@/components/security/RevokeSingleSessionDialog'
 import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
+import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
 
 /* --------------------------------
    Helpers
@@ -299,6 +300,17 @@ return
         setError(data.error || (t ? t('common.error') : 'Error'))
 
 return
+      }
+
+      // A self-edit that sets a new password (or unchecks Enabled) revokes
+      // every session of the account, including the one this tab is on
+      // (users/[id] PATCH → revokeAllSessions with no exception). Everything
+      // this function would do next — the RBAC assignment calls below,
+      // onSave()'s revalidation — can only 401 against the dead session.
+      // Leave for /login now; the operator signs back in with the new password.
+      if (isEdit && isSelf && (password || !enabled)) {
+        redirectToLoginOnce()
+        return
       }
 
       const userId = isEdit ? user.id : data.data.id
@@ -1497,6 +1509,7 @@ return () => setPageInfo('', '', '')
         onClose={() => setRevokeSessionsDialogOpen(false)}
         user={userToRevokeSessions}
         onSuccess={handleSessionsRevoked}
+        currentUserId={session?.user?.id}
         t={t}
       />
     </Box>

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -837,15 +837,6 @@ function AdminSessionsTab({ t }) {
 
   const [revokeEveryDialogOpen, setRevokeEveryDialogOpen] = useState(false)
 
-  const handleEveryRevoked = useCallback(() => {
-    // The server kept only the caller's session; reflect that without a
-    // network round-trip. mutate() will reconcile on next SWR revalidation.
-    mutate(prev => {
-      if (!prev?.data) return prev
-      return { ...prev, data: prev.data.filter(s => s.current) }
-    }, false)
-  }, [mutate])
-
   const columns = useMemo(
     () => [
       {
@@ -958,10 +949,11 @@ function AdminSessionsTab({ t }) {
         <Typography variant='body2' sx={{ opacity: 0.6 }}>
           {sessions.length} {t('sessions.columnHeader').toLowerCase()}
         </Typography>
-        {/* Same visibility rule as the profile card's revoke-all: pointless
-            when the only live session is the caller's own (the DELETE keeps
-            it by design). */}
-        {sessions.some(s => !s.current) && (
+        {/* Visible whenever anything is revocable — one session or a
+            hundred. The DELETE is total (caller included), so even a lone
+            own session is a valid target; the dialog says so and the
+            confirm ends on the /login redirect. */}
+        {sessions.length > 0 && (
           <Button
             variant='outlined'
             color='error'
@@ -1030,7 +1022,6 @@ function AdminSessionsTab({ t }) {
       <RevokeEverySessionDialog
         open={revokeEveryDialogOpen}
         onClose={() => setRevokeEveryDialogOpen(false)}
-        onSuccess={handleEveryRevoked}
         t={t}
       />
     </>

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -780,6 +780,7 @@ function Require2FADialog({ open, mode, onClose, user, onSuccess, t }) {
 function AdminSessionsTab({ t }) {
   const { data, error: fetchError, isLoading, mutate } = useAdminSessions(true)
   const sessions = data?.data || []
+  const truncated = data?.truncated === true
   const loadError = fetchError ? t('errors.connectionError') : ''
 
   const [revokeDialogOpen, setRevokeDialogOpen] = useState(false)
@@ -807,7 +808,15 @@ function AdminSessionsTab({ t }) {
         flex: 1,
         minWidth: 200,
         renderCell: params => (
-          <Typography variant='body2' noWrap sx={{ fontWeight: 600 }}>{params.row.userEmail}</Typography>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+            <Typography variant='body2' noWrap sx={{ fontWeight: 600 }}>{params.row.userEmail}</Typography>
+            {/* The listing is "every session in the installation", including the
+                caller's own — mark it the way the profile card marks its current
+                session, so a revoke click here is never a surprise. */}
+            {params.row.current && (
+              <Chip label={t('sessions.currentChip')} size='small' color='success' />
+            )}
+          </Box>
         ),
       },
       {
@@ -893,6 +902,7 @@ function AdminSessionsTab({ t }) {
       </Box>
 
       {loadError && <Alert severity='error' sx={{ mb: 2 }}>{loadError}</Alert>}
+      {truncated && <Alert severity='warning' sx={{ mb: 2 }}>{t('sessions.adminAllTruncatedWarning')}</Alert>}
 
       <Box sx={{ flex: 1, minHeight: 400 }}>
         {!isLoading && sessions.length === 0 && !loadError ? (

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -791,6 +791,9 @@ function Require2FADialog({ open, mode, onClose, user, onSuccess, t }) {
 
 function AdminSessionsTab({ t }) {
   const { data, error: fetchError, isLoading, mutate } = useAdminSessions(true)
+  // Only used to hand the caller's id to RevokeSessionsDialog, which decides
+  // whether a revoke-all targets the caller themselves (warning + redirect).
+  const { data: session } = useSession()
   const sessions = data?.data || []
   const truncated = data?.truncated === true
   const loadError = fetchError ? t('errors.connectionError') : ''
@@ -809,6 +812,25 @@ function AdminSessionsTab({ t }) {
     mutate(prev => {
       if (!prev?.data) return prev
       return { ...prev, data: prev.data.filter(s => s.id !== sessionId) }
+    }, false)
+  }, [mutate])
+
+  const [revokeAllDialogOpen, setRevokeAllDialogOpen] = useState(false)
+  const [userToRevokeAll, setUserToRevokeAll] = useState(null)
+
+  const handleRevokeAllForUser = (row) => {
+    // RevokeSessionsDialog expects a user shape ({ id, email }); the sessions
+    // row carries both, under session-listing names.
+    setUserToRevokeAll({ id: row.userId, email: row.userEmail })
+    setRevokeAllDialogOpen(true)
+  }
+
+  const handleAllRevoked = useCallback((userId) => {
+    // Optimistically drop every session row of that user without a full
+    // network round-trip. mutate() will reconcile on next SWR revalidation.
+    mutate(prev => {
+      if (!prev?.data) return prev
+      return { ...prev, data: prev.data.filter(s => s.userId !== userId) }
     }, false)
   }, [mutate])
 
@@ -887,18 +909,31 @@ function AdminSessionsTab({ t }) {
       {
         field: 'actions',
         headerName: t('common.actions'),
-        width: 90,
+        width: 110,
         sortable: false,
         renderCell: params => (
-          <Tooltip title={t('sessions.adminRevokeOneMenu')}>
-            <IconButton
-              size='small'
-              color='warning'
-              onClick={() => handleRevoke(params.row)}
-            >
-              <i className='ri-logout-box-line' />
-            </IconButton>
-          </Tooltip>
+          <>
+            <Tooltip title={t('sessions.adminRevokeOneMenu')}>
+              <IconButton
+                size='small'
+                color='warning'
+                onClick={() => handleRevoke(params.row)}
+              >
+                {/* circle-r = THIS session (same icon as the profile card's
+                    single revoke); box = ALL sessions of the row's user. */}
+                <i className='ri-logout-circle-r-line' />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title={t('sessions.adminRevokeMenu')}>
+              <IconButton
+                size='small'
+                color='warning'
+                onClick={() => handleRevokeAllForUser(params.row)}
+              >
+                <i className='ri-logout-box-line' />
+              </IconButton>
+            </Tooltip>
+          </>
         ),
       },
     ],
@@ -954,6 +989,15 @@ function AdminSessionsTab({ t }) {
         onClose={() => setRevokeDialogOpen(false)}
         session={sessionToRevoke}
         onSuccess={handleRevoked}
+        t={t}
+      />
+
+      <RevokeSessionsDialog
+        open={revokeAllDialogOpen}
+        onClose={() => setRevokeAllDialogOpen(false)}
+        user={userToRevokeAll}
+        onSuccess={handleAllRevoked}
+        currentUserId={session?.user?.id}
         t={t}
       />
     </>
@@ -1099,26 +1143,6 @@ return () => setPageInfo('', '', '')
       return {
         ...prev,
         data: prev.data.map(u => u.id === userId ? { ...u, require_2fa_enrollment: isRequired } : u),
-      }
-    }, false)
-  }, [mutateUsers])
-
-  const [revokeSessionsDialogOpen, setRevokeSessionsDialogOpen] = useState(false)
-  const [userToRevokeSessions, setUserToRevokeSessions] = useState(null)
-
-  const handleRevokeSessions = (user) => {
-    setUserToRevokeSessions(user)
-    setRevokeSessionsDialogOpen(true)
-  }
-
-  const handleSessionsRevoked = useCallback((userId) => {
-    // Optimistically zero the count for the row without a full network
-    // round-trip. mutateUsers() will reconcile on next SWR revalidation.
-    mutateUsers(prev => {
-      if (!prev?.data) return prev
-      return {
-        ...prev,
-        data: prev.data.map(u => u.id === userId ? { ...u, active_session_count: 0 } : u),
       }
     }, false)
   }, [mutateUsers])
@@ -1363,19 +1387,6 @@ return () => setPageInfo('', '', '')
                 </IconButton>
               </Tooltip>
             )}
-            {/* Revoke sessions: hidden on your own row — revoking here would log the admin
-                out mid-task; they already have the profile card's session card for that. */}
-            {params.row.id !== session?.user?.id && (
-              <Tooltip title={t('sessions.adminRevokeMenu')}>
-                <IconButton
-                  size='small'
-                  color='warning'
-                  onClick={() => handleRevokeSessions(params.row)}
-                >
-                  <i className='ri-logout-box-line' />
-                </IconButton>
-              </Tooltip>
-            )}
             {/* Hide delete on your own row — self-delete is refused by the backend */}
             {params.row.id !== session?.user?.id && (
               <Tooltip title={t('common.delete')}>
@@ -1392,7 +1403,7 @@ return () => setPageInfo('', '', '')
         ),
       },
     ],
-    [t, showRbac, showTenants, session?.user?.id, handleDisable2FA, handleRequire2FA, handleClearRequire2FA, handleRevokeSessions]
+    [t, showRbac, showTenants, session?.user?.id, handleDisable2FA, handleRequire2FA, handleClearRequire2FA]
   )
 
   return (
@@ -1501,15 +1512,6 @@ return () => setPageInfo('', '', '')
         onClose={() => setRequire2FADialogOpen(false)}
         user={userToRequire2FA}
         onSuccess={handle2FARequirementChanged}
-        t={t}
-      />
-
-      <RevokeSessionsDialog
-        open={revokeSessionsDialogOpen}
-        onClose={() => setRevokeSessionsDialogOpen(false)}
-        user={userToRevokeSessions}
-        onSuccess={handleSessionsRevoked}
-        currentUserId={session?.user?.id}
         t={t}
       />
     </Box>

--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -4,7 +4,7 @@ import NextAuth from "next-auth"
 import { getAuthOptions } from "@/lib/auth/config"
 
 async function handler(req: NextRequest, ctx: { params: Promise<{ nextauth: string[] }> }) {
-  const opts = await getAuthOptions()
+  const opts = await getAuthOptions(req)
   return NextAuth(opts)(req as any, ctx as any)
 }
 

--- a/frontend/src/app/api/v1/admin/sessions/[sid]/route.test.ts
+++ b/frontend/src/app/api/v1/admin/sessions/[sid]/route.test.ts
@@ -1,0 +1,128 @@
+/**
+ * DELETE /api/v1/admin/sessions/[sid] — super-admin revokes a single
+ * session anywhere in the installation.
+ *
+ * revokeSession(sid, userId) (@/lib/auth/sessions) is scoped to an owner, so
+ * this route must resolve which user owns the sid before it can call it. A
+ * sid that does not exist returns 404, never 403 — matching
+ * DELETE /api/v1/auth/sessions/[sid]'s convention that a 403 would confirm
+ * the id is real. The audit entry never names the sid.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const {
+  getServerSessionMock,
+  requireSuperAdminCallerMock,
+  sessionFindUniqueMock,
+  revokeSessionMock,
+  auditMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  requireSuperAdminCallerMock: vi.fn(),
+  sessionFindUniqueMock: vi.fn(),
+  revokeSessionMock: vi.fn(),
+  auditMock: vi.fn(async () => "audit-id"),
+}))
+
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/auth/totp-admin", () => ({
+  requireSuperAdminCaller: requireSuperAdminCallerMock,
+}))
+vi.mock("@/lib/auth/sessions", () => ({ revokeSession: revokeSessionMock }))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    session: { findUnique: sessionFindUniqueMock },
+  },
+}))
+
+async function importDELETE() {
+  const mod = await import("./route")
+  return mod.DELETE
+}
+
+describe("DELETE /api/v1/admin/sessions/[sid]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
+    requireSuperAdminCallerMock.mockResolvedValue(null)
+    sessionFindUniqueMock.mockResolvedValue({ userId: "target-1", user: { email: "target@example.com" } })
+    revokeSessionMock.mockResolvedValue(true)
+  })
+
+  it("returns the denial requireSuperAdminCaller produces and never resolves or revokes anything", async () => {
+    const denial = new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+    requireSuperAdminCallerMock.mockResolvedValue(denial)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { sid: "sess-1" } })
+
+    expect(res.status).toBe(403)
+    expect(sessionFindUniqueMock).not.toHaveBeenCalled()
+    expect(revokeSessionMock).not.toHaveBeenCalled()
+    expect(auditMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 404, not 403, when the sid does not exist, and reveals nothing about it", async () => {
+    sessionFindUniqueMock.mockResolvedValue(null)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { sid: "ghost" } })
+
+    expect(res.status).toBe(404)
+    expect(res.status).not.toBe(403)
+    expect(revokeSessionMock).not.toHaveBeenCalled()
+    expect(auditMock).not.toHaveBeenCalled()
+
+    const body = await readJson<any>(res)
+    expect(JSON.stringify(body)).not.toMatch(/ghost/)
+  })
+
+  it("resolves the owning user first, then calls revokeSession with (sid, ownerUserId)", async () => {
+    sessionFindUniqueMock.mockResolvedValue({ userId: "target-1", user: { email: "target@example.com" } })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { sid: "sess-1" } })
+
+    expect(res.status).toBe(200)
+    expect(sessionFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "sess-1" },
+      select: { userId: true, user: { select: { email: true } } },
+    })
+    expect(revokeSessionMock).toHaveBeenCalledWith("sess-1", "target-1")
+    expect(await readJson<any>(res)).toEqual({ data: { ok: true } })
+  })
+
+  it("returns 404 when revokeSession reports nothing was revoked (already gone)", async () => {
+    revokeSessionMock.mockResolvedValue(false)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { sid: "sess-1" } })
+
+    expect(res.status).toBe(404)
+    expect(auditMock).not.toHaveBeenCalled()
+  })
+
+  it("audits the revocation naming the owning user, but never the sid", async () => {
+    const DELETE = await importDELETE()
+    await callRoute(DELETE as any, { method: "DELETE", params: { sid: "sess-1" } })
+
+    expect(auditMock).toHaveBeenCalledTimes(1)
+    const entry = auditMock.mock.calls[0][0]
+    expect(entry.action).toBe("session_revoked_single")
+    expect(entry.category).toBe("auth")
+    expect(entry.resourceType).toBe("user")
+    expect(entry.resourceId).toBe("target-1")
+    expect(entry.resourceName).toBe("target@example.com")
+    expect(entry.userId).toBe("admin-1")
+    expect(entry.userEmail).toBe("admin@example.com")
+
+    const serialised = JSON.stringify(entry)
+    expect(serialised).not.toMatch(/sess-1/)
+  })
+})

--- a/frontend/src/app/api/v1/admin/sessions/[sid]/route.ts
+++ b/frontend/src/app/api/v1/admin/sessions/[sid]/route.ts
@@ -1,0 +1,65 @@
+// src/app/api/v1/admin/sessions/[sid]/route.ts
+//
+// Super-admin revoke of a single session, anywhere in the installation.
+// The sibling DELETE /api/v1/admin/users/[id]/sessions revokes every
+// session of one user and stays as it is; this route is per-session, which
+// is what the new listing (GET /api/v1/admin/sessions) needs for its
+// per-row revoke action.
+//
+// revokeSession(sid, userId) (@/lib/auth/sessions) is scoped to an owner, so
+// the owning user must be resolved first.
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/lib/auth/config"
+import { prisma } from "@/lib/db/prisma"
+import { audit } from "@/lib/audit"
+import { revokeSession } from "@/lib/auth/sessions"
+import { requireSuperAdminCaller } from "@/lib/auth/totp-admin"
+
+export const runtime = "nodejs"
+
+interface RouteContext {
+  params: Promise<{ sid: string }>
+}
+
+// DELETE /api/v1/admin/sessions/[sid] — revoke one session. A sid that does
+// not exist returns 404, never 403: matching
+// DELETE /api/v1/auth/sessions/[sid]'s convention, a 403 would confirm the
+// id is real. The audit entry names the owning user, never the sid.
+export async function DELETE(_req: Request, ctx: RouteContext) {
+  const denied = await requireSuperAdminCaller()
+  if (denied) return denied
+
+  const session = await getServerSession(authOptions)
+  const { sid } = await ctx.params
+
+  const target = await prisma.session.findUnique({
+    where: { id: sid },
+    select: { userId: true, user: { select: { email: true } } },
+  })
+
+  if (!target) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  const revoked = await revokeSession(sid, target.userId)
+
+  if (!revoked) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  await audit({
+    action: "session_revoked_single",
+    category: "auth",
+    userId: session?.user?.id,
+    userEmail: session?.user?.email ?? undefined,
+    resourceType: "user",
+    resourceId: target.userId,
+    resourceName: target.user.email,
+    status: "success",
+    details: { by: "admin" },
+  })
+
+  return NextResponse.json({ data: { ok: true } })
+}

--- a/frontend/src/app/api/v1/admin/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.test.ts
@@ -278,8 +278,7 @@ describe("DELETE /api/v1/admin/sessions", () => {
     expect(auditMock).not.toHaveBeenCalled()
   })
 
-  it("revokes every live session except the caller's own current one", async () => {
-    getTokenMock.mockResolvedValue({ sid: "caller-sid" })
+  it("revokes every live session, the caller's own included", async () => {
     sessionUpdateManyMock.mockResolvedValue({ count: 7 })
 
     const DELETE = await importDELETE()
@@ -291,27 +290,12 @@ describe("DELETE /api/v1/admin/sessions", () => {
 
     expect(sessionUpdateManyMock).toHaveBeenCalledTimes(1)
     const arg = sessionUpdateManyMock.mock.calls[0][0]
-    expect(arg.where).toEqual({ revokedAt: null, id: { not: "caller-sid" } })
+    // Total by design: no id exclusion, whatever the caller's token holds.
+    expect(arg.where).toEqual({ revokedAt: null })
     expect(arg.data.revokedAt).toBeInstanceOf(Date)
   })
 
-  it("revokes truly everything when the caller token carries no sid", async () => {
-    getTokenMock.mockResolvedValue(null)
-    sessionUpdateManyMock.mockResolvedValue({ count: 9 })
-
-    const DELETE = await importDELETE()
-    const res = await callRoute(DELETE as any, { method: "DELETE" })
-    const body = await readJson<any>(res)
-
-    expect(res.status).toBe(200)
-    expect(body).toEqual({ data: { revoked: 9 } })
-
-    const arg = sessionUpdateManyMock.mock.calls[0][0]
-    expect(arg.where).toEqual({ revokedAt: null })
-  })
-
   it("writes one audit entry naming the action and the count", async () => {
-    getTokenMock.mockResolvedValue({ sid: "caller-sid" })
     sessionUpdateManyMock.mockResolvedValue({ count: 3 })
 
     const DELETE = await importDELETE()
@@ -322,7 +306,8 @@ describe("DELETE /api/v1/admin/sessions", () => {
       action: "sessions_revoked_all",
       category: "auth",
       status: "success",
-      details: { by: "admin", revoked: 3, callerSessionKept: true },
+      details: { by: "admin", revoked: 3 },
     })
+    expect(auditMock.mock.calls[0][0].details).not.toHaveProperty("callerSessionKept")
   })
 })

--- a/frontend/src/app/api/v1/admin/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.test.ts
@@ -11,16 +11,28 @@
  * Liveness comes from aliveWhere() — the same boundary-tested predicate the
  * self-service and per-user routes use. This file does not re-derive the
  * liveness rule, it only checks the predicate reaches the query.
+ *
+ * The query is bounded (MAX_SESSION_ROWS in ./route.ts): an MSP installation
+ * mid-incident can have far more live sessions than a DataGrid should try to
+ * render in one response. Overflow must never be silent — the response says
+ * `truncated: true` rather than quietly dropping rows.
+ *
+ * The caller's own session is marked `current: true` via the same
+ * getToken()+sessionCookieName() pattern as /api/v1/auth/sessions/route.ts,
+ * so the UI can warn before a revoke click signs the admin out of the
+ * screen they are on.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { callRoute, readJson } from "@/__tests__/setup/route-test"
 
 const {
   requireSuperAdminCallerMock,
+  getTokenMock,
   sessionFindManyMock,
   tenantFindManyMock,
 } = vi.hoisted(() => ({
   requireSuperAdminCallerMock: vi.fn(),
+  getTokenMock: vi.fn(),
   sessionFindManyMock: vi.fn(),
   tenantFindManyMock: vi.fn(),
 }))
@@ -28,6 +40,8 @@ const {
 vi.mock("@/lib/auth/totp-admin", () => ({
   requireSuperAdminCaller: requireSuperAdminCallerMock,
 }))
+vi.mock("next-auth/jwt", () => ({ getToken: getTokenMock }))
+vi.mock("@/lib/auth/cookies", () => ({ sessionCookieName: () => "next-auth.session-token" }))
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
     session: { findMany: sessionFindManyMock },
@@ -60,6 +74,7 @@ function row(overrides: Partial<{
 beforeEach(() => {
   vi.clearAllMocks()
   requireSuperAdminCallerMock.mockResolvedValue(null)
+  getTokenMock.mockResolvedValue({}) // no sid: no row marked current unless overridden
   sessionFindManyMock.mockResolvedValue([])
   tenantFindManyMock.mockResolvedValue([])
 })
@@ -144,8 +159,9 @@ describe("GET /api/v1/admin/sessions", () => {
     const res = await callRoute(GET as any, { method: "GET" })
     const body = await readJson<any>(res)
 
+    expect(Object.keys(body).sort()).toEqual(["data", "truncated"])
     expect(Object.keys(body.data[0]).sort()).toEqual(
-      ["browser", "createdAt", "id", "ipAddress", "lastSeenAt", "os", "tenantName", "userEmail", "userId"].sort(),
+      ["browser", "createdAt", "current", "id", "ipAddress", "lastSeenAt", "os", "tenantName", "userEmail", "userId"].sort(),
     )
     const serialised = JSON.stringify(body)
     expect(serialised).not.toMatch(/userAgent/i)
@@ -161,5 +177,70 @@ describe("GET /api/v1/admin/sessions", () => {
     const body = await readJson<any>(res)
 
     expect(body.data[0].tenantName).toBe("ghost-tenant")
+  })
+
+  describe("bounding (never silently drop rows)", () => {
+    it("requests MAX_SESSION_ROWS + 1 rows and reports truncated: false under the cap", async () => {
+      sessionFindManyMock.mockResolvedValue([row()])
+      tenantFindManyMock.mockResolvedValue([{ id: "tenant-a", name: "Tenant A" }])
+
+      const GET = await importGET()
+      const res = await callRoute(GET as any, { method: "GET" })
+      const body = await readJson<any>(res)
+
+      expect(sessionFindManyMock.mock.calls[0][0].take).toBe(501)
+      expect(body.truncated).toBe(false)
+      expect(body.data).toHaveLength(1)
+    })
+
+    it("truncates to 500 rows and reports truncated: true when the 501st row comes back", async () => {
+      const rows = Array.from({ length: 501 }, (_, i) =>
+        row({ id: `sess-${i}`, user: { email: `u${i}@example.com`, tenantId: "tenant-a" } }),
+      )
+      sessionFindManyMock.mockResolvedValue(rows)
+      tenantFindManyMock.mockResolvedValue([{ id: "tenant-a", name: "Tenant A" }])
+
+      const GET = await importGET()
+      const res = await callRoute(GET as any, { method: "GET" })
+      const body = await readJson<any>(res)
+
+      expect(body.truncated).toBe(true)
+      expect(body.data).toHaveLength(500)
+      // The 500 kept are the first 500 as ordered by the query (lastSeenAt
+      // desc), not an arbitrary subset — dropping the tail, not the head.
+      expect(body.data[0].id).toBe("sess-0")
+      expect(body.data[499].id).toBe("sess-499")
+    })
+  })
+
+  describe("marking the caller's own session", () => {
+    it("marks the row matching the token's sid current:true and every other row current:false", async () => {
+      getTokenMock.mockResolvedValue({ sid: "sess-2" })
+      sessionFindManyMock.mockResolvedValue([
+        row({ id: "sess-1", user: { email: "u1@example.com", tenantId: "tenant-a" } }),
+        row({ id: "sess-2", userId: "u2", user: { email: "u2@example.com", tenantId: "tenant-a" } }),
+      ])
+      tenantFindManyMock.mockResolvedValue([{ id: "tenant-a", name: "Tenant A" }])
+
+      const GET = await importGET()
+      const res = await callRoute(GET as any, { method: "GET" })
+      const body = await readJson<any>(res)
+
+      const bySid = new Map(body.data.map((s: any) => [s.id, s.current]))
+      expect(bySid.get("sess-1")).toBe(false)
+      expect(bySid.get("sess-2")).toBe(true)
+    })
+
+    it("marks every row current:false when the token has no sid", async () => {
+      getTokenMock.mockResolvedValue({})
+      sessionFindManyMock.mockResolvedValue([row({ id: "sess-1" })])
+      tenantFindManyMock.mockResolvedValue([{ id: "tenant-a", name: "Tenant A" }])
+
+      const GET = await importGET()
+      const res = await callRoute(GET as any, { method: "GET" })
+      const body = await readJson<any>(res)
+
+      expect(body.data[0].current).toBe(false)
+    })
   })
 })

--- a/frontend/src/app/api/v1/admin/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.test.ts
@@ -1,0 +1,165 @@
+/**
+ * GET /api/v1/admin/sessions — super-admin view of every live session in
+ * the installation, across every tenant.
+ *
+ * Gated by requireSuperAdminCaller() — NOT checkPermission(ADMIN_USERS). This
+ * is broader visibility than the existing per-user revoke
+ * (admin/users/[id]/sessions), which the author deliberately kept behind
+ * admin.users; this route is a reversal of a privacy boundary and gets the
+ * stricter gate on purpose.
+ *
+ * Liveness comes from aliveWhere() — the same boundary-tested predicate the
+ * self-service and per-user routes use. This file does not re-derive the
+ * liveness rule, it only checks the predicate reaches the query.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const {
+  requireSuperAdminCallerMock,
+  sessionFindManyMock,
+  tenantFindManyMock,
+} = vi.hoisted(() => ({
+  requireSuperAdminCallerMock: vi.fn(),
+  sessionFindManyMock: vi.fn(),
+  tenantFindManyMock: vi.fn(),
+}))
+
+vi.mock("@/lib/auth/totp-admin", () => ({
+  requireSuperAdminCaller: requireSuperAdminCallerMock,
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    session: { findMany: sessionFindManyMock },
+    tenant: { findMany: tenantFindManyMock },
+  },
+}))
+// aliveWhere (@/lib/auth/sessions) and deviceLabel (@/lib/auth/deviceLabel)
+// are small pure helpers with their own boundary tests — exercised for real
+// here rather than mocked.
+
+function row(overrides: Partial<{
+  id: string
+  userId: string
+  ipAddress: string | null
+  userAgent: string | null
+  user: { email: string; tenantId: string }
+}> = {}) {
+  return {
+    id: "sess-1",
+    userId: "u1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    lastSeenAt: new Date("2026-01-02T00:00:00.000Z"),
+    ipAddress: "10.0.0.1",
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0 Safari/537.36",
+    user: { email: "u1@example.com", tenantId: "tenant-a" },
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  requireSuperAdminCallerMock.mockResolvedValue(null)
+  sessionFindManyMock.mockResolvedValue([])
+  tenantFindManyMock.mockResolvedValue([])
+})
+
+describe("GET /api/v1/admin/sessions", () => {
+  async function importGET() {
+    const mod = await import("./route")
+    return mod.GET
+  }
+
+  it("returns the denial requireSuperAdminCaller produces and never queries sessions", async () => {
+    const denial = new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+    requireSuperAdminCallerMock.mockResolvedValue(denial)
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+
+    expect(res.status).toBe(403)
+    expect(sessionFindManyMock).not.toHaveBeenCalled()
+    expect(tenantFindManyMock).not.toHaveBeenCalled()
+  })
+
+  it("returns rows across tenants, with ISO date strings and split device parts", async () => {
+    sessionFindManyMock.mockResolvedValue([
+      row({ id: "sess-1", user: { email: "u1@example.com", tenantId: "tenant-a" } }),
+      row({
+        id: "sess-2",
+        userId: "u2",
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64) Firefox/119.0",
+        ipAddress: "::1",
+        user: { email: "u2@example.com", tenantId: "tenant-b" },
+      }),
+    ])
+    tenantFindManyMock.mockResolvedValue([
+      { id: "tenant-a", name: "Tenant A" },
+      { id: "tenant-b", name: "Tenant B" },
+    ])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    expect(body.data).toHaveLength(2)
+
+    const [first, second] = body.data
+    expect(first.userEmail).toBe("u1@example.com")
+    expect(first.tenantName).toBe("Tenant A")
+    expect(second.tenantName).toBe("Tenant B")
+    expect(second.browser).toBe("Firefox")
+    expect(second.os).toBe("Linux")
+    expect(second.ipAddress).toBe("::1")
+
+    for (const s of body.data) {
+      expect(typeof s.createdAt).toBe("string")
+      expect(new Date(s.createdAt).toISOString()).toBe(s.createdAt)
+      expect(typeof s.lastSeenAt).toBe("string")
+      expect(new Date(s.lastSeenAt).toISOString()).toBe(s.lastSeenAt)
+    }
+  })
+
+  it("filters with aliveWhere()'s predicate and orders by lastSeenAt desc", async () => {
+    const GET = await importGET()
+    await callRoute(GET as any, { method: "GET" })
+
+    expect(sessionFindManyMock).toHaveBeenCalledTimes(1)
+    const args = sessionFindManyMock.mock.calls[0][0]
+    expect(args.where).toMatchObject({ revokedAt: null })
+    expect(args.where.lastSeenAt).toBeDefined()
+    expect(args.where.createdAt).toBeDefined()
+    expect(args.orderBy).toEqual({ lastSeenAt: "desc" })
+  })
+
+  it("the response contains no field beyond the documented contract", async () => {
+    sessionFindManyMock.mockResolvedValue([row()])
+    tenantFindManyMock.mockResolvedValue([{ id: "tenant-a", name: "Tenant A" }])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await readJson<any>(res)
+
+    expect(Object.keys(body.data[0]).sort()).toEqual(
+      ["browser", "createdAt", "id", "ipAddress", "lastSeenAt", "os", "tenantName", "userEmail", "userId"].sort(),
+    )
+    const serialised = JSON.stringify(body)
+    expect(serialised).not.toMatch(/userAgent/i)
+    expect(serialised).not.toMatch(/revokedAt/i)
+  })
+
+  it("falls back to the raw tenantId when the tenant row is missing", async () => {
+    sessionFindManyMock.mockResolvedValue([row({ user: { email: "u1@example.com", tenantId: "ghost-tenant" } })])
+    tenantFindManyMock.mockResolvedValue([])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await readJson<any>(res)
+
+    expect(body.data[0].tenantName).toBe("ghost-tenant")
+  })
+})

--- a/frontend/src/app/api/v1/admin/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.test.ts
@@ -29,22 +29,31 @@ const {
   requireSuperAdminCallerMock,
   getTokenMock,
   sessionFindManyMock,
+  sessionUpdateManyMock,
   tenantFindManyMock,
+  auditMock,
+  getServerSessionMock,
 } = vi.hoisted(() => ({
   requireSuperAdminCallerMock: vi.fn(),
   getTokenMock: vi.fn(),
   sessionFindManyMock: vi.fn(),
+  sessionUpdateManyMock: vi.fn(),
   tenantFindManyMock: vi.fn(),
+  auditMock: vi.fn(),
+  getServerSessionMock: vi.fn(),
 }))
 
 vi.mock("@/lib/auth/totp-admin", () => ({
   requireSuperAdminCaller: requireSuperAdminCallerMock,
 }))
 vi.mock("next-auth/jwt", () => ({ getToken: getTokenMock }))
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
 vi.mock("@/lib/auth/cookies", () => ({ sessionCookieName: () => "next-auth.session-token" }))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
-    session: { findMany: sessionFindManyMock },
+    session: { findMany: sessionFindManyMock, updateMany: sessionUpdateManyMock },
     tenant: { findMany: tenantFindManyMock },
   },
 }))
@@ -76,7 +85,10 @@ beforeEach(() => {
   requireSuperAdminCallerMock.mockResolvedValue(null)
   getTokenMock.mockResolvedValue({}) // no sid: no row marked current unless overridden
   sessionFindManyMock.mockResolvedValue([])
+  sessionUpdateManyMock.mockResolvedValue({ count: 0 })
   tenantFindManyMock.mockResolvedValue([])
+  auditMock.mockResolvedValue(undefined)
+  getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
 })
 
 describe("GET /api/v1/admin/sessions", () => {
@@ -241,6 +253,76 @@ describe("GET /api/v1/admin/sessions", () => {
       const body = await readJson<any>(res)
 
       expect(body.data[0].current).toBe(false)
+    })
+  })
+})
+
+describe("DELETE /api/v1/admin/sessions", () => {
+  async function importDELETE() {
+    const mod = await import("./route")
+    return mod.DELETE
+  }
+
+  it("is refused when the caller is not a super admin, before any write", async () => {
+    const denial = new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+    requireSuperAdminCallerMock.mockResolvedValue(denial)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE" })
+
+    expect(res.status).toBe(403)
+    expect(sessionUpdateManyMock).not.toHaveBeenCalled()
+    expect(auditMock).not.toHaveBeenCalled()
+  })
+
+  it("revokes every live session except the caller's own current one", async () => {
+    getTokenMock.mockResolvedValue({ sid: "caller-sid" })
+    sessionUpdateManyMock.mockResolvedValue({ count: 7 })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE" })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ data: { revoked: 7 } })
+
+    expect(sessionUpdateManyMock).toHaveBeenCalledTimes(1)
+    const arg = sessionUpdateManyMock.mock.calls[0][0]
+    expect(arg.where).toEqual({ revokedAt: null, id: { not: "caller-sid" } })
+    expect(arg.data.revokedAt).toBeInstanceOf(Date)
+  })
+
+  it("revokes truly everything when the caller token carries no sid", async () => {
+    getTokenMock.mockResolvedValue(null)
+    sessionUpdateManyMock.mockResolvedValue({ count: 9 })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE" })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ data: { revoked: 9 } })
+
+    const arg = sessionUpdateManyMock.mock.calls[0][0]
+    expect(arg.where).toEqual({ revokedAt: null })
+  })
+
+  it("writes one audit entry naming the action and the count", async () => {
+    getTokenMock.mockResolvedValue({ sid: "caller-sid" })
+    sessionUpdateManyMock.mockResolvedValue({ count: 3 })
+
+    const DELETE = await importDELETE()
+    await callRoute(DELETE as any, { method: "DELETE" })
+
+    expect(auditMock).toHaveBeenCalledTimes(1)
+    expect(auditMock.mock.calls[0][0]).toMatchObject({
+      action: "sessions_revoked_all",
+      category: "auth",
+      status: "success",
+      details: { by: "admin", revoked: 3, callerSessionKept: true },
     })
   })
 })

--- a/frontend/src/app/api/v1/admin/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.ts
@@ -9,18 +9,42 @@
 //
 // Gated by requireSuperAdminCaller(), not checkPermission(ADMIN_USERS).
 import { NextResponse } from "next/server"
+import { getToken } from "next-auth/jwt"
 
 import { prisma } from "@/lib/db/prisma"
+import { sessionCookieName } from "@/lib/auth/cookies"
 import { aliveWhere } from "@/lib/auth/sessions"
 import { deviceLabel } from "@/lib/auth/deviceLabel"
 import { requireSuperAdminCaller } from "@/lib/auth/totp-admin"
 
 export const runtime = "nodejs"
 
+// A hard cap, not a page size. The DataGrid only paginates client-side, so
+// an unbounded query would fetch and serialise every live session in the
+// installation in one response — exactly the moment this feature is most
+// needed (an incident with unusually many open sessions) is when that would
+// hurt most. Requesting one row past the cap tells us whether the true
+// count exceeds it without a separate count query. Overflow must never be
+// silent: a security listing that quietly drops rows is worse than no
+// listing, because an admin who doesn't find what they're looking for will
+// wrongly conclude it doesn't exist — see the `truncated` flag below.
+const MAX_SESSION_ROWS = 500
+
 // GET /api/v1/admin/sessions — every live session, newest activity first.
-export async function GET() {
+export async function GET(req: Request) {
   const denied = await requireSuperAdminCaller()
   if (denied) return denied
+
+  // getServerSession's `session` callback deliberately does not carry `sid`
+  // (lib/auth/config.ts) — reading the raw JWT is the only way to learn the
+  // caller's own session row id, needed to mark `current` below. Same
+  // pattern as /api/v1/auth/sessions/route.ts's currentSid().
+  const token = await getToken({
+    req: req as any,
+    secret: process.env.NEXTAUTH_SECRET || "",
+    cookieName: sessionCookieName(),
+  })
+  const callerSid = token?.sid ?? null
 
   const rows = await prisma.session.findMany({
     where: aliveWhere(),
@@ -34,20 +58,24 @@ export async function GET() {
       user: { select: { email: true, tenantId: true } },
     },
     orderBy: { lastSeenAt: "desc" },
+    take: MAX_SESSION_ROWS + 1,
   })
+
+  const truncated = rows.length > MAX_SESSION_ROWS
+  const visibleRows = truncated ? rows.slice(0, MAX_SESSION_ROWS) : rows
 
   // User has no `tenant` relation in schema.prisma (only a scalar tenantId —
   // membership is the separate many-to-many UserTenant table), unlike
   // ApiToken's direct tenant: { select: { name: true } } join. Resolve names
   // in a second batched query instead, same pattern as
   // /api/v1/storage and /api/v1/rbac/assignments.
-  const tenantIds = Array.from(new Set(rows.map((row) => row.user.tenantId)))
+  const tenantIds = Array.from(new Set(visibleRows.map((row) => row.user.tenantId)))
   const tenants = tenantIds.length
     ? await prisma.tenant.findMany({ where: { id: { in: tenantIds } }, select: { id: true, name: true } })
     : []
   const tenantNameById = new Map(tenants.map((tenant) => [tenant.id, tenant.name]))
 
-  const data = rows.map((row) => {
+  const data = visibleRows.map((row) => {
     const { browser, os } = deviceLabel(row.userAgent)
 
     return {
@@ -60,8 +88,11 @@ export async function GET() {
       ipAddress: row.ipAddress,
       browser,
       os,
+      // A token with no sid (pre-hardening token, or a failed row insert at
+      // sign-in) marks every session as not-current rather than guessing.
+      current: callerSid !== null && row.id === callerSid,
     }
   })
 
-  return NextResponse.json({ data })
+  return NextResponse.json({ data, truncated })
 }

--- a/frontend/src/app/api/v1/admin/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.ts
@@ -1,0 +1,67 @@
+// src/app/api/v1/admin/sessions/route.ts
+//
+// Super-admin view of every live session in the installation, across every
+// tenant. This intentionally reverses the "count only" boundary the sibling
+// admin/users/[id]/sessions route documents: the author asked for a real
+// listing (IP, device) after testing, restricted to super admins — a
+// narrower audience than admin.users, because this is strictly broader
+// visibility than that per-user revoke.
+//
+// Gated by requireSuperAdminCaller(), not checkPermission(ADMIN_USERS).
+import { NextResponse } from "next/server"
+
+import { prisma } from "@/lib/db/prisma"
+import { aliveWhere } from "@/lib/auth/sessions"
+import { deviceLabel } from "@/lib/auth/deviceLabel"
+import { requireSuperAdminCaller } from "@/lib/auth/totp-admin"
+
+export const runtime = "nodejs"
+
+// GET /api/v1/admin/sessions — every live session, newest activity first.
+export async function GET() {
+  const denied = await requireSuperAdminCaller()
+  if (denied) return denied
+
+  const rows = await prisma.session.findMany({
+    where: aliveWhere(),
+    select: {
+      id: true,
+      userId: true,
+      createdAt: true,
+      lastSeenAt: true,
+      ipAddress: true,
+      userAgent: true,
+      user: { select: { email: true, tenantId: true } },
+    },
+    orderBy: { lastSeenAt: "desc" },
+  })
+
+  // User has no `tenant` relation in schema.prisma (only a scalar tenantId —
+  // membership is the separate many-to-many UserTenant table), unlike
+  // ApiToken's direct tenant: { select: { name: true } } join. Resolve names
+  // in a second batched query instead, same pattern as
+  // /api/v1/storage and /api/v1/rbac/assignments.
+  const tenantIds = Array.from(new Set(rows.map((row) => row.user.tenantId)))
+  const tenants = tenantIds.length
+    ? await prisma.tenant.findMany({ where: { id: { in: tenantIds } }, select: { id: true, name: true } })
+    : []
+  const tenantNameById = new Map(tenants.map((tenant) => [tenant.id, tenant.name]))
+
+  const data = rows.map((row) => {
+    const { browser, os } = deviceLabel(row.userAgent)
+
+    return {
+      id: row.id,
+      userId: row.userId,
+      userEmail: row.user.email,
+      tenantName: tenantNameById.get(row.user.tenantId) ?? row.user.tenantId,
+      createdAt: row.createdAt.toISOString(),
+      lastSeenAt: row.lastSeenAt.toISOString(),
+      ipAddress: row.ipAddress,
+      browser,
+      os,
+    }
+  })
+
+  return NextResponse.json({ data })
+}

--- a/frontend/src/app/api/v1/admin/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.ts
@@ -101,28 +101,18 @@ export async function GET(req: Request) {
 }
 
 // DELETE /api/v1/admin/sessions — revoke every live session in the
-// installation EXCEPT the caller's own current one. This is an incident
-// action ("everyone out"); signing the operator out mid-incident would only
-// slow the response, and their own session stays one click away in the same
-// listing, behind its own warning and /login redirect. Same response shape
-// as the per-user collection DELETE: { data: { revoked: n } }.
-export async function DELETE(req: Request) {
+// installation, the caller's own included. Total by design (product call,
+// reversing the first version's caller-exception): the UI redirects the
+// caller to /login immediately after. All auth reads happen BEFORE the
+// revoke, so the audit entry can still name the caller.
+// Same response shape as the per-user collection DELETE: { data: { revoked: n } }.
+export async function DELETE() {
   const denied = await requireSuperAdminCaller()
   if (denied) return denied
 
   const session = await getServerSession(authOptions)
 
-  // Same getToken()+sessionCookieName() pattern as the GET above: `sid` is
-  // deliberately absent from the session callback, the raw JWT is the only
-  // place to learn which row is the caller's own.
-  const token = await getToken({
-    req: req as any,
-    secret: process.env.NEXTAUTH_SECRET || "",
-    cookieName: sessionCookieName(),
-  })
-  const callerSid = token?.sid ?? null
-
-  const revoked = await revokeEverySession(callerSid)
+  const revoked = await revokeEverySession()
 
   await audit({
     action: "sessions_revoked_all",
@@ -133,7 +123,7 @@ export async function DELETE(req: Request) {
     resourceId: session?.user?.id ?? "unknown",
     resourceName: "every session in the installation",
     status: "success",
-    details: { by: "admin", revoked, callerSessionKept: callerSid !== null },
+    details: { by: "admin", revoked },
   })
 
   return NextResponse.json({ data: { revoked } })

--- a/frontend/src/app/api/v1/admin/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/sessions/route.ts
@@ -10,12 +10,15 @@
 // Gated by requireSuperAdminCaller(), not checkPermission(ADMIN_USERS).
 import { NextResponse } from "next/server"
 import { getToken } from "next-auth/jwt"
+import { getServerSession } from "next-auth"
 
 import { prisma } from "@/lib/db/prisma"
+import { authOptions } from "@/lib/auth/config"
 import { sessionCookieName } from "@/lib/auth/cookies"
-import { aliveWhere } from "@/lib/auth/sessions"
+import { aliveWhere, revokeEverySession } from "@/lib/auth/sessions"
 import { deviceLabel } from "@/lib/auth/deviceLabel"
 import { requireSuperAdminCaller } from "@/lib/auth/totp-admin"
+import { audit } from "@/lib/audit"
 
 export const runtime = "nodejs"
 
@@ -95,4 +98,43 @@ export async function GET(req: Request) {
   })
 
   return NextResponse.json({ data, truncated })
+}
+
+// DELETE /api/v1/admin/sessions — revoke every live session in the
+// installation EXCEPT the caller's own current one. This is an incident
+// action ("everyone out"); signing the operator out mid-incident would only
+// slow the response, and their own session stays one click away in the same
+// listing, behind its own warning and /login redirect. Same response shape
+// as the per-user collection DELETE: { data: { revoked: n } }.
+export async function DELETE(req: Request) {
+  const denied = await requireSuperAdminCaller()
+  if (denied) return denied
+
+  const session = await getServerSession(authOptions)
+
+  // Same getToken()+sessionCookieName() pattern as the GET above: `sid` is
+  // deliberately absent from the session callback, the raw JWT is the only
+  // place to learn which row is the caller's own.
+  const token = await getToken({
+    req: req as any,
+    secret: process.env.NEXTAUTH_SECRET || "",
+    cookieName: sessionCookieName(),
+  })
+  const callerSid = token?.sid ?? null
+
+  const revoked = await revokeEverySession(callerSid)
+
+  await audit({
+    action: "sessions_revoked_all",
+    category: "auth",
+    userId: session?.user?.id,
+    userEmail: session?.user?.email ?? undefined,
+    resourceType: "user",
+    resourceId: session?.user?.id ?? "unknown",
+    resourceName: "every session in the installation",
+    status: "success",
+    details: { by: "admin", revoked, callerSessionKept: callerSid !== null },
+  })
+
+  return NextResponse.json({ data: { revoked } })
 }

--- a/frontend/src/app/api/v1/admin/users/[id]/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/users/[id]/sessions/route.test.ts
@@ -1,0 +1,137 @@
+/**
+ * DELETE /api/v1/admin/users/[id]/sessions — admin revokes every session of
+ * another user (or their own, targeted explicitly).
+ *
+ * Guarded by checkPermission(PERMISSIONS.ADMIN_USERS) — the same permission
+ * the user-management routes already require — not requireSuperAdminCaller.
+ * PATCH /api/v1/users/[id] can already revoke every session of a user (by
+ * disabling the account) under that same permission, so gating this
+ * standalone action behind super-admin would be strictly more restrictive
+ * than an existing route producing the same effect.
+ *
+ * The admin surface exposes a count and nothing else: the response body must
+ * never carry ipAddress or userAgent, and no per-session detail is logged to
+ * the audit trail either.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const {
+  getServerSessionMock,
+  checkPermissionMock,
+  revokeAllSessionsMock,
+  userFindUniqueMock,
+  auditMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  revokeAllSessionsMock: vi.fn(),
+  userFindUniqueMock: vi.fn(),
+  auditMock: vi.fn(async () => "audit-id"),
+}))
+
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_USERS: "admin.users" },
+}))
+vi.mock("@/lib/auth/sessions", () => ({ revokeAllSessions: revokeAllSessionsMock }))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { user: { findUnique: userFindUniqueMock } },
+}))
+
+async function importDELETE() {
+  const mod = await import("./route")
+  return mod.DELETE
+}
+
+describe("DELETE /api/v1/admin/users/[id]/sessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
+    checkPermissionMock.mockResolvedValue(null)
+    userFindUniqueMock.mockResolvedValue({ email: "target@example.com" })
+    revokeAllSessionsMock.mockResolvedValue(3)
+    auditMock.mockResolvedValue("audit-id")
+  })
+
+  it("returns the denial checkPermission produces and never calls revokeAllSessions", async () => {
+    const denial = new Response(JSON.stringify({ error: "Permission denied: admin.users" }), {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    })
+    checkPermissionMock.mockResolvedValue(denial)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(403)
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+    expect(userFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it("revokes every session of the TARGET user, not the caller — no exception sid", async () => {
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledTimes(1)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("target-1")
+    // Called with exactly one argument: no exception sid is passed through.
+    expect(revokeAllSessionsMock.mock.calls[0]).toEqual(["target-1"])
+  })
+
+  it("allows an admin to target their own account", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ email: "admin@example.com" })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "admin-1" } })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("admin-1")
+  })
+
+  it("returns { data: { revoked } } with no ipAddress or userAgent key anywhere in the body", async () => {
+    revokeAllSessionsMock.mockResolvedValue(5)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    const body = await readJson<any>(res)
+    expect(body).toEqual({ data: { revoked: 5 } })
+
+    const serialised = JSON.stringify(body)
+    expect(serialised).not.toMatch(/ipAddress/i)
+    expect(serialised).not.toMatch(/userAgent/i)
+  })
+
+  it("writes an audit entry naming the target but no session-identifying detail", async () => {
+    const DELETE = await importDELETE()
+    await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(auditMock).toHaveBeenCalledTimes(1)
+    const entry = auditMock.mock.calls[0][0]
+    expect(entry.category).toBe("auth")
+    expect(entry.resourceType).toBe("user")
+    expect(entry.resourceId).toBe("target-1")
+    expect(entry.resourceName).toBe("target@example.com")
+    expect(entry.userId).toBe("admin-1")
+
+    const serialised = JSON.stringify(entry)
+    expect(serialised).not.toMatch(/ipAddress/i)
+    expect(serialised).not.toMatch(/userAgent/i)
+  })
+
+  it("returns 404 and never revokes when the target user does not exist", async () => {
+    userFindUniqueMock.mockResolvedValue(null)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "ghost" } })
+
+    expect(res.status).toBe(404)
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/admin/users/[id]/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/admin/users/[id]/sessions/route.test.ts
@@ -9,6 +9,17 @@
  * standalone action behind super-admin would be strictly more restrictive
  * than an existing route producing the same effect.
  *
+ * That permission check alone only proves the caller holds admin.users
+ * somewhere — it says nothing about which target user they may act on. So,
+ * matching every handler in the sibling `users/[id]/route.ts` exactly, this
+ * route also applies the two shared guards from
+ * `@/lib/rbac/userTargetGuards` in the same order: the protected-target
+ * check first, then tenant resolution + membership (with the provider-view
+ * bypass). Those two guards are NOT mocked in this file — their own
+ * dependencies (`isUserProtected`, `isUserSuperAdmin`, `prisma.userTenant`)
+ * are, so the real shared implementation runs and any drift in the wiring
+ * would show up here.
+ *
  * The admin surface exposes a count and nothing else: the response body must
  * never carry ipAddress or userAgent, and no per-session detail is logged to
  * the audit trail either.
@@ -19,14 +30,22 @@ import { callRoute, readJson } from "@/__tests__/setup/route-test"
 const {
   getServerSessionMock,
   checkPermissionMock,
+  isUserProtectedMock,
+  isUserSuperAdminMock,
+  getCurrentTenantIdMock,
   revokeAllSessionsMock,
   userFindUniqueMock,
+  userTenantFindUniqueMock,
   auditMock,
 } = vi.hoisted(() => ({
   getServerSessionMock: vi.fn(),
   checkPermissionMock: vi.fn(),
+  isUserProtectedMock: vi.fn(),
+  isUserSuperAdminMock: vi.fn(),
+  getCurrentTenantIdMock: vi.fn(),
   revokeAllSessionsMock: vi.fn(),
   userFindUniqueMock: vi.fn(),
+  userTenantFindUniqueMock: vi.fn(),
   auditMock: vi.fn(async () => "audit-id"),
 }))
 
@@ -35,11 +54,20 @@ vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
 vi.mock("@/lib/rbac", () => ({
   checkPermission: checkPermissionMock,
   PERMISSIONS: { ADMIN_USERS: "admin.users" },
+  isUserProtected: isUserProtectedMock,
+  isUserSuperAdmin: isUserSuperAdminMock,
+}))
+vi.mock("@/lib/tenant", () => ({
+  DEFAULT_TENANT_ID: "default",
+  getCurrentTenantId: getCurrentTenantIdMock,
 }))
 vi.mock("@/lib/auth/sessions", () => ({ revokeAllSessions: revokeAllSessionsMock }))
 vi.mock("@/lib/audit", () => ({ audit: auditMock }))
 vi.mock("@/lib/db/prisma", () => ({
-  prisma: { user: { findUnique: userFindUniqueMock } },
+  prisma: {
+    user: { findUnique: userFindUniqueMock },
+    userTenant: { findUnique: userTenantFindUniqueMock },
+  },
 }))
 
 async function importDELETE() {
@@ -52,7 +80,14 @@ describe("DELETE /api/v1/admin/users/[id]/sessions", () => {
     vi.clearAllMocks()
     getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
     checkPermissionMock.mockResolvedValue(null)
-    userFindUniqueMock.mockResolvedValue({ email: "target@example.com" })
+    isUserProtectedMock.mockResolvedValue(false)
+    isUserSuperAdminMock.mockResolvedValue(false)
+    // Provider view by default (default tenant) — matches the sibling
+    // routes' default bypass path used by most of these tests; the
+    // tenant-scoped path is exercised explicitly below.
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    userFindUniqueMock.mockResolvedValue({ id: "target-1", email: "target@example.com" })
+    userTenantFindUniqueMock.mockResolvedValue(null)
     revokeAllSessionsMock.mockResolvedValue(3)
     auditMock.mockResolvedValue("audit-id")
   })
@@ -85,7 +120,7 @@ describe("DELETE /api/v1/admin/users/[id]/sessions", () => {
 
   it("allows an admin to target their own account", async () => {
     getServerSessionMock.mockResolvedValue({ user: { id: "admin-1", email: "admin@example.com" } })
-    userFindUniqueMock.mockResolvedValue({ email: "admin@example.com" })
+    userFindUniqueMock.mockResolvedValue({ id: "admin-1", email: "admin@example.com" })
 
     const DELETE = await importDELETE()
     const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "admin-1" } })
@@ -125,13 +160,89 @@ describe("DELETE /api/v1/admin/users/[id]/sessions", () => {
     expect(serialised).not.toMatch(/userAgent/i)
   })
 
-  it("returns 404 and never revokes when the target user does not exist", async () => {
+  it("returns the sibling's 404 (and the sibling's exact message) when the target does not exist", async () => {
     userFindUniqueMock.mockResolvedValue(null)
 
     const DELETE = await importDELETE()
     const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "ghost" } })
 
     expect(res.status).toBe(404)
+    expect(await readJson<any>(res)).toEqual({ error: "Utilisateur non trouvé" })
     expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+  })
+
+  it("refuses a non-super-admin caller targeting a protected (super_admin) user, before any tenant lookup", async () => {
+    isUserProtectedMock.mockResolvedValue(true)
+    isUserSuperAdminMock.mockResolvedValue(false)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(404)
+    expect(await readJson<any>(res)).toEqual({ error: "Utilisateur non trouvé" })
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+    expect(isUserSuperAdminMock).toHaveBeenCalledWith("admin-1")
+    // Blocked before tenant resolution / target lookup ever runs — same
+    // order as GET/PATCH/DELETE /api/v1/users/[id].
+    expect(getCurrentTenantIdMock).not.toHaveBeenCalled()
+    expect(userFindUniqueMock).not.toHaveBeenCalled()
+    expect(userTenantFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it("allows a super-admin caller to target a protected (super_admin) user", async () => {
+    isUserProtectedMock.mockResolvedValue(true)
+    isUserSuperAdminMock.mockResolvedValue(true)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("target-1")
+  })
+
+  it("returns the sibling's 404 when a tenant-scoped caller's target has no membership in their tenant", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("tenant-a")
+    userTenantFindUniqueMock.mockResolvedValue(null)
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(404)
+    expect(await readJson<any>(res)).toEqual({ error: "Utilisateur non trouvé" })
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+    expect(userTenantFindUniqueMock).toHaveBeenCalledWith({
+      where: { userId_tenantId: { userId: "target-1", tenantId: "tenant-a" } },
+      include: { user: true },
+    })
+    // Tenant-scoped path never falls back to the cross-tenant lookup.
+    expect(userFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it("revokes a tenant-scoped caller's own-tenant target found via membership", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("tenant-a")
+    userTenantFindUniqueMock.mockResolvedValue({
+      user: { id: "target-1", email: "target@example.com" },
+    })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("target-1")
+    const entry = auditMock.mock.calls[0][0]
+    expect(entry.resourceName).toBe("target@example.com")
+  })
+
+  it("lets a provider-view caller target a user regardless of tenant (sibling bypass)", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    userFindUniqueMock.mockResolvedValue({ id: "target-1", email: "target@example.com" })
+
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: "DELETE", params: { id: "target-1" } })
+
+    expect(res.status).toBe(200)
+    // Bypasses tenant membership entirely, same as the sibling routes.
+    expect(userTenantFindUniqueMock).not.toHaveBeenCalled()
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("target-1")
   })
 })

--- a/frontend/src/app/api/v1/admin/users/[id]/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/users/[id]/sessions/route.ts
@@ -10,6 +10,19 @@
 // here would be strictly more restrictive than an existing route that
 // produces the same effect.
 //
+// That permission check alone only proves the caller holds admin.users
+// somewhere — it says nothing about which target user they may act on. Every
+// handler in the sibling `users/[id]/route.ts` (GET/PATCH/DELETE) layers two
+// more checks on top of it, in this order:
+//   1. denyIfTargetIsProtectedAndCallerIsNot — a tenant-scoped admin must
+//      never reach a super_admin/provider_admin target.
+//   2. tenant resolution + membership (findUserInTenant), bypassed entirely
+//      from the provider view (default tenant) — a tenant-scoped admin must
+//      never reach a user outside their own tenant.
+// This route applies the exact same two checks, in the exact same order,
+// via the shared @/lib/rbac/userTargetGuards module (see that file for why
+// they're shared rather than duplicated).
+//
 // The admin surface is deliberately limited to a count and this revoke
 // action: no IP addresses, no device labels, no per-session timestamps for
 // other users, and no listing endpoint. The response body must never carry
@@ -21,6 +34,8 @@ import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { audit } from "@/lib/audit"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { denyIfTargetIsProtectedAndCallerIsNot, findUserInTenant } from "@/lib/rbac/userTargetGuards"
+import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
 import { revokeAllSessions } from "@/lib/auth/sessions"
 
 export const runtime = "nodejs"
@@ -35,13 +50,23 @@ export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string 
   const session = await getServerSession(authOptions)
   const { id: targetId } = await ctx.params
 
-  const target = await prisma.user.findUnique({
-    where: { id: targetId },
-    select: { email: true },
-  })
+  const superAdminBlock = await denyIfTargetIsProtectedAndCallerIsNot(targetId, session?.user?.id)
+  if (superAdminBlock) return superAdminBlock
+
+  const tenantId = await getCurrentTenantId()
+  const isProviderView = tenantId === DEFAULT_TENANT_ID
+
+  // Provider view (default tenant) can target any user, including those
+  // with no membership in `default` — mirrors GET/PATCH/DELETE
+  // /api/v1/users/[id]. Tenant-scoped callers stay pinned to their own
+  // tenant's memberships so they can't reach a user in another tenant by
+  // guessing an id.
+  const target = isProviderView
+    ? await prisma.user.findUnique({ where: { id: targetId } })
+    : await findUserInTenant(targetId, tenantId)
 
   if (!target) {
-    return NextResponse.json({ error: "User not found" }, { status: 404 })
+    return NextResponse.json({ error: "Utilisateur non trouvé" }, { status: 404 })
   }
 
   // No exception sid: every session of the target dies, unlike the

--- a/frontend/src/app/api/v1/admin/users/[id]/sessions/route.ts
+++ b/frontend/src/app/api/v1/admin/users/[id]/sessions/route.ts
@@ -1,0 +1,64 @@
+// src/app/api/v1/admin/users/[id]/sessions/route.ts
+//
+// Admin bulk revoke: cut every session of the target user right now.
+//
+// Guarded by checkPermission(PERMISSIONS.ADMIN_USERS) — the same permission
+// the user-management routes already require — not requireSuperAdminCaller
+// (used by the sibling 2FA admin routes). PATCH /api/v1/users/[id] already
+// revokes every session of a user as a side effect of disabling the account,
+// gated behind that same admin.users permission, so requiring super-admin
+// here would be strictly more restrictive than an existing route that
+// produces the same effect.
+//
+// The admin surface is deliberately limited to a count and this revoke
+// action: no IP addresses, no device labels, no per-session timestamps for
+// other users, and no listing endpoint. The response body must never carry
+// ipAddress or userAgent, and the audit entry never identifies a session.
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/lib/auth/config"
+import { prisma } from "@/lib/db/prisma"
+import { audit } from "@/lib/audit"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { revokeAllSessions } from "@/lib/auth/sessions"
+
+export const runtime = "nodejs"
+
+// DELETE /api/v1/admin/users/[id]/sessions — revoke every session of the
+// target user. The target may be the caller themselves: that is allowed and
+// simply logs them out too, same as disabling one's own account would.
+export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const denied = await checkPermission(PERMISSIONS.ADMIN_USERS)
+  if (denied) return denied
+
+  const session = await getServerSession(authOptions)
+  const { id: targetId } = await ctx.params
+
+  const target = await prisma.user.findUnique({
+    where: { id: targetId },
+    select: { email: true },
+  })
+
+  if (!target) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 })
+  }
+
+  // No exception sid: every session of the target dies, unlike the
+  // self-service DELETE /api/v1/auth/sessions which spares the caller's own.
+  const revoked = await revokeAllSessions(targetId)
+
+  await audit({
+    action: "sessions_revoked",
+    category: "auth",
+    userId: session?.user?.id,
+    userEmail: session?.user?.email ?? undefined,
+    resourceType: "user",
+    resourceId: targetId,
+    resourceName: target.email,
+    status: "success",
+    details: { by: "admin", revoked },
+  })
+
+  return NextResponse.json({ data: { revoked } })
+}

--- a/frontend/src/app/api/v1/auth/2fa/__tests__/routes.test.ts
+++ b/frontend/src/app/api/v1/auth/2fa/__tests__/routes.test.ts
@@ -3,7 +3,7 @@
  * Each route is dynamically imported AFTER mocks are set so Vitest's module
  * registry wires the fakes in correctly.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { callRoute, readJson } from "@/__tests__/setup/route-test"
 
 // ─── Mock factories ────────────────────────────────────────────────────────
@@ -84,6 +84,16 @@ vi.mock("@/lib/audit", () => ({ audit: auditMock }))
 vi.mock("qrcode", () => ({ default: { toDataURL: qrToDataURLMock } }))
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
+
+// cookies.ts is real code in this file (not mocked): resolveCookieSecure()
+// reads NEXTAUTH_URL, so tests that exercise the Secure flag must pin and
+// restore it.
+const ORIGINAL_NEXTAUTH_URL = process.env.NEXTAUTH_URL
+
+afterEach(() => {
+  if (ORIGINAL_NEXTAUTH_URL === undefined) delete process.env.NEXTAUTH_URL
+  else process.env.NEXTAUTH_URL = ORIGINAL_NEXTAUTH_URL
+})
 
 function makeSession(overrides: Record<string, any> = {}) {
   return {
@@ -272,6 +282,75 @@ describe("POST /api/v1/auth/2fa/enroll/verify", () => {
     expect(auditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: "2fa_enrolled" }),
     )
+  })
+
+  // This route previously derived the cookie's `secure` flag from the cookie
+  // NAME, which stays unprefixed unless NEXTAUTH_URL is https. That silently
+  // wrote a non-Secure cookie on an HTTPS request. The fix reads the actual
+  // transport via resolveCookieSecure(req.headers) instead, so these two
+  // cases must diverge even though NEXTAUTH_URL (and therefore the cookie
+  // name) is held fixed across both.
+  it("sets the Secure flag on the cookie when the request arrived over https", async () => {
+    process.env.NEXTAUTH_URL = "http://localhost:3000"
+    getServerSessionMock.mockResolvedValue(makeSession({ id: "user-1" }))
+    verifyEnrollTokenMock.mockResolvedValue({ userId: "user-1", secretEnc: "enc:SECRET" })
+    decryptSecretMock.mockReturnValue("SECRET")
+    checkTotpCodeMock.mockReturnValue(true)
+    generateRecoveryCodesMock.mockReturnValue(["CODE1-AAAAA", "CODE2-BBBBB"])
+    transactionMock.mockImplementation((cb: (tx: any) => Promise<any>) =>
+      cb({
+        user: { update: vi.fn().mockResolvedValue({}) },
+        userTotpRecoveryCode: {
+          deleteMany: vi.fn().mockResolvedValue({}),
+          createMany: vi.fn().mockResolvedValue({}),
+        },
+      }),
+    )
+    replaceRecoveryCodesMock.mockResolvedValue(undefined)
+    auditMock.mockResolvedValue(undefined)
+    getTokenMock.mockResolvedValue({ sub: "user-1", mustEnroll2fa: true })
+    encodeMock.mockResolvedValue("new-jwt-token")
+
+    const POST = await importPOST()
+    const res = await callRoute(POST as any, {
+      body: { enrollToken: "tok", code: "123456" },
+      headers: { "x-forwarded-proto": "https" },
+    })
+    expect(res.status).toBe(200)
+
+    const setCookie = res.headers.get("set-cookie")
+    expect(setCookie).not.toBeNull()
+    expect(setCookie).toContain("Secure")
+  })
+
+  it("omits the Secure flag when there is no forwarded-proto and NEXTAUTH_URL is http", async () => {
+    process.env.NEXTAUTH_URL = "http://localhost:3000"
+    getServerSessionMock.mockResolvedValue(makeSession({ id: "user-1" }))
+    verifyEnrollTokenMock.mockResolvedValue({ userId: "user-1", secretEnc: "enc:SECRET" })
+    decryptSecretMock.mockReturnValue("SECRET")
+    checkTotpCodeMock.mockReturnValue(true)
+    generateRecoveryCodesMock.mockReturnValue(["CODE1-AAAAA", "CODE2-BBBBB"])
+    transactionMock.mockImplementation((cb: (tx: any) => Promise<any>) =>
+      cb({
+        user: { update: vi.fn().mockResolvedValue({}) },
+        userTotpRecoveryCode: {
+          deleteMany: vi.fn().mockResolvedValue({}),
+          createMany: vi.fn().mockResolvedValue({}),
+        },
+      }),
+    )
+    replaceRecoveryCodesMock.mockResolvedValue(undefined)
+    auditMock.mockResolvedValue(undefined)
+    getTokenMock.mockResolvedValue({ sub: "user-1", mustEnroll2fa: true })
+    encodeMock.mockResolvedValue("new-jwt-token")
+
+    const POST = await importPOST()
+    const res = await callRoute(POST as any, { body: { enrollToken: "tok", code: "123456" } })
+    expect(res.status).toBe(200)
+
+    const setCookie = res.headers.get("set-cookie")
+    expect(setCookie).not.toBeNull()
+    expect(setCookie).not.toContain("Secure")
   })
 })
 

--- a/frontend/src/app/api/v1/auth/2fa/enroll/verify/route.ts
+++ b/frontend/src/app/api/v1/auth/2fa/enroll/verify/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/lib/auth/config"
 import { sessionCookieName, resolveCookieSecure } from "@/lib/auth/cookies"
+import { sessionDurations } from "@/lib/auth/durations"
 import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { verifyEnrollToken } from "@/lib/auth/enroll-token"
@@ -82,6 +83,10 @@ export async function POST(req: Request) {
     const newJwt = await encode({
       token: refreshed,
       secret: process.env.NEXTAUTH_SECRET || "",
+      // Without this, next-auth's encode() defaults maxAge to 30 days, so
+      // this re-issued cookie would outlive the absolute cap that every
+      // other session cookie is now held to.
+      maxAge: Math.ceil(sessionDurations().absoluteMs / 1000),
     })
 
     // Name and flag both come from the shared module. Deriving `secure` from

--- a/frontend/src/app/api/v1/auth/2fa/enroll/verify/route.ts
+++ b/frontend/src/app/api/v1/auth/2fa/enroll/verify/route.ts
@@ -3,6 +3,7 @@ import { getToken, encode } from "next-auth/jwt"
 import { getServerSession } from "next-auth"
 
 import { authOptions } from "@/lib/auth/config"
+import { sessionCookieName, resolveCookieSecure } from "@/lib/auth/cookies"
 import { prisma } from "@/lib/db/prisma"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { verifyEnrollToken } from "@/lib/auth/enroll-token"
@@ -67,6 +68,7 @@ export async function POST(req: Request) {
     req: req as any,
     secret: process.env.NEXTAUTH_SECRET || "",
     raw: false,
+    cookieName: sessionCookieName(),
   })
 
   const res = NextResponse.json({ data: { recoveryCodes: plainCodes } })
@@ -82,15 +84,15 @@ export async function POST(req: Request) {
       secret: process.env.NEXTAUTH_SECRET || "",
     })
 
-    const cookieName = (process.env.NEXTAUTH_URL || "").startsWith("https://")
-      ? "__Secure-next-auth.session-token"
-      : "next-auth.session-token"
-
-    res.cookies.set(cookieName, newJwt, {
+    // Name and flag both come from the shared module. Deriving `secure` from
+    // the cookie NAME (the previous behaviour) would write a non-Secure cookie
+    // on an https request whenever the name is unprefixed, silently undoing
+    // the fix on this path.
+    res.cookies.set(sessionCookieName(), newJwt, {
       httpOnly: true,
       sameSite: "lax",
       path: "/",
-      secure: cookieName.startsWith("__Secure"),
+      secure: resolveCookieSecure(req.headers),
     })
   }
 

--- a/frontend/src/app/api/v1/auth/sessions/[sid]/route.ts
+++ b/frontend/src/app/api/v1/auth/sessions/[sid]/route.ts
@@ -1,0 +1,39 @@
+// src/app/api/v1/auth/sessions/[sid]/route.ts
+//
+// Revoke one of the caller's own sessions. Scoped entirely to session.user.id
+// — there is no admin path here (that's a separate route with its own
+// permission check).
+export const runtime = "nodejs"
+
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/lib/auth/config"
+import { revokeSession } from "@/lib/auth/sessions"
+
+interface RouteContext {
+  params: Promise<{ sid: string }>
+}
+
+// DELETE /api/v1/auth/sessions/[sid] — revoke a single session belonging to
+// the caller. revokeSession scopes its update to (id, userId), so a sid that
+// belongs to another user updates zero rows exactly like a sid that doesn't
+// exist. Both cases return 404, never 403: a 403 would confirm the sid is
+// real, leaking whether a given session id exists.
+export async function DELETE(req: Request, context: RouteContext) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const { sid } = await context.params
+
+  const revoked = await revokeSession(sid, session.user.id)
+
+  if (!revoked) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json({ data: { ok: true } })
+}

--- a/frontend/src/app/api/v1/auth/sessions/route.test.ts
+++ b/frontend/src/app/api/v1/auth/sessions/route.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const {
+  getServerSessionMock,
+  getTokenMock,
+  listSessionsMock,
+  revokeSessionMock,
+  revokeAllSessionsMock,
+} = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  getTokenMock: vi.fn(),
+  listSessionsMock: vi.fn(),
+  revokeSessionMock: vi.fn(),
+  revokeAllSessionsMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('next-auth/jwt', () => ({ getToken: getTokenMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/auth/cookies', () => ({ sessionCookieName: () => 'next-auth.session-token' }))
+vi.mock('@/lib/auth/sessions', () => ({
+  listSessions: listSessionsMock,
+  revokeSession: revokeSessionMock,
+  revokeAllSessions: revokeAllSessionsMock,
+}))
+// deviceLabel is a small pure heuristic (no I/O) — exercised for real rather
+// than mocked, so the browser/os fields in the response get a real assertion.
+
+function row(overrides: Partial<{
+  id: string
+  ipAddress: string | null
+  userAgent: string | null
+}> = {}) {
+  return {
+    id: 'sess-1',
+    userId: 'u1',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    lastSeenAt: new Date('2026-01-02T00:00:00.000Z'),
+    revokedAt: null,
+    ipAddress: '10.0.0.1',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0 Safari/537.36',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getServerSessionMock.mockResolvedValue({ user: { id: 'u1', email: 'u1@x' } })
+  getTokenMock.mockResolvedValue({ sid: 'sess-1' })
+})
+
+describe('GET /api/v1/auth/sessions', () => {
+  async function importGET() {
+    const mod = await import('./route')
+    return mod.GET
+  }
+
+  it('returns 401 when there is no session', async () => {
+    getServerSessionMock.mockResolvedValue(null)
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: 'GET' })
+    expect(res.status).toBe(401)
+  })
+
+  it("returns only the caller's sessions, with exactly one current:true and ISO date strings", async () => {
+    listSessionsMock.mockResolvedValue([
+      row({ id: 'sess-1' }),
+      row({
+        id: 'sess-2',
+        ipAddress: '10.0.0.2',
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Firefox/119.0',
+      }),
+    ])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: 'GET' })
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    expect(listSessionsMock).toHaveBeenCalledWith('u1')
+    expect(body.data).toHaveLength(2)
+
+    const currentOnes = body.data.filter((s: any) => s.current)
+    expect(currentOnes).toHaveLength(1)
+    expect(currentOnes[0].id).toBe('sess-1')
+
+    for (const s of body.data) {
+      expect(typeof s.createdAt).toBe('string')
+      expect(new Date(s.createdAt).toISOString()).toBe(s.createdAt)
+      expect(typeof s.lastSeenAt).toBe('string')
+      expect(new Date(s.lastSeenAt).toISOString()).toBe(s.lastSeenAt)
+    }
+
+    const other = body.data.find((s: any) => s.id === 'sess-2')
+    expect(other.browser).toBe('Firefox')
+    expect(other.os).toBe('Linux')
+    expect(other.current).toBe(false)
+  })
+
+  it('does not crash and marks no session current when the token has no sid', async () => {
+    getTokenMock.mockResolvedValue({}) // no sid: pre-hardening token, or a failed row insert at sign-in
+    listSessionsMock.mockResolvedValue([row({ id: 'sess-1' }), row({ id: 'sess-2' })])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: 'GET' })
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    expect(body.data).toHaveLength(2)
+    expect(body.data.every((s: any) => s.current === false)).toBe(true)
+  })
+})
+
+describe('DELETE /api/v1/auth/sessions/[sid]', () => {
+  async function importDELETE() {
+    const mod = await import('./[sid]/route')
+    return mod.DELETE
+  }
+
+  it('returns 401 when there is no session', async () => {
+    getServerSessionMock.mockResolvedValue(null)
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: 'DELETE', params: { sid: 'sess-1' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 404, not 403, for a sid belonging to another user, and the body reveals nothing about it', async () => {
+    revokeSessionMock.mockResolvedValue(false)
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { sid: 'someone-elses-sid' },
+    })
+    expect(res.status).toBe(404)
+    expect(res.status).not.toBe(403)
+
+    const body = await readJson<any>(res)
+    expect(JSON.stringify(body)).not.toMatch(/someone-elses-sid/)
+    expect(revokeSessionMock).toHaveBeenCalledWith('someone-elses-sid', 'u1')
+  })
+
+  it("revokes the caller's own sid and succeeds", async () => {
+    revokeSessionMock.mockResolvedValue(true)
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: 'DELETE', params: { sid: 'sess-1' } })
+    expect(res.status).toBe(200)
+    expect(revokeSessionMock).toHaveBeenCalledWith('sess-1', 'u1')
+  })
+})
+
+describe('DELETE /api/v1/auth/sessions (collection)', () => {
+  async function importDELETE() {
+    const mod = await import('./route')
+    return mod.DELETE
+  }
+
+  it('returns 401 when there is no session', async () => {
+    getServerSessionMock.mockResolvedValue(null)
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: 'DELETE' })
+    expect(res.status).toBe(401)
+  })
+
+  it("passes the caller's own sid as the exception so the current session survives", async () => {
+    revokeAllSessionsMock.mockResolvedValue(3)
+    const DELETE = await importDELETE()
+    const res = await callRoute(DELETE as any, { method: 'DELETE' })
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith('u1', 'sess-1')
+
+    const body = await readJson<any>(res)
+    expect(body.data.revoked).toBe(3)
+  })
+})

--- a/frontend/src/app/api/v1/auth/sessions/route.ts
+++ b/frontend/src/app/api/v1/auth/sessions/route.ts
@@ -1,0 +1,76 @@
+// src/app/api/v1/auth/sessions/route.ts
+//
+// Self-service session listing and bulk revocation. Scoped entirely to the
+// caller: every query below runs against session.user.id, and there is no
+// parameter to act on anyone else's sessions. The admin equivalent is a
+// separate route with its own permission check.
+export const runtime = "nodejs"
+
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { getToken } from "next-auth/jwt"
+
+import { authOptions } from "@/lib/auth/config"
+import { sessionCookieName } from "@/lib/auth/cookies"
+import { deviceLabel } from "@/lib/auth/deviceLabel"
+import { listSessions, revokeAllSessions } from "@/lib/auth/sessions"
+
+// getServerSession's `session` callback deliberately does not carry `sid`
+// (lib/auth/config.ts) — reading the raw JWT is the only way to learn the
+// caller's own session row id, needed to mark `current` below.
+async function currentSid(req: Request): Promise<string | null> {
+  const token = await getToken({
+    req: req as any,
+    secret: process.env.NEXTAUTH_SECRET || "",
+    cookieName: sessionCookieName(),
+  })
+
+  return token?.sid ?? null
+}
+
+// GET /api/v1/auth/sessions — the caller's own live sessions.
+export async function GET(req: Request) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const sid = await currentSid(req)
+  const rows = await listSessions(session.user.id)
+
+  const data = rows.map((row) => {
+    const { browser, os } = deviceLabel(row.userAgent)
+
+    return {
+      id: row.id,
+      // A token with no sid (pre-hardening token, or a failed row insert at
+      // sign-in) marks every session as not-current rather than guessing.
+      current: sid !== null && row.id === sid,
+      browser,
+      os,
+      userAgent: row.userAgent,
+      ipAddress: row.ipAddress,
+      createdAt: row.createdAt.toISOString(),
+      lastSeenAt: row.lastSeenAt.toISOString(),
+    }
+  })
+
+  return NextResponse.json({ data })
+}
+
+// DELETE /api/v1/auth/sessions — revoke all of the caller's sessions except
+// the one making this request. Excluding the current session is deliberate:
+// a single click must not log the user out of the screen they are on.
+export async function DELETE(req: Request) {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const sid = await currentSid(req)
+  const revoked = await revokeAllSessions(session.user.id, sid)
+
+  return NextResponse.json({ data: { revoked } })
+}

--- a/frontend/src/app/api/v1/users/[id]/__tests__/sessions-revoke.test.ts
+++ b/frontend/src/app/api/v1/users/[id]/__tests__/sessions-revoke.test.ts
@@ -1,0 +1,187 @@
+/**
+ * PATCH /users/[id] — revoke open sessions on password change / disable.
+ *
+ * A password change is what a user does when they believe they are
+ * compromised; a disable is an admin doing the same on their behalf. Both
+ * are credential-state changes that must cut sessions already open,
+ * otherwise a stolen cookie survives the exact defensive act taken against
+ * it. This is deliberately hooked after the write lands and before the
+ * audit call, and a failure inside it must never turn an already-applied
+ * password change into a 500.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const getServerSessionMock = vi.fn()
+const userFindUniqueMock = vi.fn()
+const userUpdateMock = vi.fn()
+const isUserProtectedMock = vi.fn()
+const isUserSuperAdminMock = vi.fn()
+const getCurrentTenantIdMock = vi.fn()
+const checkPermissionMock = vi.fn()
+const hashPasswordMock = vi.fn(async () => "hashed")
+const auditMock = vi.fn(async () => "audit-id")
+const revokeAllSessionsMock = vi.fn(async () => 0)
+
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }))
+vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
+vi.mock("@/lib/auth/password", () => ({ hashPassword: hashPasswordMock }))
+vi.mock("@/lib/auth/sessions", () => ({ revokeAllSessions: revokeAllSessionsMock }))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { user: { findUnique: userFindUniqueMock, update: userUpdateMock } },
+}))
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_USERS: "admin.users" },
+  isUserSuperAdmin: isUserSuperAdminMock,
+  isUserProtected: isUserProtectedMock,
+  PROTECTED_ROLE_IDS: ["role_super_admin", "role_provider_admin"],
+  PROVIDER_ONLY_ROLE_IDS: ["role_operator", "role_vm_admin", "role_viewer", "role_vm_user"],
+}))
+vi.mock("@/lib/tenant", () => ({
+  DEFAULT_TENANT_ID: "default",
+  getCurrentTenantId: getCurrentTenantIdMock,
+  addUserToTenant: vi.fn(),
+  removeUserFromTenant: vi.fn(),
+  TenantMembershipError: class extends Error {},
+}))
+
+async function importPATCH() {
+  const mod = await import("../route")
+  return mod.PATCH
+}
+
+function updatedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "u1",
+    email: "u1@example.com",
+    name: "U1",
+    role: null,
+    authProvider: "credentials",
+    enabled: true,
+    lastLoginAt: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  }
+}
+
+describe("PATCH /users/[id] — session revocation on credential change", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    revokeAllSessionsMock.mockResolvedValue(0)
+    hashPasswordMock.mockResolvedValue("hashed")
+    auditMock.mockResolvedValue("audit-id")
+    isUserProtectedMock.mockResolvedValue(false)
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    checkPermissionMock.mockResolvedValue(null)
+  })
+
+  it("revokes every session (no exception sid) when the PATCH contains a password", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "u1", email: "u1@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u1", email: "u1@example.com", authProvider: "credentials" })
+    userUpdateMock.mockResolvedValue(updatedRow())
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u1" },
+      body: { password: "longenoughpw" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledTimes(1)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("u1")
+  })
+
+  it("does not revoke sessions when the PATCH only changes name", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "u1", email: "u1@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u1", email: "u1@example.com", authProvider: "credentials" })
+    userUpdateMock.mockResolvedValue(updatedRow({ name: "New Name" }))
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u1" },
+      body: { name: "New Name" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+  })
+
+  it("revokes sessions when the PATCH disables the account", async () => {
+    // Admin (u-admin) disabling another user (u2) — not self, so the
+    // self-lockout guard doesn't intercept before the revocation runs.
+    getServerSessionMock.mockResolvedValue({ user: { id: "u-admin", email: "admin@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u2", email: "u2@example.com", authProvider: "credentials" })
+    userUpdateMock.mockResolvedValue(updatedRow({ id: "u2", email: "u2@example.com", enabled: false }))
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u2" },
+      body: { enabled: false },
+    })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).toHaveBeenCalledTimes(1)
+    expect(revokeAllSessionsMock).toHaveBeenCalledWith("u2")
+  })
+
+  it("does not revoke sessions when the PATCH re-enables the account", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "u-admin", email: "admin@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u2", email: "u2@example.com", authProvider: "credentials" })
+    userUpdateMock.mockResolvedValue(updatedRow({ id: "u2", email: "u2@example.com", enabled: true }))
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u2" },
+      body: { enabled: true },
+    })
+
+    expect(res.status).toBe(200)
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+  })
+
+  it("still returns success and keeps the password change when revokeAllSessions rejects", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "u1", email: "u1@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u1", email: "u1@example.com", authProvider: "credentials" })
+    userUpdateMock.mockResolvedValue(updatedRow())
+    revokeAllSessionsMock.mockRejectedValueOnce(new Error("db unreachable"))
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u1" },
+      body: { password: "longenoughpw" },
+    })
+
+    expect(res.status).toBe(200)
+    const json = await readJson<{ success: boolean }>(res)
+    expect(json?.success).toBe(true)
+    expect(userUpdateMock).toHaveBeenCalledTimes(1)
+    expect(userUpdateMock).toHaveBeenCalledWith({
+      where: { id: "u1" },
+      data: expect.objectContaining({ password: "hashed" }),
+    })
+  })
+
+  it("never reaches revokeAllSessions when the external-IdP guard refuses the password change", async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: "u1", email: "u1@example.com" } })
+    userFindUniqueMock.mockResolvedValue({ id: "u1", email: "u1@example.com", authProvider: "oidc" })
+
+    const PATCH = await importPATCH()
+    const res = await callRoute(PATCH as any, {
+      method: "PATCH",
+      params: { id: "u1" },
+      body: { password: "longenoughpw" },
+    })
+
+    expect(res.status).toBe(403)
+    expect(userUpdateMock).not.toHaveBeenCalled()
+    expect(revokeAllSessionsMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/users/[id]/route.ts
+++ b/frontend/src/app/api/v1/users/[id]/route.ts
@@ -6,6 +6,7 @@ import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { hashPassword } from "@/lib/auth/password"
+import { safeLog } from "@/lib/log/sanitize"
 import { checkPermission, PERMISSIONS, isUserSuperAdmin, isUserProtected, PROTECTED_ROLE_IDS, PROVIDER_ONLY_ROLE_IDS } from "@/lib/rbac"
 import { nanoid } from "nanoid"
 import { DEFAULT_TENANT_ID, addUserToTenant, removeUserFromTenant, TenantMembershipError, getCurrentTenantId } from "@/lib/tenant"
@@ -335,6 +336,24 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     const updated = Object.keys(data).length > 0
       ? await prisma.user.update({ where: { id }, data })
       : user
+
+    // A password change (or a disable) must kill the sessions that are already
+    // open, otherwise a stolen cookie survives the exact action a compromised
+    // user takes to defend themselves. No exception sid: the caller's own
+    // session goes too, which is the expected outcome of "change my password".
+    if (password || enabled === false) {
+      try {
+        const { revokeAllSessions } = await import("@/lib/auth/sessions")
+        const revoked = await revokeAllSessions(id)
+        if (revoked > 0) {
+          console.log(`[auth-session] revoked ${revoked} session(s) for ${safeLog(id)}`)
+        }
+      } catch (e: any) {
+        // The password is already changed; failing the request now would be
+        // worse than leaving the sweep to the next read-path evaluation.
+        console.error('[auth-session] revocation after credential change failed:', e?.message ?? e)
+      }
+    }
 
     // Audit
     const { audit } = await import("@/lib/audit")

--- a/frontend/src/app/api/v1/users/[id]/route.ts
+++ b/frontend/src/app/api/v1/users/[id]/route.ts
@@ -7,37 +7,10 @@ import { authOptions } from "@/lib/auth/config"
 import { prisma } from "@/lib/db/prisma"
 import { hashPassword } from "@/lib/auth/password"
 import { safeLog } from "@/lib/log/sanitize"
-import { checkPermission, PERMISSIONS, isUserSuperAdmin, isUserProtected, PROTECTED_ROLE_IDS, PROVIDER_ONLY_ROLE_IDS } from "@/lib/rbac"
+import { checkPermission, PERMISSIONS, PROTECTED_ROLE_IDS, PROVIDER_ONLY_ROLE_IDS } from "@/lib/rbac"
+import { denyIfTargetIsProtectedAndCallerIsNot, findUserInTenant } from "@/lib/rbac/userTargetGuards"
 import { nanoid } from "nanoid"
 import { DEFAULT_TENANT_ID, addUserToTenant, removeUserFromTenant, TenantMembershipError, getCurrentTenantId } from "@/lib/tenant"
-
-/**
- * Hide provider-level accounts (super_admin + provider_admin) from
- * non-super-admin callers. Returns 404 rather than 403 so existence is not
- * leaked.
- */
-async function denyIfTargetIsProtectedAndCallerIsNot(
-  targetUserId: string,
-  callerUserId: string | undefined
-): Promise<NextResponse | null> {
-  if (!(await isUserProtected(targetUserId))) return null
-  if (callerUserId && (await isUserSuperAdmin(callerUserId))) return null
-  return NextResponse.json({ error: "Utilisateur non trouvé" }, { status: 404 })
-}
-
-/**
- * Fetch a user that belongs to the given tenant. Returns the full Prisma row
- * or null if the user doesn't exist or has no membership in this tenant.
- * Centralised so the GET / PATCH / DELETE handlers all use the same lookup
- * + tenant-scoping rules.
- */
-async function findUserInTenant(userId: string, tenantId: string) {
-  const membership = await prisma.userTenant.findUnique({
-    where: { userId_tenantId: { userId, tenantId } },
-    include: { user: true },
-  })
-  return membership?.user ?? null
-}
 
 export const runtime = "nodejs"
 

--- a/frontend/src/app/api/v1/users/route.test.ts
+++ b/frontend/src/app/api/v1/users/route.test.ts
@@ -9,20 +9,26 @@
  * Community), the same signal that drives RBAC picker visibility in the UI.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { callRoute } from "@/__tests__/setup/route-test"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
 
 const checkPermissionMock = vi.fn()
 const getCurrentTenantIdMock = vi.fn()
 const getServerLicenseMock = vi.fn()
 const hashPasswordMock = vi.fn(async () => "hashed")
 const auditMock = vi.fn(async () => {})
+const isUserSuperAdminMock = vi.fn()
 
 const userFindUniqueMock = vi.fn()
 const userCreateMock = vi.fn((args: any) => ({ __op: "user.create", args }))
+const userFindManyMock = vi.fn()
 const userTenantCreateMock = vi.fn((args: any) => ({ __op: "userTenant.create", args }))
+const userTenantFindManyMock = vi.fn()
 const rbacUserRoleCreateMock = vi.fn((args: any) => ({ __op: "rbacUserRole.create", args }))
+const rbacUserRoleFindManyMock = vi.fn()
 const tenantFindManyMock = vi.fn()
 const transactionMock = vi.fn(async (ops: any[]) => ops)
+const sessionGroupByMock = vi.fn()
+const sessionCountMock = vi.fn()
 
 vi.mock("next-auth", () => ({ getServerSession: vi.fn(async () => ({ user: { id: "admin" } })) }))
 vi.mock("@/lib/auth/config", () => ({ authOptions: {} }))
@@ -30,17 +36,18 @@ vi.mock("@/lib/auth/password", () => ({ hashPassword: hashPasswordMock }))
 vi.mock("@/lib/audit", () => ({ audit: auditMock }))
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
-    user: { findUnique: userFindUniqueMock, create: userCreateMock },
-    userTenant: { create: userTenantCreateMock },
-    rbacUserRole: { create: rbacUserRoleCreateMock },
+    user: { findUnique: userFindUniqueMock, create: userCreateMock, findMany: userFindManyMock },
+    userTenant: { create: userTenantCreateMock, findMany: userTenantFindManyMock },
+    rbacUserRole: { create: rbacUserRoleCreateMock, findMany: rbacUserRoleFindManyMock },
     tenant: { findMany: tenantFindManyMock },
+    session: { groupBy: sessionGroupByMock, count: sessionCountMock },
     $transaction: transactionMock,
   },
 }))
 vi.mock("@/lib/rbac", () => ({
   checkPermission: checkPermissionMock,
   PERMISSIONS: { ADMIN_USERS: "admin.users" },
-  isUserSuperAdmin: vi.fn(),
+  isUserSuperAdmin: isUserSuperAdminMock,
   PROTECTED_ROLE_IDS: ["role_super_admin", "role_provider_admin"],
 }))
 vi.mock("@/lib/tenant", () => ({
@@ -52,6 +59,28 @@ vi.mock("@/lib/auth/requireEnterprise", () => ({ getServerLicense: getServerLice
 async function importPOST() {
   const mod = await import("./route")
   return mod.POST
+}
+
+async function importGET() {
+  const mod = await import("./route")
+  return mod.GET
+}
+
+function userRow(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    email: `${id}@example.com`,
+    name: id,
+    role: "user",
+    authProvider: "credentials",
+    enabled: true,
+    totpEnabled: false,
+    require2faEnrollment: false,
+    lastLoginAt: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...overrides,
+  }
 }
 
 describe("POST /api/v1/users — Community auto super-admin (issue #512)", () => {
@@ -116,5 +145,79 @@ describe("POST /api/v1/users — Community auto super-admin (issue #512)", () =>
     expect(auditMock).toHaveBeenCalledWith(
       expect.objectContaining({ details: expect.objectContaining({ superAdminGranted: false }) }),
     )
+  })
+})
+
+/**
+ * GET /api/v1/users — active_session_count (Task 12).
+ *
+ * One grouped query for the whole page, not one count() per user: a per-row
+ * count() is an N+1 on a list route. isUserSuperAdmin is stubbed to resolve
+ * true so the caller skips the protected-role filtering branch entirely,
+ * keeping these tests focused on the session-count wiring.
+ */
+describe("GET /api/v1/users — active_session_count", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermissionMock.mockResolvedValue(null)
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    isUserSuperAdminMock.mockResolvedValue(true)
+    userTenantFindManyMock.mockResolvedValue([])
+    rbacUserRoleFindManyMock.mockResolvedValue([])
+    sessionGroupByMock.mockResolvedValue([])
+    sessionCountMock.mockResolvedValue(0)
+  })
+
+  it("attaches active_session_count from a single groupBy call, defaulting absent users to 0", async () => {
+    userFindManyMock.mockResolvedValue([userRow("u1"), userRow("u2"), userRow("u3")])
+    sessionGroupByMock.mockResolvedValue([
+      { userId: "u1", _count: 2 },
+      { userId: "u2", _count: 0 },
+    ])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    const byId = Object.fromEntries(body.data.map((u: any) => [u.id, u.active_session_count]))
+    expect(byId.u1).toBe(2)
+    expect(byId.u2).toBe(0)
+    // Absent from the grouped result => 0, not undefined and not a missing key.
+    expect(byId.u3).toBe(0)
+    expect("active_session_count" in body.data.find((u: any) => u.id === "u3")).toBe(true)
+
+    // Exactly one grouped query for the whole page — never a per-user count().
+    expect(sessionGroupByMock).toHaveBeenCalledTimes(1)
+    expect(sessionCountMock).not.toHaveBeenCalled()
+  })
+
+  it("scopes the groupBy to the visible page's users and to alive sessions only", async () => {
+    userFindManyMock.mockResolvedValue([userRow("u1")])
+    sessionGroupByMock.mockResolvedValue([{ userId: "u1", _count: 1 }])
+
+    const GET = await importGET()
+    await callRoute(GET as any, { method: "GET" })
+
+    expect(sessionGroupByMock).toHaveBeenCalledTimes(1)
+    const arg = sessionGroupByMock.mock.calls[0][0]
+    expect(arg.by).toEqual(["userId"])
+    expect(arg.where.userId).toEqual({ in: ["u1"] })
+    // aliveWhere() liveness fragment: not revoked, within idle + absolute cap.
+    expect(arg.where.revokedAt).toBeNull()
+    expect(arg.where.lastSeenAt).toBeDefined()
+    expect(arg.where.createdAt).toBeDefined()
+  })
+
+  it("does not call groupBy at all when the page has no visible users", async () => {
+    userFindManyMock.mockResolvedValue([])
+
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await readJson<any>(res)
+    expect(body.data).toEqual([])
+    expect(sessionGroupByMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/users/route.ts
+++ b/frontend/src/app/api/v1/users/route.ts
@@ -11,6 +11,7 @@ import { authOptions } from "@/lib/auth/config"
 import { checkPermission, PERMISSIONS, isUserSuperAdmin, PROTECTED_ROLE_IDS } from "@/lib/rbac"
 import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
 import { getServerLicense } from "@/lib/auth/requireEnterprise"
+import { aliveWhere } from "@/lib/auth/sessions"
 
 export const runtime = "nodejs"
 
@@ -80,7 +81,10 @@ export async function GET() {
     // collapse their list to a single "all tenants" chip — they're
     // pinned to every tenant by design (cf. createTenant).
     const visibleUserIds = memberships.map(m => m.userId)
-    const [allMemberships, superAdminRows] = visibleUserIds.length > 0
+    // Session counts: one grouped query for the whole page, scoped to the
+    // users actually being returned. A count() per user would be an N+1 on
+    // a list route; users absent from the grouped result get 0 below.
+    const [allMemberships, superAdminRows, sessionCounts] = visibleUserIds.length > 0
       ? await Promise.all([
           prisma.userTenant.findMany({
             where: { userId: { in: visibleUserIds } },
@@ -95,8 +99,13 @@ export async function GET() {
             select: { userId: true },
             distinct: ["userId"],
           }),
+          prisma.session.groupBy({
+            by: ["userId"],
+            where: { userId: { in: visibleUserIds }, ...aliveWhere() },
+            _count: true,
+          }),
         ])
-      : [[], []]
+      : [[], [], []]
     const tenantsByUser = new Map<string, Array<{ id: string; name: string; isDefault: boolean }>>()
     for (const m of allMemberships) {
       const list = tenantsByUser.get(m.userId) ?? []
@@ -104,6 +113,9 @@ export async function GET() {
       tenantsByUser.set(m.userId, list)
     }
     const superAdminIds = new Set(superAdminRows.map(r => r.userId))
+    const sessionCountByUser = new Map<string, number>(
+      sessionCounts.map(row => [row.userId, row._count]),
+    )
 
     const users = memberships.map(m => ({
       id: m.user.id,
@@ -118,6 +130,7 @@ export async function GET() {
       created_at: m.user.createdAt.toISOString(),
       updated_at: m.user.updatedAt.toISOString(),
       is_super_admin: superAdminIds.has(m.user.id),
+      active_session_count: sessionCountByUser.get(m.user.id) ?? 0,
       tenants: (tenantsByUser.get(m.user.id) ?? []).sort((a, b) => {
         if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1
         return a.name.localeCompare(b.name)

--- a/frontend/src/components/AuthProvider.jsx
+++ b/frontend/src/components/AuthProvider.jsx
@@ -4,7 +4,14 @@ import { SessionProvider } from 'next-auth/react'
 
 export default function AuthProvider({ children, session }) {
   return (
-    <SessionProvider session={session}>
+    // refetchInterval polls /api/auth/session, which runs the auth-session-
+    // hardening `jwt` callback (a DB read) on every tick — so a user sitting
+    // on a page eventually notices a dead session instead of the UI just
+    // emptying itself as calls 401. 60s keeps that at one query per tab per
+    // minute; do not shorten it, that multiplies DB load per open tab.
+    // refetchOnWindowFocus stays at its default (true): returning to a tab
+    // still revalidates immediately.
+    <SessionProvider session={session} refetchInterval={60}>
       {children}
     </SessionProvider>
   )

--- a/frontend/src/components/SessionExpiryGuard.jsx
+++ b/frontend/src/components/SessionExpiryGuard.jsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter, usePathname } from 'next/navigation'
+
+// The auth-session-hardening branch clears the cookie server-side whenever a
+// session dies (idle timeout, absolute-cap expiry, revocation, or a legacy
+// cookie with no sid): the jwt callback throws, next-auth's session route
+// catches it, calls sessionStore.clean(), and returns an empty body. Nothing
+// on the client reacted to that — every guarded data call just started
+// returning 401 and the open page quietly emptied itself instead of sending
+// the user to /login. AuthProvider's refetchInterval is what makes
+// useSession() notice within a minute; this guard is what acts on it.
+export default function SessionExpiryGuard({ children }) {
+  const { status } = useSession()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    // Do nothing while the initial session fetch is in flight: redirecting
+    // on "loading" would bounce every user on every page load.
+    if (status !== 'unauthenticated') return
+
+    // callbackUrl matches middleware.ts's own no-token redirect
+    // (`loginUrl.searchParams.set("callbackUrl", pathname)`) so
+    // re-authenticating returns the user where they were.
+    const loginUrl = `/login?callbackUrl=${encodeURIComponent(pathname)}`
+
+    // replace(), not push(): the dead page must not stay in history. No
+    // signOut() — the cookie is already cleared server-side by the time
+    // status is "unauthenticated", so it would only be a redundant round trip.
+    router.replace(loginUrl)
+  }, [status, pathname, router])
+
+  return children
+}

--- a/frontend/src/components/SessionExpiryGuard.test.tsx
+++ b/frontend/src/components/SessionExpiryGuard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import SessionExpiryGuard from './SessionExpiryGuard'
+
+// This file drives its own session/router states, overriding the fixed
+// authenticated/idle stubs that src/__tests__/setup/renderWithProviders.tsx
+// installs for other tests — this component has no other dependency
+// (no i18n, no theme, no fetch), so it renders standalone like
+// src/components/guards/FeatureGuard.test.tsx does.
+const useSessionMock = vi.fn()
+vi.mock('next-auth/react', () => ({
+  useSession: () => useSessionMock(),
+}))
+
+const replaceMock = vi.fn()
+let currentPathname = '/dashboard'
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+  usePathname: () => currentPathname,
+}))
+
+describe('SessionExpiryGuard', () => {
+  beforeEach(() => {
+    useSessionMock.mockReset()
+    replaceMock.mockClear()
+    currentPathname = '/dashboard'
+  })
+  afterEach(() => cleanup())
+
+  it('redirects to /login with a callbackUrl when the session is unauthenticated', () => {
+    useSessionMock.mockReturnValue({ status: 'unauthenticated' })
+
+    render(<SessionExpiryGuard><div>content</div></SessionExpiryGuard>)
+
+    expect(replaceMock).toHaveBeenCalledTimes(1)
+    expect(replaceMock).toHaveBeenCalledWith('/login?callbackUrl=%2Fdashboard')
+  })
+
+  it('does nothing while the initial session fetch is loading', () => {
+    useSessionMock.mockReturnValue({ status: 'loading' })
+
+    render(<SessionExpiryGuard><div>content</div></SessionExpiryGuard>)
+
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing while authenticated', () => {
+    useSessionMock.mockReturnValue({ status: 'authenticated' })
+
+    render(<SessionExpiryGuard><div>content</div></SessionExpiryGuard>)
+
+    expect(replaceMock).not.toHaveBeenCalled()
+  })
+
+  it('encodes the current path in callbackUrl, matching middleware.ts', () => {
+    currentPathname = '/settings/security'
+    useSessionMock.mockReturnValue({ status: 'unauthenticated' })
+
+    render(<SessionExpiryGuard><div>content</div></SessionExpiryGuard>)
+
+    expect(replaceMock).toHaveBeenCalledWith('/login?callbackUrl=%2Fsettings%2Fsecurity')
+  })
+
+  it('still renders children (no signOut round trip, no blocking gate)', () => {
+    useSessionMock.mockReturnValue({ status: 'authenticated' })
+
+    const { getByText } = render(<SessionExpiryGuard><div>content</div></SessionExpiryGuard>)
+
+    expect(getByText('content')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/profile/SessionsCard.jsx
+++ b/frontend/src/components/profile/SessionsCard.jsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useTranslations } from 'next-intl'
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Divider,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+
+import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
+
+// Returns the browser/OS parts rather than a single joined string, so the
+// caller decides how to compose them (separator only when both exist). It
+// lives here, not in the shared server-side lib/auth/deviceLabel.ts, because
+// the "unknown device" fallback needs next-intl's t(), which only exists
+// client-side.
+function deviceLabel(row, t) {
+  const { browser, os } = row
+  if (!browser && !os) return [t('common.unknown')]
+  return [browser, os].filter(Boolean)
+}
+
+export default function SessionsCard() {
+  const t = useTranslations()
+
+  const [sessions, setSessions] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [actionError, setActionError] = useState('')
+
+  const [revoking, setRevoking] = useState(null) // session row pending single revoke
+  const [revokeAllOpen, setRevokeAllOpen] = useState(false)
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/v1/auth/sessions')
+      const data = await res.json()
+      if (res.ok) {
+        setSessions(Array.isArray(data?.data) ? data.data : [])
+      } else {
+        setError(data?.error || t('common.error'))
+      }
+    } catch {
+      setError(t('settings.connectionError'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => { fetchSessions() }, [fetchSessions])
+
+  // ---- Loading -----------------------------------------------------
+  if (loading) {
+    return (
+      <Card variant='outlined'>
+        <CardContent sx={{ p: 3, display: 'flex', alignItems: 'center', gap: 2 }}>
+          <CircularProgress size={20} />
+          <Typography variant='body2' color='text.secondary'>
+            {t('sessions.cardTitle')}
+          </Typography>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // ---- Handlers ------------------------------------------------------
+
+  const handleRevokeOne = async () => {
+    const target = revoking
+    if (!target) return
+    setRevoking(null)
+    setActionError('')
+    try {
+      const res = await fetch(`/api/v1/auth/sessions/${target.id}`, { method: 'DELETE' })
+      const data = await res.json()
+      if (res.ok) {
+        fetchSessions()
+      } else {
+        setActionError(data?.error || t('common.error'))
+      }
+    } catch {
+      setActionError(t('settings.connectionError'))
+    }
+  }
+
+  const handleRevokeAll = async () => {
+    setRevokeAllOpen(false)
+    setActionError('')
+    try {
+      // The collection DELETE excludes the current session server-side by
+      // design (Task 11's contract): a single click here must never sign the
+      // caller out of the screen they are on. Do not "fix" this to also
+      // revoke the current session.
+      const res = await fetch('/api/v1/auth/sessions', { method: 'DELETE' })
+      const data = await res.json()
+      if (res.ok) {
+        fetchSessions()
+      } else {
+        setActionError(data?.error || t('common.error'))
+      }
+    } catch {
+      setActionError(t('settings.connectionError'))
+    }
+  }
+
+  const otherSessionsCount = sessions.filter(s => !s.current).length
+
+  // ---- Render ----------------------------------------------------
+
+  return (
+    <>
+      <Card variant='outlined'>
+        <CardContent sx={{ p: 3 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2, gap: 2, flexWrap: 'wrap' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <i className='ri-device-line' style={{ fontSize: 20, opacity: 0.7 }} />
+              <Typography variant='h6' sx={{ fontWeight: 600 }}>
+                {t('sessions.cardTitle')}
+              </Typography>
+            </Box>
+            {otherSessionsCount > 0 && (
+              <Button
+                variant='outlined'
+                color='error'
+                size='small'
+                startIcon={<i className='ri-logout-box-line' />}
+                onClick={() => setRevokeAllOpen(true)}
+              >
+                {t('sessions.revokeAllButton')}
+              </Button>
+            )}
+          </Box>
+
+          {error && (
+            <Alert severity='error' sx={{ mb: 2 }} onClose={() => setError('')}>
+              {error}
+            </Alert>
+          )}
+
+          {actionError && (
+            <Alert severity='error' sx={{ mb: 2 }} onClose={() => setActionError('')}>
+              {actionError}
+            </Alert>
+          )}
+
+          {sessions.length === 0 ? (
+            <Typography variant='body2' color='text.secondary'>
+              {t('sessions.empty')}
+            </Typography>
+          ) : (
+            <Stack divider={<Divider />} spacing={2}>
+              {sessions.map(row => (
+                <Box
+                  key={row.id}
+                  sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5, minWidth: 0 }}>
+                    <i className='ri-computer-line' style={{ fontSize: 18, opacity: 0.6, marginTop: 2 }} />
+                    <Box sx={{ minWidth: 0 }}>
+                      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                        <Tooltip title={row.userAgent || t('common.unknown')} slotProps={tooltipSlotProps}>
+                          <Typography variant='body2' sx={{ fontWeight: 500 }}>
+                            {deviceLabel(row, t).join(' · ')}
+                          </Typography>
+                        </Tooltip>
+                        {row.current && (
+                          <Chip label={t('sessions.currentChip')} size='small' color='success' />
+                        )}
+                      </Box>
+                      <Typography variant='caption' color='text.secondary' display='block'>
+                        {t('sessions.ipLabel')}: {row.ipAddress || t('common.unknown')}
+                      </Typography>
+                      <Typography variant='caption' color='text.secondary' display='block'>
+                        {t('sessions.lastActiveLabel')}: {row.lastSeenAt ? new Date(row.lastSeenAt).toLocaleString() : t('common.unknown')}
+                        {' · '}
+                        {t('sessions.signedInLabel')}: {row.createdAt ? new Date(row.createdAt).toLocaleDateString() : t('common.unknown')}
+                      </Typography>
+                    </Box>
+                  </Box>
+
+                  {!row.current && (
+                    <Tooltip title={t('sessions.revokeButton')} slotProps={tooltipSlotProps}>
+                      <IconButton
+                        size='small'
+                        aria-label={t('sessions.revokeButton')}
+                        onClick={() => setRevoking(row)}
+                      >
+                        <i className='ri-logout-circle-r-line' />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Confirm single revoke */}
+      <Dialog open={!!revoking} onClose={() => setRevoking(null)} maxWidth='xs' fullWidth>
+        <AppDialogTitle
+          onClose={() => setRevoking(null)}
+          icon={<i className='ri-logout-circle-r-line' style={{ fontSize: 20 }} />}
+        >
+          {t('sessions.revokeConfirmTitle')}
+        </AppDialogTitle>
+        <DialogContent sx={{ pt: 1 }}>
+          <Typography variant='body2'>{t('sessions.revokeConfirmBody')}</Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setRevoking(null)}>{t('common.cancel')}</Button>
+          <Button variant='contained' color='error' onClick={handleRevokeOne}>
+            {t('common.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Confirm revoke-all-others */}
+      <Dialog open={revokeAllOpen} onClose={() => setRevokeAllOpen(false)} maxWidth='xs' fullWidth>
+        <AppDialogTitle
+          onClose={() => setRevokeAllOpen(false)}
+          icon={<i className='ri-logout-box-line' style={{ fontSize: 20 }} />}
+        >
+          {t('sessions.revokeAllConfirmTitle')}
+        </AppDialogTitle>
+        <DialogContent sx={{ pt: 1 }}>
+          <Typography variant='body2'>{t('sessions.revokeAllConfirmBody')}</Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setRevokeAllOpen(false)}>{t('common.cancel')}</Button>
+          <Button variant='contained' color='error' onClick={handleRevokeAll}>
+            {t('common.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/components/profile/SessionsCard.test.tsx
+++ b/frontend/src/components/profile/SessionsCard.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import SessionsCard from './SessionsCard'
+
+const SESSIONS_URL = '*/api/v1/auth/sessions'
+
+function makeSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 's1',
+    current: false,
+    browser: 'Chrome',
+    os: 'Windows',
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0 Safari/537.36',
+    ipAddress: '203.0.113.5',
+    createdAt: '2026-07-01T10:00:00.000Z',
+    lastSeenAt: '2026-08-01T09:30:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('SessionsCard', () => {
+  afterEach(() => cleanup())
+
+  it('renders one row per session, marks the current one, and falls back to Unknown for an unidentifiable device', async () => {
+    server.use(
+      http.get(SESSIONS_URL, () =>
+        HttpResponse.json({
+          data: [
+            makeSession({ id: 'current', current: true, browser: 'Firefox', os: 'macOS', ipAddress: '198.51.100.1' }),
+            makeSession({ id: 'other', current: false, ipAddress: '203.0.113.5' }),
+            makeSession({ id: 'mystery', current: false, browser: null, os: null, userAgent: null, ipAddress: '192.0.2.9' }),
+          ],
+        }),
+      ),
+    )
+
+    renderWithProviders(<SessionsCard />)
+
+    await screen.findByText('Firefox · macOS')
+    expect(screen.getByText('Chrome · Windows')).toBeInTheDocument()
+
+    // Both null -> translated "unknown device" fallback, not an empty cell.
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+
+    // Only the current session carries the chip marker.
+    expect(screen.getAllByText('This device')).toHaveLength(1)
+
+    // IP address and last-activity are shown per row, never in monospace.
+    const ipText = screen.getByText('IP address: 203.0.113.5')
+    expect(ipText).toBeInTheDocument()
+    expect(ipText).not.toHaveStyle({ fontFamily: 'monospace' })
+  })
+
+  it('renders the empty state when there are no sessions', async () => {
+    server.use(http.get(SESSIONS_URL, () => HttpResponse.json({ data: [] })))
+
+    renderWithProviders(<SessionsCard />)
+
+    expect(await screen.findByText('No active sessions.')).toBeInTheDocument()
+  })
+
+  it('shows the connection-error alert when the fetch fails', async () => {
+    server.use(http.get(SESSIONS_URL, () => HttpResponse.error()))
+
+    renderWithProviders(<SessionsCard />)
+
+    expect(await screen.findByText('Connection error')).toBeInTheDocument()
+  })
+
+  it('revoking one row issues the single DELETE and refreshes the list', async () => {
+    const user = userEvent.setup()
+    let getCalls = 0
+    let deleteOtherCalls = 0
+
+    server.use(
+      http.get(SESSIONS_URL, () => {
+        getCalls += 1
+        return HttpResponse.json({
+          data: [
+            makeSession({ id: 'current', current: true }),
+            makeSession({ id: 'other', current: false }),
+          ],
+        })
+      }),
+      http.delete('*/api/v1/auth/sessions/other', () => {
+        deleteOtherCalls += 1
+        return HttpResponse.json({ data: { ok: true } })
+      }),
+    )
+
+    renderWithProviders(<SessionsCard />)
+
+    await screen.findByRole('button', { name: 'Sign out other sessions' })
+    expect(getCalls).toBe(1)
+
+    await user.click(screen.getByRole('button', { name: 'Sign out' }))
+    await screen.findByText('Sign out this session?')
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    await waitFor(() => expect(deleteOtherCalls).toBe(1))
+    await waitFor(() => expect(getCalls).toBe(2))
+  })
+
+  it('"sign out other sessions" issues the collection DELETE and excludes the current session', async () => {
+    const user = userEvent.setup()
+    let getCalls = 0
+    let deleteAllCalls = 0
+
+    server.use(
+      http.get(SESSIONS_URL, () => {
+        getCalls += 1
+        return HttpResponse.json({
+          data: [
+            makeSession({ id: 'current', current: true }),
+            makeSession({ id: 'other', current: false }),
+          ],
+        })
+      }),
+      http.delete(SESSIONS_URL, () => {
+        deleteAllCalls += 1
+        return HttpResponse.json({ data: { revoked: 1 } })
+      }),
+    )
+
+    renderWithProviders(<SessionsCard />)
+
+    await screen.findByRole('button', { name: 'Sign out other sessions' })
+
+    await user.click(screen.getByRole('button', { name: 'Sign out other sessions' }))
+    await screen.findByText('Sign out all other sessions?')
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    await waitFor(() => expect(deleteAllCalls).toBe(1))
+    await waitFor(() => expect(getCalls).toBe(2))
+  })
+})

--- a/frontend/src/components/security/RevokeEverySessionDialog.jsx
+++ b/frontend/src/components/security/RevokeEverySessionDialog.jsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+
+/* --------------------------------
+   Revoke Every Session Confirm Dialog (super-admin, installation-wide)
+   (non-destructive — everyone can sign back in right away)
+
+   The collection DELETE excludes the caller's current session server-side
+   by design: this is an incident action ("everyone out") and signing the
+   operator out mid-incident would slow the response. Their own row stays
+   one click away in the listing behind this dialog, with its own warning
+   and /login redirect. Do not "fix" this to also revoke the caller.
+
+   Named RevokeEverySessionDialog — "Every" = every user of the
+   installation — so it cannot be confused with its siblings
+   RevokeSessionsDialog (every session of ONE user) and
+   RevokeSingleSessionDialog (one session). `t` stays a prop, matching the
+   convention of the page that renders it.
+-------------------------------- */
+
+export default function RevokeEverySessionDialog({ open, onClose, onSuccess, t }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch('/api/v1/admin/sessions', { method: 'DELETE' })
+      if (res.ok) {
+        onSuccess()
+        onClose()
+        return
+      }
+      let data = {}
+      try { data = await res.json() } catch (_) {}
+      setError(data.error || t('common.error'))
+    } catch (_) {
+      setError(t('errors.connectionError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setError('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <i className='ri-logout-box-line' />
+        {t('sessions.adminRevokeEveryConfirmTitle')}
+      </DialogTitle>
+      <DialogContent sx={{ pt: '20px !important' }}>
+        {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        <Typography>{t('sessions.adminRevokeEveryConfirmBody')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{t('common.cancel')}</Button>
+        <Button
+          variant='contained'
+          onClick={handleConfirm}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {t('common.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/security/RevokeEverySessionDialog.jsx
+++ b/frontend/src/components/security/RevokeEverySessionDialog.jsx
@@ -13,15 +13,17 @@ import {
   Typography,
 } from '@mui/material'
 
+import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
+
 /* --------------------------------
    Revoke Every Session Confirm Dialog (super-admin, installation-wide)
    (non-destructive — everyone can sign back in right away)
 
-   The collection DELETE excludes the caller's current session server-side
-   by design: this is an incident action ("everyone out") and signing the
-   operator out mid-incident would slow the response. Their own row stays
-   one click away in the listing behind this dialog, with its own warning
-   and /login redirect. Do not "fix" this to also revoke the caller.
+   The collection DELETE is TOTAL by design (a product call, reversing the
+   first version's caller-exception): it revokes the caller's own session
+   too, so on success this dialog's only correct move is the same
+   deterministic /login redirect every other self-revocation flow uses —
+   the page behind it can no longer make an authenticated call.
 
    Named RevokeEverySessionDialog — "Every" = every user of the
    installation — so it cannot be confused with its siblings
@@ -30,7 +32,7 @@ import {
    convention of the page that renders it.
 -------------------------------- */
 
-export default function RevokeEverySessionDialog({ open, onClose, onSuccess, t }) {
+export default function RevokeEverySessionDialog({ open, onClose, t }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -40,8 +42,10 @@ export default function RevokeEverySessionDialog({ open, onClose, onSuccess, t }
     try {
       const res = await fetch('/api/v1/admin/sessions', { method: 'DELETE' })
       if (res.ok) {
-        onSuccess()
-        onClose()
+        // Every session is gone, this tab's included: the session is dead
+        // server-side, nothing here can succeed anymore. Straight to /login,
+        // no poller wait.
+        redirectToLoginOnce()
         return
       }
       let data = {}

--- a/frontend/src/components/security/RevokeEverySessionDialog.test.tsx
+++ b/frontend/src/components/security/RevokeEverySessionDialog.test.tsx
@@ -6,6 +6,13 @@ import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
 import RevokeEverySessionDialog from './RevokeEverySessionDialog'
 
+const { redirectToLoginOnceMock } = vi.hoisted(() => ({ redirectToLoginOnceMock: vi.fn() }))
+
+vi.mock('@/hooks/useSWRFetch', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/hooks/useSWRFetch')>()),
+  redirectToLoginOnce: redirectToLoginOnceMock,
+}))
+
 // Translate stub: return the key unchanged — same convention as the two
 // sibling revoke dialogs' tests.
 const t = (k: string) => k
@@ -13,11 +20,13 @@ const t = (k: string) => k
 const SESSIONS_URL = '*/api/v1/admin/sessions'
 
 describe('RevokeEverySessionDialog', () => {
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    redirectToLoginOnceMock.mockClear()
+  })
 
-  it('issues DELETE /api/v1/admin/sessions and calls onSuccess() then onClose()', async () => {
+  it('issues DELETE /api/v1/admin/sessions and navigates to /login (the caller is signed out too)', async () => {
     const user = userEvent.setup()
-    const onSuccess = vi.fn()
     const onClose = vi.fn()
     let deleteCalls = 0
 
@@ -29,19 +38,19 @@ describe('RevokeEverySessionDialog', () => {
     )
 
     renderWithProviders(
-      <RevokeEverySessionDialog open onClose={onClose} onSuccess={onSuccess} t={t} />,
+      <RevokeEverySessionDialog open onClose={onClose} t={t} />,
     )
 
     await user.click(screen.getByRole('button', { name: 'common.confirm' }))
 
     await waitFor(() => expect(deleteCalls).toBe(1))
-    expect(onSuccess).toHaveBeenCalledOnce()
-    expect(onClose).toHaveBeenCalledOnce()
+    await waitFor(() => expect(redirectToLoginOnceMock).toHaveBeenCalledTimes(1))
+    // The page is being left; the dialog does not bother closing first.
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it('surfaces errors.connectionError on a network failure and does not close', async () => {
     const user = userEvent.setup()
-    const onSuccess = vi.fn()
     const onClose = vi.fn()
 
     server.use(
@@ -49,14 +58,14 @@ describe('RevokeEverySessionDialog', () => {
     )
 
     renderWithProviders(
-      <RevokeEverySessionDialog open onClose={onClose} onSuccess={onSuccess} t={t} />,
+      <RevokeEverySessionDialog open onClose={onClose} t={t} />,
     )
 
     await user.click(screen.getByRole('button', { name: 'common.confirm' }))
 
     expect(await screen.findByText('errors.connectionError')).toBeInTheDocument()
-    expect(onSuccess).not.toHaveBeenCalled()
     expect(onClose).not.toHaveBeenCalled()
+    expect(redirectToLoginOnceMock).not.toHaveBeenCalled()
   })
 
   it('disables the confirm button while the request is in flight', async () => {
@@ -74,7 +83,7 @@ describe('RevokeEverySessionDialog', () => {
     )
 
     renderWithProviders(
-      <RevokeEverySessionDialog open onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+      <RevokeEverySessionDialog open onClose={vi.fn()} t={t} />,
     )
 
     const confirmBtn = screen.getByRole('button', { name: 'common.confirm' })

--- a/frontend/src/components/security/RevokeEverySessionDialog.test.tsx
+++ b/frontend/src/components/security/RevokeEverySessionDialog.test.tsx
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import RevokeEverySessionDialog from './RevokeEverySessionDialog'
+
+// Translate stub: return the key unchanged — same convention as the two
+// sibling revoke dialogs' tests.
+const t = (k: string) => k
+
+const SESSIONS_URL = '*/api/v1/admin/sessions'
+
+describe('RevokeEverySessionDialog', () => {
+  afterEach(() => cleanup())
+
+  it('issues DELETE /api/v1/admin/sessions and calls onSuccess() then onClose()', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+    let deleteCalls = 0
+
+    server.use(
+      http.delete(SESSIONS_URL, () => {
+        deleteCalls += 1
+        return HttpResponse.json({ data: { revoked: 7 } })
+      }),
+    )
+
+    renderWithProviders(
+      <RevokeEverySessionDialog open onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(deleteCalls).toBe(1))
+    expect(onSuccess).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces errors.connectionError on a network failure and does not close', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSIONS_URL, () => HttpResponse.error()),
+    )
+
+    renderWithProviders(
+      <RevokeEverySessionDialog open onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    expect(await screen.findByText('errors.connectionError')).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('disables the confirm button while the request is in flight', async () => {
+    const user = userEvent.setup()
+    let resolveDelete: (() => void) | null = null
+
+    server.use(
+      http.delete(
+        SESSIONS_URL,
+        () =>
+          new Promise(resolve => {
+            resolveDelete = () => resolve(HttpResponse.json({ data: { revoked: 1 } }))
+          }),
+      ),
+    )
+
+    renderWithProviders(
+      <RevokeEverySessionDialog open onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    const confirmBtn = screen.getByRole('button', { name: 'common.confirm' })
+    expect(confirmBtn).not.toBeDisabled()
+
+    await user.click(confirmBtn)
+
+    await waitFor(() => expect(confirmBtn).toBeDisabled())
+
+    // Let the in-flight request resolve so it doesn't leak into the next test.
+    resolveDelete?.()
+  })
+})

--- a/frontend/src/components/security/RevokeSessionsDialog.jsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.jsx
@@ -13,6 +13,8 @@ import {
   Typography,
 } from '@mui/material'
 
+import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
+
 /* --------------------------------
    Revoke Sessions Confirm Dialog
    (non-destructive — simple confirm, recoverable by signing back in)
@@ -27,7 +29,7 @@ import {
    useTranslations() pattern.
 -------------------------------- */
 
-export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t }) {
+export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t, currentUserId }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -39,6 +41,13 @@ export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t
         method: 'DELETE',
       })
       if (res.ok) {
+        // "Every session of user X" includes the caller's own when X is the
+        // caller: this tab's session is already revoked server-side. Navigate
+        // now instead of letting the page 401 until a poller reacts.
+        if (user?.id && user.id === currentUserId) {
+          redirectToLoginOnce()
+          return
+        }
         onSuccess(user.id)
         onClose()
         return

--- a/frontend/src/components/security/RevokeSessionsDialog.jsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.jsx
@@ -33,6 +33,11 @@ export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
+  // Self-targeting is legitimate (a super admin may end their own sessions)
+  // but must never be a surprise: warn before the click, and navigate to
+  // /login after it instead of updating a list this tab can no longer read.
+  const isSelf = !!user?.id && user.id === currentUserId
+
   const handleConfirm = async () => {
     setLoading(true)
     setError('')
@@ -44,7 +49,7 @@ export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t
         // "Every session of user X" includes the caller's own when X is the
         // caller: this tab's session is already revoked server-side. Navigate
         // now instead of letting the page 401 until a poller reacts.
-        if (user?.id && user.id === currentUserId) {
+        if (isSelf) {
           redirectToLoginOnce()
           return
         }
@@ -75,6 +80,9 @@ export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t
       </DialogTitle>
       <DialogContent sx={{ pt: '20px !important' }}>
         {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        {isSelf && (
+          <Alert severity='warning' sx={{ mb: 2 }}>{t('sessions.adminRevokeAllOwnConfirmWarning')}</Alert>
+        )}
         <Typography>{t('sessions.adminRevokeConfirmBody')}</Typography>
       </DialogContent>
       <DialogActions>

--- a/frontend/src/components/security/RevokeSessionsDialog.jsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.jsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+
+/* --------------------------------
+   Revoke Sessions Confirm Dialog
+   (non-destructive — simple confirm, recoverable by signing back in)
+
+   Extracted out of the admin users page (rather than exported from
+   page.jsx) so it can be tested in isolation: Next.js only allows a
+   page module to export config/metadata/viewport helpers, never a named
+   component — an export there is inert at runtime (the router only
+   reads `.default`) and unchecked by tsc (checkJs is off in this repo).
+   `t` stays a prop, matching the convention of the page that renders it
+   (UsersPage passes t={t} to every dialog), not the profile cards'
+   useTranslations() pattern.
+-------------------------------- */
+
+export default function RevokeSessionsDialog({ open, onClose, user, onSuccess, t }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/v1/admin/users/${user.id}/sessions`, {
+        method: 'DELETE',
+      })
+      if (res.ok) {
+        onSuccess(user.id)
+        onClose()
+        return
+      }
+      let data = {}
+      try { data = await res.json() } catch (_) {}
+      setError(data.error || t('common.error'))
+    } catch (_) {
+      setError(t('errors.connectionError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setError('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <i className='ri-logout-box-line' />
+        {t('sessions.adminRevokeConfirmTitle', { email: user?.email || '' })}
+      </DialogTitle>
+      <DialogContent sx={{ pt: '20px !important' }}>
+        {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        <Typography>{t('sessions.adminRevokeConfirmBody')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{t('common.cancel')}</Button>
+        <Button
+          variant='contained'
+          onClick={handleConfirm}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {t('common.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/security/RevokeSessionsDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.test.tsx
@@ -6,6 +6,15 @@ import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
 import RevokeSessionsDialog from './RevokeSessionsDialog'
 
+const { redirectToLoginOnceMock } = vi.hoisted(() => ({ redirectToLoginOnceMock: vi.fn() }))
+
+// Partial module mock: the dialog must call the SHARED redirect helper (the
+// same one useSWRFetch's fetcher uses on a 401), not roll its own navigation.
+vi.mock('@/hooks/useSWRFetch', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/hooks/useSWRFetch')>()),
+  redirectToLoginOnce: redirectToLoginOnceMock,
+}))
+
 // Translate stub: return the key unchanged. The dialog receives `t` as a prop
 // (not the next-intl hook), matching how the admin users page passes it down
 // — see RoleDefaultScopeEditor.test.tsx for the same convention.
@@ -15,7 +24,10 @@ const targetUser = { id: 'u1', email: 'target@example.com' }
 const SESSIONS_URL = '*/api/v1/admin/users/u1/sessions'
 
 describe('RevokeSessionsDialog', () => {
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    redirectToLoginOnceMock.mockClear()
+  })
 
   it('issues DELETE /api/v1/admin/users/<id>/sessions and calls onSuccess(user.id) then onClose()', async () => {
     const user = userEvent.setup()
@@ -88,5 +100,58 @@ describe('RevokeSessionsDialog', () => {
 
     // Let the in-flight request resolve so it doesn't leak into the next test.
     resolveDelete?.()
+  })
+
+  it('revoking all sessions of the caller themselves navigates to /login instead of updating the list', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSIONS_URL, () => HttpResponse.json({ data: { revoked: 3 } })),
+    )
+
+    renderWithProviders(
+      <RevokeSessionsDialog
+        open
+        user={targetUser}
+        currentUserId='u1'
+        onClose={onClose}
+        onSuccess={onSuccess}
+        t={t}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(redirectToLoginOnceMock).toHaveBeenCalledTimes(1))
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("revoking another user's sessions does not navigate even with a currentUserId present", async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSIONS_URL, () => HttpResponse.json({ data: { revoked: 2 } })),
+    )
+
+    renderWithProviders(
+      <RevokeSessionsDialog
+        open
+        user={targetUser}
+        currentUserId='someone-else'
+        onClose={onClose}
+        onSuccess={onSuccess}
+        t={t}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('u1'))
+    expect(redirectToLoginOnceMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/security/RevokeSessionsDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.test.tsx
@@ -4,11 +4,11 @@ import { cleanup } from '@testing-library/react'
 import { renderWithProviders, screen, userEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
-import { RevokeSessionsDialog } from './page'
+import RevokeSessionsDialog from './RevokeSessionsDialog'
 
 // Translate stub: return the key unchanged. The dialog receives `t` as a prop
-// (not the next-intl hook), matching how page.jsx passes it down — see
-// RoleDefaultScopeEditor.test.tsx for the same convention.
+// (not the next-intl hook), matching how the admin users page passes it down
+// — see RoleDefaultScopeEditor.test.tsx for the same convention.
 const t = (k: string) => k
 
 const targetUser = { id: 'u1', email: 'target@example.com' }

--- a/frontend/src/components/security/RevokeSessionsDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSessionsDialog.test.tsx
@@ -154,4 +154,20 @@ describe('RevokeSessionsDialog', () => {
     await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('u1'))
     expect(redirectToLoginOnceMock).not.toHaveBeenCalled()
   })
+
+  it('warns when the target user is the caller themselves', () => {
+    renderWithProviders(
+      <RevokeSessionsDialog open user={targetUser} currentUserId='u1' onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    expect(screen.getByText('sessions.adminRevokeAllOwnConfirmWarning')).toBeInTheDocument()
+  })
+
+  it('does not warn when the target is another user', () => {
+    renderWithProviders(
+      <RevokeSessionsDialog open user={targetUser} currentUserId='someone-else' onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    expect(screen.queryByText('sessions.adminRevokeAllOwnConfirmWarning')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/security/RevokeSingleSessionDialog.jsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.jsx
@@ -69,6 +69,14 @@ export default function RevokeSingleSessionDialog({ open, onClose, session, onSu
       </DialogTitle>
       <DialogContent sx={{ pt: '20px !important' }}>
         {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        {/* The list has no way to hide the caller's own session — it's still
+            "every session in the installation" — so a revoke click on that
+            row must not be a surprise. Not blocked (a super admin is
+            entitled to end their own session), just called out before the
+            click. */}
+        {session?.current && (
+          <Alert severity='warning' sx={{ mb: 2 }}>{t('sessions.adminRevokeOwnConfirmWarning')}</Alert>
+        )}
         <Typography>{t('sessions.adminRevokeOneConfirmBody')}</Typography>
       </DialogContent>
       <DialogActions>

--- a/frontend/src/components/security/RevokeSingleSessionDialog.jsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.jsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useState } from 'react'
+
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Typography,
+} from '@mui/material'
+
+/* --------------------------------
+   Revoke Single Session Confirm Dialog (super-admin, one session)
+   (non-destructive — simple confirm, recoverable by signing back in)
+
+   Named RevokeSingleSessionDialog, not RevokeSessionDialog, so it cannot be
+   mistaken at a glance (or by grep) for its sibling RevokeSessionsDialog.jsx
+   (plural — revokes EVERY session of a user). Getting the two confused
+   would silently open the wrong dialog. This one targets exactly one
+   session id from the admin-wide sessions listing. Extracted into its own
+   file rather than exported from page.jsx for the same reason as its
+   sibling — a Next.js page module may only export its default plus
+   specific config names, an export there is inert at runtime (the router
+   only reads `.default`) and unchecked by tsc (checkJs is off in this
+   repo). `t` stays a prop, matching the convention of the page that
+   renders it (UsersPage passes t={t} to every dialog).
+-------------------------------- */
+
+export default function RevokeSingleSessionDialog({ open, onClose, session, onSuccess, t }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    setError('')
+    try {
+      const res = await fetch(`/api/v1/admin/sessions/${session.id}`, {
+        method: 'DELETE',
+      })
+      if (res.ok) {
+        onSuccess(session.id)
+        onClose()
+        return
+      }
+      let data = {}
+      try { data = await res.json() } catch (_) {}
+      setError(data.error || t('common.error'))
+    } catch (_) {
+      setError(t('errors.connectionError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setError('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth='sm' fullWidth>
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <i className='ri-logout-box-line' />
+        {t('sessions.adminRevokeOneConfirmTitle', { email: session?.userEmail || '' })}
+      </DialogTitle>
+      <DialogContent sx={{ pt: '20px !important' }}>
+        {error && <Alert severity='error' sx={{ mb: 2 }}>{error}</Alert>}
+        <Typography>{t('sessions.adminRevokeOneConfirmBody')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>{t('common.cancel')}</Button>
+        <Button
+          variant='contained'
+          onClick={handleConfirm}
+          disabled={loading}
+          startIcon={loading ? <CircularProgress size={16} /> : null}
+        >
+          {t('common.confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/security/RevokeSingleSessionDialog.jsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.jsx
@@ -13,6 +13,8 @@ import {
   Typography,
 } from '@mui/material'
 
+import { redirectToLoginOnce } from '@/hooks/useSWRFetch'
+
 /* --------------------------------
    Revoke Single Session Confirm Dialog (super-admin, one session)
    (non-destructive — simple confirm, recoverable by signing back in)
@@ -42,6 +44,15 @@ export default function RevokeSingleSessionDialog({ open, onClose, session, onSu
         method: 'DELETE',
       })
       if (res.ok) {
+        // Revoking the row this tab is sitting on kills THIS session: every
+        // call the page makes from here on will 401. Don't wait for a poller
+        // to notice — leave for /login now. Deterministic counterpart of the
+        // 401 redirect in useSWRFetch's fetcher, for the one case where the
+        // client knows it caused the session's death.
+        if (session?.current) {
+          redirectToLoginOnce()
+          return
+        }
         onSuccess(session.id)
         onClose()
         return

--- a/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import RevokeSingleSessionDialog from './RevokeSingleSessionDialog'
+
+// Translate stub: return the key unchanged. The dialog receives `t` as a prop
+// (not the next-intl hook), matching how the admin users page passes it down
+// — same convention as RevokeSessionsDialog.test.tsx.
+const t = (k: string) => k
+
+const targetSession = { id: 'sess-1', userEmail: 'target@example.com' }
+const SESSION_URL = '*/api/v1/admin/sessions/sess-1'
+
+describe('RevokeSingleSessionDialog', () => {
+  afterEach(() => cleanup())
+
+  it('issues DELETE /api/v1/admin/sessions/<sid> and calls onSuccess(session.id) then onClose()', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+    let deleteCalls = 0
+
+    server.use(
+      http.delete(SESSION_URL, () => {
+        deleteCalls += 1
+        return HttpResponse.json({ data: { ok: true } })
+      }),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog open session={targetSession} onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(deleteCalls).toBe(1))
+    expect(onSuccess).toHaveBeenCalledWith('sess-1')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces errors.connectionError on a network failure and does not close', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSION_URL, () => HttpResponse.error()),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog open session={targetSession} onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    expect(await screen.findByText('errors.connectionError')).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a 404 error body and does not call onSuccess', async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSION_URL, () => HttpResponse.json({ error: 'Not found' }, { status: 404 })),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog open session={targetSession} onClose={onClose} onSuccess={onSuccess} t={t} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    expect(await screen.findByText('Not found')).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('disables the confirm button while the request is in flight', async () => {
+    const user = userEvent.setup()
+    let resolveDelete: (() => void) | null = null
+
+    server.use(
+      http.delete(
+        SESSION_URL,
+        () =>
+          new Promise(resolve => {
+            resolveDelete = () => resolve(HttpResponse.json({ data: { ok: true } }))
+          }),
+      ),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog open session={targetSession} onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    const confirmBtn = screen.getByRole('button', { name: 'common.confirm' })
+    expect(confirmBtn).not.toBeDisabled()
+
+    await user.click(confirmBtn)
+
+    await waitFor(() => expect(confirmBtn).toBeDisabled())
+
+    // Let the in-flight request resolve so it doesn't leak into the next test.
+    resolveDelete?.()
+  })
+
+  it('renders the target email in the confirm title', async () => {
+    renderWithProviders(
+      <RevokeSingleSessionDialog open session={targetSession} onClose={vi.fn()} onSuccess={vi.fn()} t={t} />,
+    )
+
+    expect(screen.getByText('sessions.adminRevokeOneConfirmTitle')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
@@ -6,6 +6,15 @@ import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
 import RevokeSingleSessionDialog from './RevokeSingleSessionDialog'
 
+const { redirectToLoginOnceMock } = vi.hoisted(() => ({ redirectToLoginOnceMock: vi.fn() }))
+
+// Partial module mock: the dialog must call the SHARED redirect helper (the
+// same one useSWRFetch's fetcher uses on a 401), not roll its own navigation.
+vi.mock('@/hooks/useSWRFetch', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/hooks/useSWRFetch')>()),
+  redirectToLoginOnce: redirectToLoginOnceMock,
+}))
+
 // Translate stub: return the key unchanged. The dialog receives `t` as a prop
 // (not the next-intl hook), matching how the admin users page passes it down
 // — same convention as RevokeSessionsDialog.test.tsx.
@@ -15,7 +24,10 @@ const targetSession = { id: 'sess-1', userEmail: 'target@example.com' }
 const SESSION_URL = '*/api/v1/admin/sessions/sess-1'
 
 describe('RevokeSingleSessionDialog', () => {
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    redirectToLoginOnceMock.mockClear()
+  })
 
   it('issues DELETE /api/v1/admin/sessions/<sid> and calls onSuccess(session.id) then onClose()', async () => {
     const user = userEvent.setup()
@@ -144,5 +156,57 @@ describe('RevokeSingleSessionDialog', () => {
     )
 
     expect(screen.queryByText('sessions.adminRevokeOwnConfirmWarning')).not.toBeInTheDocument()
+  })
+
+  it("revoking the caller's own current session navigates to /login instead of updating the list", async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSION_URL, () => HttpResponse.json({ data: { ok: true } })),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog
+        open
+        session={{ ...targetSession, current: true }}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        t={t}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(redirectToLoginOnceMock).toHaveBeenCalledTimes(1))
+    // The page is being left: the row-drop callback and onClose must NOT run.
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("revoking a session that is not the caller's does not navigate", async () => {
+    const user = userEvent.setup()
+    const onSuccess = vi.fn()
+    const onClose = vi.fn()
+
+    server.use(
+      http.delete(SESSION_URL, () => HttpResponse.json({ data: { ok: true } })),
+    )
+
+    renderWithProviders(
+      <RevokeSingleSessionDialog
+        open
+        session={{ ...targetSession, current: false }}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        t={t}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'common.confirm' }))
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('sess-1'))
+    expect(redirectToLoginOnceMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
+++ b/frontend/src/components/security/RevokeSingleSessionDialog.test.tsx
@@ -117,4 +117,32 @@ describe('RevokeSingleSessionDialog', () => {
 
     expect(screen.getByText('sessions.adminRevokeOneConfirmTitle')).toBeInTheDocument()
   })
+
+  it('warns when the target session is the caller\'s own current session', async () => {
+    renderWithProviders(
+      <RevokeSingleSessionDialog
+        open
+        session={{ ...targetSession, current: true }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        t={t}
+      />,
+    )
+
+    expect(screen.getByText('sessions.adminRevokeOwnConfirmWarning')).toBeInTheDocument()
+  })
+
+  it('does not show the own-session warning for a session that is not current', async () => {
+    renderWithProviders(
+      <RevokeSingleSessionDialog
+        open
+        session={{ ...targetSession, current: false }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+        t={t}
+      />,
+    )
+
+    expect(screen.queryByText('sessions.adminRevokeOwnConfirmWarning')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/hooks/useSWRFetch.test.ts
+++ b/frontend/src/hooks/useSWRFetch.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for useSWRFetch's fetcher: the 401 → immediate session recheck path.
+ *
+ * Environment: node (no React rendering — `fetcher` is a plain function),
+ * hence a .test.ts lane run via vitest.unit.config.ts, not .test.tsx/jsdom.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const mockGetSession = vi.fn()
+
+vi.mock('next-auth/react', () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}))
+
+function fakeResponse(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+  } as Response
+}
+
+describe('useSWRFetch fetcher', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    mockGetSession.mockReset()
+    mockGetSession.mockResolvedValue(null)
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('a 401 triggers exactly one session re-check', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(401))
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 401')
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('a 403 triggers no session re-check', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(403))
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 403')
+
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('a 500 triggers no session re-check', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(500))
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 500')
+
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('two 401s in quick succession trigger only one session re-check', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(401))
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/a')).rejects.toThrow('API error: 401')
+    await expect(fetcher('/api/v1/b')).rejects.toThrow('API error: 401')
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws the same "API error: <status>" message for 401, 403 and 500 alike', async () => {
+    for (const status of [401, 403, 500]) {
+      vi.resetModules()
+      fetchMock.mockResolvedValue(fakeResponse(status))
+      const { fetcher } = await import('./useSWRFetch')
+
+      await expect(fetcher('/api/v1/whatever')).rejects.toThrow(`API error: ${status}`)
+    }
+  })
+
+  it('still throws on invalid JSON for an ok response, without touching the session', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () => 'not json',
+    } as Response)
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/whatever')).rejects.toThrow('Invalid JSON response from /api/v1/whatever')
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/hooks/useSWRFetch.test.ts
+++ b/frontend/src/hooks/useSWRFetch.test.ts
@@ -1,16 +1,13 @@
 /**
- * Tests for useSWRFetch's fetcher: the 401 → immediate session recheck path.
+ * Tests for useSWRFetch's fetcher: the 401 → immediate redirect-to-login path.
  *
- * Environment: node (no React rendering — `fetcher` is a plain function),
- * hence a .test.ts lane run via vitest.unit.config.ts, not .test.tsx/jsdom.
+ * Environment: node (no jsdom, no React rendering — `fetcher` is a plain
+ * function), hence a .test.ts lane run via vitest.unit.config.ts, not
+ * .test.tsx/jsdom. `window` doesn't exist in this environment by default, so
+ * each test stubs a minimal fake (`location.pathname` + `location.replace`)
+ * to exercise the browser-only code path.
  */
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-
-const mockGetSession = vi.fn()
-
-vi.mock('next-auth/react', () => ({
-  getSession: (...args: unknown[]) => mockGetSession(...args),
-}))
 
 function fakeResponse(status: number, body: unknown = {}) {
   return {
@@ -20,13 +17,17 @@ function fakeResponse(status: number, body: unknown = {}) {
   } as Response
 }
 
+function stubWindow(pathname: string) {
+  const replace = vi.fn()
+  vi.stubGlobal('window', { location: { pathname, replace } })
+  return replace
+}
+
 describe('useSWRFetch fetcher', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     vi.resetModules()
-    mockGetSession.mockReset()
-    mockGetSession.mockResolvedValue(null)
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
   })
@@ -35,46 +36,62 @@ describe('useSWRFetch fetcher', () => {
     vi.unstubAllGlobals()
   })
 
-  it('a 401 triggers exactly one session re-check', async () => {
+  it('a 401 triggers exactly one redirect to /login with the current path as callbackUrl', async () => {
+    const replace = stubWindow('/infrastructure/inventory')
     fetchMock.mockResolvedValue(fakeResponse(401))
     const { fetcher } = await import('./useSWRFetch')
 
     await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 401')
 
-    expect(mockGetSession).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledWith('/login?callbackUrl=%2Finfrastructure%2Finventory')
   })
 
-  it('a 403 triggers no session re-check', async () => {
+  it('a 403 triggers no redirect', async () => {
+    const replace = stubWindow('/infrastructure/inventory')
     fetchMock.mockResolvedValue(fakeResponse(403))
     const { fetcher } = await import('./useSWRFetch')
 
     await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 403')
 
-    expect(mockGetSession).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
-  it('a 500 triggers no session re-check', async () => {
+  it('a 500 triggers no redirect', async () => {
+    const replace = stubWindow('/infrastructure/inventory')
     fetchMock.mockResolvedValue(fakeResponse(500))
     const { fetcher } = await import('./useSWRFetch')
 
     await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 500')
 
-    expect(mockGetSession).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
-  it('two 401s in quick succession trigger only one session re-check', async () => {
+  it('two 401s in quick succession trigger only one redirect', async () => {
+    const replace = stubWindow('/infrastructure/inventory')
     fetchMock.mockResolvedValue(fakeResponse(401))
     const { fetcher } = await import('./useSWRFetch')
 
     await expect(fetcher('/api/v1/a')).rejects.toThrow('API error: 401')
     await expect(fetcher('/api/v1/b')).rejects.toThrow('API error: 401')
 
-    expect(mockGetSession).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not redirect when already on /login (avoids a redirect loop)', async () => {
+    const replace = stubWindow('/login')
+    fetchMock.mockResolvedValue(fakeResponse(401))
+    const { fetcher } = await import('./useSWRFetch')
+
+    await expect(fetcher('/api/v1/whatever')).rejects.toThrow('API error: 401')
+
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('throws the same "API error: <status>" message for 401, 403 and 500 alike', async () => {
     for (const status of [401, 403, 500]) {
       vi.resetModules()
+      stubWindow('/infrastructure/inventory')
       fetchMock.mockResolvedValue(fakeResponse(status))
       const { fetcher } = await import('./useSWRFetch')
 
@@ -82,7 +99,8 @@ describe('useSWRFetch fetcher', () => {
     }
   })
 
-  it('still throws on invalid JSON for an ok response, without touching the session', async () => {
+  it('still throws on invalid JSON for an ok response, without touching navigation', async () => {
+    const replace = stubWindow('/infrastructure/inventory')
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -91,6 +109,6 @@ describe('useSWRFetch fetcher', () => {
     const { fetcher } = await import('./useSWRFetch')
 
     await expect(fetcher('/api/v1/whatever')).rejects.toThrow('Invalid JSON response from /api/v1/whatever')
-    expect(mockGetSession).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/hooks/useSWRFetch.ts
+++ b/frontend/src/hooks/useSWRFetch.ts
@@ -1,8 +1,41 @@
 import useSWR, { type SWRConfiguration } from 'swr'
 import { dequal } from 'dequal'
+import { getSession } from 'next-auth/react'
 
-const fetcher = (url: string) => fetch(url, { cache: 'no-store' }).then(async res => {
-  if (!res.ok) throw new Error(`API error: ${res.status}`)
+// A dead session makes every hook on the page 401 within the same tick.
+// next-auth throttles its own re-checks via __NEXTAUTH._lastSync, but that is
+// an internal detail of next-auth, not something to depend on here — this is
+// a second, local throttle so a burst of 401s triggers at most one
+// getSession() call within RECHECK_WINDOW_MS.
+const RECHECK_WINDOW_MS = 2000
+let lastRecheckAt = 0
+
+function recheckSessionOnce() {
+  const now = Date.now()
+  if (now - lastRecheckAt < RECHECK_WINDOW_MS) return
+  lastRecheckAt = now
+  // getSession() calls next-auth's own fetchData("session", ...), which hits
+  // /api/auth/session directly with the platform fetch — it never goes
+  // through this file's fetcher, so this cannot recurse. It updates
+  // next-auth's internal session state, which flips useSession() to
+  // "unauthenticated" so SessionExpiryGuard redirects, instead of waiting up
+  // to 60s for AuthProvider's refetchInterval to tick.
+  // Fire-and-forget: never awaited here, so it cannot delay or change the
+  // error this fetcher throws below.
+  void getSession().catch(() => {})
+}
+
+// Exported for testing: this is the file's chokepoint for every SWR-backed
+// data call, so its 401 handling is covered directly (useSWRFetch.test.ts)
+// rather than only indirectly through a hook that calls it.
+export const fetcher = (url: string) => fetch(url, { cache: 'no-store' }).then(async res => {
+  if (!res.ok) {
+    // 401 = not authenticated (session is dead) → worth an immediate recheck.
+    // 403 = authenticated but forbidden for this resource, a normal outcome
+    // for a user lacking a right — must NOT trigger a sign-out.
+    if (res.status === 401) recheckSessionOnce()
+    throw new Error(`API error: ${res.status}`)
+  }
   const text = await res.text()
   try {
     return JSON.parse(text)

--- a/frontend/src/hooks/useSWRFetch.ts
+++ b/frontend/src/hooks/useSWRFetch.ts
@@ -1,28 +1,45 @@
 import useSWR, { type SWRConfiguration } from 'swr'
 import { dequal } from 'dequal'
-import { getSession } from 'next-auth/react'
 
-// A dead session makes every hook on the page 401 within the same tick.
-// next-auth throttles its own re-checks via __NEXTAUTH._lastSync, but that is
-// an internal detail of next-auth, not something to depend on here — this is
-// a second, local throttle so a burst of 401s triggers at most one
-// getSession() call within RECHECK_WINDOW_MS.
-const RECHECK_WINDOW_MS = 2000
-let lastRecheckAt = 0
+// A dead session makes every hook on the page 401 within the same tick. A
+// 401 is proof the session is already gone server-side — the jwt callback
+// refused and the cookie was cleared before this response was even sent — so
+// there is nothing left to re-check; redirect straight away.
+//
+// next-auth's own getSession() cannot do this job from here: it fetches
+// /api/auth/session and then only notifies OTHER tabs, via a
+// localStorage-backed channel (node_modules/next-auth/client/_utils.js:
+// `post` does localStorage.setItem, `receive` listens for the DOM "storage"
+// event). Per the storage-event spec, that event fires in every other
+// same-origin document and NEVER in the one that wrote the value — so
+// calling getSession() from this tab's own fetcher updates every other open
+// tab's SessionProvider but never this one, leaving this tab waiting on
+// AuthProvider's 60s refetchInterval. Hence the hard navigation below
+// instead.
+const REDIRECT_WINDOW_MS = 2000
+let lastRedirectAt = 0
 
-function recheckSessionOnce() {
+function redirectToLoginOnce() {
+  // This module can be evaluated server-side (SSR); nothing to do there.
+  if (typeof window === 'undefined') return
+
+  // Already on the login page: don't re-navigate into a redirect loop.
+  if (window.location.pathname.startsWith('/login')) return
+
+  // A dead session makes ~10 hooks 401 at once; only one navigation is
+  // needed. Same throttle shape as before, just guarding a navigation now
+  // instead of a getSession() call.
   const now = Date.now()
-  if (now - lastRecheckAt < RECHECK_WINDOW_MS) return
-  lastRecheckAt = now
-  // getSession() calls next-auth's own fetchData("session", ...), which hits
-  // /api/auth/session directly with the platform fetch — it never goes
-  // through this file's fetcher, so this cannot recurse. It updates
-  // next-auth's internal session state, which flips useSession() to
-  // "unauthenticated" so SessionExpiryGuard redirects, instead of waiting up
-  // to 60s for AuthProvider's refetchInterval to tick.
-  // Fire-and-forget: never awaited here, so it cannot delay or change the
-  // error this fetcher throws below.
-  void getSession().catch(() => {})
+  if (now - lastRedirectAt < REDIRECT_WINDOW_MS) return
+  lastRedirectAt = now
+
+  // Hard navigation (not next/navigation's router — this is a plain module,
+  // not a component). replace(), not assign(), so the dead page doesn't
+  // stay in history — consistent with SessionExpiryGuard's router.replace().
+  // callbackUrl mirrors SessionExpiryGuard's and middleware.ts's own
+  // no-token redirect so re-authenticating returns the user where they were.
+  const callbackUrl = encodeURIComponent(window.location.pathname)
+  window.location.replace(`/login?callbackUrl=${callbackUrl}`)
 }
 
 // Exported for testing: this is the file's chokepoint for every SWR-backed
@@ -30,10 +47,10 @@ function recheckSessionOnce() {
 // rather than only indirectly through a hook that calls it.
 export const fetcher = (url: string) => fetch(url, { cache: 'no-store' }).then(async res => {
   if (!res.ok) {
-    // 401 = not authenticated (session is dead) → worth an immediate recheck.
-    // 403 = authenticated but forbidden for this resource, a normal outcome
-    // for a user lacking a right — must NOT trigger a sign-out.
-    if (res.status === 401) recheckSessionOnce()
+    // 401 = not authenticated (session is dead) → redirect now. 403 =
+    // authenticated but forbidden for this resource, a normal outcome for a
+    // user lacking a right — must NOT trigger a sign-out.
+    if (res.status === 401) redirectToLoginOnce()
     throw new Error(`API error: ${res.status}`)
   }
   const text = await res.text()

--- a/frontend/src/hooks/useSWRFetch.ts
+++ b/frontend/src/hooks/useSWRFetch.ts
@@ -19,7 +19,11 @@ import { dequal } from 'dequal'
 const REDIRECT_WINDOW_MS = 2000
 let lastRedirectAt = 0
 
-function redirectToLoginOnce() {
+// Exported: also called deliberately by the flows that knowingly kill the
+// caller's own session (admin sessions-tab revoke of the current row, admin
+// revoke-all targeting yourself, self password change). Those must not wait
+// for some poller's 401 echo — they know at click time the session is dead.
+export function redirectToLoginOnce() {
   // This module can be evaluated server-side (SSR); nothing to do there.
   if (typeof window === 'undefined') return
 

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -18,3 +18,10 @@ export function useTenants(enabled: boolean) {
   // sessions and from Community editions where multi-tenancy is hidden.
   return useSWRFetch(enabled ? '/api/v1/tenants' : null, { revalidateOnFocus: false })
 }
+
+export function useAdminSessions(enabled: boolean) {
+  // /api/v1/admin/sessions is gated to super admins by requireSuperAdminCaller.
+  // The caller passes `enabled` so a non-super-admin (or the tab before it is
+  // selected) never issues the request.
+  return useSWRFetch(enabled ? '/api/v1/admin/sessions' : null, { revalidateOnFocus: true })
+}

--- a/frontend/src/instrumentation-node.ts
+++ b/frontend/src/instrumentation-node.ts
@@ -7,6 +7,7 @@
 // branding, login backgrounds and compliance PDF logos.
 import path from 'node:path'
 
+import { startSessionSweeper } from '@/lib/auth/sessionSweeper'
 import { importDiskAssets } from '@/lib/branding/importDiskAssets'
 import { prisma } from '@/lib/db/prisma'
 import { resolveInstanceId, sweepOrphanedMigrationJobs } from '@/lib/migration/orphan-sweep'
@@ -35,5 +36,16 @@ export async function registerNode(): Promise<void> {
     // Boot must never depend on the sweep: the rows stay non-terminal and the
     // next boot retries.
     console.error('[startup] orphaned migration sweep failed (non-fatal):', err)
+  }
+
+  try {
+    // Bounds how long a dead session row's ipAddress/userAgent survives for a
+    // user who never signs in again. Runs on every HA replica; no leader
+    // election needed since the purge is an idempotent deleteMany.
+    startSessionSweeper()
+  } catch (err) {
+    // Boot must never depend on this: the rows stay in place and the next
+    // boot retries starting the sweeper.
+    console.error('[startup] session sweeper failed to start (non-fatal):', err)
   }
 }

--- a/frontend/src/lib/api-tokens/contract.test.ts
+++ b/frontend/src/lib/api-tokens/contract.test.ts
@@ -62,7 +62,7 @@ function walkImportGraph(entryFile: string): Map<string, string> {
  * dataflow analysis: that's what makes it "vérifiable mécaniquement" per
  * spec D2/section 11 in the first place). It cannot tell "reachable via a
  * branch a token principal can never take" from "reachable and read for
- * every caller". Two distinct entries, for two distinct reasons:
+ * every caller". Three distinct entries, for three distinct reasons:
  *
  * - `lib/storage/fleetScope.ts` (`canReadFleetStorage`) reads
  *   `getServerSession()` DIRECTLY, independent of `getPrincipal()`/the
@@ -98,16 +98,28 @@ function walkImportGraph(entryFile: string): Map<string, string> {
  *   `authOptions` from it. Recorded anyway, distinctly, so the exception
  *   list stays an exact, pinned mirror of reality rather than a vague
  *   wildcard.
+ * - `lib/auth/jwtContext.ts` is the same kind of harmless TEXTUAL false
+ *   positive as `config.ts` above, added by the auth-session-hardening
+ *   branch: it never imports or calls `getServerSession`, it only mentions
+ *   the name once, in a prose comment on line 3 ("The callback runs on
+ *   EVERY getServerSession, so on every guarded API call ..."). It is
+ *   reachable from THIS route only through a two-hop chain: `config.ts` now
+ *   imports `loadJwtContext` from it for the consolidated per-request read
+ *   that branch added to the NextAuth `jwt` callback, and `fleetScope.ts`
+ *   (already in this list, above) imports `authOptions` from `config.ts`.
+ *   No new session read reaches a token-authenticated request through this
+ *   edge; it is bookkeeping for a comment string, not a security exception.
  *
- * Both entries are PINNED below (not just permitted): if either file ever
- * stops being an offender (fixed, or the comment is reworded), the second
- * assertion in the test body fails too, forcing a conscious update instead
- * of leaving a stale exception in place.
+ * All three entries are PINNED below (not just permitted): if any of these
+ * files ever stops being an offender (fixed, or the comment is reworded),
+ * the second assertion in the test body fails too, forcing a conscious
+ * update instead of leaving a stale exception in place.
  */
 const KNOWN_SESSION_READ_EXCEPTIONS: Record<string, string[]> = {
   'storage-list': [
     path.join('lib', 'storage', 'fleetScope.ts'),
     path.join('lib', 'auth', 'config.ts'),
+    path.join('lib', 'auth', 'jwtContext.ts'),
   ],
 }
 

--- a/frontend/src/lib/audit/index.ts
+++ b/frontend/src/lib/audit/index.ts
@@ -33,6 +33,7 @@ export type AuditAction =
   | "logout"
   | "login_failed"
   | "password_changed"
+  | "sessions_revoked"
 
   // CRUD
   | "create"

--- a/frontend/src/lib/audit/index.ts
+++ b/frontend/src/lib/audit/index.ts
@@ -35,6 +35,7 @@ export type AuditAction =
   | "password_changed"
   | "sessions_revoked"
   | "session_revoked_single"
+  | "sessions_revoked_all"
 
   // CRUD
   | "create"

--- a/frontend/src/lib/audit/index.ts
+++ b/frontend/src/lib/audit/index.ts
@@ -34,6 +34,7 @@ export type AuditAction =
   | "login_failed"
   | "password_changed"
   | "sessions_revoked"
+  | "session_revoked_single"
 
   // CRUD
   | "create"

--- a/frontend/src/lib/auth/config.cookies.test.ts
+++ b/frontend/src/lib/auth/config.cookies.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/lib/db/prisma', () => ({ prisma: {} }))
+vi.mock('@/lib/auth/oidc', () => ({
+  getOidcConfig: async () => null,
+  isOidcEnabled: async () => false,
+}))
+
+import { getAuthOptions } from './config'
+
+const ORIGINAL = process.env.NEXTAUTH_URL
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXTAUTH_URL
+  else process.env.NEXTAUTH_URL = ORIGINAL
+})
+
+function cookieOpts(opts: any) {
+  return {
+    session: opts.cookies.sessionToken.options.secure,
+    callback: opts.cookies.callbackUrl.options.secure,
+    csrf: opts.cookies.csrfToken.options.secure,
+  }
+}
+
+describe('getAuthOptions(req) overrides only the secure flag', () => {
+  beforeEach(() => { process.env.NEXTAUTH_URL = 'http://192.168.1.151:3000' })
+
+  it('sets secure on all three cookies when the request arrived over https', async () => {
+    const req = new Request('http://internal/api/auth/session', {
+      headers: { 'x-forwarded-proto': 'https' },
+    })
+    const opts = await getAuthOptions(req)
+    expect(cookieOpts(opts)).toEqual({ session: true, callback: true, csrf: true })
+  })
+
+  it('leaves secure false on a genuinely plaintext request', async () => {
+    const req = new Request('http://internal/api/auth/session')
+    const opts = await getAuthOptions(req)
+    expect(cookieOpts(opts)).toEqual({ session: false, callback: false, csrf: false })
+  })
+
+  it('does NOT change the cookie names when the flag flips', async () => {
+    const req = new Request('http://internal/api/auth/session', {
+      headers: { 'x-forwarded-proto': 'https' },
+    })
+    const opts = await getAuthOptions(req)
+    // Readers depend on the name; only the flag is per-request.
+    expect(opts.cookies.sessionToken.name).toBe('next-auth.session-token')
+    expect(opts.cookies.csrfToken.name).toBe('next-auth.csrf-token')
+  })
+
+  it('works with no argument, for the 71 getServerSession call sites', async () => {
+    const opts = await getAuthOptions()
+    expect(opts.cookies.sessionToken.name).toBe('next-auth.session-token')
+    expect(cookieOpts(opts)).toEqual({ session: false, callback: false, csrf: false })
+  })
+})

--- a/frontend/src/lib/auth/config.jwt.test.ts
+++ b/frontend/src/lib/auth/config.jwt.test.ts
@@ -118,8 +118,22 @@ describe('read path (no user) — refuses by throwing', () => {
 })
 
 describe('session config', () => {
-  it('caps maxAge at the absolute timeout and drops the inert updateAge', () => {
+  afterEach(() => {
+    delete process.env.SESSION_ABSOLUTE_TIMEOUT
+  })
+
+  it('caps maxAge at the absolute-timeout default (env unset) and drops the inert updateAge', () => {
     expect(authOptions.session?.maxAge).toBe(7 * 86400)
     expect((authOptions.session as any)?.updateAge).toBeUndefined()
+  })
+
+  it('derives maxAge from SESSION_ABSOLUTE_TIMEOUT instead of hardcoding it', async () => {
+    // The point of this test: a hardcoded 7*86400 would pass the test above
+    // but NOT this one. Module-load evaluation means we need a fresh import
+    // with the env var already set.
+    process.env.SESSION_ABSOLUTE_TIMEOUT = String(30 * 86400)
+    vi.resetModules()
+    const { authOptions: reloaded } = await import('./config')
+    expect(reloaded.session?.maxAge).toBe(30 * 86400)
   })
 })

--- a/frontend/src/lib/auth/config.jwt.test.ts
+++ b/frontend/src/lib/auth/config.jwt.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const { loadJwtContextMock, createSessionMock, touchSessionMock } = vi.hoisted(() => ({
+  loadJwtContextMock: vi.fn(),
+  createSessionMock: vi.fn(),
+  touchSessionMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({ prisma: { user: { findUnique: vi.fn(async () => null) } } }))
+vi.mock('@/lib/auth/oidc', () => ({ getOidcConfig: async () => null, isOidcEnabled: async () => false }))
+vi.mock('./jwtContext', () => ({ loadJwtContext: loadJwtContextMock }))
+vi.mock('./sessions', async (orig) => {
+  const actual = await orig<typeof import('./sessions')>()
+  return { ...actual, createSession: createSessionMock, touchSession: touchSessionMock }
+})
+vi.mock('next/headers', () => ({
+  headers: async () => new Headers({ 'x-forwarded-for': '10.0.0.9, 172.16.0.1', 'user-agent': 'UA/1' }),
+}))
+
+import { authOptions } from './config'
+
+const jwtCb = (authOptions.callbacks as any).jwt
+
+afterEach(() => vi.clearAllMocks())
+
+const liveSession = {
+  id: 'sid1', userId: 'u1',
+  createdAt: new Date(Date.now() - 3600_000),
+  lastSeenAt: new Date(Date.now() - 1000),
+  revokedAt: null, ipAddress: null, userAgent: null,
+}
+
+describe('sign-in path (user present) — MUST NEVER THROW', () => {
+  it('mints a sid and authAt and records the request origin', async () => {
+    createSessionMock.mockResolvedValue('new-sid')
+    const token = await jwtCb({
+      token: {},
+      user: { id: 'u1', email: 'a@b', name: 'A', role: 'admin', authProvider: 'credentials' },
+      account: { provider: 'credentials' },
+    })
+
+    expect(token.sid).toBe('new-sid')
+    expect(typeof token.authAt).toBe('number')
+    expect(createSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u1', ipAddress: '10.0.0.9', userAgent: 'UA/1' }),
+    )
+  })
+
+  it('still returns a usable token when the session insert FAILS (no 500 on login)', async () => {
+    // callbacks.jwt is invoked at core/routes/callback.js:397-413 with no local
+    // try/catch: throwing here is a 500 for every user signing in.
+    createSessionMock.mockRejectedValue(new Error('db down'))
+    const token = await jwtCb({
+      token: {},
+      user: { id: 'u1', email: 'a@b', name: 'A', role: 'admin', authProvider: 'credentials' },
+      account: { provider: 'credentials' },
+    })
+    expect(token.id).toBe('u1')
+    expect(token.sid).toBeUndefined()
+  })
+
+  it('never throws even when loadJwtContext fails on sign-in', async () => {
+    createSessionMock.mockResolvedValue('new-sid')
+    loadJwtContextMock.mockRejectedValue(new Error('db down'))
+    await expect(
+      jwtCb({
+        token: {},
+        user: { id: 'u1', email: 'a@b', name: 'A', role: 'v', authProvider: 'credentials' },
+        account: { provider: 'oidc' },
+      }),
+    ).resolves.toBeTruthy()
+  })
+})
+
+describe('read path (no user) — refuses by throwing', () => {
+  it('passes a live session through and touches it', async () => {
+    loadJwtContextMock.mockResolvedValue({
+      enabled: true, tenantId: 'tenant-a', mustEnroll2fa: false, session: liveSession,
+    })
+    const token = await jwtCb({ token: { id: 'u1', sid: 'sid1', authAt: Date.now() } })
+    expect(token.tenantId).toBe('tenant-a')
+    expect(touchSessionMock).toHaveBeenCalledOnce()
+  })
+
+  it('throws when the session row is gone', async () => {
+    loadJwtContextMock.mockResolvedValue({
+      enabled: true, tenantId: 'default', mustEnroll2fa: false, session: null,
+    })
+    await expect(jwtCb({ token: { id: 'u1', sid: 'sid1' } })).rejects.toThrow(/session/i)
+  })
+
+  it('throws when the session was revoked', async () => {
+    loadJwtContextMock.mockResolvedValue({
+      enabled: true, tenantId: 'default', mustEnroll2fa: false,
+      session: { ...liveSession, revokedAt: new Date() },
+    })
+    await expect(jwtCb({ token: { id: 'u1', sid: 'sid1' } })).rejects.toThrow(/session/i)
+  })
+
+  it('throws when the account has been disabled since sign-in', async () => {
+    loadJwtContextMock.mockResolvedValue({
+      enabled: false, tenantId: 'default', mustEnroll2fa: false, session: liveSession,
+    })
+    await expect(jwtCb({ token: { id: 'u1', sid: 'sid1' } })).rejects.toThrow(/disabled/i)
+  })
+
+  it('throws on a legacy token with no sid (forces the one-off reconnection)', async () => {
+    await expect(jwtCb({ token: { id: 'u1' } })).rejects.toThrow(/session/i)
+  })
+
+  it('FAILS OPEN when the database is unreachable', async () => {
+    // A Postgres outage already makes the app unusable, so refusing adds no
+    // security and only causes a reconnection storm when the DB returns.
+    loadJwtContextMock.mockRejectedValue(new Error('ECONNREFUSED'))
+    const token = await jwtCb({ token: { id: 'u1', sid: 'sid1', tenantId: 'kept' } })
+    expect(token.tenantId).toBe('kept')
+  })
+})
+
+describe('session config', () => {
+  it('caps maxAge at the absolute timeout and drops the inert updateAge', () => {
+    expect(authOptions.session?.maxAge).toBe(7 * 86400)
+    expect((authOptions.session as any)?.updateAge).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/auth/config.logger.test.ts
+++ b/frontend/src/lib/auth/config.logger.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// Same import-time mocks as config.jwt.test.ts: config.ts pulls in prisma,
+// oidc and next/headers at module load, none of which may touch a real DB
+// or request scope in this test.
+vi.mock('@/lib/db/prisma', () => ({ prisma: { user: { findUnique: vi.fn(async () => null) } } }))
+vi.mock('@/lib/auth/oidc', () => ({ getOidcConfig: async () => null, isOidcEnabled: async () => false }))
+vi.mock('next/headers', () => ({
+  headers: async () => new Headers(),
+}))
+
+import { authOptions } from './config'
+
+const errorLog = authOptions.logger?.error as (code: string, metadata: unknown) => void
+
+describe('authOptions.logger.error', () => {
+  const consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+  afterEach(() => {
+    consoleInfoSpy.mockClear()
+    consoleErrorSpy.mockClear()
+  })
+
+  // Every exact message the `jwt` callback's read path throws in ./config.ts.
+  const ourRefusalMessages = [
+    'Session not valid: no sid on token',
+    'Session not valid: missing',
+    'Session not valid: revoked',
+    'Session not valid: idle',
+    'Session not valid: absolute',
+    'Account disabled',
+  ]
+
+  it.each(ourRefusalMessages)('reports our own refusal "%s" as a quiet info line, no stack', message => {
+    errorLog('JWT_SESSION_ERROR', new Error(message))
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(consoleInfoSpy).toHaveBeenCalledTimes(1)
+
+    const loggedArgs = consoleInfoSpy.mock.calls[0]
+    expect(loggedArgs.join(' ')).toContain(message)
+    expect(loggedArgs.join(' ')).not.toContain('at Object.jwt') // no stack trace text
+    expect(loggedArgs.some(arg => typeof arg === 'object' && arg !== null && 'stack' in arg)).toBe(false)
+  })
+
+  it('does NOT silence JWT_SESSION_ERROR wholesale: an unrelated message stays loud, with its stack', () => {
+    const unrelated = new Error('JWT invalid')
+
+    errorLog('JWT_SESSION_ERROR', unrelated)
+
+    expect(consoleInfoSpy).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+
+    const [, , message, metadata] = consoleErrorSpy.mock.calls[0]
+    expect(message).toBe('JWT invalid')
+    expect(metadata).toMatchObject({ message: 'JWT invalid', name: 'Error' })
+    expect((metadata as { stack?: string }).stack).toContain('JWT invalid')
+  })
+
+  it('passes through a different error code untouched (loud, default shape)', () => {
+    const err = new Error('some oauth failure')
+
+    errorLog('OAUTH_CALLBACK_ERROR', err)
+
+    expect(consoleInfoSpy).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    const [prefix, , message] = consoleErrorSpy.mock.calls[0]
+    expect(prefix).toContain('OAUTH_CALLBACK_ERROR')
+    expect(message).toBe('some oauth failure')
+  })
+
+  it('a message that merely CONTAINS our refusal text as a substring is NOT matched (exact match only)', () => {
+    const lookalike = new Error('wrapper: Session not valid: idle (retry #3)')
+
+    errorLog('JWT_SESSION_ERROR', lookalike)
+
+    // Not an exact match against our known set, so it must stay loud —
+    // proving the check is not a loose substring test.
+    expect(consoleInfoSpy).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/auth/config.logger.test.ts
+++ b/frontend/src/lib/auth/config.logger.test.ts
@@ -52,22 +52,26 @@ describe('authOptions.logger.error', () => {
     expect(consoleInfoSpy).not.toHaveBeenCalled()
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
 
-    const [, , message, metadata] = consoleErrorSpy.mock.calls[0]
-    expect(message).toBe('JWT invalid')
-    expect(metadata).toMatchObject({ message: 'JWT invalid', name: 'Error' })
-    expect((metadata as { stack?: string }).stack).toContain('JWT invalid')
+    const [prefix, metadata] = consoleErrorSpy.mock.calls[0]
+    expect(prefix).toContain('JWT_SESSION_ERROR')
+    // Logged AS RECEIVED (no reformatting): the raw Error instance itself,
+    // so its message and stack are exactly what console.error renders them
+    // to be, not a rebuilt {message, stack, name} object.
+    expect(metadata).toBe(unrelated)
+    expect((metadata as Error).message).toBe('JWT invalid')
+    expect((metadata as Error).stack).toContain('JWT invalid')
   })
 
-  it('passes through a different error code untouched (loud, default shape)', () => {
+  it('passes through a different error code untouched (loud, unmodified metadata)', () => {
     const err = new Error('some oauth failure')
 
     errorLog('OAUTH_CALLBACK_ERROR', err)
 
     expect(consoleInfoSpy).not.toHaveBeenCalled()
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
-    const [prefix, , message] = consoleErrorSpy.mock.calls[0]
+    const [prefix, metadata] = consoleErrorSpy.mock.calls[0]
     expect(prefix).toContain('OAUTH_CALLBACK_ERROR')
-    expect(message).toBe('some oauth failure')
+    expect(metadata).toBe(err)
   })
 
   it('a message that merely CONTAINS our refusal text as a substring is NOT matched (exact match only)', () => {
@@ -79,5 +83,31 @@ describe('authOptions.logger.error', () => {
     // proving the check is not a loose substring test.
     expect(consoleInfoSpy).not.toHaveBeenCalled()
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves every field of an ENVELOPE metadata object (OIDC provider errors must not lose context)', () => {
+    // Several next-auth codes (OAUTH_CALLBACK_ERROR, OAUTH_CALLBACK_HANDLER_ERROR,
+    // OAUTH_PARSE_PROFILE_ERROR, SIGNIN_OAUTH_ERROR, SIGNIN_EMAIL_ERROR) report
+    // an envelope object, not a bare Error. A hand-rolled reformatter that only
+    // special-cases `instanceof Error` would silently drop providerId here —
+    // this is the regression test for exactly that mistake.
+    const envelope = {
+      error: new Error('boom'),
+      providerId: 'keycloak',
+      error_description: 'invalid_grant',
+    }
+
+    errorLog('OAUTH_CALLBACK_ERROR', envelope)
+
+    expect(consoleInfoSpy).not.toHaveBeenCalled()
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+
+    const [, metadata] = consoleErrorSpy.mock.calls[0]
+    // Logged as the exact same reference: nothing was reconstructed, so
+    // providerId (and every other sibling key) cannot have been dropped.
+    expect(metadata).toBe(envelope)
+    expect((metadata as typeof envelope).providerId).toBe('keycloak')
+    expect((metadata as typeof envelope).error_description).toBe('invalid_grant')
+    expect((metadata as typeof envelope).error).toBe(envelope.error)
   })
 })

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -12,6 +12,7 @@ import { authenticateLdap, isLdapEnabled, getLdapConfig, resolveLdapRole, syncLd
 import { getOidcConfig, oidcRoleId, syncOidcRoleAssignment } from "./oidc"
 import { loadJwtContext } from "./jwtContext"
 import { createSession, evaluateSession, touchSession } from "./sessions"
+import { sessionDurations } from "./durations"
 
 export type UserRole = "super_admin" | "admin" | "operator" | "viewer"
 
@@ -687,14 +688,16 @@ export const authOptions: NextAuthOptions = {
   },
   session: {
     strategy: "jwt",
-    // Aligned on SESSION_ABSOLUTE_TIMEOUT so the cookie cannot outlive the
-    // session. This is only the second barrier: the row in `sessions` is what
-    // actually decides, since a JWT's exp is frozen at encoding time.
+    // Derived from SESSION_ABSOLUTE_TIMEOUT (default 7 days) so the cookie
+    // cannot outlive the session. This is only the second barrier: the row in
+    // `sessions` is what actually decides, since a JWT's exp is frozen at
+    // encoding time. Evaluated once at module load, which is correct: the
+    // environment is fixed when the process starts.
     //
     // updateAge is intentionally absent: next-auth only reads it in the
     // database branch (core/routes/session.js:109, inside the else), so with
     // strategy "jwt" it did nothing. lastSeenAt throttling is ours.
-    maxAge: 7 * 24 * 60 * 60,
+    maxAge: Math.ceil(sessionDurations().absoluteMs / 1000),
   },
   secret: process.env.NEXTAUTH_SECRET || "build-time-placeholder",
 }

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -10,6 +10,8 @@ import { verifyPassword, hashPassword } from "./password"
 import { readGroupsClaim, isLdapGroupAllowed } from "./groupMapping"
 import { authenticateLdap, isLdapEnabled, getLdapConfig, resolveLdapRole, syncLdapRoleAssignment } from "./ldap"
 import { getOidcConfig, oidcRoleId, syncOidcRoleAssignment } from "./oidc"
+import { loadJwtContext } from "./jwtContext"
+import { createSession, evaluateSession, touchSession } from "./sessions"
 
 export type UserRole = "super_admin" | "admin" | "operator" | "viewer"
 
@@ -40,6 +42,14 @@ declare module "next-auth/jwt" {
     authProvider: "credentials" | "ldap" | "oidc"
     tenantId: string
     mustEnroll2fa?: boolean
+    /**
+     * Server-side session row id (sessions table). Absent only on tokens
+     * issued before session hardening, or when the row insert failed at
+     * sign-in — both refused on the next read-path evaluation.
+     */
+    sid?: string
+    /** When the user authenticated, epoch ms. */
+    authAt?: number
   }
 }
 
@@ -54,6 +64,25 @@ import {
   envPrefersSecureCookies,
   resolveCookieSecure,
 } from './cookies'
+
+/**
+ * Best-effort request origin for a new session row.
+ *
+ * The jwt callback receives no request object, so this reads the ambient
+ * request headers. headers() throws outside a request scope, hence the
+ * try/catch: an unknown origin is a cosmetic loss, a thrown sign-in is not.
+ */
+async function requestOrigin(): Promise<{ ipAddress: string | null; userAgent: string | null }> {
+  try {
+    const { headers } = await import("next/headers")
+    const h = await headers()
+    const fwd = h.get("x-forwarded-for")
+    const ip = fwd ? fwd.split(",")[0]?.trim() : h.get("x-real-ip")
+    return { ipAddress: ip || null, userAgent: h.get("user-agent") }
+  } catch {
+    return { ipAddress: null, userAgent: null }
+  }
+}
 
 export const authOptions: NextAuthOptions = {
   cookies: {
@@ -508,6 +537,10 @@ export const authOptions: NextAuthOptions = {
       return true
     },
     async jwt({ token, user, account }) {
+      // ---- SIGN-IN PATH -------------------------------------------------
+      // callbacks.jwt runs here from core/routes/callback.js:397-413, which
+      // has NO try/catch around it. Anything thrown below is a 500 on login
+      // for every user. This branch must therefore swallow every error.
       if (user) {
         token.id = user.id
         token.email = user.email
@@ -516,25 +549,81 @@ export const authOptions: NextAuthOptions = {
         // Avatar will be fetched from DB in session callback
         token.role = user.role
         token.authProvider = account?.provider === 'oidc' ? 'oidc' : user.authProvider
-      }
 
-      // Always refresh tenantId from DB (supports tenant switching without re-login)
-      if (token.id) {
         try {
-          const { getUserDefaultTenantId } = await import("@/lib/tenant")
-          token.tenantId = await getUserDefaultTenantId(token.id as string)
+          const origin = await requestOrigin()
+          token.sid = await createSession({ userId: user.id, ...origin })
+          token.authAt = Date.now()
+        } catch (e: any) {
+          // No sid means the next read-path evaluation refuses this token, so
+          // the user is asked to sign in again. That is the safe outcome; a
+          // 500 here would deny everyone.
+          console.error('[auth-session] could not create the session row:', e?.message ?? e)
+        }
+
+        try {
+          const ctx = await loadJwtContext(user.id, null)
+          token.tenantId = ctx.tenantId
+          token.mustEnroll2fa = ctx.mustEnroll2fa
         } catch {
           token.tenantId = token.tenantId || 'default'
-        }
-      }
-
-      if (token.id) {
-        try {
-          const { needsEnrollment } = await import("@/lib/auth/enforce-2fa")
-          token.mustEnroll2fa = await needsEnrollment(token.id)
-        } catch {
           token.mustEnroll2fa = false
         }
+
+        return token
+      }
+
+      // ---- READ PATH ----------------------------------------------------
+      // Reached from core/routes/session.js:53, which IS wrapped in a
+      // try/catch that calls sessionStore.clean(). Throwing here therefore
+      // clears the cookie and makes getServerSession return null, which is
+      // exactly the refusal we want, on every guarded route, with no
+      // call-site changes.
+      if (!token.id) return token
+
+      const sid = token.sid ?? null
+      if (!sid) {
+        // A token with no sid predates session hardening (or its row insert
+        // failed at sign-in): no row can vouch for it, so refuse without a
+        // database read. This is the intended one-off reconnection at deploy,
+        // and it must hold even while the database is unreachable — the
+        // fail-open below only protects sessions that were once valid.
+        throw new Error('Session not valid: no sid on token')
+      }
+
+      let ctx
+      try {
+        ctx = await loadJwtContext(token.id, sid)
+      } catch (e: any) {
+        // FAIL OPEN, deliberately: a Postgres outage already breaks every
+        // route (they all need the DB, including to decrypt the PVE token),
+        // so refusing buys no security and only causes a reconnection storm
+        // when the database comes back. Logged loudly on purpose.
+        console.error('[auth-session] validity check unavailable, allowing:', e?.message ?? e)
+        return token
+      }
+
+      if (!ctx.enabled) {
+        throw new Error('Account disabled')
+      }
+
+      const verdict = evaluateSession(ctx.session)
+      if (!verdict.alive) {
+        // Cast: tsconfig has strict:false, which disables discriminated-union
+        // narrowing, so `verdict.reason` does not typecheck on its own.
+        const { reason } = verdict as { alive: false; reason: string }
+        throw new Error(`Session not valid: ${reason}`)
+      }
+
+      token.tenantId = ctx.tenantId
+      token.mustEnroll2fa = ctx.mustEnroll2fa
+      if (!token.authAt && ctx.session) token.authAt = ctx.session.createdAt.getTime()
+
+      // Throttled inside touchSession using the row we already read.
+      try {
+        await touchSession(sid, new Date(), ctx.session)
+      } catch (e: any) {
+        console.warn('[auth-session] lastSeenAt refresh failed:', e?.message ?? e)
       }
 
       return token
@@ -598,12 +687,14 @@ export const authOptions: NextAuthOptions = {
   },
   session: {
     strategy: "jwt",
-    maxAge: 30 * 24 * 60 * 60, // 30 jours
-    // Refresh the JWT (and re-run the jwt() callback that recomputes
-    // mustEnroll2fa) every 60 s of session activity. Closes the gap where
-    // an admin enables the 2FA-required policy and an already-logged-in
-    // session would otherwise keep its stale token until it expires.
-    updateAge: 60,
+    // Aligned on SESSION_ABSOLUTE_TIMEOUT so the cookie cannot outlive the
+    // session. This is only the second barrier: the row in `sessions` is what
+    // actually decides, since a JWT's exp is frozen at encoding time.
+    //
+    // updateAge is intentionally absent: next-auth only reads it in the
+    // database branch (core/routes/session.js:109, inside the else), so with
+    // strategy "jwt" it did nothing. lastSeenAt throttling is ours.
+    maxAge: 7 * 24 * 60 * 60,
   },
   secret: process.env.NEXTAUTH_SECRET || "build-time-placeholder",
 }

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -716,12 +716,25 @@ export const authOptions: NextAuthOptions = {
   // decode failure (corrupted token, changed NEXTAUTH_SECRET), so the real
   // signal drowns in routine noise. Only OUR own refusals (matched exactly
   // above) are downgraded to one quiet info line with no stack; everything
-  // else — including a real JWT_SESSION_ERROR — falls through to the same
-  // loud, stack-carrying output next-auth would have produced. It cannot
-  // delegate to next-auth's real default logger: `next-auth/utils/logger`
-  // is not a published subpath (its package.json `exports` map omits it;
-  // `require("next-auth/utils/logger")` throws ERR_PACKAGE_PATH_NOT_EXPORTED),
-  // so this reproduces that default's formatting inline instead.
+  // else falls through untouched.
+  //
+  // It cannot delegate to next-auth's real default logger: `next-auth/utils
+  // /logger` is not a published subpath (its package.json `exports` map
+  // omits it; `require("next-auth/utils/logger")` throws
+  // ERR_PACKAGE_PATH_NOT_EXPORTED). An earlier version of this reproduced
+  // that default's `formatError` inline (Error -> {message, stack, name}),
+  // but that reformatting only special-cased a bare Error: for the several
+  // codes next-auth reports with an ENVELOPE object — OAUTH_CALLBACK_ERROR,
+  // OAUTH_CALLBACK_HANDLER_ERROR, OAUTH_PARSE_PROFILE_ERROR,
+  // SIGNIN_OAUTH_ERROR, SIGNIN_EMAIL_ERROR — it discarded every sibling key
+  // (providerId, error_description, the raw OAuthProfile, ...) and kept only
+  // the nested `.error`. That is exactly the OIDC diagnostic detail this app
+  // needs when SSO breaks, so instead of rebuilding next-auth's formatting,
+  // log the metadata exactly as received: `console.error` already renders a
+  // bare Error with its message and stack, and renders an envelope object
+  // with every one of its fields, so nothing can be dropped because nothing
+  // is reconstructed. The cosmetic difference from next-auth's own default
+  // shape is an acceptable trade for never losing a diagnostic field.
   logger: {
     error(code, metadata) {
       if (isOurSessionRefusal(code, metadata)) {
@@ -729,15 +742,7 @@ export const authOptions: NextAuthOptions = {
         return
       }
 
-      const err = metadata instanceof Error ? metadata : metadata.error
-      const formatted: unknown = err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : metadata
-
-      console.error(
-        `[next-auth][error][${code}]`,
-        `\nhttps://next-auth.js.org/errors#${code.toLowerCase()}`,
-        (formatted as { message?: string } | undefined)?.message,
-        formatted,
-      )
+      console.error(`[next-auth][error][${code}]`, metadata)
     },
   },
   session: {

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -85,6 +85,28 @@ async function requestOrigin(): Promise<{ ipAddress: string | null; userAgent: s
   }
 }
 
+/**
+ * Exact messages the `jwt` callback's READ PATH throws below (never the
+ * sign-in path, which never throws). Every one is a deliberate, expected
+ * refusal — a legacy cookie with no `sid`, one of `evaluateSession`'s
+ * `DeadReason`s (missing/revoked/idle/absolute — see ./sessions.ts), or a
+ * disabled account — not evidence of a corrupted token or a rotated
+ * NEXTAUTH_SECRET. This is an exact-match Set, not a substring test, so an
+ * unrelated error that merely mentions "session" cannot be swept in here.
+ */
+const OUR_SESSION_REFUSAL_MESSAGES = new Set<string>([
+  'Session not valid: no sid on token',
+  'Session not valid: missing',
+  'Session not valid: revoked',
+  'Session not valid: idle',
+  'Session not valid: absolute',
+  'Account disabled',
+])
+
+function isOurSessionRefusal(code: string, metadata: unknown): metadata is Error {
+  return code === 'JWT_SESSION_ERROR' && metadata instanceof Error && OUR_SESSION_REFUSAL_MESSAGES.has(metadata.message)
+}
+
 export const authOptions: NextAuthOptions = {
   cookies: {
     sessionToken: {
@@ -685,6 +707,38 @@ export const authOptions: NextAuthOptions = {
   pages: {
     signIn: "/login",
     error: "/login",
+  },
+  // Every idle timeout, absolute-cap expiry, revocation, and pre-branch
+  // cookie surfaces as a JWT_SESSION_ERROR (next-auth core/routes/session.js
+  // catches the jwt callback's throw, calls sessionStore.clean(), logs, and
+  // returns an empty body). next-auth's default logger prints those at
+  // `error` level with a full stack — indistinguishable from a genuine
+  // decode failure (corrupted token, changed NEXTAUTH_SECRET), so the real
+  // signal drowns in routine noise. Only OUR own refusals (matched exactly
+  // above) are downgraded to one quiet info line with no stack; everything
+  // else — including a real JWT_SESSION_ERROR — falls through to the same
+  // loud, stack-carrying output next-auth would have produced. It cannot
+  // delegate to next-auth's real default logger: `next-auth/utils/logger`
+  // is not a published subpath (its package.json `exports` map omits it;
+  // `require("next-auth/utils/logger")` throws ERR_PACKAGE_PATH_NOT_EXPORTED),
+  // so this reproduces that default's formatting inline instead.
+  logger: {
+    error(code, metadata) {
+      if (isOurSessionRefusal(code, metadata)) {
+        console.info('[auth-session] session refused, cookie cleared:', metadata.message)
+        return
+      }
+
+      const err = metadata instanceof Error ? metadata : metadata.error
+      const formatted: unknown = err instanceof Error ? { message: err.message, stack: err.stack, name: err.name } : metadata
+
+      console.error(
+        `[next-auth][error][${code}]`,
+        `\nhttps://next-auth.js.org/errors#${code.toLowerCase()}`,
+        (formatted as { message?: string } | undefined)?.message,
+        formatted,
+      )
+    },
   },
   session: {
     strategy: "jwt",

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -43,37 +43,45 @@ declare module "next-auth/jwt" {
   }
 }
 
-// Explicitly control secure cookies based on NEXTAUTH_URL protocol
-// Prevents login failures when NEXTAUTH_URL=https but access is via HTTP
-const useSecureCookies = process.env.NEXTAUTH_URL?.startsWith('https://') ?? false
+// Cookie names and the `secure` flag both live in lib/auth/cookies.ts. The
+// names are static (readers must agree with the issuer); the flag is resolved
+// per request in getAuthOptions(req) so a TLS reverse proxy gets `Secure`
+// without the operator having to remember to edit NEXTAUTH_URL.
+import {
+  sessionCookieName,
+  callbackUrlCookieName,
+  csrfCookieName,
+  envPrefersSecureCookies,
+  resolveCookieSecure,
+} from './cookies'
 
 export const authOptions: NextAuthOptions = {
   cookies: {
     sessionToken: {
-      name: useSecureCookies ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
+      name: sessionCookieName(),
       options: {
         httpOnly: true,
         sameSite: 'lax' as const,
         path: '/',
-        secure: useSecureCookies,
+        secure: envPrefersSecureCookies(),
       },
     },
     callbackUrl: {
-      name: useSecureCookies ? '__Secure-next-auth.callback-url' : 'next-auth.callback-url',
+      name: callbackUrlCookieName(),
       options: {
         httpOnly: true,
         sameSite: 'lax' as const,
         path: '/',
-        secure: useSecureCookies,
+        secure: envPrefersSecureCookies(),
       },
     },
     csrfToken: {
-      name: useSecureCookies ? '__Host-next-auth.csrf-token' : 'next-auth.csrf-token',
+      name: csrfCookieName(),
       options: {
         httpOnly: true,
         sameSite: 'lax' as const,
         path: '/',
-        secure: useSecureCookies,
+        secure: envPrefersSecureCookies(),
       },
     },
   },
@@ -601,15 +609,38 @@ export const authOptions: NextAuthOptions = {
 }
 
 /**
- * Returns authOptions with OIDC provider dynamically included if configured.
- * Used only in the [...nextauth] route handler.
- * All getServerSession(authOptions) calls remain unchanged (JWT validation doesn't need the provider list).
+ * Returns authOptions with OIDC included when configured, and with the cookie
+ * `secure` flag resolved against THIS request's transport.
+ *
+ * `req` is optional: getServerSession(authOptions) callers only read the JWT
+ * and never issue a cookie, so they do not need it. The NextAuth route handler
+ * does issue cookies, and passes it.
  */
-export async function getAuthOptions(): Promise<NextAuthOptions> {
+export async function getAuthOptions(req?: Request): Promise<NextAuthOptions> {
+  const secure = resolveCookieSecure(req?.headers)
+
+  const withSecure = (opts: NextAuthOptions): NextAuthOptions => ({
+    ...opts,
+    cookies: {
+      sessionToken: {
+        name: sessionCookieName(),
+        options: { ...opts.cookies!.sessionToken!.options, secure },
+      },
+      callbackUrl: {
+        name: callbackUrlCookieName(),
+        options: { ...opts.cookies!.callbackUrl!.options, secure },
+      },
+      csrfToken: {
+        name: csrfCookieName(),
+        options: { ...opts.cookies!.csrfToken!.options, secure },
+      },
+    },
+  })
+
   const oidcConfig = await getOidcConfig()
 
   if (!oidcConfig || !oidcConfig.enabled || !oidcConfig.issuerUrl || !oidcConfig.clientId) {
-    return authOptions
+    return withSecure(authOptions)
   }
 
   const oidcProvider: OAuthConfig<any> = {
@@ -646,8 +677,8 @@ export async function getAuthOptions(): Promise<NextAuthOptions> {
     },
   }
 
-  return {
+  return withSecure({
     ...authOptions,
     providers: [...authOptions.providers, oidcProvider],
-  }
+  })
 }

--- a/frontend/src/lib/auth/cookies.test.ts
+++ b/frontend/src/lib/auth/cookies.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+
+import {
+  envPrefersSecureCookies,
+  sessionCookieName,
+  csrfCookieName,
+  callbackUrlCookieName,
+  requestPrefersSecure,
+  resolveCookieSecure,
+} from './cookies'
+
+const ORIGINAL = process.env.NEXTAUTH_URL
+
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.NEXTAUTH_URL
+  else process.env.NEXTAUTH_URL = ORIGINAL
+})
+
+describe('cookie names follow NEXTAUTH_URL and never vary per request', () => {
+  it('uses unprefixed names on an http NEXTAUTH_URL', () => {
+    process.env.NEXTAUTH_URL = 'http://192.168.1.151:3000'
+    expect(envPrefersSecureCookies()).toBe(false)
+    expect(sessionCookieName()).toBe('next-auth.session-token')
+    expect(callbackUrlCookieName()).toBe('next-auth.callback-url')
+    expect(csrfCookieName()).toBe('next-auth.csrf-token')
+  })
+
+  it('uses prefixed names on an https NEXTAUTH_URL', () => {
+    process.env.NEXTAUTH_URL = 'https://proxcenter.example.com'
+    expect(envPrefersSecureCookies()).toBe(true)
+    expect(sessionCookieName()).toBe('__Secure-next-auth.session-token')
+    expect(callbackUrlCookieName()).toBe('__Secure-next-auth.callback-url')
+    expect(csrfCookieName()).toBe('__Host-next-auth.csrf-token')
+  })
+
+  it('treats a missing NEXTAUTH_URL as not secure', () => {
+    delete process.env.NEXTAUTH_URL
+    expect(envPrefersSecureCookies()).toBe(false)
+    expect(sessionCookieName()).toBe('next-auth.session-token')
+  })
+})
+
+describe('requestPrefersSecure reads the forwarded protocol', () => {
+  it('accepts a single https hop', () => {
+    expect(requestPrefersSecure(new Headers({ 'x-forwarded-proto': 'https' }))).toBe(true)
+  })
+
+  it('reads only the FIRST hop of a multi-hop header', () => {
+    // nginx -> another proxy: the client-facing hop is the one that matters.
+    expect(requestPrefersSecure(new Headers({ 'x-forwarded-proto': 'https, http' }))).toBe(true)
+    expect(requestPrefersSecure(new Headers({ 'x-forwarded-proto': 'http, https' }))).toBe(false)
+  })
+
+  it('tolerates whitespace and case', () => {
+    expect(requestPrefersSecure(new Headers({ 'x-forwarded-proto': '  HTTPS ' }))).toBe(true)
+  })
+
+  it('falls back to x-forwarded-ssl and returns false with no headers', () => {
+    expect(requestPrefersSecure(new Headers({ 'x-forwarded-ssl': 'on' }))).toBe(true)
+    expect(requestPrefersSecure(new Headers())).toBe(false)
+    expect(requestPrefersSecure(null)).toBe(false)
+    expect(requestPrefersSecure(undefined)).toBe(false)
+  })
+})
+
+describe('resolveCookieSecure is a monotonic OR: it can only ADD the flag', () => {
+  it.each([
+    ['http://h:3000', 'http', false],
+    ['http://h:3000', 'https', true],
+    ['https://h', 'http', true],
+    ['https://h', 'https', true],
+  ])('NEXTAUTH_URL=%s + forwarded=%s -> %s', (url, proto, expected) => {
+    process.env.NEXTAUTH_URL = url
+    expect(resolveCookieSecure(new Headers({ 'x-forwarded-proto': proto }))).toBe(expected)
+  })
+
+  it('never drops the flag an https NEXTAUTH_URL already grants, even with no headers', () => {
+    process.env.NEXTAUTH_URL = 'https://h'
+    expect(resolveCookieSecure(null)).toBe(true)
+  })
+})

--- a/frontend/src/lib/auth/cookies.ts
+++ b/frontend/src/lib/auth/cookies.ts
@@ -1,0 +1,51 @@
+// Single source of truth for NextAuth cookie names and the `secure` flag.
+//
+// The NAMES stay derived from NEXTAUTH_URL and static for the process
+// lifetime: three readers (middleware.ts twice, the 2FA verify route) must
+// look up the same name the issuer wrote, and they have no per-request
+// agreement with it.
+//
+// The FLAG is per-request and monotonic: env OR actual transport. It can only
+// ever ADD `Secure`, never remove it, so no existing session regresses. A
+// spoofed x-forwarded-proto can only make the attacker's own browser refuse
+// to send the cookie over http — the failure direction is safe, which is why
+// this needs no TRUST_PROXY_HEADERS opt-in. Requiring one would recreate the
+// exact trap being fixed: TLS added, variable forgotten, still vulnerable.
+
+export function envPrefersSecureCookies(): boolean {
+  return process.env.NEXTAUTH_URL?.startsWith('https://') ?? false
+}
+
+export function sessionCookieName(): string {
+  return envPrefersSecureCookies()
+    ? '__Secure-next-auth.session-token'
+    : 'next-auth.session-token'
+}
+
+export function callbackUrlCookieName(): string {
+  return envPrefersSecureCookies()
+    ? '__Secure-next-auth.callback-url'
+    : 'next-auth.callback-url'
+}
+
+export function csrfCookieName(): string {
+  return envPrefersSecureCookies()
+    ? '__Host-next-auth.csrf-token'
+    : 'next-auth.csrf-token'
+}
+
+export function requestPrefersSecure(headers: Headers | null | undefined): boolean {
+  if (!headers) return false
+  const proto = headers.get('x-forwarded-proto')
+  if (proto) {
+    // Only the first hop is client-facing; later hops describe internal legs.
+    const first = proto.split(',')[0]?.trim().toLowerCase()
+    if (first === 'https') return true
+    if (first === 'http') return false
+  }
+  return headers.get('x-forwarded-ssl')?.trim().toLowerCase() === 'on'
+}
+
+export function resolveCookieSecure(headers: Headers | null | undefined): boolean {
+  return envPrefersSecureCookies() || requestPrefersSecure(headers)
+}

--- a/frontend/src/lib/auth/deviceLabel.test.ts
+++ b/frontend/src/lib/auth/deviceLabel.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+
+import { deviceLabel } from './deviceLabel'
+
+describe('deviceLabel recognises the browsers and platforms that matter', () => {
+  it.each([
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', 'Chrome', 'Windows'],
+    ['Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15', 'Safari', 'macOS'],
+    ['Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1', 'Safari', 'iOS'],
+    ['Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36', 'Chrome', 'Linux'],
+    ['Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0', 'Firefox', 'Windows'],
+    ['Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36', 'Chrome', 'Android'],
+  ])('parses %s', (ua, browser, os) => {
+    expect(deviceLabel(ua)).toEqual({ browser, os })
+  })
+
+  it('prefers Edge over the Chrome token it also carries', () => {
+    const ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0'
+    expect(deviceLabel(ua)).toEqual({ browser: 'Edge', os: 'Windows' })
+  })
+
+  it('prefers Chrome over the Safari token it also carries', () => {
+    const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+    expect(deviceLabel(ua)).toEqual({ browser: 'Chrome', os: 'macOS' })
+  })
+
+  it('returns nulls rather than guessing on unknown, empty or missing input', () => {
+    expect(deviceLabel('some-cli/1.0')).toEqual({ browser: null, os: null })
+    expect(deviceLabel('')).toEqual({ browser: null, os: null })
+    expect(deviceLabel(null)).toEqual({ browser: null, os: null })
+    expect(deviceLabel(undefined)).toEqual({ browser: null, os: null })
+  })
+
+  it('still reports the OS when only the browser is unknown', () => {
+    expect(deviceLabel('curl/8.5.0 (Windows NT 10.0)')).toEqual({ browser: null, os: 'Windows' })
+  })
+})

--- a/frontend/src/lib/auth/deviceLabel.ts
+++ b/frontend/src/lib/auth/deviceLabel.ts
@@ -1,0 +1,44 @@
+// Turn a raw user-agent string into a browser + OS pair for display.
+//
+// Deliberately a small heuristic and not ua-parser-js: this is a display
+// label, a wrong guess on an exotic browser costs nothing, and a dependency
+// costs maintenance forever. Unknown input yields nulls so the caller can
+// render a translated "Unknown" rather than an empty cell, and the raw string
+// stays available in a tooltip.
+//
+// Order matters in both tables: Edge and Opera also carry a Chrome token, and
+// Chrome also carries a Safari token.
+
+const BROWSERS: Array<[RegExp, string]> = [
+  [/\bEdg(?:e|A|iOS)?\//i, "Edge"],
+  [/\bOPR\/|\bOpera\//i, "Opera"],
+  [/\bChrome\/|\bCriOS\//i, "Chrome"],
+  [/\bFirefox\/|\bFxiOS\//i, "Firefox"],
+  [/\bSafari\//i, "Safari"],
+]
+
+const PLATFORMS: Array<[RegExp, string]> = [
+  [/\bAndroid\b/i, "Android"],
+  [/\biPhone\b|\biPad\b|\biPod\b|\biOS\b/i, "iOS"],
+  [/\bWindows NT\b|\bWindows\b/i, "Windows"],
+  [/\bMac OS X\b|\bMacintosh\b/i, "macOS"],
+  [/\bLinux\b|\bX11\b/i, "Linux"],
+]
+
+function firstMatch(ua: string, table: Array<[RegExp, string]>): string | null {
+  for (const [re, label] of table) {
+    if (re.test(ua)) return label
+  }
+  return null
+}
+
+export function deviceLabel(userAgent: string | null | undefined): {
+  browser: string | null
+  os: string | null
+} {
+  if (!userAgent) return { browser: null, os: null }
+  return {
+    browser: firstMatch(userAgent, BROWSERS),
+    os: firstMatch(userAgent, PLATFORMS),
+  }
+}

--- a/frontend/src/lib/auth/durations.test.ts
+++ b/frontend/src/lib/auth/durations.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest'
+
+import { sessionDurations } from './durations'
+
+const ENV = { idle: process.env.SESSION_IDLE_TIMEOUT, abs: process.env.SESSION_ABSOLUTE_TIMEOUT }
+
+afterEach(() => {
+  if (ENV.idle === undefined) delete process.env.SESSION_IDLE_TIMEOUT
+  else process.env.SESSION_IDLE_TIMEOUT = ENV.idle
+  if (ENV.abs === undefined) delete process.env.SESSION_ABSOLUTE_TIMEOUT
+  else process.env.SESSION_ABSOLUTE_TIMEOUT = ENV.abs
+})
+
+describe('sessionDurations', () => {
+  it('defaults to 12h idle and 7d absolute', () => {
+    delete process.env.SESSION_IDLE_TIMEOUT
+    delete process.env.SESSION_ABSOLUTE_TIMEOUT
+    expect(sessionDurations()).toEqual({ idleMs: 12 * 3600_000, absoluteMs: 7 * 86400_000 })
+  })
+
+  it('reads seconds from the environment', () => {
+    process.env.SESSION_IDLE_TIMEOUT = '3600'
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '86400'
+    expect(sessionDurations()).toEqual({ idleMs: 3600_000, absoluteMs: 86400_000 })
+  })
+
+  it('ignores non-numeric and non-positive values rather than disabling the cap', () => {
+    process.env.SESSION_IDLE_TIMEOUT = 'nonsense'
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '0'
+    expect(sessionDurations()).toEqual({ idleMs: 12 * 3600_000, absoluteMs: 7 * 86400_000 })
+  })
+})

--- a/frontend/src/lib/auth/durations.test.ts
+++ b/frontend/src/lib/auth/durations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest'
 
-import { sessionDurations } from './durations'
+import { sessionDurations, isPastAbsoluteCap } from './durations'
 
 const ENV = { idle: process.env.SESSION_IDLE_TIMEOUT, abs: process.env.SESSION_ABSOLUTE_TIMEOUT }
 
@@ -28,5 +28,25 @@ describe('sessionDurations', () => {
     process.env.SESSION_IDLE_TIMEOUT = 'nonsense'
     process.env.SESSION_ABSOLUTE_TIMEOUT = '0'
     expect(sessionDurations()).toEqual({ idleMs: 12 * 3600_000, absoluteMs: 7 * 86400_000 })
+  })
+})
+
+describe('isPastAbsoluteCap: the one shared rule for both sides of the Edge boundary', () => {
+  const DURATIONS = { idleMs: 12 * 3600_000, absoluteMs: 7 * 86400_000 }
+  const NOW = Date.parse('2026-08-03T12:00:00.000Z')
+
+  it('is not past the cap while still below it', () => {
+    const startMs = NOW - (DURATIONS.absoluteMs - 1)
+    expect(isPastAbsoluteCap(startMs, NOW, DURATIONS)).toBe(false)
+  })
+
+  it('is not past the cap exactly at it (strictly greater-than, not gte)', () => {
+    const startMs = NOW - DURATIONS.absoluteMs
+    expect(isPastAbsoluteCap(startMs, NOW, DURATIONS)).toBe(false)
+  })
+
+  it('is past the cap one millisecond after it', () => {
+    const startMs = NOW - DURATIONS.absoluteMs - 1
+    expect(isPastAbsoluteCap(startMs, NOW, DURATIONS)).toBe(true)
   })
 })

--- a/frontend/src/lib/auth/durations.ts
+++ b/frontend/src/lib/auth/durations.ts
@@ -1,0 +1,29 @@
+// Session timeout configuration, read fresh from the environment on every
+// call so a changed timeout applies immediately without a restart.
+//
+// This module must import NOTHING beyond process.env: Task 8's middleware
+// needs sessionDurations() and runs in the Edge runtime, which cannot load
+// sessions.ts (it imports Prisma). Keeping this file import-free keeps the
+// middleware bundle clean.
+
+const DEFAULT_IDLE_SECONDS = 12 * 3600
+const DEFAULT_ABSOLUTE_SECONDS = 7 * 86400
+
+export interface SessionDurations {
+  idleMs: number
+  absoluteMs: number
+}
+
+function positiveSeconds(raw: string | undefined, fallback: number): number {
+  const n = Number(raw)
+  // A malformed or non-positive value must not silently disable a security
+  // deadline, so it falls back to the default rather than to "no limit".
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+export function sessionDurations(): SessionDurations {
+  return {
+    idleMs: positiveSeconds(process.env.SESSION_IDLE_TIMEOUT, DEFAULT_IDLE_SECONDS) * 1000,
+    absoluteMs: positiveSeconds(process.env.SESSION_ABSOLUTE_TIMEOUT, DEFAULT_ABSOLUTE_SECONDS) * 1000,
+  }
+}

--- a/frontend/src/lib/auth/durations.ts
+++ b/frontend/src/lib/auth/durations.ts
@@ -27,3 +27,24 @@ export function sessionDurations(): SessionDurations {
     absoluteMs: positiveSeconds(process.env.SESSION_ABSOLUTE_TIMEOUT, DEFAULT_ABSOLUTE_SECONDS) * 1000,
   }
 }
+
+/**
+ * The one absolute-cap rule, shared by both sides of the Edge boundary:
+ * `sessions.ts:evaluateSession` (Node, DB-backed session rows) and
+ * `middleware.ts` (Edge, the JWT's `authAt` claim) each need "has this long
+ * elapsed since the start instant exceeded the cap", and had drifted into
+ * two separately-written copies of the same comparison. This file already
+ * has zero imports and is loaded by both, so the predicate lives here rather
+ * than in `sessions.ts` (Prisma-adjacent, Edge-hostile) or `middleware.ts`
+ * (would leave `sessions.ts` still duplicating it).
+ *
+ * Strictly greater-than, matching the existing behaviour in both callers: an
+ * elapsed time exactly equal to the cap is NOT past it.
+ */
+export function isPastAbsoluteCap(
+  startMs: number,
+  nowMs: number = Date.now(),
+  durations: SessionDurations = sessionDurations(),
+): boolean {
+  return nowMs - startMs > durations.absoluteMs
+}

--- a/frontend/src/lib/auth/enrollmentEquivalence.test.ts
+++ b/frontend/src/lib/auth/enrollmentEquivalence.test.ts
@@ -1,0 +1,78 @@
+// jwtContext.ts's resolveMustEnroll is a second, independent implementation of
+// the branching in enforce-2fa.ts's needsEnrollment / isEnrollmentRequiredFor.
+// The duplication is deliberate — calling the originals from the consolidated
+// read would undo the whole point of collapsing five round trips into one —
+// but nothing else keeps the two in sync. If someone changes the enrollment
+// policy in enforce-2fa.ts only (adds a role exemption, changes the
+// expiresAt comparator, flips a condition), this is the ONLY test that
+// notices: it drives the exact same mocked Prisma responses through both
+// implementations and asserts they agree, across the full fixture matrix of
+// inputs that can change the answer. If this file is deleted or skipped, the
+// two implementations can silently diverge on who gets forced into 2FA
+// enrollment with nothing else failing.
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const { userFindUniqueMock, policyFindFirstMock, roleFindFirstMock } = vi.hoisted(() => ({
+  userFindUniqueMock: vi.fn(),
+  policyFindFirstMock: vi.fn(),
+  roleFindFirstMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: { findUnique: userFindUniqueMock },
+    securityPolicy: { findFirst: policyFindFirstMock },
+    rbacUserRole: { findFirst: roleFindFirstMock },
+  },
+}))
+
+import { needsEnrollment } from '@/lib/auth/enforce-2fa'
+
+import { loadJwtContext } from './jwtContext'
+
+afterEach(() => vi.clearAllMocks())
+
+const BOOLS = [true, false] as const
+type RoleState = 'absent' | 'unexpired' | 'expired'
+const ROLE_STATES: RoleState[] = ['absent', 'unexpired', 'expired']
+
+/**
+ * What prisma.rbacUserRole.findFirst would actually return for each state,
+ * given the real query's `OR: [{ expiresAt: null }, { expiresAt: { gt: now } }]`.
+ * An expired-only assignment fails both branches of that OR, so a real query
+ * excludes it just like "absent" does — both implementations issue the same
+ * query shape (asserted separately in jwtContext.test.ts), so mocking the
+ * already-filtered result is what a real DB round trip would hand back.
+ */
+function roleRowFor(state: RoleState) {
+  return state === 'unexpired' ? { id: 'assign-1' } : null
+}
+
+describe('needsEnrollment (enforce-2fa.ts) vs loadJwtContext (jwtContext.ts) — enrollment decision equivalence', () => {
+  for (const totpEnabled of BOOLS) {
+    for (const require2faEnrollment of BOOLS) {
+      for (const require2faForSuperAdmin of BOOLS) {
+        for (const roleState of ROLE_STATES) {
+          const label = `totpEnabled=${totpEnabled} require2faEnrollment=${require2faEnrollment} require2faForSuperAdmin=${require2faForSuperAdmin} role=${roleState}`
+
+          it(`agree when ${label}`, async () => {
+            userFindUniqueMock.mockResolvedValue({
+              enabled: true,
+              totpEnabled,
+              require2faEnrollment,
+              tenants: [],
+              sessions: [],
+            })
+            policyFindFirstMock.mockResolvedValue({ require2faForSuperAdmin })
+            roleFindFirstMock.mockResolvedValue(roleRowFor(roleState))
+
+            const viaOriginal = await needsEnrollment('u1')
+            const ctx = await loadJwtContext('u1', 'sid1')
+
+            expect(ctx.mustEnroll2fa).toBe(viaOriginal)
+          })
+        }
+      }
+    }
+  }
+})

--- a/frontend/src/lib/auth/jwtContext.test.ts
+++ b/frontend/src/lib/auth/jwtContext.test.ts
@@ -42,6 +42,14 @@ describe('loadJwtContext', () => {
     // An enrolled user needs no policy lookup at all.
     expect(policyFindFirstMock).not.toHaveBeenCalled()
     expect(roleFindFirstMock).not.toHaveBeenCalled()
+    // The nested tenant lookup must reproduce getUserDefaultTenantId's predicate exactly.
+    expect(userFindUniqueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          tenants: { where: { isDefault: true }, select: { tenantId: true }, take: 1 },
+        }),
+      }),
+    )
   })
 
   it('honours the per-user 2FA flag without consulting the policy', async () => {
@@ -65,6 +73,16 @@ describe('loadJwtContext', () => {
     const ctx = await loadJwtContext('u1', 'sid1')
     expect(ctx.mustEnroll2fa).toBe(true)
     expect(roleFindFirstMock).toHaveBeenCalledOnce()
+    // roleId and the "unexpired" OR clause are the whole security boundary here —
+    // a wrong roleId or a dropped expiresAt branch must fail this test.
+    expect(roleFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        userId: 'u1',
+        roleId: 'role_super_admin',
+        OR: [{ expiresAt: null }, { expiresAt: { gt: expect.any(Date) } }],
+      },
+      select: { id: true },
+    })
   })
 
   it('does not require 2FA when the policy is off', async () => {

--- a/frontend/src/lib/auth/jwtContext.test.ts
+++ b/frontend/src/lib/auth/jwtContext.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const { userFindUniqueMock, policyFindFirstMock, roleFindFirstMock } = vi.hoisted(() => ({
+  userFindUniqueMock: vi.fn(),
+  policyFindFirstMock: vi.fn(),
+  roleFindFirstMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    user: { findUnique: userFindUniqueMock },
+    securityPolicy: { findFirst: policyFindFirstMock },
+    rbacUserRole: { findFirst: roleFindFirstMock },
+  },
+}))
+
+import { loadJwtContext } from './jwtContext'
+
+afterEach(() => vi.clearAllMocks())
+
+const sessionRow = {
+  id: 'sid1', userId: 'u1',
+  createdAt: new Date('2026-08-03T11:00:00Z'),
+  lastSeenAt: new Date('2026-08-03T11:59:00Z'),
+  revokedAt: null, ipAddress: null, userAgent: null,
+}
+
+describe('loadJwtContext', () => {
+  it('reads enabled, tenant, 2FA and the session row in ONE query for an enrolled user', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: true, require2faEnrollment: false,
+      tenants: [{ tenantId: 'tenant-a' }],
+      sessions: [sessionRow],
+    })
+
+    const ctx = await loadJwtContext('u1', 'sid1')
+
+    expect(ctx).toEqual({
+      enabled: true, tenantId: 'tenant-a', mustEnroll2fa: false, session: sessionRow,
+    })
+    expect(userFindUniqueMock).toHaveBeenCalledOnce()
+    // An enrolled user needs no policy lookup at all.
+    expect(policyFindFirstMock).not.toHaveBeenCalled()
+    expect(roleFindFirstMock).not.toHaveBeenCalled()
+  })
+
+  it('honours the per-user 2FA flag without consulting the policy', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: false, require2faEnrollment: true,
+      tenants: [], sessions: [],
+    })
+    const ctx = await loadJwtContext('u1', 'sid1')
+    expect(ctx.mustEnroll2fa).toBe(true)
+    expect(policyFindFirstMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the super_admin policy path when neither shortcut applies', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: false, require2faEnrollment: false,
+      tenants: [], sessions: [],
+    })
+    policyFindFirstMock.mockResolvedValue({ require2faForSuperAdmin: true })
+    roleFindFirstMock.mockResolvedValue({ id: 'assign1' })
+
+    const ctx = await loadJwtContext('u1', 'sid1')
+    expect(ctx.mustEnroll2fa).toBe(true)
+    expect(roleFindFirstMock).toHaveBeenCalledOnce()
+  })
+
+  it('does not require 2FA when the policy is off', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: false, require2faEnrollment: false,
+      tenants: [], sessions: [],
+    })
+    policyFindFirstMock.mockResolvedValue({ require2faForSuperAdmin: false })
+
+    const ctx = await loadJwtContext('u1', 'sid1')
+    expect(ctx.mustEnroll2fa).toBe(false)
+    expect(roleFindFirstMock).not.toHaveBeenCalled()
+  })
+
+  it('defaults the tenant to "default" when the user has no default membership', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: true, require2faEnrollment: false,
+      tenants: [], sessions: [],
+    })
+    const ctx = await loadJwtContext('u1', 'sid1')
+    expect(ctx.tenantId).toBe('default')
+  })
+
+  it('reports a deleted user as disabled with a null session', async () => {
+    userFindUniqueMock.mockResolvedValue(null)
+    const ctx = await loadJwtContext('u1', 'sid1')
+    expect(ctx).toEqual({ enabled: false, tenantId: 'default', mustEnroll2fa: false, session: null })
+  })
+
+  it('skips the session sub-select entirely when the token carries no sid', async () => {
+    userFindUniqueMock.mockResolvedValue({
+      enabled: true, totpEnabled: true, require2faEnrollment: false,
+      tenants: [{ tenantId: 'default' }], sessions: [],
+    })
+    const ctx = await loadJwtContext('u1', null)
+    expect(ctx.session).toBeNull()
+    expect(userFindUniqueMock.mock.calls[0][0].select.sessions).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/auth/jwtContext.ts
+++ b/frontend/src/lib/auth/jwtContext.ts
@@ -1,0 +1,78 @@
+// One read for everything the NextAuth `jwt` callback needs per request.
+//
+// The callback runs on EVERY getServerSession, so on every guarded API call
+// (checkPermission calls it first thing). Before consolidation that path cost
+// up to five round trips, including two separate user.findUnique on the same
+// row. This collapses the tenant lookup, both 2FA lookups and the session
+// lookup into a single query, so adding the session check makes the hot path
+// faster than it was rather than slower.
+//
+// getUserDefaultTenantId and needsEnrollment keep their own callers and their
+// own behaviour; this is an additional, faster path, not a replacement.
+import { prisma } from "@/lib/db/prisma"
+
+import type { SessionRow } from "./sessions"
+
+const SUPER_ADMIN_ROLE_ID = "role_super_admin"
+const DEFAULT_TENANT = "default"
+
+export interface JwtContext {
+  enabled: boolean
+  tenantId: string
+  mustEnroll2fa: boolean
+  session: SessionRow | null
+}
+
+export async function loadJwtContext(userId: string, sid: string | null): Promise<JwtContext> {
+  const row = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      enabled: true,
+      totpEnabled: true,
+      require2faEnrollment: true,
+      tenants: { where: { isDefault: true }, select: { tenantId: true }, take: 1 },
+      // Only ask for the session when the token actually carries one.
+      ...(sid ? { sessions: { where: { id: sid }, take: 1 } } : {}),
+    },
+  })
+
+  if (!row) {
+    return { enabled: false, tenantId: DEFAULT_TENANT, mustEnroll2fa: false, session: null }
+  }
+
+  const tenantId = row.tenants[0]?.tenantId || DEFAULT_TENANT
+  const session = (sid ? ((row as any).sessions?.[0] ?? null) : null) as SessionRow | null
+
+  return {
+    enabled: row.enabled,
+    tenantId,
+    mustEnroll2fa: await resolveMustEnroll(userId, row.totpEnabled, row.require2faEnrollment),
+    session,
+  }
+}
+
+/** Mirrors needsEnrollment / isEnrollmentRequiredFor, reusing the row already read. */
+async function resolveMustEnroll(
+  userId: string,
+  totpEnabled: boolean,
+  require2faEnrollment: boolean,
+): Promise<boolean> {
+  if (totpEnabled) return false
+  if (require2faEnrollment) return true
+
+  const policy = await prisma.securityPolicy.findFirst({
+    where: { id: "default" },
+    select: { require2faForSuperAdmin: true },
+  })
+  if (!policy?.require2faForSuperAdmin) return false
+
+  const sa = await prisma.rbacUserRole.findFirst({
+    where: {
+      userId,
+      roleId: SUPER_ADMIN_ROLE_ID,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    },
+    select: { id: true },
+  })
+  return !!sa
+}

--- a/frontend/src/lib/auth/jwtContext.ts
+++ b/frontend/src/lib/auth/jwtContext.ts
@@ -10,11 +10,11 @@
 // getUserDefaultTenantId and needsEnrollment keep their own callers and their
 // own behaviour; this is an additional, faster path, not a replacement.
 import { prisma } from "@/lib/db/prisma"
+import { DEFAULT_TENANT_ID } from "@/lib/tenant/constants"
 
 import type { SessionRow } from "./sessions"
 
 const SUPER_ADMIN_ROLE_ID = "role_super_admin"
-const DEFAULT_TENANT = "default"
 
 export interface JwtContext {
   enabled: boolean
@@ -37,10 +37,10 @@ export async function loadJwtContext(userId: string, sid: string | null): Promis
   })
 
   if (!row) {
-    return { enabled: false, tenantId: DEFAULT_TENANT, mustEnroll2fa: false, session: null }
+    return { enabled: false, tenantId: DEFAULT_TENANT_ID, mustEnroll2fa: false, session: null }
   }
 
-  const tenantId = row.tenants[0]?.tenantId || DEFAULT_TENANT
+  const tenantId = row.tenants[0]?.tenantId || DEFAULT_TENANT_ID
   const session = (sid ? ((row as any).sessions?.[0] ?? null) : null) as SessionRow | null
 
   return {

--- a/frontend/src/lib/auth/sessionSweeper.test.ts
+++ b/frontend/src/lib/auth/sessionSweeper.test.ts
@@ -31,18 +31,6 @@ describe("startSessionSweeper", () => {
     stop()
   })
 
-  it("a throwing onError hook is swallowed too", async () => {
-    const purge = vi.fn().mockRejectedValue(new Error("db down"))
-    const stop = startSessionSweeper({
-      intervalMs: 1000,
-      purge,
-      onError: () => { throw new Error("bad hook") },
-    })
-    await vi.advanceTimersByTimeAsync(2000)
-    expect(purge).toHaveBeenCalledTimes(2)
-    stop()
-  })
-
   it("skips a tick while the previous purge is still in-flight (no overlap)", async () => {
     let resolvePurge: (n: number) => void
     const pending = new Promise<number>(r => { resolvePurge = r })

--- a/frontend/src/lib/auth/sessionSweeper.test.ts
+++ b/frontend/src/lib/auth/sessionSweeper.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { startSessionSweeper, SESSION_SWEEP_INTERVAL_MS } from "./sessionSweeper"
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers() })
+
+describe("startSessionSweeper", () => {
+  it("runs the purge once per interval (N advances -> N purges)", async () => {
+    const purge = vi.fn().mockResolvedValue(0)
+    const stop = startSessionSweeper({ intervalMs: 1000, purge })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(purge).toHaveBeenCalledTimes(3)
+    stop()
+  })
+
+  it("defaults to an hourly interval", async () => {
+    const purge = vi.fn().mockResolvedValue(0)
+    const stop = startSessionSweeper({ purge })
+    await vi.advanceTimersByTimeAsync(SESSION_SWEEP_INTERVAL_MS - 1)
+    expect(purge).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(purge).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it("a rejected purge does not throw and does not stop the sweeper", async () => {
+    const purge = vi.fn().mockRejectedValue(new Error("db down"))
+    const stop = startSessionSweeper({ intervalMs: 1000, purge })
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(purge).toHaveBeenCalledTimes(3)
+    stop()
+  })
+
+  it("a throwing onError hook is swallowed too", async () => {
+    const purge = vi.fn().mockRejectedValue(new Error("db down"))
+    const stop = startSessionSweeper({
+      intervalMs: 1000,
+      purge,
+      onError: () => { throw new Error("bad hook") },
+    })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(purge).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("skips a tick while the previous purge is still in-flight (no overlap)", async () => {
+    let resolvePurge: (n: number) => void
+    const pending = new Promise<number>(r => { resolvePurge = r })
+    const purge = vi.fn().mockReturnValueOnce(pending).mockResolvedValue(0)
+    const stop = startSessionSweeper({ intervalMs: 1000, purge })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(purge).toHaveBeenCalledTimes(1)
+
+    resolvePurge!(0)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(purge).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("stop() halts further purges; calling stop() twice is safe", async () => {
+    const purge = vi.fn().mockResolvedValue(0)
+    const stop = startSessionSweeper({ intervalMs: 1000, purge })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(purge).toHaveBeenCalledTimes(2)
+    stop()
+    stop() // second call must not throw
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(purge).toHaveBeenCalledTimes(2) // no additional purges
+  })
+
+  it("unrefs the interval timer so it cannot keep the process alive", () => {
+    vi.useRealTimers()
+    const unref = vi.fn()
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue({ unref } as any)
+    try {
+      const purge = vi.fn().mockResolvedValue(0)
+      const stop = startSessionSweeper({ intervalMs: 1000, purge })
+      expect(unref).toHaveBeenCalledTimes(1)
+      stop()
+    } finally {
+      setIntervalSpy.mockRestore()
+    }
+  })
+
+  it("logs only when the purge actually deleted rows", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {})
+    try {
+      const purge = vi.fn().mockResolvedValueOnce(0).mockResolvedValueOnce(3)
+      const stop = startSessionSweeper({ intervalMs: 1000, purge })
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(logSpy).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(logSpy).toHaveBeenCalledTimes(1)
+      expect(logSpy.mock.calls[0][0]).toMatch(/^\[session-sweeper\]/)
+      stop()
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})

--- a/frontend/src/lib/auth/sessionSweeper.ts
+++ b/frontend/src/lib/auth/sessionSweeper.ts
@@ -18,8 +18,6 @@ export const SESSION_SWEEP_INTERVAL_MS = 60 * 60 * 1000
 export interface SessionSweeperOptions {
   intervalMs?: number
   purge?: () => Promise<number>
-  /** Observability hook — sweep failures are swallowed, never thrown into the process. */
-  onError?: (err: unknown) => void
 }
 
 /**
@@ -32,7 +30,7 @@ export interface SessionSweeperOptions {
  * @returns A stop() function, safe to call multiple times.
  */
 export function startSessionSweeper(options: SessionSweeperOptions = {}): () => void {
-  const { intervalMs = SESSION_SWEEP_INTERVAL_MS, purge = purgeDeadSessions, onError } = options
+  const { intervalMs = SESSION_SWEEP_INTERVAL_MS, purge = purgeDeadSessions } = options
   let stopped = false
   let inFlight = false
 
@@ -47,7 +45,6 @@ export function startSessionSweeper(options: SessionSweeperOptions = {}): () => 
           if (count > 0) console.log(`[session-sweeper] purged ${count} dead session row(s)`)
         },
         (err) => {
-          try { onError?.(err) } catch { /* observability must never kill the process */ }
           console.error("[session-sweeper] purge failed (non-fatal):", err)
         },
       )

--- a/frontend/src/lib/auth/sessionSweeper.ts
+++ b/frontend/src/lib/auth/sessionSweeper.ts
@@ -1,0 +1,66 @@
+/**
+ * Hourly purge of dead session rows.
+ *
+ * The `sessions` table carries `ipAddress` and `userAgent` — personal data.
+ * evaluateSession()/isDeadPredicate() (sessions.ts) already say when a row is
+ * dead, and login-time cleanup removes it for a user who signs in again, but
+ * a user who never comes back would keep their IP forever. This sweeper is
+ * what turns the retention bound into a fact rather than a claim.
+ *
+ * Timer discipline copied from job-heartbeat.ts: an in-flight guard so a slow
+ * purge cannot overlap the next tick, unref() so the interval never keeps the
+ * process alive by itself, and an error path that can never throw.
+ */
+import { purgeDeadSessions } from "@/lib/auth/sessions"
+
+export const SESSION_SWEEP_INTERVAL_MS = 60 * 60 * 1000
+
+export interface SessionSweeperOptions {
+  intervalMs?: number
+  purge?: () => Promise<number>
+  /** Observability hook — sweep failures are swallowed, never thrown into the process. */
+  onError?: (err: unknown) => void
+}
+
+/**
+ * Start the hourly dead-session sweep.
+ *
+ * Safe to run from every HA replica: the purge is a single deleteMany with a
+ * time-based predicate, so concurrent runs are idempotent (no leader election
+ * needed) and the only cost of N replicas is a redundant query per hour.
+ *
+ * @returns A stop() function, safe to call multiple times.
+ */
+export function startSessionSweeper(options: SessionSweeperOptions = {}): () => void {
+  const { intervalMs = SESSION_SWEEP_INTERVAL_MS, purge = purgeDeadSessions, onError } = options
+  let stopped = false
+  let inFlight = false
+
+  const sweep = () => {
+    if (stopped || inFlight) return
+    inFlight = true
+    purge()
+      .then(
+        (count) => {
+          // An hourly "deleted 0 rows" line for the rest of the deployment's
+          // life is noise that trains people to ignore the log.
+          if (count > 0) console.log(`[session-sweeper] purged ${count} dead session row(s)`)
+        },
+        (err) => {
+          try { onError?.(err) } catch { /* observability must never kill the process */ }
+          console.error("[session-sweeper] purge failed (non-fatal):", err)
+        },
+      )
+      .finally(() => { inFlight = false })
+  }
+
+  const timer = setInterval(sweep, intervalMs)
+  // Do not keep the Node process alive just for this sweep timer.
+  if (typeof (timer as any).unref === "function") (timer as any).unref()
+
+  return function stop() {
+    if (stopped) return
+    stopped = true
+    clearInterval(timer)
+  }
+}

--- a/frontend/src/lib/auth/sessions.test.ts
+++ b/frontend/src/lib/auth/sessions.test.ts
@@ -235,18 +235,15 @@ describe('revocation', () => {
     expect(where.id).toBeUndefined()
   })
 
-  it('revokeEverySession can spare the caller\'s own current session', async () => {
-    updateManyMock.mockResolvedValue({ count: 7 })
-    await expect(revokeEverySession('keep-me')).resolves.toBe(7)
-    expect(updateManyMock.mock.calls[0][0].where).toEqual({
-      revokedAt: null, id: { not: 'keep-me' },
-    })
-  })
+  it('revokeEverySession marks every live row revoked, with no exclusion', async () => {
+    updateManyMock.mockResolvedValue({ count: 12 })
 
-  it('revokeEverySession with no exception revokes every live row installation-wide', async () => {
-    updateManyMock.mockResolvedValue({ count: 9 })
-    await expect(revokeEverySession()).resolves.toBe(9)
-    expect(updateManyMock.mock.calls[0][0].where).toEqual({ revokedAt: null })
+    const count = await revokeEverySession()
+
+    expect(count).toBe(12)
+    const arg = updateManyMock.mock.calls[0][0]
+    expect(arg.where).toEqual({ revokedAt: null })
+    expect(arg.data.revokedAt).toBeInstanceOf(Date)
   })
 })
 

--- a/frontend/src/lib/auth/sessions.test.ts
+++ b/frontend/src/lib/auth/sessions.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+const { createMock, findUniqueMock, findManyMock, countMock, updateManyMock, deleteManyMock } =
+  vi.hoisted(() => ({
+    createMock: vi.fn(),
+    findUniqueMock: vi.fn(),
+    findManyMock: vi.fn(),
+    countMock: vi.fn(),
+    updateManyMock: vi.fn(),
+    deleteManyMock: vi.fn(),
+  }))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    session: {
+      create: createMock,
+      findUnique: findUniqueMock,
+      findMany: findManyMock,
+      count: countMock,
+      updateMany: updateManyMock,
+      deleteMany: deleteManyMock,
+    },
+  },
+}))
+
+import {
+  evaluateSession,
+  createSession,
+  touchSession,
+  revokeSession,
+  revokeAllSessions,
+  purgeDeadSessions,
+  countActiveSessions,
+  TOUCH_THROTTLE_MS,
+  type SessionRow,
+} from './sessions'
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+const NOW = new Date('2026-08-03T12:00:00.000Z')
+const row = (over: Partial<SessionRow> = {}): SessionRow => ({
+  id: 'sid1',
+  userId: 'u1',
+  createdAt: new Date('2026-08-03T11:00:00.000Z'),
+  lastSeenAt: new Date('2026-08-03T11:59:00.000Z'),
+  revokedAt: null,
+  ipAddress: '10.0.0.1',
+  userAgent: 'UA',
+  ...over,
+})
+
+describe('evaluateSession is pure and names why a session is dead', () => {
+  it('accepts a fresh session', () => {
+    expect(evaluateSession(row(), NOW)).toEqual({ alive: true })
+  })
+
+  it('rejects a missing row', () => {
+    expect(evaluateSession(null, NOW)).toEqual({ alive: false, reason: 'missing' })
+    expect(evaluateSession(undefined, NOW)).toEqual({ alive: false, reason: 'missing' })
+  })
+
+  it('rejects a revoked row', () => {
+    const r = row({ revokedAt: new Date('2026-08-03T11:30:00.000Z') })
+    expect(evaluateSession(r, NOW)).toEqual({ alive: false, reason: 'revoked' })
+  })
+
+  it('rejects an idle session', () => {
+    const r = row({ lastSeenAt: new Date('2026-08-02T23:00:00.000Z') })
+    expect(evaluateSession(r, NOW)).toEqual({ alive: false, reason: 'idle' })
+  })
+
+  it('rejects a session past the absolute cap even when it is active right now', () => {
+    const r = row({
+      createdAt: new Date('2026-07-20T12:00:00.000Z'),
+      lastSeenAt: new Date('2026-08-03T11:59:59.000Z'),
+    })
+    expect(evaluateSession(r, NOW)).toEqual({ alive: false, reason: 'absolute' })
+  })
+
+  it('reports revoked before idle when both apply', () => {
+    const r = row({
+      revokedAt: new Date('2026-08-01T00:00:00.000Z'),
+      lastSeenAt: new Date('2026-08-01T00:00:00.000Z'),
+    })
+    expect(evaluateSession(r, NOW)).toEqual({ alive: false, reason: 'revoked' })
+  })
+})
+
+describe('createSession', () => {
+  it('mints a 32-char id and stores both timestamps', async () => {
+    createMock.mockResolvedValue({})
+    const sid = await createSession({ userId: 'u1', ipAddress: '1.2.3.4', userAgent: 'UA' })
+    expect(sid).toHaveLength(32)
+    const arg = createMock.mock.calls[0][0]
+    expect(arg.data.id).toBe(sid)
+    expect(arg.data.userId).toBe('u1')
+    expect(arg.data.createdAt).toBeInstanceOf(Date)
+    expect(arg.data.lastSeenAt).toBeInstanceOf(Date)
+    expect(arg.data.revokedAt).toBeUndefined()
+  })
+
+  it('truncates an oversized user-agent instead of storing it whole', async () => {
+    createMock.mockResolvedValue({})
+    await createSession({ userId: 'u1', userAgent: 'x'.repeat(1000) })
+    expect(createMock.mock.calls[0][0].data.userAgent).toHaveLength(255)
+  })
+
+  it('accepts a null ip and user-agent', async () => {
+    createMock.mockResolvedValue({})
+    await createSession({ userId: 'u1' })
+    const d = createMock.mock.calls[0][0].data
+    expect(d.ipAddress).toBeNull()
+    expect(d.userAgent).toBeNull()
+  })
+})
+
+describe('touchSession is throttled so one API call is not one write', () => {
+  it('does not write when lastSeenAt is younger than the throttle', async () => {
+    await touchSession('sid1', NOW, row({ lastSeenAt: new Date(NOW.getTime() - 1000) }))
+    expect(updateManyMock).not.toHaveBeenCalled()
+  })
+
+  it('writes when lastSeenAt is older than the throttle', async () => {
+    updateManyMock.mockResolvedValue({ count: 1 })
+    await touchSession('sid1', NOW, row({ lastSeenAt: new Date(NOW.getTime() - TOUCH_THROTTLE_MS - 1) }))
+    expect(updateManyMock).toHaveBeenCalledOnce()
+    const arg = updateManyMock.mock.calls[0][0]
+    expect(arg.where.id).toBe('sid1')
+    // Scoped to a live row so a touch racing a revoke cannot resurrect it.
+    expect(arg.where.revokedAt).toBeNull()
+  })
+})
+
+describe('revocation', () => {
+  it('revokeSession is scoped to the owner and reports whether it hit', async () => {
+    updateManyMock.mockResolvedValue({ count: 1 })
+    await expect(revokeSession('sid1', 'u1')).resolves.toBe(true)
+    expect(updateManyMock.mock.calls[0][0].where).toMatchObject({
+      id: 'sid1', userId: 'u1', revokedAt: null,
+    })
+  })
+
+  it('revokeSession returns false when nothing matched (someone else\'s sid)', async () => {
+    updateManyMock.mockResolvedValue({ count: 0 })
+    await expect(revokeSession('sid-other', 'u1')).resolves.toBe(false)
+  })
+
+  it('revokeAllSessions can spare the current session', async () => {
+    updateManyMock.mockResolvedValue({ count: 3 })
+    await expect(revokeAllSessions('u1', 'sid-current')).resolves.toBe(3)
+    expect(updateManyMock.mock.calls[0][0].where).toMatchObject({
+      userId: 'u1', revokedAt: null, id: { not: 'sid-current' },
+    })
+  })
+
+  it('revokeAllSessions with no exception revokes every live row', async () => {
+    updateManyMock.mockResolvedValue({ count: 4 })
+    await revokeAllSessions('u1')
+    const where = updateManyMock.mock.calls[0][0].where
+    expect(where).toMatchObject({ userId: 'u1', revokedAt: null })
+    expect(where.id).toBeUndefined()
+  })
+})
+
+describe('countActiveSessions counts only live rows', () => {
+  it('excludes revoked, idle and over-cap rows', async () => {
+    countMock.mockResolvedValue(2)
+    await expect(countActiveSessions('u1')).resolves.toBe(2)
+    const where = countMock.mock.calls[0][0].where
+    expect(where.userId).toBe('u1')
+    expect(where.revokedAt).toBeNull()
+    expect(where.lastSeenAt).toHaveProperty('gt')
+    expect(where.createdAt).toHaveProperty('gt')
+  })
+})
+
+describe('purgeDeadSessions', () => {
+  it('deletes revoked OR idle OR over-cap rows and returns the count', async () => {
+    deleteManyMock.mockResolvedValue({ count: 7 })
+    await expect(purgeDeadSessions(NOW)).resolves.toBe(7)
+    const where = deleteManyMock.mock.calls[0][0].where
+    expect(where.OR).toHaveLength(3)
+  })
+})

--- a/frontend/src/lib/auth/sessions.test.ts
+++ b/frontend/src/lib/auth/sessions.test.ts
@@ -32,6 +32,7 @@ import {
   listSessions,
   revokeSession,
   revokeAllSessions,
+  revokeEverySession,
   purgeDeadSessions,
   countActiveSessions,
   TOUCH_THROTTLE_MS,
@@ -232,6 +233,20 @@ describe('revocation', () => {
     const where = updateManyMock.mock.calls[0][0].where
     expect(where).toMatchObject({ userId: 'u1', revokedAt: null })
     expect(where.id).toBeUndefined()
+  })
+
+  it('revokeEverySession can spare the caller\'s own current session', async () => {
+    updateManyMock.mockResolvedValue({ count: 7 })
+    await expect(revokeEverySession('keep-me')).resolves.toBe(7)
+    expect(updateManyMock.mock.calls[0][0].where).toEqual({
+      revokedAt: null, id: { not: 'keep-me' },
+    })
+  })
+
+  it('revokeEverySession with no exception revokes every live row installation-wide', async () => {
+    updateManyMock.mockResolvedValue({ count: 9 })
+    await expect(revokeEverySession()).resolves.toBe(9)
+    expect(updateManyMock.mock.calls[0][0].where).toEqual({ revokedAt: null })
   })
 })
 

--- a/frontend/src/lib/auth/sessions.test.ts
+++ b/frontend/src/lib/auth/sessions.test.ts
@@ -25,8 +25,11 @@ vi.mock('@/lib/db/prisma', () => ({
 
 import {
   evaluateSession,
+  aliveWhere,
+  isDeadPredicate,
   createSession,
   touchSession,
+  listSessions,
   revokeSession,
   revokeAllSessions,
   purgeDeadSessions,
@@ -85,6 +88,74 @@ describe('evaluateSession is pure and names why a session is dead', () => {
       lastSeenAt: new Date('2026-08-01T00:00:00.000Z'),
     })
     expect(evaluateSession(r, NOW)).toEqual({ alive: false, reason: 'revoked' })
+  })
+})
+
+// aliveWhere and isDeadPredicate are `where` fragments, not booleans, so we
+// can't call them on a row directly. `matchesClause` duck-types whichever
+// Prisma comparison operator (gt/gte/lt/lte) the fragment carries so these
+// assertions read the ACTUAL cutoff, not just that some operator key exists —
+// a shape-only assertion (e.g. `toHaveProperty('gt')`) cannot catch an
+// off-by-one operator error, which is exactly what happened here.
+type ComparisonClause = { gt?: Date; gte?: Date; lt?: Date; lte?: Date }
+const matchesClause = (value: Date, clause: ComparisonClause): boolean => {
+  const t = value.getTime()
+  if (clause.gt !== undefined && !(t > clause.gt.getTime())) return false
+  if (clause.gte !== undefined && !(t >= clause.gte.getTime())) return false
+  if (clause.lt !== undefined && !(t < clause.lt.getTime())) return false
+  if (clause.lte !== undefined && !(t <= clause.lte.getTime())) return false
+  return true
+}
+
+describe('aliveWhere and isDeadPredicate agree with evaluateSession at the exact threshold', () => {
+  const DURATIONS = { idleMs: 12 * 3600_000, absoluteMs: 7 * 86400_000 }
+
+  it('a row exactly at the idle cutoff is alive under all three', () => {
+    const lastSeenAt = new Date(NOW.getTime() - DURATIONS.idleMs)
+    const r = row({ lastSeenAt })
+    expect(evaluateSession(r, NOW, DURATIONS)).toEqual({ alive: true })
+
+    const alive = aliveWhere(NOW, DURATIONS) as { lastSeenAt: ComparisonClause }
+    expect(matchesClause(lastSeenAt, alive.lastSeenAt)).toBe(true)
+
+    const dead = isDeadPredicate(NOW, DURATIONS) as { OR: [unknown, { lastSeenAt: ComparisonClause }, unknown] }
+    expect(matchesClause(lastSeenAt, dead.OR[1].lastSeenAt)).toBe(false)
+  })
+
+  it('a row one millisecond past the idle cutoff is dead under all three', () => {
+    const lastSeenAt = new Date(NOW.getTime() - DURATIONS.idleMs - 1)
+    const r = row({ lastSeenAt })
+    expect(evaluateSession(r, NOW, DURATIONS)).toEqual({ alive: false, reason: 'idle' })
+
+    const alive = aliveWhere(NOW, DURATIONS) as { lastSeenAt: ComparisonClause }
+    expect(matchesClause(lastSeenAt, alive.lastSeenAt)).toBe(false)
+
+    const dead = isDeadPredicate(NOW, DURATIONS) as { OR: [unknown, { lastSeenAt: ComparisonClause }, unknown] }
+    expect(matchesClause(lastSeenAt, dead.OR[1].lastSeenAt)).toBe(true)
+  })
+
+  it('a row exactly at the absolute cutoff is alive under all three', () => {
+    const createdAt = new Date(NOW.getTime() - DURATIONS.absoluteMs)
+    const r = row({ createdAt, lastSeenAt: NOW })
+    expect(evaluateSession(r, NOW, DURATIONS)).toEqual({ alive: true })
+
+    const alive = aliveWhere(NOW, DURATIONS) as { createdAt: ComparisonClause }
+    expect(matchesClause(createdAt, alive.createdAt)).toBe(true)
+
+    const dead = isDeadPredicate(NOW, DURATIONS) as { OR: [unknown, unknown, { createdAt: ComparisonClause }] }
+    expect(matchesClause(createdAt, dead.OR[2].createdAt)).toBe(false)
+  })
+
+  it('a row one millisecond past the absolute cutoff is dead under all three', () => {
+    const createdAt = new Date(NOW.getTime() - DURATIONS.absoluteMs - 1)
+    const r = row({ createdAt, lastSeenAt: NOW })
+    expect(evaluateSession(r, NOW, DURATIONS)).toEqual({ alive: false, reason: 'absolute' })
+
+    const alive = aliveWhere(NOW, DURATIONS) as { createdAt: ComparisonClause }
+    expect(matchesClause(createdAt, alive.createdAt)).toBe(false)
+
+    const dead = isDeadPredicate(NOW, DURATIONS) as { OR: [unknown, unknown, { createdAt: ComparisonClause }] }
+    expect(matchesClause(createdAt, dead.OR[2].createdAt)).toBe(true)
   })
 })
 
@@ -164,6 +235,19 @@ describe('revocation', () => {
   })
 })
 
+describe('listSessions', () => {
+  it('scopes to userId and the alive predicate, ordered by lastSeenAt desc', async () => {
+    findManyMock.mockResolvedValue([])
+    await listSessions('u1')
+    const arg = findManyMock.mock.calls[0][0]
+    expect(arg.where.userId).toBe('u1')
+    expect(arg.where.revokedAt).toBeNull()
+    expect(arg.where.lastSeenAt).toBeTruthy()
+    expect(arg.where.createdAt).toBeTruthy()
+    expect(arg.orderBy).toEqual({ lastSeenAt: 'desc' })
+  })
+})
+
 describe('countActiveSessions counts only live rows', () => {
   it('excludes revoked, idle and over-cap rows', async () => {
     countMock.mockResolvedValue(2)
@@ -171,8 +255,8 @@ describe('countActiveSessions counts only live rows', () => {
     const where = countMock.mock.calls[0][0].where
     expect(where.userId).toBe('u1')
     expect(where.revokedAt).toBeNull()
-    expect(where.lastSeenAt).toHaveProperty('gt')
-    expect(where.createdAt).toHaveProperty('gt')
+    expect(where.lastSeenAt).toHaveProperty('gte')
+    expect(where.createdAt).toHaveProperty('gte')
   })
 })
 

--- a/frontend/src/lib/auth/sessions.ts
+++ b/frontend/src/lib/auth/sessions.ts
@@ -1,0 +1,156 @@
+// Server-side session store over the `sessions` table.
+//
+// The cookie remains a NextAuth JWT carrying this row's id as `sid`. What the
+// row adds is the ability to say "no" after the fact: revocation, an idle
+// timeout, and an absolute cap that activity cannot renew.
+//
+// Deadlines are derived from the CURRENT configuration at evaluation time, not
+// stored on the row, so raising or lowering a timeout applies to sessions that
+// are already open.
+import { nanoid } from "nanoid"
+
+import { prisma } from "@/lib/db/prisma"
+
+import { sessionDurations, type SessionDurations } from "./durations"
+
+/** A touch is at most one write per session per minute: this callback runs on every guarded request. */
+export const TOUCH_THROTTLE_MS = 60_000
+
+const USER_AGENT_MAX = 255
+
+export interface SessionRow {
+  id: string
+  userId: string
+  createdAt: Date
+  lastSeenAt: Date
+  revokedAt: Date | null
+  ipAddress: string | null
+  userAgent: string | null
+}
+
+export type DeadReason = "missing" | "revoked" | "idle" | "absolute"
+export type SessionVerdict = { alive: true } | { alive: false; reason: DeadReason }
+
+export function evaluateSession(
+  row: SessionRow | null | undefined,
+  now: Date = new Date(),
+  durations: SessionDurations = sessionDurations(),
+): SessionVerdict {
+  if (!row) return { alive: false, reason: "missing" }
+  if (row.revokedAt) return { alive: false, reason: "revoked" }
+  if (now.getTime() - row.createdAt.getTime() > durations.absoluteMs) {
+    return { alive: false, reason: "absolute" }
+  }
+  if (now.getTime() - row.lastSeenAt.getTime() > durations.idleMs) {
+    return { alive: false, reason: "idle" }
+  }
+  return { alive: true }
+}
+
+/** Prisma `where` fragment matching live rows. Mirrors evaluateSession. */
+export function aliveWhere(
+  now: Date = new Date(),
+  durations: SessionDurations = sessionDurations(),
+) {
+  return {
+    revokedAt: null,
+    lastSeenAt: { gt: new Date(now.getTime() - durations.idleMs) },
+    createdAt: { gt: new Date(now.getTime() - durations.absoluteMs) },
+  }
+}
+
+/** Prisma `where` fragment matching dead rows, for the purge. */
+export function isDeadPredicate(
+  now: Date = new Date(),
+  durations: SessionDurations = sessionDurations(),
+) {
+  return {
+    OR: [
+      { revokedAt: { not: null } },
+      { lastSeenAt: { lt: new Date(now.getTime() - durations.idleMs) } },
+      { createdAt: { lt: new Date(now.getTime() - durations.absoluteMs) } },
+    ],
+  }
+}
+
+export async function createSession(args: {
+  userId: string
+  ipAddress?: string | null
+  userAgent?: string | null
+}): Promise<string> {
+  const id = nanoid(32)
+  const now = new Date()
+
+  await prisma.session.create({
+    data: {
+      id,
+      userId: args.userId,
+      createdAt: now,
+      lastSeenAt: now,
+      ipAddress: args.ipAddress ?? null,
+      userAgent: args.userAgent ? args.userAgent.slice(0, USER_AGENT_MAX) : null,
+    },
+  })
+
+  return id
+}
+
+/**
+ * Refresh lastSeenAt, at most once per TOUCH_THROTTLE_MS per session.
+ *
+ * `known` lets the caller pass the row it has already read (the jwt callback
+ * always has it) so the throttle costs no extra query. The update is scoped to
+ * a live row so a touch racing a revoke cannot resurrect the session.
+ */
+export async function touchSession(
+  sid: string,
+  now: Date = new Date(),
+  known?: SessionRow | null,
+): Promise<void> {
+  if (known && now.getTime() - known.lastSeenAt.getTime() <= TOUCH_THROTTLE_MS) return
+
+  await prisma.session.updateMany({
+    where: { id: sid, revokedAt: null },
+    data: { lastSeenAt: now },
+  })
+}
+
+export async function listSessions(userId: string): Promise<SessionRow[]> {
+  return prisma.session.findMany({
+    where: { userId, ...aliveWhere() },
+    orderBy: { lastSeenAt: "desc" },
+  }) as unknown as Promise<SessionRow[]>
+}
+
+export async function countActiveSessions(userId: string): Promise<number> {
+  return prisma.session.count({ where: { userId, ...aliveWhere() } })
+}
+
+/** Scoped to the owner: another user's sid must be indistinguishable from a missing one. */
+export async function revokeSession(sid: string, userId: string): Promise<boolean> {
+  const res = await prisma.session.updateMany({
+    where: { id: sid, userId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  })
+  return res.count > 0
+}
+
+export async function revokeAllSessions(
+  userId: string,
+  exceptSid?: string | null,
+): Promise<number> {
+  const res = await prisma.session.updateMany({
+    where: {
+      userId,
+      revokedAt: null,
+      ...(exceptSid ? { id: { not: exceptSid } } : {}),
+    },
+    data: { revokedAt: new Date() },
+  })
+  return res.count
+}
+
+export async function purgeDeadSessions(now: Date = new Date()): Promise<number> {
+  const res = await prisma.session.deleteMany({ where: isDeadPredicate(now) })
+  return res.count
+}

--- a/frontend/src/lib/auth/sessions.ts
+++ b/frontend/src/lib/auth/sessions.ts
@@ -156,6 +156,23 @@ export async function revokeAllSessions(
   return res.count
 }
 
+/**
+ * Installation-wide revoke: every live session of every user, except the
+ * caller's own current one when provided. The exception is the point — this
+ * backs the admin "everyone out" incident button, and signing the operator
+ * out mid-incident would only slow the response.
+ */
+export async function revokeEverySession(exceptSid?: string | null): Promise<number> {
+  const res = await prisma.session.updateMany({
+    where: {
+      revokedAt: null,
+      ...(exceptSid ? { id: { not: exceptSid } } : {}),
+    },
+    data: { revokedAt: new Date() },
+  })
+  return res.count
+}
+
 export async function purgeDeadSessions(now: Date = new Date()): Promise<number> {
   const res = await prisma.session.deleteMany({ where: isDeadPredicate(now) })
   return res.count

--- a/frontend/src/lib/auth/sessions.ts
+++ b/frontend/src/lib/auth/sessions.ts
@@ -157,17 +157,14 @@ export async function revokeAllSessions(
 }
 
 /**
- * Installation-wide revoke: every live session of every user, except the
- * caller's own current one when provided. The exception is the point — this
- * backs the admin "everyone out" incident button, and signing the operator
- * out mid-incident would only slow the response.
+ * Installation-wide revoke: every live session of every user, the caller's
+ * own included. Total by design — this backs the admin "everyone out"
+ * button, and the UI's next act is to send the caller to /login through the
+ * same deterministic redirect as every other self-revocation flow.
  */
-export async function revokeEverySession(exceptSid?: string | null): Promise<number> {
+export async function revokeEverySession(): Promise<number> {
   const res = await prisma.session.updateMany({
-    where: {
-      revokedAt: null,
-      ...(exceptSid ? { id: { not: exceptSid } } : {}),
-    },
+    where: { revokedAt: null },
     data: { revokedAt: new Date() },
   })
   return res.count

--- a/frontend/src/lib/auth/sessions.ts
+++ b/frontend/src/lib/auth/sessions.ts
@@ -54,8 +54,14 @@ export function aliveWhere(
 ) {
   return {
     revokedAt: null,
-    lastSeenAt: { gt: new Date(now.getTime() - durations.idleMs) },
-    createdAt: { gt: new Date(now.getTime() - durations.absoluteMs) },
+    // gte, not gt: evaluateSession treats a row exactly at the cutoff as
+    // still alive (it only kills a row once elapsed time is STRICTLY
+    // greater than the duration), and isDeadPredicate below only kills a
+    // row once elapsed time is strictly less than the cutoff (lt). gte is
+    // the exact complement of that lt, so a row sits in exactly one of
+    // aliveWhere/isDeadPredicate at every instant, never neither.
+    lastSeenAt: { gte: new Date(now.getTime() - durations.idleMs) },
+    createdAt: { gte: new Date(now.getTime() - durations.absoluteMs) },
   }
 }
 

--- a/frontend/src/lib/auth/sessions.ts
+++ b/frontend/src/lib/auth/sessions.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid"
 
 import { prisma } from "@/lib/db/prisma"
 
-import { sessionDurations, type SessionDurations } from "./durations"
+import { isPastAbsoluteCap, sessionDurations, type SessionDurations } from "./durations"
 
 /** A touch is at most one write per session per minute: this callback runs on every guarded request. */
 export const TOUCH_THROTTLE_MS = 60_000
@@ -38,7 +38,7 @@ export function evaluateSession(
 ): SessionVerdict {
   if (!row) return { alive: false, reason: "missing" }
   if (row.revokedAt) return { alive: false, reason: "revoked" }
-  if (now.getTime() - row.createdAt.getTime() > durations.absoluteMs) {
+  if (isPastAbsoluteCap(row.createdAt.getTime(), now.getTime(), durations)) {
     return { alive: false, reason: "absolute" }
   }
   if (now.getTime() - row.lastSeenAt.getTime() > durations.idleMs) {

--- a/frontend/src/lib/rbac/userTargetGuards.ts
+++ b/frontend/src/lib/rbac/userTargetGuards.ts
@@ -1,0 +1,51 @@
+// src/lib/rbac/userTargetGuards.ts
+//
+// Shared authorization guards for any admin route that acts on a specific
+// target user id after `checkPermission(PERMISSIONS.ADMIN_USERS)` passes.
+// That permission check alone only proves the caller holds admin.users
+// somewhere — it says nothing about which target user they may act on, so
+// every route touching a target id layers these two rules on top of it:
+//
+//   1. denyIfTargetIsProtectedAndCallerIsNot — a tenant-scoped admin must
+//      never be able to act on a super_admin/provider_admin account.
+//   2. findUserInTenant (+ the provider-view bypass callers apply around
+//      it) — a tenant-scoped admin must never reach a user outside their
+//      own tenant.
+//
+// Originally three private copies inside users/[id]/route.ts (GET, PATCH,
+// DELETE each called the same two checks). Extracted here so every route
+// enforcing "admin acting on a target user" — including
+// admin/users/[id]/sessions — shares one implementation instead of
+// re-deriving an authorization rule that could drift between copies.
+import { NextResponse } from "next/server"
+
+import { prisma } from "@/lib/db/prisma"
+import { isUserProtected, isUserSuperAdmin } from "@/lib/rbac"
+
+/**
+ * Hide provider-level accounts (super_admin + provider_admin) from
+ * non-super-admin callers. Returns 404 rather than 403 so existence is not
+ * leaked.
+ */
+export async function denyIfTargetIsProtectedAndCallerIsNot(
+  targetUserId: string,
+  callerUserId: string | undefined
+): Promise<NextResponse | null> {
+  if (!(await isUserProtected(targetUserId))) return null
+  if (callerUserId && (await isUserSuperAdmin(callerUserId))) return null
+  return NextResponse.json({ error: "Utilisateur non trouvé" }, { status: 404 })
+}
+
+/**
+ * Fetch a user that belongs to the given tenant. Returns the full Prisma row
+ * or null if the user doesn't exist or has no membership in this tenant.
+ * Centralised so every route scoping a target user to the caller's tenant
+ * uses the same lookup rule.
+ */
+export async function findUserInTenant(userId: string, tenantId: string) {
+  const membership = await prisma.userTenant.findUnique({
+    where: { userId_tenantId: { userId, tenantId } },
+    include: { user: true },
+  })
+  return membership?.user ?? null
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7262,7 +7262,11 @@
     "revokeConfirmBody": "This device will be signed out immediately.",
     "revokeAllButton": "Sign out other sessions",
     "revokeAllConfirmTitle": "Sign out all other sessions?",
-    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Revoke sessions",
+    "adminRevokeConfirmTitle": "Revoke sessions for {email}",
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7281,7 +7281,7 @@
     "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
     "adminRevokeEveryButton": "Revoke all sessions",
     "adminRevokeEveryConfirmTitle": "Revoke every session?",
-    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation, including yourself. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7250,6 +7250,20 @@
     "policyToggleHelp": "Sobald aktiviert, müssen sich super_admin-Nutzer ohne 2FA bei der nächsten Anmeldung registrieren. Sie müssen 2FA auf Ihrem eigenen Konto bereits aktiviert haben, um diese Richtlinie zu aktivieren.",
     "policyNeedOwn2fa": "Aktivieren Sie zuerst 2FA auf Ihrem eigenen Konto, bevor Sie diese Richtlinie durchsetzen."
   },
+  "sessions": {
+    "cardTitle": "Active sessions",
+    "empty": "No active sessions.",
+    "currentChip": "This device",
+    "ipLabel": "IP address",
+    "lastActiveLabel": "Last active",
+    "signedInLabel": "Signed in",
+    "revokeButton": "Sign out",
+    "revokeConfirmTitle": "Sign out this session?",
+    "revokeConfirmBody": "This device will be signed out immediately.",
+    "revokeAllButton": "Sign out other sessions",
+    "revokeAllConfirmTitle": "Sign out all other sessions?",
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+  },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",
     "failed": "{description} - Fehlgeschlagen: {error}",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7266,7 +7266,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Revoke sessions",
     "adminRevokeConfirmTitle": "Revoke sessions for {email}",
-    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away.",
+    "adminAllTab": "All sessions",
+    "adminAllEmptyTitle": "No active sessions",
+    "adminAllEmptyDesc": "There are no active sessions in this installation right now.",
+    "userHeader": "User",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Device",
+    "adminRevokeOneMenu": "Revoke session",
+    "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7278,7 +7278,10 @@
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
     "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
-    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
+    "adminRevokeEveryButton": "Revoke all sessions",
+    "adminRevokeEveryConfirmTitle": "Revoke every session?",
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7275,7 +7275,9 @@
     "deviceHeader": "Device",
     "adminRevokeOneMenu": "Revoke session",
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
-    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
+    "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7277,7 +7277,8 @@
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
-    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Abgeschlossen",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7420,7 +7420,8 @@
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
-    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7405,7 +7405,11 @@
     "revokeConfirmBody": "This device will be signed out immediately.",
     "revokeAllButton": "Sign out other sessions",
     "revokeAllConfirmTitle": "Sign out all other sessions?",
-    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Revoke sessions",
+    "adminRevokeConfirmTitle": "Revoke sessions for {email}",
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7421,7 +7421,10 @@
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
     "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
-    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
+    "adminRevokeEveryButton": "Revoke all sessions",
+    "adminRevokeEveryConfirmTitle": "Revoke every session?",
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7418,7 +7418,9 @@
     "deviceHeader": "Device",
     "adminRevokeOneMenu": "Revoke session",
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
-    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
+    "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7393,6 +7393,20 @@
     "policyToggleHelp": "Once enabled, super_admin users without 2FA will be forced to enroll on their next login. You must already have 2FA enabled on your own account to turn this on.",
     "policyNeedOwn2fa": "Enable 2FA on your own account before enforcing this policy."
   },
+  "sessions": {
+    "cardTitle": "Active sessions",
+    "empty": "No active sessions.",
+    "currentChip": "This device",
+    "ipLabel": "IP address",
+    "lastActiveLabel": "Last active",
+    "signedInLabel": "Signed in",
+    "revokeButton": "Sign out",
+    "revokeConfirmTitle": "Sign out this session?",
+    "revokeConfirmBody": "This device will be signed out immediately.",
+    "revokeAllButton": "Sign out other sessions",
+    "revokeAllConfirmTitle": "Sign out all other sessions?",
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+  },
   "taskTracker": {
     "completed": "{description} - Completed",
     "failed": "{description} - Failed: {error}",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7424,7 +7424,7 @@
     "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
     "adminRevokeEveryButton": "Revoke all sessions",
     "adminRevokeEveryConfirmTitle": "Revoke every session?",
-    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation, including yourself. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7409,7 +7409,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Revoke sessions",
     "adminRevokeConfirmTitle": "Revoke sessions for {email}",
-    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away.",
+    "adminAllTab": "All sessions",
+    "adminAllEmptyTitle": "No active sessions",
+    "adminAllEmptyDesc": "There are no active sessions in this installation right now.",
+    "userHeader": "User",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Device",
+    "adminRevokeOneMenu": "Revoke session",
+    "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completed",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7393,6 +7393,20 @@
     "policyToggleHelp": "Una vez habilitado, los usuarios super_admin sin 2FA estarán obligados a registrarse en su próximo login. Debes tener ya 2FA habilitado en tu propia cuenta para activarlo.",
     "policyNeedOwn2fa": "Habilita 2FA en tu propia cuenta antes de aplicar esta política."
   },
+  "sessions": {
+    "cardTitle": "Active sessions",
+    "empty": "No active sessions.",
+    "currentChip": "This device",
+    "ipLabel": "IP address",
+    "lastActiveLabel": "Last active",
+    "signedInLabel": "Signed in",
+    "revokeButton": "Sign out",
+    "revokeConfirmTitle": "Sign out this session?",
+    "revokeConfirmBody": "This device will be signed out immediately.",
+    "revokeAllButton": "Sign out other sessions",
+    "revokeAllConfirmTitle": "Sign out all other sessions?",
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+  },
   "taskTracker": {
     "completed": "{description} - Completado",
     "failed": "{description} - Error: {error}",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7424,7 +7424,7 @@
     "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
     "adminRevokeEveryButton": "Revoke all sessions",
     "adminRevokeEveryConfirmTitle": "Revoke every session?",
-    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation, including yourself. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7409,7 +7409,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Revoke sessions",
     "adminRevokeConfirmTitle": "Revoke sessions for {email}",
-    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away.",
+    "adminAllTab": "All sessions",
+    "adminAllEmptyTitle": "No active sessions",
+    "adminAllEmptyDesc": "There are no active sessions in this installation right now.",
+    "userHeader": "User",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Device",
+    "adminRevokeOneMenu": "Revoke session",
+    "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7421,7 +7421,10 @@
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
     "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
-    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
+    "adminRevokeEveryButton": "Revoke all sessions",
+    "adminRevokeEveryConfirmTitle": "Revoke every session?",
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7405,7 +7405,11 @@
     "revokeConfirmBody": "This device will be signed out immediately.",
     "revokeAllButton": "Sign out other sessions",
     "revokeAllConfirmTitle": "Sign out all other sessions?",
-    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Revoke sessions",
+    "adminRevokeConfirmTitle": "Revoke sessions for {email}",
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7420,7 +7420,8 @@
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
-    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7418,7 +7418,9 @@
     "deviceHeader": "Device",
     "adminRevokeOneMenu": "Revoke session",
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
-    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
+    "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - Completado",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7422,7 +7422,10 @@
     "adminRevokeOneConfirmBody": "Cela déconnecte immédiatement cet appareil. L'utilisateur pourra se reconnecter à tout moment.",
     "adminAllTruncatedWarning": "Affichage des 500 sessions les plus récemment actives. Cette installation compte davantage de sessions actives : certaines ne sont pas affichées.",
     "adminRevokeOwnConfirmWarning": "Il s'agit de votre propre session actuelle. Confirmer vous déconnectera immédiatement.",
-    "adminRevokeAllOwnConfirmWarning": "Cela inclut votre session actuelle. Confirmer vous déconnectera immédiatement."
+    "adminRevokeAllOwnConfirmWarning": "Cela inclut votre session actuelle. Confirmer vous déconnectera immédiatement.",
+    "adminRevokeEveryButton": "Révoquer toutes les sessions",
+    "adminRevokeEveryConfirmTitle": "Révoquer toutes les sessions ?",
+    "adminRevokeEveryConfirmBody": "Cela déconnecte immédiatement tous les utilisateurs de l'installation. Votre session actuelle est conservée. Chacun peut se reconnecter aussitôt."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7410,7 +7410,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Révoquer les sessions",
     "adminRevokeConfirmTitle": "Révoquer les sessions de {email}",
-    "adminRevokeConfirmBody": "Cela déconnecte immédiatement l'utilisateur de toutes ses sessions actives. Il pourra se reconnecter à tout moment."
+    "adminRevokeConfirmBody": "Cela déconnecte immédiatement l'utilisateur de toutes ses sessions actives. Il pourra se reconnecter à tout moment.",
+    "adminAllTab": "Toutes les sessions",
+    "adminAllEmptyTitle": "Aucune session active",
+    "adminAllEmptyDesc": "Il n'y a actuellement aucune session active dans cette installation.",
+    "userHeader": "Utilisateur",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Appareil",
+    "adminRevokeOneMenu": "Révoquer la session",
+    "adminRevokeOneConfirmTitle": "Révoquer la session de {email} ?",
+    "adminRevokeOneConfirmBody": "Cela déconnecte immédiatement cet appareil. L'utilisateur pourra se reconnecter à tout moment."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7394,6 +7394,20 @@
     "policyToggleHelp": "Une fois activé, les comptes super_admin sans 2FA seront forcés de l'activer à leur prochaine connexion. Vous devez avoir la 2FA active sur votre propre compte pour activer cette policy.",
     "policyNeedOwn2fa": "Activez la 2FA sur votre propre compte avant d'imposer cette policy."
   },
+  "sessions": {
+    "cardTitle": "Sessions actives",
+    "empty": "Aucune session active.",
+    "currentChip": "Cet appareil",
+    "ipLabel": "Adresse IP",
+    "lastActiveLabel": "Dernière activité",
+    "signedInLabel": "Connecté depuis",
+    "revokeButton": "Déconnecter",
+    "revokeConfirmTitle": "Déconnecter cette session ?",
+    "revokeConfirmBody": "Cet appareil sera déconnecté immédiatement.",
+    "revokeAllButton": "Déconnecter les autres sessions",
+    "revokeAllConfirmTitle": "Déconnecter toutes les autres sessions ?",
+    "revokeAllConfirmBody": "Toutes les autres sessions sont déconnectées immédiatement. Cet appareil reste connecté."
+  },
   "taskTracker": {
     "completed": "{description} - Terminé",
     "failed": "{description} - Échec : {error}",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7425,7 +7425,7 @@
     "adminRevokeAllOwnConfirmWarning": "Cela inclut votre session actuelle. Confirmer vous déconnectera immédiatement.",
     "adminRevokeEveryButton": "Révoquer toutes les sessions",
     "adminRevokeEveryConfirmTitle": "Révoquer toutes les sessions ?",
-    "adminRevokeEveryConfirmBody": "Cela déconnecte immédiatement tous les utilisateurs de l'installation. Votre session actuelle est conservée. Chacun peut se reconnecter aussitôt."
+    "adminRevokeEveryConfirmBody": "Cela déconnecte immédiatement tous les utilisateurs de l'installation, vous y compris. Chacun peut se reconnecter aussitôt."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7406,7 +7406,11 @@
     "revokeConfirmBody": "Cet appareil sera déconnecté immédiatement.",
     "revokeAllButton": "Déconnecter les autres sessions",
     "revokeAllConfirmTitle": "Déconnecter toutes les autres sessions ?",
-    "revokeAllConfirmBody": "Toutes les autres sessions sont déconnectées immédiatement. Cet appareil reste connecté."
+    "revokeAllConfirmBody": "Toutes les autres sessions sont déconnectées immédiatement. Cet appareil reste connecté.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Révoquer les sessions",
+    "adminRevokeConfirmTitle": "Révoquer les sessions de {email}",
+    "adminRevokeConfirmBody": "Cela déconnecte immédiatement l'utilisateur de toutes ses sessions actives. Il pourra se reconnecter à tout moment."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7421,7 +7421,8 @@
     "adminRevokeOneConfirmTitle": "Révoquer la session de {email} ?",
     "adminRevokeOneConfirmBody": "Cela déconnecte immédiatement cet appareil. L'utilisateur pourra se reconnecter à tout moment.",
     "adminAllTruncatedWarning": "Affichage des 500 sessions les plus récemment actives. Cette installation compte davantage de sessions actives : certaines ne sont pas affichées.",
-    "adminRevokeOwnConfirmWarning": "Il s'agit de votre propre session actuelle. Confirmer vous déconnectera immédiatement."
+    "adminRevokeOwnConfirmWarning": "Il s'agit de votre propre session actuelle. Confirmer vous déconnectera immédiatement.",
+    "adminRevokeAllOwnConfirmWarning": "Cela inclut votre session actuelle. Confirmer vous déconnectera immédiatement."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7419,7 +7419,9 @@
     "deviceHeader": "Appareil",
     "adminRevokeOneMenu": "Révoquer la session",
     "adminRevokeOneConfirmTitle": "Révoquer la session de {email} ?",
-    "adminRevokeOneConfirmBody": "Cela déconnecte immédiatement cet appareil. L'utilisateur pourra se reconnecter à tout moment."
+    "adminRevokeOneConfirmBody": "Cela déconnecte immédiatement cet appareil. L'utilisateur pourra se reconnecter à tout moment.",
+    "adminAllTruncatedWarning": "Affichage des 500 sessions les plus récemment actives. Cette installation compte davantage de sessions actives : certaines ne sont pas affichées.",
+    "adminRevokeOwnConfirmWarning": "Il s'agit de votre propre session actuelle. Confirmer vous déconnectera immédiatement."
   },
   "taskTracker": {
     "completed": "{description} - Terminé",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7420,7 +7420,8 @@
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
-    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7424,7 +7424,7 @@
     "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
     "adminRevokeEveryButton": "Revoke all sessions",
     "adminRevokeEveryConfirmTitle": "Revoke every session?",
-    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation, including yourself. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7405,7 +7405,11 @@
     "revokeConfirmBody": "This device will be signed out immediately.",
     "revokeAllButton": "Sign out other sessions",
     "revokeAllConfirmTitle": "Sign out all other sessions?",
-    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Revoke sessions",
+    "adminRevokeConfirmTitle": "Revoke sessions for {email}",
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7393,6 +7393,20 @@
     "policyToggleHelp": "활성화하면 2FA가 없는 super_admin 사용자는 다음 로그인 시 강제로 등록해야 합니다. 이 옵션을 켜려면 먼저 본인 계정에 2FA가 활성화되어 있어야 합니다.",
     "policyNeedOwn2fa": "이 정책을 적용하기 전에 본인 계정에서 2FA를 활성화하세요."
   },
+  "sessions": {
+    "cardTitle": "Active sessions",
+    "empty": "No active sessions.",
+    "currentChip": "This device",
+    "ipLabel": "IP address",
+    "lastActiveLabel": "Last active",
+    "signedInLabel": "Signed in",
+    "revokeButton": "Sign out",
+    "revokeConfirmTitle": "Sign out this session?",
+    "revokeConfirmBody": "This device will be signed out immediately.",
+    "revokeAllButton": "Sign out other sessions",
+    "revokeAllConfirmTitle": "Sign out all other sessions?",
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+  },
   "taskTracker": {
     "completed": "{description} - 완료됨",
     "failed": "{description} - 실패: {error}",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7409,7 +7409,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Revoke sessions",
     "adminRevokeConfirmTitle": "Revoke sessions for {email}",
-    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away.",
+    "adminAllTab": "All sessions",
+    "adminAllEmptyTitle": "No active sessions",
+    "adminAllEmptyDesc": "There are no active sessions in this installation right now.",
+    "userHeader": "User",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Device",
+    "adminRevokeOneMenu": "Revoke session",
+    "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7418,7 +7418,9 @@
     "deviceHeader": "Device",
     "adminRevokeOneMenu": "Revoke session",
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
-    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
+    "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7421,7 +7421,10 @@
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
     "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
-    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
+    "adminRevokeEveryButton": "Revoke all sessions",
+    "adminRevokeEveryConfirmTitle": "Revoke every session?",
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 완료됨",

--- a/frontend/src/messages/sessionsMessages.test.ts
+++ b/frontend/src/messages/sessionsMessages.test.ts
@@ -63,6 +63,9 @@ describe('sessions message namespace', () => {
       'adminAllTruncatedWarning',
       'adminRevokeOwnConfirmWarning',
       'adminRevokeAllOwnConfirmWarning',
+      'adminRevokeEveryButton',
+      'adminRevokeEveryConfirmTitle',
+      'adminRevokeEveryConfirmBody',
     ]) {
       expect(reference).toContain(required)
     }

--- a/frontend/src/messages/sessionsMessages.test.ts
+++ b/frontend/src/messages/sessionsMessages.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+
+import en from './en.json'
+import fr from './fr.json'
+import de from './de.json'
+import zhCN from './zh-CN.json'
+import ko from './ko.json'
+import es from './es.json'
+
+type Messages = Record<string, unknown>
+
+function keyPaths(obj: Messages, prefix = ''): string[] {
+  const out: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (value && typeof value === 'object') {
+      out.push(...keyPaths(value as Messages, path))
+    } else {
+      out.push(path)
+    }
+  }
+  return out.sort()
+}
+
+const locales: Array<[string, Messages]> = [
+  ['fr', fr as Messages],
+  ['de', de as Messages],
+  ['zh-CN', zhCN as Messages],
+  ['ko', ko as Messages],
+  ['es', es as Messages],
+]
+
+describe('sessions message namespace', () => {
+  const reference = keyPaths((en as Messages).sessions as Messages)
+
+  it('en defines the full sessions key inventory', () => {
+    for (const required of [
+      'cardTitle',
+      'empty',
+      'currentChip',
+      'ipLabel',
+      'lastActiveLabel',
+      'signedInLabel',
+      'revokeButton',
+      'revokeConfirmTitle',
+      'revokeConfirmBody',
+      'revokeAllButton',
+      'revokeAllConfirmTitle',
+      'revokeAllConfirmBody',
+      'columnHeader',
+      'adminRevokeMenu',
+      'adminRevokeConfirmTitle',
+      'adminRevokeConfirmBody',
+    ]) {
+      expect(reference).toContain(required)
+    }
+  })
+
+  for (const [name, messages] of locales) {
+    it(`${name} has exactly the same sessions keys as en`, () => {
+      expect(messages.sessions, `${name}.json is missing the top-level "sessions" section`).toBeDefined()
+      expect(keyPaths(messages.sessions as Messages)).toEqual(reference)
+    })
+  }
+})

--- a/frontend/src/messages/sessionsMessages.test.ts
+++ b/frontend/src/messages/sessionsMessages.test.ts
@@ -62,6 +62,7 @@ describe('sessions message namespace', () => {
       'adminRevokeOneConfirmBody',
       'adminAllTruncatedWarning',
       'adminRevokeOwnConfirmWarning',
+      'adminRevokeAllOwnConfirmWarning',
     ]) {
       expect(reference).toContain(required)
     }

--- a/frontend/src/messages/sessionsMessages.test.ts
+++ b/frontend/src/messages/sessionsMessages.test.ts
@@ -51,6 +51,15 @@ describe('sessions message namespace', () => {
       'adminRevokeMenu',
       'adminRevokeConfirmTitle',
       'adminRevokeConfirmBody',
+      'adminAllTab',
+      'adminAllEmptyTitle',
+      'adminAllEmptyDesc',
+      'userHeader',
+      'tenantHeader',
+      'deviceHeader',
+      'adminRevokeOneMenu',
+      'adminRevokeOneConfirmTitle',
+      'adminRevokeOneConfirmBody',
     ]) {
       expect(reference).toContain(required)
     }

--- a/frontend/src/messages/sessionsMessages.test.ts
+++ b/frontend/src/messages/sessionsMessages.test.ts
@@ -60,6 +60,8 @@ describe('sessions message namespace', () => {
       'adminRevokeOneMenu',
       'adminRevokeOneConfirmTitle',
       'adminRevokeOneConfirmBody',
+      'adminAllTruncatedWarning',
+      'adminRevokeOwnConfirmWarning',
     ]) {
       expect(reference).toContain(required)
     }

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7281,7 +7281,10 @@
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
     "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
-    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
+    "adminRevokeEveryButton": "Revoke all sessions",
+    "adminRevokeEveryConfirmTitle": "Revoke every session?",
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7280,7 +7280,8 @@
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
     "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
     "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
-    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately.",
+    "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7278,7 +7278,9 @@
     "deviceHeader": "Device",
     "adminRevokeOneMenu": "Revoke session",
     "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
-    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away.",
+    "adminAllTruncatedWarning": "Showing the 500 most recently active sessions. This installation has more live sessions than that — some are not shown.",
+    "adminRevokeOwnConfirmWarning": "This is your own current session. Confirming will sign you out immediately."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7284,7 +7284,7 @@
     "adminRevokeAllOwnConfirmWarning": "This includes your own current session. Confirming will sign you out immediately.",
     "adminRevokeEveryButton": "Revoke all sessions",
     "adminRevokeEveryConfirmTitle": "Revoke every session?",
-    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation. Your own current session is kept. Everyone can sign back in right away."
+    "adminRevokeEveryConfirmBody": "This immediately signs out every user of the installation, including yourself. Everyone can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7265,7 +7265,11 @@
     "revokeConfirmBody": "This device will be signed out immediately.",
     "revokeAllButton": "Sign out other sessions",
     "revokeAllConfirmTitle": "Sign out all other sessions?",
-    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in.",
+    "columnHeader": "Sessions",
+    "adminRevokeMenu": "Revoke sessions",
+    "adminRevokeConfirmTitle": "Revoke sessions for {email}",
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7253,6 +7253,20 @@
     "policyToggleHelp": "启用后,未启用 2FA 的 super_admin 用户在下次登录时将被强制完成绑定。您必须先在自己的账户上启用 2FA,才能开启此策略。",
     "policyNeedOwn2fa": "在强制此策略之前,请先在您自己的账户上启用 2FA。"
   },
+  "sessions": {
+    "cardTitle": "Active sessions",
+    "empty": "No active sessions.",
+    "currentChip": "This device",
+    "ipLabel": "IP address",
+    "lastActiveLabel": "Last active",
+    "signedInLabel": "Signed in",
+    "revokeButton": "Sign out",
+    "revokeConfirmTitle": "Sign out this session?",
+    "revokeConfirmBody": "This device will be signed out immediately.",
+    "revokeAllButton": "Sign out other sessions",
+    "revokeAllConfirmTitle": "Sign out all other sessions?",
+    "revokeAllConfirmBody": "Every other session is signed out immediately. This device stays signed in."
+  },
   "taskTracker": {
     "completed": "{description} - 已完成",
     "failed": "{description} - 失败：{error}",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7269,7 +7269,16 @@
     "columnHeader": "Sessions",
     "adminRevokeMenu": "Revoke sessions",
     "adminRevokeConfirmTitle": "Revoke sessions for {email}",
-    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away."
+    "adminRevokeConfirmBody": "This immediately signs the user out of every active session. They can sign back in right away.",
+    "adminAllTab": "All sessions",
+    "adminAllEmptyTitle": "No active sessions",
+    "adminAllEmptyDesc": "There are no active sessions in this installation right now.",
+    "userHeader": "User",
+    "tenantHeader": "Tenant",
+    "deviceHeader": "Device",
+    "adminRevokeOneMenu": "Revoke session",
+    "adminRevokeOneConfirmTitle": "Revoke session for {email}?",
+    "adminRevokeOneConfirmBody": "This immediately signs this device out. The user can sign back in right away."
   },
   "taskTracker": {
     "completed": "{description} - 已完成",

--- a/frontend/src/middleware.authAt.test.ts
+++ b/frontend/src/middleware.authAt.test.ts
@@ -54,21 +54,31 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
     expect(res?.headers.get('location')).toBeNull()
   })
 
-  it('never redirects /api/auth/* (NextAuth machinery) even with an expired authAt', async () => {
+  // The two tests below pin ROUTING SEPARATION, not the authAt gate itself.
+  // Both paths have isApiPath === true, so they short-circuit in the
+  // public-route check (isPublicRoute / isPublicApiRoute) before the
+  // page-navigation branch that holds the authAt check above is ever
+  // reached — getToken is never even called for them. They exist to catch a
+  // future refactor that accidentally merges the API and page branches and
+  // lets the authAt redirect leak onto API routes (which expect JSON, not a
+  // redirect).
+  it('routes /api/auth/* through the public-route short-circuit, never reaching the authAt check', async () => {
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
     const res = await middleware(req('/api/auth/session'))
 
     expect(res?.headers.get('location')).toBeNull()
+    expect(getTokenMock).not.toHaveBeenCalled()
   })
 
-  it('never redirects a public API allowlist route even with an expired authAt', async () => {
+  it('routes the public API allowlist through the same short-circuit, never reaching the authAt check', async () => {
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
     const res = await middleware(req('/api/health'))
 
     expect(res?.headers.get('location')).toBeNull()
+    expect(getTokenMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/middleware.authAt.test.ts
+++ b/frontend/src/middleware.authAt.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+const { getTokenMock } = vi.hoisted(() => ({
+  getTokenMock: vi.fn<() => Promise<any>>(),
+}))
+
+vi.mock('next-auth/jwt', () => ({ getToken: getTokenMock }))
+
+import { NextRequest } from 'next/server'
+
+import { middleware } from './middleware'
+
+afterEach(() => {
+  vi.clearAllMocks()
+  delete process.env.SESSION_ABSOLUTE_TIMEOUT
+})
+
+const req = (path: string) => new NextRequest(new URL(`http://h:3000${path}`))
+
+describe('middleware enforces the absolute cap from authAt, with no DB access', () => {
+  it('redirects to /login when authAt is past the cap', async () => {
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
+
+    const res = await middleware(req('/dashboard'))
+
+    expect(res?.status).toBe(307)
+    expect(res?.headers.get('location')).toContain('/login')
+  })
+
+  it('lets a recent authAt through', async () => {
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 60_000 })
+
+    const res = await middleware(req('/dashboard'))
+
+    expect(res?.headers.get('location')).toBeNull()
+  })
+
+  it('lets a token with no authAt through, leaving refusal to the read path', async () => {
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1' })
+
+    const res = await middleware(req('/dashboard'))
+
+    expect(res?.headers.get('location')).toBeNull()
+  })
+
+  it('never redirects /login itself, so an expired session cannot loop', async () => {
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
+
+    const res = await middleware(req('/login'))
+
+    expect(res?.headers.get('location')).toBeNull()
+  })
+
+  it('never redirects /api/auth/* (NextAuth machinery) even with an expired authAt', async () => {
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
+
+    const res = await middleware(req('/api/auth/session'))
+
+    expect(res?.headers.get('location')).toBeNull()
+  })
+
+  it('never redirects a public API allowlist route even with an expired authAt', async () => {
+    process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
+    getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
+
+    const res = await middleware(req('/api/health'))
+
+    expect(res?.headers.get('location')).toBeNull()
+  })
+})

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,7 +6,7 @@ import { getToken } from "next-auth/jwt"
 
 import { matchPublicApiPath } from "@/lib/api-tokens/allowlist"
 import { sessionCookieName } from "@/lib/auth/cookies"
-import { sessionDurations } from "@/lib/auth/durations"
+import { isPastAbsoluteCap } from "@/lib/auth/durations"
 
 const AUTH_SECRET = process.env.NEXTAUTH_SECRET || ""
 
@@ -288,13 +288,16 @@ export async function middleware(request: NextRequest) {
     // only decodes the JWT (jwt/index.js:118) — no callbacks, so the read-path
     // validation never runs for the middleware. authAt makes the one deadline
     // that matters against a stolen cookie enforceable with pure arithmetic,
-    // keeping this file Prisma-free and Edge-valid.
+    // keeping this file Prisma-free and Edge-valid. isPastAbsoluteCap is the
+    // same predicate lib/auth/sessions.ts:evaluateSession uses for the DB-backed
+    // row's createdAt, so the two never drift into separately-worded copies of
+    // one rule.
     //
     // A token without authAt is left alone: the read path refuses it anyway,
     // and redirecting here as well risks a loop. This code only runs past the
     // isPublicRoute early-return above, so /login itself can never be
     // redirected by this check.
-    if (token.authAt && Date.now() - Number(token.authAt) > sessionDurations().absoluteMs) {
+    if (token.authAt && isPastAbsoluteCap(Number(token.authAt))) {
       const url = request.nextUrl.clone()
 
       url.pathname = "/login"

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,6 +6,7 @@ import { getToken } from "next-auth/jwt"
 
 import { matchPublicApiPath } from "@/lib/api-tokens/allowlist"
 import { sessionCookieName } from "@/lib/auth/cookies"
+import { sessionDurations } from "@/lib/auth/durations"
 
 const AUTH_SECRET = process.env.NEXTAUTH_SECRET || ""
 
@@ -281,6 +282,25 @@ export async function middleware(request: NextRequest) {
       loginUrl.searchParams.set("callbackUrl", pathname)
 
       return NextResponse.redirect(loginUrl)
+    }
+
+    // Absolute cap, checked here so it also holds for page navigation. getToken
+    // only decodes the JWT (jwt/index.js:118) — no callbacks, so the read-path
+    // validation never runs for the middleware. authAt makes the one deadline
+    // that matters against a stolen cookie enforceable with pure arithmetic,
+    // keeping this file Prisma-free and Edge-valid.
+    //
+    // A token without authAt is left alone: the read path refuses it anyway,
+    // and redirecting here as well risks a loop. This code only runs past the
+    // isPublicRoute early-return above, so /login itself can never be
+    // redirected by this check.
+    if (token.authAt && Date.now() - Number(token.authAt) > sessionDurations().absoluteMs) {
+      const url = request.nextUrl.clone()
+
+      url.pathname = "/login"
+      url.search = ""
+
+      return NextResponse.redirect(url)
     }
 
     if (token.mustEnroll2fa && !isEnrollBypass(pathname)) {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,6 +4,8 @@ import type { NextRequest } from "next/server"
 
 import { getToken } from "next-auth/jwt"
 
+import { sessionCookieName } from "@/lib/auth/cookies"
+
 const AUTH_SECRET = process.env.NEXTAUTH_SECRET || ""
 
 // HA VIP redirect configuration
@@ -235,7 +237,8 @@ export async function middleware(request: NextRequest) {
     // Vérifier le token JWT
     const token = await getToken({
       req: request,
-      secret: AUTH_SECRET
+      secret: AUTH_SECRET,
+      cookieName: sessionCookieName()
     })
 
     // Si pas de token, rediriger vers login
@@ -261,7 +264,8 @@ export async function middleware(request: NextRequest) {
   // Vérifier le token JWT pour les API
   const token = await getToken({
     req: request,
-    secret: AUTH_SECRET
+    secret: AUTH_SECRET,
+    cookieName: sessionCookieName()
   })
 
   // Si pas de token, retourner 401 pour les API


### PR DESCRIPTION
## Summary

Sessions were pure stateless JWTs: nothing server-side could end one before its 30-day expiry, and the cookie's `Secure` flag depended on a hand-rolled URL check. This PR makes every session a revocable server-side record and lets both users and admins see and end sessions.

## What changed

**Server-side session store**
- Each login creates a row in the `sessions` table (previously unused); the JWT carries its id (`sid`). The `jwt` callback validates the row on every read and refuses dead sessions; the cookie is then cleared by the framework.
- Idle timeout and absolute cap, both env-configurable (`SESSION_IDLE_TIMEOUT`, `SESSION_ABSOLUTE_TIMEOUT`, documented in `.env.example`), evaluated against current config so changes apply to open sessions. The middleware enforces the absolute cap Edge-side without touching the database. The cookie lifetime is derived from the absolute cap instead of a hardcoded 7 days.
- Dead rows are purged hourly.

**Revocation triggers (six)**
- Self-service: revoke one device or all other devices (profile page card, with IP/device/last-activity listing).
- Admin: revoke one session or all sessions of a user, or every session in the installation (new "All sessions" tab, super-admin only, bounded at 500 rows with an explicit truncation flag). Each admin revocation is audited.
- Automatic: password change and account disable revoke all of the target's sessions.
- When an action kills the caller's own session, the tab redirects to `/login` immediately instead of quietly emptying itself.

**Cookie hardening**
- Cookie names and the `Secure` flag are derived statically from the environment (HTTPS `NEXTAUTH_URL` or `x-forwarded-proto`), replacing per-request string checks; the 2FA verification route now issues cookies with the same cap and flags (previously re-issued 30-day cookies).
- Normal session expiry is no longer logged as a JWT error; real JWT faults stay loud.

## Upgrade note

The migration clears the legacy `sessions` table rows (unreadable by design, keyed by a dropped column). All users are signed out once on upgrade and sign back in.

## Testing

- 101 new unit tests plus jsdom coverage for the new UI; full suite matches the pre-branch baseline exactly.
- Build green including the Edge middleware; lint unchanged.
- Manually tested: expiry, all six revocation triggers, self-revocation redirect, admin tab, secure-cookie flag on HTTPS.

## Notes

- The `sessions` i18n namespace currently ships English strings in de/es/ko/zh-CN (translation decision pending, tracked separately).
