### PR TITLE
feat(console): lead console window labels with the VM name (#630)

### DIFF
--- a/frontend/public/novnc/console.html
+++ b/frontend/public/novnc/console.html
@@ -163,9 +163,22 @@ node bundle-novnc.js
     let reconnectTimer = null;
     let userDisconnected = false; // true when user explicitly closes
     
-    document.title = `Console - ${type?.toUpperCase()} ${vmid} - ${node}`;
-    vmInfo.textContent = `${type?.toUpperCase()} ${vmid} • ${node}`;
-    
+    // Le nom de la VM mène le libellé: la barre des tâches tronque après une
+    // quinzaine de caractères, et c'est le seul champ qui distingue deux
+    // consoles ouvertes côte à côte (issue #630). Le nom n'arrive qu'avec la
+    // première réponse /status, d'où le repli "vmid • node" en attendant.
+    let vmName = null;
+
+    function renderVmLabel() {
+      const suffix = `${type?.toUpperCase()} ${vmid} • ${node}`;
+      const label = vmName ? `${vmName} • ${suffix}` : suffix;
+
+      document.title = label;
+      vmInfo.textContent = label;
+    }
+
+    renderVmLabel();
+
     function setStatus(status, text) {
       statusDot.className = status;
       statusText.textContent = `• ${text}`;
@@ -197,6 +210,14 @@ node bundle-novnc.js
         if (res.ok) {
           const json = await res.json();
           vmStatus = json?.data?.status || 'unknown';
+
+          const name = json?.data?.name;
+
+          if (name && name !== vmName) {
+            vmName = name;
+            renderVmLabel();
+          }
+
           updateVmButtons();
         }
       } catch (err) {

--- a/frontend/public/spice/console.html
+++ b/frontend/public/spice/console.html
@@ -41,8 +41,40 @@
     const messageBox = document.getElementById('message');
     let sc = null;
 
-    title.textContent = `SPICE • ${type?.toUpperCase()} ${vmid} • ${node}`;
-    document.title = `SPICE - ${vmid} - ${node}`;
+    // Même libellé dans la barre d'outils et dans le titre de fenêtre, nom de
+    // la VM en tête pour survivre à la troncature de la barre des tâches
+    // (issue #630). Le type est toujours qemu ici, SPICE le sous-entend.
+    let vmName = null;
+
+    function renderVmLabel() {
+      const suffix = `SPICE ${vmid} • ${node}`;
+      const label = vmName ? `${vmName} • ${suffix}` : suffix;
+
+      document.title = label;
+      title.textContent = label;
+    }
+
+    renderVmLabel();
+
+    // Cette page ne suit pas l'état de la VM: un seul GET suffit à nommer la
+    // fenêtre. Un échec laisse simplement le libellé sur son repli.
+    async function fetchVmName() {
+      if (!connId || !type || !node || !vmid) return;
+
+      try {
+        const res = await fetch(
+          `/api/v1/connections/${encodeURIComponent(connId)}/guests/${encodeURIComponent(type)}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/status`
+        );
+        if (!res.ok) return;
+        const json = await res.json();
+        if (json?.data?.name) {
+          vmName = json.data.name;
+          renderVmLabel();
+        }
+      } catch (e) {
+        console.error('Failed to fetch VM name:', e);
+      }
+    }
 
     function setStatus(s, text) { dot.className = s; status.textContent = '• ' + text; }
     function fail(big, small) {
@@ -88,6 +120,7 @@
         });
       } catch (e) { fail('SPICE init failed', e.message); }
     }
+    fetchVmName();
     connect();
   </script>
 </body>

--- a/frontend/public/xterm/console.html
+++ b/frontend/public/xterm/console.html
@@ -116,8 +116,39 @@
     let fitAddon = null;
     let socket = null;
     
-    document.title = `Terminal - ${type?.toUpperCase()} ${vmid} - ${node}`;
-    vmInfo.textContent = `${type?.toUpperCase()} ${vmid} • ${node}`;
+    // Nom de la VM en tête du libellé, comme les consoles noVNC et SPICE
+    // (issue #630) : c'est ce que la barre des tâches laisse voir.
+    let vmName = null;
+
+    function renderVmLabel() {
+      const suffix = `Terminal ${type?.toUpperCase()} ${vmid} • ${node}`;
+      const label = vmName ? `${vmName} • ${suffix}` : suffix;
+
+      document.title = label;
+      vmInfo.textContent = label;
+    }
+
+    renderVmLabel();
+
+    // Un seul GET suffit à nommer la fenêtre; en cas d'échec le libellé garde
+    // son repli.
+    async function fetchVmName() {
+      if (!type || !node || !vmid) return;
+
+      try {
+        const res = await fetch(
+          `/api/v1/connections/${encodeURIComponent(connId)}/guests/${encodeURIComponent(type)}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/status`
+        );
+        if (!res.ok) return;
+        const json = await res.json();
+        if (json?.data?.name) {
+          vmName = json.data.name;
+          renderVmLabel();
+        }
+      } catch (err) {
+        console.error('Failed to fetch VM name:', err);
+      }
+    }
     
     function setStatus(status, text) {
       statusDot.className = status;
@@ -317,6 +348,7 @@
     btnClose.addEventListener('click', () => window.close());
     
     // Démarrer
+    fetchVmName();
     connect();
   </script>
 </body>


### PR DESCRIPTION
Closes #630

## Problem

With several consoles open, every window read `Console - QEMU ##` in the taskbar, so there was no way to tell which VM a window belonged to. The taskbar truncates after roughly fifteen characters, so the shared `Console - ` prefix consumed exactly the space that could have identified the window.

## Change

The VM name now leads the label, and the same string is rendered in the window title and in the console toolbar from a single function.

| Before | After |
| --- | --- |
| `Console - QEMU 101 - pve01` | `webserver01 • QEMU 101 • pve01` |
| `SPICE - 101 - pve01` | `webserver01 • SPICE 101 • pve01` |
| `Terminal - QEMU 101 - pve01` | `webserver01 • Terminal QEMU 101 • pve01` |

The name comes from the `/status` endpoint, which already returned it. No call site and no API signature changed, so all seven entry points into the console (inventory tree, VM table, console preview tile, deploy wizard, failover dialog and the fullscreen console route) get the new label for free, and no stale name is carried in a URL after a rename.

Applied to the three console pages so they stay consistent: noVNC, SPICE and xterm.

## Fallback

Until the first `/status` response lands, and if it fails or is denied, the label falls back to `QEMU 101 • pve01`. The name is never required for the console to work.

## Verification

The three pages were loaded with a simulated `/status` covering all three cases, checking both the window title and the toolbar:

| `/status` | Label |
| --- | --- |
| returns a name | `webserver01 • QEMU 101 • pve01` |
| guest has no name | `QEMU 101 • pve01` |
| denied (403) | `QEMU 101 • pve01` |

Then confirmed in the browser with two consoles open side by side.

## Notes

No unit test is added. These are static HTML pages under `public/` with inline scripts, outside the Vitest scope (nothing to import) and outside `sonar.sources`, so the quality gate is unaffected. Making the label testable would require extracting it into a module shared by the three pages, which is broader than this issue.