### PR TITLE
fix(migration): boot Windows guests from SATA instead of LSI SCSI (#653)

### DIFF
--- a/frontend/src/lib/migration/configMapper.test.ts
+++ b/frontend/src/lib/migration/configMapper.test.ts
@@ -61,19 +61,29 @@ describe("mapEsxiToPveConfig — NIC MAC preservation", () => {
   })
 })
 
-describe("mapEsxiToPveConfig — baseline behavior (unchanged)", () => {
-  it("uses virtio-scsi-single + virtio NIC for Linux", () => {
+describe("mapEsxiToPveConfig — controller and boot disk bus (#653)", () => {
+  it("uses virtio-scsi-single + virtio NIC for Linux, boot disk on scsi0", () => {
     const p = mapEsxiToPveConfig(makeConfig(), 100, "local-lvm", "vmbr0")
     expect(p.scsihw).toBe("virtio-scsi-single")
     expect(p.net0.startsWith("virtio,")).toBe(true)
+    expect(p.bootDiskSlot).toBe("scsi0")
+    expect(p.boot).toBe("order=scsi0")
   })
 
-  it("uses lsi + e1000 NIC for Windows (no injected drivers)", () => {
+  it("keeps virtio-scsi-single but boots Windows from SATA (no inbox LSI/VirtIO boot driver)", () => {
     const p = mapEsxiToPveConfig(
       makeConfig({ guestId: "windows9Server64Guest", guestOS: "Microsoft Windows Server 2022 (64-bit)" }),
       100, "local-lvm", "vmbr0",
     )
-    expect(p.scsihw).toBe("lsi")
+    expect(p.scsihw).toBe("virtio-scsi-single")
     expect(p.net0.startsWith("e1000,")).toBe(true)
+    expect(p.bootDiskSlot).toBe("sata0")
+    expect(p.boot).toBe("order=sata0")
+  })
+
+  it("boots EFI guests from SATA regardless of OS", () => {
+    const p = mapEsxiToPveConfig(makeConfig({ firmware: "efi" }), 100, "local-lvm", "vmbr0")
+    expect(p.bootDiskSlot).toBe("sata0")
+    expect(p.boot).toBe("order=sata0")
   })
 })

--- a/frontend/src/lib/migration/configMapper.ts
+++ b/frontend/src/lib/migration/configMapper.ts
@@ -16,6 +16,7 @@ export interface PveVmCreateParams {
   bios: string
   machine: string
   boot: string
+  bootDiskSlot: "sata0" | "scsi0"
   agent: string
   // Network
   net0: string
@@ -70,10 +71,18 @@ export function mapEsxiToPveConfig(
   const isEfi = esxiConfig.firmware === "efi"
   const isWin = isWindowsVm(esxiConfig)
 
-  // For Windows without virtio drivers, use LSI + e1000 initially for boot compatibility
-  // For Linux, use virtio for best performance
-  const scsihw = isWin ? "lsi" : "virtio-scsi-single"
+  // virtio-scsi for every guest: data disks appear as soon as VirtIO drivers are
+  // installed. The boot disk cannot rely on that (a raw byte copy never has a
+  // boot-start VirtIO driver), so Windows boots from SATA — AHCI is inbox and
+  // boot-start in every supported Windows. The old `lsi` fallback bluescreened
+  // every modern Windows with INACCESSIBLE_BOOT_DEVICE: no inbox LSI driver
+  // since the XP era (#653).
+  const scsihw = "virtio-scsi-single"
   const nicModel = isWin ? "e1000" : mapNicModel(esxiConfig.nics[0]?.type || "Vmxnet3")
+  // Boot disk bus: SATA when the firmware is OVMF (existing rule — OVMF cannot
+  // enumerate an LSI controller) or the guest is Windows (#653). Data disks
+  // stay on SCSI.
+  const bootDiskSlot: "sata0" | "scsi0" = isEfi || isWin ? "sata0" : "scsi0"
 
   const tagSuffix =
     typeof vlanTag === "number" && Number.isInteger(vlanTag) && vlanTag >= 1 && vlanTag <= 4094
@@ -103,7 +112,8 @@ export function mapEsxiToPveConfig(
     scsihw,
     bios: isEfi ? "ovmf" : "seabios",
     machine: "q35",
-    boot: "order=scsi0",
+    boot: `order=${bootDiskSlot}`,
+    bootDiskSlot,
     agent: "1",
     net0: `${nicModel},bridge=${networkBridge}${macSuffix}${tagSuffix}`,
   }

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -439,9 +439,9 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
 
     // Attach a pre-allocated block volume to a SCSI slot
     async function attachBlockDisk(i: number, volumeId: string) {
-      // Same EFI SATA rule as convertAndImportDisk — OVMF has no LSI driver, boot disk must
-      // land on a bus OVMF can enumerate (AHCI/SATA). Data disks stay on SCSI.
-      const scsiSlot = (pveParams.bios === "ovmf" && i === 0) ? "sata0" : `scsi${i}`
+      // Boot disk slot comes from the mapper (sata0 for OVMF and Windows guests,
+      // #653). Data disks stay on SCSI.
+      const scsiSlot = i === 0 ? pveParams.bootDiskSlot : `scsi${i}`
       const attachBody = new URLSearchParams({ [scsiSlot]: volumeId })
       try {
         await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
@@ -1659,11 +1659,11 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
     // Helper: convert + import + attach a single disk
     async function convertAndImportDisk(i: number) {
       const tmpFile = storageTempDir ? `${storageTempDir}/proxcenter-mig-${jobId}-disk${i}` : `${tempBase}/proxcenter-mig-${jobId}-disk${i}`
-      // For EFI guests, attach the boot disk (i=0) as SATA: OVMF ships AHCI/VirtIO/NVMe/USB
-      // drivers but not LSI, so a disk attached to the default `scsihw: lsi` controller is
-      // invisible to the firmware. Windows has AHCI built-in, so this works without driver
-      // injection. Data disks (i>=1) stay on SCSI for performance.
-      const scsiSlot = (pveParams.bios === "ovmf" && i === 0) ? "sata0" : `scsi${i}`
+      // Boot disk slot comes from the mapper: sata0 for OVMF guests (the firmware
+      // cannot enumerate an LSI controller) and for Windows guests (no boot-start
+      // VirtIO driver in an untouched guest, #653). Data disks (i>=1) stay on
+      // SCSI for performance.
+      const scsiSlot = i === 0 ? pveParams.bootDiskSlot : `scsi${i}`
 
       // Convert VMDK to target format
       await appendLog(jobId, `[Disk ${i + 1}/${vmConfig.disks.length}] Converting to ${importFormat} format...`)
@@ -2058,9 +2058,11 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
 
           // Device spec matching the disk controller
           let deviceSpec: string
-          if (diskBus === "scsi") {
+          if (diskBus === "scsi" && !(di === 0 && pveParams.bootDiskSlot === "sata0")) {
             deviceSpec = `scsi-hd,bus=scsihw0.0,scsi-id=${di},lun=0,drive=${driveId},bootindex=${di}`
           } else {
+            // Boot disk rides the q35 AHCI when the guest cannot boot from SCSI
+            // (Windows / OVMF, #653) — mirrors the sata0 slot used at cutover.
             deviceSpec = `ide-hd,drive=${driveId},bus=ide.${Math.floor(di / 2)},unit=${di % 2},bootindex=${di}`
           }
 
@@ -2137,7 +2139,9 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
                 ndbSocketPaths.push(sockPath)
                 const driveId = `nbd-disk${di}`
                 const driveSpec = `file.driver=nbd,file.path=${sockPath},format=raw,if=none,id=${driveId},cache=writeback,aio=threads`
-                const deviceSpec = diskBus === "scsi"
+                // Same boot-disk rule as the SSHFS -args builder above: sata0
+                // guests (Windows / OVMF, #653) boot from the q35 AHCI.
+                const deviceSpec = diskBus === "scsi" && !(di === 0 && pveParams.bootDiskSlot === "sata0")
                   ? `scsi-hd,bus=scsihw0.0,scsi-id=${di},lun=0,drive=${driveId},bootindex=${di}`
                   : `ide-hd,drive=${driveId},bus=ide.${Math.floor(di / 2)},unit=${di % 2},bootindex=${di}`
                 nbdFallbackParts.push(`-drive ${driveSpec}`)
@@ -2533,20 +2537,20 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         await executeSSH(config.targetConnectionId, nodeIp,
           `sed -i '/^args:/d' "${confPath}"`)
 
-        // For EFI guests with a SCSI source controller, attach the boot disk as SATA.
-        // OVMF ships AHCI/VirtIO/NVMe/USB drivers but NOT an LSI SCSI driver, so it cannot
-        // enumerate (and therefore cannot boot) a disk attached via scsihw=lsi. Windows has
-        // AHCI in its built-in driver set, so moving the boot disk to SATA works without
-        // guest driver injection. Data disks stay on SCSI for performance.
-        const forceEfiSataForBoot = pveParams.bios === "ovmf" && diskBus === "scsi"
-        if (forceEfiSataForBoot) {
-          await appendLog(jobId, "EFI guest: attaching boot disk as SATA (OVMF lacks LSI SCSI driver)", "info")
+        // When the source controller is SCSI but the guest cannot boot from it,
+        // attach the boot disk as SATA instead. The sata0 decision now comes from
+        // pveParams.bootDiskSlot: OVMF guests (the firmware cannot enumerate an
+        // LSI controller) and Windows guests (no boot-start VirtIO/LSI driver in
+        // an untouched guest, #653). Data disks stay on SCSI for performance.
+        const forceSataForBoot = pveParams.bootDiskSlot === "sata0" && diskBus === "scsi"
+        if (forceSataForBoot) {
+          await appendLog(jobId, "Attaching boot disk as SATA (firmware or guest cannot boot from the SCSI controller without drivers)", "info")
         }
         const slotPerDisk: string[] = []
         for (let di = 0; di < localVolumes.length; di++) {
           let slot: string
-          if (forceEfiSataForBoot && di === 0) slot = "sata0"
-          else if (forceEfiSataForBoot) slot = `scsi${di - 1}`
+          if (forceSataForBoot && di === 0) slot = "sata0"
+          else if (forceSataForBoot) slot = `scsi${di - 1}`
           else slot = diskBus === "scsi" ? `scsi${di}` : `sata${di}`
           slotPerDisk.push(slot)
         }
@@ -2763,18 +2767,17 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       await updateJob(jobId, "configuring", { progress: 90 })
       await appendLog(jobId, "Configuring VM (boot order, agent)...")
 
-      // Set boot order — honour the EFI SATA rule applied in convertAndImportDisk/attachBlockDisk.
-      const finalBootSlot = pveParams.bios === "ovmf" ? "sata0" : "scsi0"
+      // Set boot order — same slot the attach helpers used for disk 0.
+      const finalBootSlot = pveParams.bootDiskSlot
       await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, new URLSearchParams({ boot: `order=${finalBootSlot}` }))
 
-      // For Windows VMs: advise on post-migration driver work. The boot chain is correct
-      // out of the box (EFI guests get their boot disk on SATA — OVMF can boot it; BIOS
-      // guests stay on LSI SCSI which SeaBIOS reads natively) and the e1000 NIC uses
-      // Windows' built-in driver, so the VM comes up. Installing VirtIO afterwards gives
-      // better disk and network performance but is optional.
+      // For Windows VMs: advise on post-migration driver work. The boot disk is
+      // on SATA (inbox boot-start AHCI driver — Windows has no LSI driver and
+      // VirtIO is never boot-start in an untouched guest, #653) and the e1000
+      // NIC uses the inbox driver, so the VM comes up. Data disks sit on VirtIO
+      // SCSI and appear once the virtio-win drivers are installed.
       if (isWindowsVm(vmConfig)) {
-        const bootBusLabel = pveParams.bios === "ovmf" ? "SATA (OVMF-compatible)" : "LSI SCSI"
-        await appendLog(jobId, `Windows VM detected - boot disk on ${bootBusLabel} + e1000 NIC (built-in Windows drivers). Install VirtIO drivers from the virtio-win ISO afterwards for better disk/network performance.`, "warn")
+        await appendLog(jobId, `Windows VM detected - boot disk on SATA + e1000 NIC (built-in Windows drivers). Install VirtIO drivers from the virtio-win ISO afterwards for better disk/network performance and to bring up any VirtIO SCSI data disks.`, "warn")
       }
 
       await appendLog(jobId, "VM configuration complete", "success")

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -728,7 +728,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     const reconfig = new URLSearchParams()
     const slots: string[] = []
     for (let i = 0; i < vmConfig.disks.length; i++) {
-      const slot = pveParams.bios === "ovmf" && i === 0 ? "sata0" : `scsi${i}`
+      const slot = i === 0 ? pveParams.bootDiskSlot : `scsi${i}`
       slots.push(slot)
       reconfig.set(slot, allocatedVolumes[i].volumeId)
     }

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -422,7 +422,8 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
 
     // Attach a pre-allocated block volume to a SCSI slot
     async function attachBlockDisk(i: number, volumeId: string) {
-      const scsiSlot = `scsi${i}`
+      // sata0 for Windows/EFI boot disks (#653), SCSI for data disks.
+      const scsiSlot = i === 0 ? pveParams.bootDiskSlot : `scsi${i}`
       const attachBody = new URLSearchParams({ [scsiSlot]: volumeId })
       try {
         await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
@@ -577,7 +578,8 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     // Helper: convert + import + attach a single disk
     async function convertAndImportDisk(i: number) {
       const tmpFile = `${storageTempDir}/proxcenter-mig-${jobId}-disk${i}`
-      const scsiSlot = `scsi${i}`
+      // sata0 for Windows/EFI boot disks (#653), SCSI for data disks.
+      const scsiSlot = i === 0 ? pveParams.bootDiskSlot : `scsi${i}`
 
       await appendLog(jobId, `[Disk ${i + 1}/${vmConfig.disks.length}] Converting VHD to ${importFormat} format...`)
       await updateJob(jobId, "transferring", { currentStep: `converting_disk_${i + 1}` })
@@ -796,10 +798,10 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     await updateJob(jobId, "configuring", { progress: 90 })
     await appendLog(jobId, "Configuring VM (boot order, agent)...")
 
-    await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, new URLSearchParams({ boot: "order=scsi0" }))
+    await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, new URLSearchParams({ boot: `order=${pveParams.bootDiskSlot}` }))
 
     if (isWindowsXoVm(vmConfig)) {
-      await appendLog(jobId, "Windows VM detected — using LSI SCSI + e1000 NIC for initial boot compatibility. Install VirtIO drivers for best performance.", "warn")
+      await appendLog(jobId, "Windows VM detected — boot disk on SATA + e1000 NIC (built-in Windows drivers). Install VirtIO drivers for better performance and to bring up any VirtIO SCSI data disks.", "warn")
     }
 
     await appendLog(jobId, "VM configuration complete", "success")

--- a/frontend/src/lib/migration/xcpngConfigMapper.test.ts
+++ b/frontend/src/lib/migration/xcpngConfigMapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { mapXoToPveConfig } from "./xcpngConfigMapper"
+import type { XoVmConfig } from "@/lib/xcpng/client"
+
+function makeConfig(overrides: Partial<XoVmConfig> = {}): XoVmConfig {
+  return {
+    uuid: "xo-uuid-1234",
+    name: "test-vm",
+    powerState: "Running",
+    numCPU: 2,
+    memoryMB: 2048,
+    firmware: "bios",
+    virtualizationMode: "hvm",
+    guestOS: "Ubuntu 22.04 LTS",
+    tags: [],
+    snapshotCount: 0,
+    disks: [{ vdiUuid: "vdi-1", label: "disk0", sizeBytes: 10737418240, position: 0, srUuid: "sr-1" }],
+    networks: [{ device: "0", mac: "aa:bb:cc:dd:ee:ff", network: "Pool-wide network" }],
+    ...overrides,
+  }
+}
+
+describe("mapXoToPveConfig — controller and boot disk bus (#653)", () => {
+  it("uses virtio-scsi-single + virtio NIC for Linux, boot disk on scsi0", () => {
+    const p = mapXoToPveConfig(makeConfig(), 100, "local-lvm", "vmbr0")
+    expect(p.scsihw).toBe("virtio-scsi-single")
+    expect(p.net0.startsWith("virtio,")).toBe(true)
+    expect(p.bootDiskSlot).toBe("scsi0")
+    expect(p.boot).toBe("order=scsi0")
+  })
+
+  it("keeps virtio-scsi-single but boots Windows from SATA (no inbox LSI/VirtIO boot driver)", () => {
+    const p = mapXoToPveConfig(
+      makeConfig({ guestOS: "Windows Server 2022 Standard" }),
+      100, "local-lvm", "vmbr0",
+    )
+    expect(p.scsihw).toBe("virtio-scsi-single")
+    expect(p.net0.startsWith("e1000,")).toBe(true)
+    expect(p.bootDiskSlot).toBe("sata0")
+    expect(p.boot).toBe("order=sata0")
+  })
+
+  it("boots UEFI guests from SATA regardless of OS and creates an EFI disk", () => {
+    const p = mapXoToPveConfig(makeConfig({ firmware: "uefi" }), 100, "local-lvm", "vmbr0")
+    expect(p.bootDiskSlot).toBe("sata0")
+    expect(p.boot).toBe("order=sata0")
+    expect(p.efidisk0).toBeDefined()
+  })
+})

--- a/frontend/src/lib/migration/xcpngConfigMapper.ts
+++ b/frontend/src/lib/migration/xcpngConfigMapper.ts
@@ -42,11 +42,13 @@ export function mapXoToPveConfig(
   const isEfi = xoConfig.firmware === "uefi"
   const isWin = isWindowsXoVm(xoConfig)
 
-  // XCP-ng VMs often use paravirtualized drivers already
-  // For Windows: use LSI + e1000 for safe boot compatibility
-  // For Linux: use virtio since XO Linux VMs are usually already using PV drivers
-  const scsihw = isWin ? "lsi" : "virtio-scsi-single"
+  // virtio-scsi for every guest; Windows keeps e1000 (inbox driver). Boot disk
+  // goes to SATA for Windows and EFI guests — same rule as the ESXi mapper: an
+  // untouched Windows guest has no boot-start VirtIO (or LSI) driver and stops
+  // with INACCESSIBLE_BOOT_DEVICE (#653).
+  const scsihw = "virtio-scsi-single"
   const nicModel = isWin ? "e1000" : "virtio"
+  const bootDiskSlot: "sata0" | "scsi0" = isEfi || isWin ? "sata0" : "scsi0"
 
   const tagSuffix =
     typeof vlanTag === "number" && Number.isInteger(vlanTag) && vlanTag >= 1 && vlanTag <= 4094
@@ -64,7 +66,8 @@ export function mapXoToPveConfig(
     scsihw,
     bios: isEfi ? "ovmf" : "seabios",
     machine: "q35",
-    boot: "order=scsi0",
+    boot: `order=${bootDiskSlot}`,
+    bootDiskSlot,
     agent: "1",
     net0: `${nicModel},bridge=${networkBridge}${tagSuffix}`,
   }


### PR DESCRIPTION
Fixes #653

## Problem

A Windows VM migrated from ESXi 6.5 completed its warm migration cleanly, then bluescreened on first boot with stop code `INACCESSIBLE_BOOT_DEVICE`. The copied data was intact; the boot disk bus was not. The mappers assigned `scsihw: "lsi"` to Windows guests "for boot compatibility", but the emulated LSI 53C895A has had no inbox Windows driver since the XP/2003 era: SeaBIOS loads the bootloader fine, then the Windows kernel cannot reach its boot volume and stops with 0x7B.

Every BIOS-firmware Windows guest was affected on the warm, direct cold, and XCP-ng pipelines. UEFI Windows guests booted only by accident on the ESXi paths (the OVMF rule already forced `sata0`); the XCP-ng pipeline lacked even that rule, so UEFI Windows guests from XCP-ng were broken too. Installing VirtIO drivers in the source guest could not help: the target controller was LSI, and a driver installed while its device is absent is never boot-start anyway.

## Fix

The bus decision is now computed once in the mappers and consumed everywhere:

- `PveVmCreateParams` gains `bootDiskSlot: "sata0" | "scsi0"` — `sata0` for Windows and EFI guests (Windows ships a boot-start AHCI driver; OVMF keeps its existing SATA rule), `scsi0` otherwise.
- `scsihw` is always `virtio-scsi-single`. Windows data disks (scsi1+) now appear as soon as virtio-win drivers are installed; on LSI they would never appear.
- All consumption sites use the mapper's decision instead of recomputing a local OVMF-only rule: warm cutover attach, cold `attachBlockDisk` / `convertAndImportDisk`, the SSHFS-boot cutover slots and final boot order, the SSHFS live-boot QEMU `-args` builder and its NBD fallback (boot disk rides the q35 AHCI there), and both XCP-ng attach helpers plus its boot-order call.
- Windows advisory log messages updated accordingly.

Linux BIOS guests are untouched (`scsi0` before and after). Linux EFI guests keep the existing SATA boot rule.

## Verification

- `configMapper.test.ts` updated (it previously locked in the broken `lsi` expectation) and new `xcpngConfigMapper.test.ts`: 11 tests, all green.
- `tsc --noEmit`: zero errors in the touched files; `PveVmCreateParams` is only constructed by the two mappers, both updated.
- Upstream impact reviewed: both direct callers of the mappers (the cold and warm pipelines) are updated in this PR.

## Notes and trade-offs

- **Legacy guests (XP/2003)**: those had an inbox LSI driver but no AHCI driver, so this change is not for them. They were already hostile territory on q35 + e1000; if one ever needs migrating, switch its boot disk to IDE manually after migration.
- **No real-environment integration run yet**: the bus/firmware matrix is covered by unit tests and review. A live warm migration of a BIOS Windows guest should be exercised before cutting a release.
- Workaround for VMs already migrated with the old bus (no re-migration needed): detach the disk, reattach as `sata0`, set `boot: order=sata0`.
