### PR TITLE
fix(migration): hide the virt-v2v temp storage requirement in warm mode

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -835,6 +835,74 @@ describe('migration dialog options', () => {
     expect(screen.queryByText(QCOW2_LABEL)).not.toBeInTheDocument()
   })
 
+  // Warm migration streams via nbdkit straight into the target block device and
+  // never stages the disk locally, so the virt-v2v temp-storage selector and its
+  // "2x the VM disk" space requirement must not be shown in warm mode (a partner
+  // read the false space error as warm needing ~192 GB of /tmp it does not use).
+  const GIB = 1073741824
+  const VCENTER_VM = { ...ESXI_VM, hostType: 'vcenter', committed: 100 * GIB }
+  const PREFLIGHT_TEMP_TOO_SMALL = {
+    checked: true, ok: true, installing: false, errors: [] as string[],
+    virtV2vInstalled: true, virtioWinInstalled: true, nbdkitInstalled: true,
+    nbdcopyInstalled: true, guestfsToolsInstalled: true, ovmfInstalled: true,
+    detectedDisks: [] as string[],
+    tempStorages: [{ path: '/tmp', availableBytes: 150 * GIB, totalBytes: 200 * GIB, filesystem: 'ext4' }],
+  }
+
+  it('hides the Temporary Storage selector and its space error in warm mode (single VM)', () => {
+    const { unmount } = renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: VCENTER_VM,
+          migType: 'cold',
+          migTempStorage: '/tmp',
+          vcenterPreflight: PREFLIGHT_TEMP_TOO_SMALL,
+        })}
+      />,
+    )
+    expect(screen.getAllByText('Temporary Storage').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Insufficient space/)).toBeInTheDocument()
+    unmount()
+
+    renderWithProviders(
+      <InventoryDialogs
+        {...makeProps({
+          esxiMigrateVm: VCENTER_VM,
+          migType: 'warm',
+          migTempStorage: '/tmp',
+          vcenterPreflight: PREFLIGHT_TEMP_TOO_SMALL,
+        })}
+      />,
+    )
+    expect(screen.queryByText('Temporary Storage')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Insufficient space/)).not.toBeInTheDocument()
+  })
+
+  it('hides the Temporary Storage selector and its space error in warm mode (bulk)', () => {
+    const bulkProps = (migType: 'cold' | 'warm') =>
+      makeProps({
+        bulkMigOpen: true,
+        bulkMigHostInfo: {
+          hostType: 'vcenter',
+          connectionId: 'vc-1',
+          connectionName: 'vcenter-lab',
+          vms: [{ vmid: '42', name: 'web01', status: 'poweredOff', committed: 100 * GIB }],
+        },
+        bulkMigSelected: new Set(['42']),
+        migType,
+        migTempStorage: '/tmp',
+        vcenterPreflight: PREFLIGHT_TEMP_TOO_SMALL,
+      })
+    const { unmount } = renderWithProviders(<InventoryDialogs {...bulkProps('cold')} />)
+    expect(screen.getAllByText('Temporary Storage').length).toBeGreaterThan(0)
+    expect(screen.getByText(/Insufficient space/)).toBeInTheDocument()
+    unmount()
+
+    renderWithProviders(<InventoryDialogs {...bulkProps('warm')} />)
+    expect(screen.queryByText('Temporary Storage')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Insufficient space/)).not.toBeInTheDocument()
+  })
+
   it('forwards convertDisksToQcow2=true in the single-VM migration request', async () => {
     const bodies: any[] = []
     server.use(

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -2560,8 +2560,11 @@ return
                   {/* Temporary storage — used by virt-v2v for vcenter/hyperv/nutanix sources,
                       and by the direct-ESXi pipeline for SSHFS mount root + VMDK dumps + clone
                       targets. /tmp is often a tiny tmpfs on PVE; offering the selector lets the
-                      user pin the multi-GB work to a real filesystem. */}
-                  {vcenterPreflight?.tempStorages && vcenterPreflight.tempStorages.length > 0 && (
+                      user pin the multi-GB work to a real filesystem. Hidden for warm: nbdkit
+                      streams from VMware straight into the target block device (only byte-sized
+                      sockets/pw files touch /tmp), so the 2x-disk space requirement below would
+                      be a false alarm there. */}
+                  {migType !== 'warm' && vcenterPreflight?.tempStorages && vcenterPreflight.tempStorages.length > 0 && (
                     <Box>
                       <TextField
                         select
@@ -3649,8 +3652,10 @@ return
                     Without this, paths default to /tmp on the target node, which is
                     often a small partition (tmpfs or root FS). For bulk jobs with
                     several multi-GB VMs the dir fills up and subsequent migrations
-                    hang or fail with "no space left on device". */}
-                {vcenterPreflight?.tempStorages && vcenterPreflight.tempStorages.length > 0 && (() => {
+                    hang or fail with "no space left on device". Hidden for warm:
+                    nbdkit streams straight into the target block device, so the
+                    2x-disk space requirement would be a false alarm there. */}
+                {migType !== 'warm' && vcenterPreflight?.tempStorages && vcenterPreflight.tempStorages.length > 0 && (() => {
                   const selectedBulkVms = (bulkMigHostInfo?.vms || []).filter((vm: any) => bulkMigSelected.has(vm.vmid))
                   // Peak disk usage in bulk = biggest committed disk × 2 (source + converted).
                   // Sequential runs (BULK_MIG_CONCURRENCY=1) so only one VM occupies tempStorage at a time.


### PR DESCRIPTION
## Problem

With Warm Migration selected, the migration dialog still showed the Temporary Storage selector with the virt-v2v space heuristic (2x the source VM disk). For a 95.9 GB VM it displayed `Insufficient space: 188.7 GB available, ~191.8 GB required`, telling users that warm migration needs local staging space almost twice the VM size. A partner preparing a customer demo read this as a blocker and asked whether warm migration really requires it.

It does not: the warm engine streams disk data from VMware through nbdkit straight into the target block device. The only local writes are byte-sized nbdkit sockets and password files, and the API route does not even forward `tempStorage` to the warm engine. The message was a false alarm, purely cosmetic (the Migrate button was never gated on it in warm mode), but misleading enough to derail a pre-sales evaluation.

## Change

- Gate the Temporary Storage selector (and its space error) on `migType !== 'warm'` in both the single-VM and bulk migration dialogs. Offline/live/v2v flows are untouched.

## Tests

- 2 new regression tests (single + bulk): the selector and the space error render in cold mode and are absent in warm mode, with a preflight fixture reproducing the reported case (committed x 2 > available).
- Full `InventoryDialogs` suite green: 28/28.
- `tsc --noEmit`: no errors in touched files.