### PR TITLE
fix(inventory): send "pc" for the i440fx machine type (#657)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.test.ts
@@ -26,6 +26,10 @@ import {
   formatRrdTick,
   formatRrdTooltipTs,
   rrdTimeframeFromSeries,
+  parseMachineType,
+  buildMachineType,
+  formatMachineType,
+  machineTypeRow,
 } from './helpers'
 
 /* ------------------------------------------------------------------ */
@@ -847,5 +851,152 @@ describe('rrdTimeframeFromSeries', () => {
   it('falls back to hour when timestamps are not finite', () => {
     expect(rrdTimeframeFromSeries([pt(NaN), pt(NaN)])).toBe('hour')
     expect(rrdTimeframeFromSeries([{ t: 'x' } as any, { t: 'y' } as any])).toBe('hour')
+  })
+})
+
+/* ------------------------------------------------------------------ */
+/* QEMU machine type                                                   */
+/* ------------------------------------------------------------------ */
+
+describe('parseMachineType', () => {
+  it('treats an unset machine as the i440fx family', () => {
+    expect(parseMachineType(undefined)).toEqual({ family: 'pc', type: '', extras: [] })
+    expect(parseMachineType('')).toEqual({ family: 'pc', type: '', extras: [] })
+  })
+
+  it('recognises the bare families', () => {
+    expect(parseMachineType('pc').family).toBe('pc')
+    expect(parseMachineType('q35').family).toBe('q35')
+  })
+
+  it('recognises pinned versions, and does not mistake pc-q35 for i440fx', () => {
+    expect(parseMachineType('pc-i440fx-9.2+pve1').family).toBe('pc')
+    expect(parseMachineType('pc-i440fx-8.1.pxe').family).toBe('pc')
+    expect(parseMachineType('pc-q35-8.1').family).toBe('q35')
+    expect(parseMachineType('pc-q35-9.2+pve1').family).toBe('q35')
+  })
+
+  it('splits the property string, with or without the explicit type= key', () => {
+    expect(parseMachineType('q35,viommu=intel')).toEqual({
+      family: 'q35', type: 'q35', extras: ['viommu=intel'],
+    })
+    expect(parseMachineType('type=q35,viommu=intel,aw-bits=48')).toEqual({
+      family: 'q35', type: 'q35', extras: ['viommu=intel', 'aw-bits=48'],
+    })
+    expect(parseMachineType('pc-i440fx-9.2+pve1,enable-s3=1')).toEqual({
+      family: 'pc', type: 'pc-i440fx-9.2+pve1', extras: ['enable-s3=1'],
+    })
+  })
+
+  it('flags an unknown family instead of silently claiming i440fx', () => {
+    expect(parseMachineType('virt').family).toBe('other')
+    expect(parseMachineType('virt-8.1').family).toBe('other')
+  })
+})
+
+describe('buildMachineType', () => {
+  it('spells the i440fx machine "pc" — "i440fx" is rejected by PVE', () => {
+    expect(buildMachineType('', 'pc')).toBe('pc')
+    expect(buildMachineType('q35', 'pc')).toBe('pc')
+  })
+
+  it('switches to q35', () => {
+    expect(buildMachineType('', 'q35')).toBe('q35')
+    expect(buildMachineType('pc', 'q35')).toBe('q35')
+  })
+
+  it('keeps a pinned version when the family is unchanged', () => {
+    expect(buildMachineType('pc-i440fx-9.2+pve1', 'pc')).toBe('pc-i440fx-9.2+pve1')
+    expect(buildMachineType('pc-q35-8.1', 'q35')).toBe('pc-q35-8.1')
+  })
+
+  it('drops the version pin when switching family, since pins are family-specific', () => {
+    expect(buildMachineType('pc-i440fx-9.2+pve1', 'q35')).toBe('q35')
+    expect(buildMachineType('pc-q35-8.1', 'pc')).toBe('pc')
+  })
+
+  it('preserves the other property-string keys instead of wiping them', () => {
+    expect(buildMachineType('q35,viommu=intel', 'pc')).toBe('pc,viommu=intel')
+    expect(buildMachineType('type=q35,viommu=intel,aw-bits=48', 'q35')).toBe('q35,viommu=intel,aw-bits=48')
+    expect(buildMachineType('pc,enable-s3=1,enable-s4=0', 'q35')).toBe('q35,enable-s3=1,enable-s4=0')
+  })
+
+  it('overwrites an unrecognised family with the requested one', () => {
+    expect(buildMachineType('virt', 'q35')).toBe('q35')
+  })
+
+  it('only ever emits a type PVE accepts', () => {
+    // Verbatim from qemu-server PVE/QemuServer/Machine.pm $machine_fmt{type}{pattern}.
+    // This is the check that rejected `machine=i440fx` and produced issue #657.
+    const PVE_MACHINE_TYPE = /^(pc|pc(-i440fx)?-\d+(\.\d+)+(\+pve\d+)?(\.pxe)?|q35|pc-q35-\d+(\.\d+)+(\+pve\d+)?(\.pxe)?|virt(?:-\d+(\.\d+)+)?(\+pve\d+)?)$/
+    const currents = ['', 'pc', 'q35', 'pc-i440fx-9.2+pve1', 'pc-q35-8.1', 'q35,viommu=intel', 'type=pc,enable-s3=1', 'virt']
+
+    for (const current of currents) {
+      for (const family of ['pc', 'q35'] as const) {
+        const emitted = buildMachineType(current, family)
+        expect(emitted.split(',')[0]).toMatch(PVE_MACHINE_TYPE)
+      }
+    }
+  })
+})
+
+describe('formatMachineType', () => {
+  it('names the default machine so the row is readable', () => {
+    expect(formatMachineType('')).toBe('pc (i440fx)')
+    expect(formatMachineType(undefined)).toBe('pc (i440fx)')
+    expect(formatMachineType('pc')).toBe('pc (i440fx)')
+  })
+
+  it('shows the pinned version and the extra keys verbatim', () => {
+    expect(formatMachineType('q35')).toBe('q35')
+    expect(formatMachineType('pc-i440fx-9.2+pve1')).toBe('pc-i440fx-9.2+pve1')
+    expect(formatMachineType('type=q35,viommu=intel')).toBe('q35, viommu=intel')
+  })
+})
+
+describe('machineTypeRow', () => {
+  it('offers pc and q35, and preselects i440fx when the VM has no machine key', () => {
+    const row = machineTypeRow('')
+
+    expect(row.value).toBe('pc (i440fx)')
+    expect(row.editValue).toBe('pc')
+    expect(row.options).toEqual([
+      { value: 'pc', label: 'pc (i440fx)' },
+      { value: 'q35', label: 'q35' },
+    ])
+  })
+
+  it('preselects an option that actually exists, so the Select is never blank', () => {
+    for (const raw of ['', 'pc', 'q35', 'pc-i440fx-9.2+pve1', 'pc-q35-8.1', 'q35,viommu=intel', 'virt']) {
+      const row = machineTypeRow(raw)
+
+      expect(row.options.map(o => o.value)).toContain(row.editValue)
+    }
+  })
+
+  it('keeps the pinned version selectable instead of silently unpinning it', () => {
+    const row = machineTypeRow('pc-i440fx-9.2+pve1')
+
+    expect(row.editValue).toBe('pc-i440fx-9.2+pve1')
+    expect(row.options).toEqual([
+      { value: 'pc-i440fx-9.2+pve1', label: 'pc-i440fx-9.2+pve1' },
+      { value: 'q35', label: 'q35' },
+    ])
+  })
+
+  it('carries the other property-string keys into both options', () => {
+    const row = machineTypeRow('q35,viommu=intel')
+
+    expect(row.value).toBe('q35, viommu=intel')
+    expect(row.editValue).toBe('q35,viommu=intel')
+    expect(row.options.map(o => o.value)).toEqual(['pc,viommu=intel', 'q35,viommu=intel'])
+  })
+
+  it('adds an entry for an unrecognised family rather than dropping the VM into a blank Select', () => {
+    const row = machineTypeRow('virt')
+
+    expect(row.editValue).toBe('virt')
+    expect(row.options).toHaveLength(3)
+    expect(row.options[2]).toEqual({ value: 'virt', label: 'virt' })
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -179,6 +179,87 @@ export function formatOsType(code: string | undefined): string {
   return osTypeLabels[code] || code
 }
 
+/* ------------------------------------------------------------------ */
+/* QEMU machine type                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * PVE stores `machine` as a property string whose default key is the machine
+ * type: `[type=]<machine type>[,viommu=…][,aw-bits=…][,enable-s3=…][,enable-s4=…]`.
+ * The type must match qemu-server's regex, which knows `pc`, `q35`, `virt` and
+ * their pinned variants (`pc-i440fx-9.2+pve1`, `pc-q35-8.1`) — but never the
+ * marketing name `i440fx`. The i440fx machine is spelled `pc`; sending
+ * `machine=i440fx` is what PVE rejected in issue #657.
+ */
+export type MachineFamily = 'pc' | 'q35' | 'other'
+
+export function parseMachineType(raw: string | undefined | null): {
+  family: MachineFamily
+  type: string
+  extras: string[]
+} {
+  const parts = String(raw ?? '').split(',').map(p => p.trim()).filter(Boolean)
+  const typePart = parts.find(p => !p.includes('=') || p.startsWith('type='))
+  const type = (typePart ?? '').replace(/^type=/, '')
+  const extras = parts.filter(p => p !== typePart)
+
+  // pc-q35-* also starts with "pc-", so q35 has to be tested first.
+  let family: MachineFamily = 'other'
+  if (/^(q35|pc-q35)(-|$)/.test(type)) family = 'q35'
+  else if (type === '' || /^(pc|pc-i440fx)(-|$)/.test(type)) family = 'pc'
+
+  return { family, type, extras }
+}
+
+/**
+ * Rebuild the `machine` value for the family the user picked, keeping every
+ * property-string key we do not own (viommu, enable-s3/s4…) and the pinned
+ * version when the family is unchanged. Version pins are family-specific, so
+ * switching families has to fall back to the bare family name.
+ */
+export function buildMachineType(raw: string | undefined | null, family: 'pc' | 'q35'): string {
+  const current = parseMachineType(raw)
+  const type = current.family === family && current.type ? current.type : family
+
+  return [type, ...current.extras].join(',')
+}
+
+/** Human-readable machine type for the read-only Hardware row. */
+export function formatMachineType(raw: string | undefined | null): string {
+  const { type, extras } = parseMachineType(raw)
+  const base = type || 'pc'
+
+  return [base === 'pc' ? 'pc (i440fx)' : base, ...extras].join(', ')
+}
+
+/**
+ * Everything the Hardware "Machine type" row needs. Option values are the exact
+ * strings PUT back to PVE, and every label states what that option will write.
+ */
+export function machineTypeRow(raw: string | undefined | null): {
+  value: string
+  editValue: string
+  options: { value: string; label: string }[]
+} {
+  const current = String(raw ?? '')
+  const { family } = parseMachineType(current)
+  const options = (['pc', 'q35'] as const).map(f => {
+    const value = buildMachineType(current, f)
+
+    return { value, label: formatMachineType(value) }
+  })
+
+  // An unrecognised family (arm64 `virt`…) keeps its own entry so the Select
+  // shows the truth instead of going blank.
+  if (family === 'other') options.push({ value: current, label: formatMachineType(current) })
+
+  return {
+    value: formatMachineType(current),
+    editValue: family === 'other' ? current : buildMachineType(current, family),
+    options,
+  }
+}
+
 export function formatBytes(bytes: number) {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
   const u = ['B', 'KB', 'MB', 'GB', 'TB']
@@ -1134,7 +1215,7 @@ return Number.isFinite(num) ? num.toFixed(2) : String(v)
 
         systemInfo = {
           bios: config.bios || 'seabios',
-          machine: config.machine || 'i440fx',
+          machine: config.machine || '',
           vga: config.vga || 'std',
           scsihw: config.scsihw || 'virtio-scsi-single',
         }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -75,7 +75,7 @@ const DetachConfirmDialog = dynamic(() => import('@/components/hardware/DetachCo
 const DeleteUnusedDiskDialog = dynamic(() => import('@/components/hardware/DeleteUnusedDiskDialog').then(mod => ({ default: mod.DeleteUnusedDiskDialog })), { ssr: false })
 
 import type { InventorySelection, DetailsPayload, RrdTimeframe, SeriesPoint, Status } from '../types'
-import { formatBps, formatOsType, formatRrdTick, formatRrdTooltipTs, formatUptime, parseMarkdown, markdownSx, parseNodeId, parseVmId, cpuPct, pct, buildSeriesFromRrd, fetchRrd } from '../helpers'
+import { formatBps, formatOsType, formatRrdTick, formatRrdTooltipTs, formatUptime, parseMarkdown, markdownSx, parseNodeId, parseVmId, cpuPct, pct, buildSeriesFromRrd, fetchRrd, machineTypeRow } from '../helpers'
 import { useTagColors } from '@/contexts/TagColorContext'
 import { useTenant } from '@/contexts/TenantContext'
 import { AreaPctChart, AreaBpsChart2 } from '../components/RrdCharts'
@@ -1924,9 +1924,10 @@ export default function VmDetailTabs(props: any) {
                                       key: 'machine',
                                       icon: 'ri-instance-line',
                                       label: t('inventory.machineType'),
-                                      value: data.systemInfo.machine || 'i440fx',
-                                      editValue: data.systemInfo.machine || 'i440fx',
-                                      options: [{ value: 'i440fx', label: 'i440fx (Default)' }, { value: 'q35', label: 'q35' }],
+                                      // Option values are the strings we PUT back to PVE: they carry the
+                                      // whole property string (version pin, viommu, enable-s3/s4…) and
+                                      // spell the i440fx machine `pc` — `i440fx` fails PVE's regex (#657).
+                                      ...machineTypeRow(data.systemInfo.machine),
                                     },
                                     {
                                       key: 'vga',


### PR DESCRIPTION
Fixes #657.

## Problem

Changing a VM's machine type to i440fx from **Hardware > System** always failed with:

```
Parameter verification failed.
machine: invalid format - format error
machine.type: value does not match the regex pattern
```

The select offered `i440fx` and `q35` as option **values**, and the save handler PUTs the selected value verbatim as `machine=<value>`. But `i440fx` is a marketing name, not a QEMU machine type. qemu-server parses `machine` as a property string and validates its default `type` key against:

```
(pc|pc(-i440fx)?-\d+(\.\d+)+(\+pve\d+)?(\.pxe)?|q35|pc-q35-\d+(\.\d+)+(\+pve\d+)?(\.pxe)?|virt(?:-\d+(\.\d+)+)?(\+pve\d+)?)
```

The i440fx machine is spelled `pc`. Of the two options only `q35` ever validated, so the row has been one-way since the System section was added. It is not a PVE 9 regression; PVE 9 only changed the error text, because `machine` became a property string and the failure is now reported on the `type` sub-key.

## Fix

Option values are derived from the VM's current `machine` string instead of being hardcoded, which also closes two adjacent defects in the same select:

- a versioned type (`pc-i440fx-9.2+pve1`, `pc-q35-8.1`) or one carrying extra property-string keys (`viommu`, `aw-bits`, `enable-s3`, `enable-s4`) matched neither hardcoded option, so MUI rendered the Select **blank**;
- saving from that state silently dropped those extra keys.

Behaviour now:

| VM config | Row shows | Options offered |
|---|---|---|
| no `machine` key | `pc (i440fx)` | `pc`, `q35` |
| `q35` | `q35` | `pc`, `q35` |
| `pc-i440fx-9.2+pve1` | `pc-i440fx-9.2+pve1` | `pc-i440fx-9.2+pve1`, `q35` |
| `q35,viommu=intel` | `q35, viommu=intel` | `pc,viommu=intel`, `q35,viommu=intel` |
| `virt` (arm64) | `virt` | `pc`, `q35`, `virt` |

The version pin is kept while the family is unchanged and dropped only when switching family, since pins are family-specific. Each label states exactly what that option will write.

Picking i440fx on a VM that has no `machine` key writes `machine=pc` rather than leaving the key absent. The two are semantically identical (i440fx is PVE's default) and this keeps the change contained to the select.

## Tests

Parsing, rebuilding and labelling live in `helpers.ts` behind 19 new unit tests. One of them embeds qemu-server's regex verbatim and asserts that every value the select can emit satisfies it, which is the guard against reintroducing this class of bug.

`vitest run inventory/`: 465 passed, 16 files.

## Verification

Checked in the browser against a live PVE host: on a stopped VM both directions now succeed, i440fx to q35 and q35 back to i440fx. The second one is the case reported here and it failed before this change.

