### PR TITLE
feat(migration): warn before CBT-fallback warm migrations and surface live progress

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -40,6 +40,8 @@ import {
 import { NodeRow, BulkAction } from '@/components/NodesTable'
 import NumericTextField from '@/components/ui/NumericTextField'
 import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
+// Dependency-free eligibility check (NOT ./cbt, which pulls the server-only SOAP client).
+import { cbtEligibility } from '@/lib/vmware/cbt-eligibility'
 
 // Dynamic imports for HardwareModals (code-split, loaded on demand)
 const AddDiskDialog = dynamic(() => import('@/components/HardwareModals').then(mod => ({ default: mod.AddDiskDialog })), { ssr: false })
@@ -585,33 +587,64 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
     }
   }, [migTargetConn, setVcenterPreflight])
 
-  // Source datastore pre-flight: detect vSAN-backed source disks for direct-ESXi sources so
-  // we can block the migration upfront with a clear message rather than letting the user fill
-  // the form and hit submit before the backend throws. vCenter/Hyper-V/Nutanix sources go
-  // through v2v-pipeline which uses NFC and handles vSAN natively, so we skip the check for them.
+  // Source detail pre-flight, two consumers off one fetch:
+  // - vSAN detection (direct ESXi only): block the migration upfront with a clear
+  //   message rather than letting the user fill the form and hit submit before the
+  //   backend throws. vCenter goes through v2v/NFC which handles vSAN natively, so
+  //   its datastores are deliberately NOT collected (vSAN never blocks vCenter).
+  // - CBT-fallback inputs (direct ESXi AND vCenter): snapshotCount, vmxVersion and
+  //   the per-disk diskMode/sharing feed the warm-migration fallback warning below.
+  // Hyper-V/Nutanix sources are not VMware — no fetch at all for them.
   const [sourceDatastores, setSourceDatastores] = useState<string[]>([])
   const [sourceDatastoresLoading, setSourceDatastoresLoading] = useState(false)
+  const [sourceVmDetail, setSourceVmDetail] = useState<{ snapshotCount: number; vmxVersion: string; disks: { diskMode?: string; sharing?: string }[] } | null>(null)
   React.useEffect(() => {
-    if (!esxiMigrateVm) { setSourceDatastores([]); return }
-    if (esxiMigrateVm.hostType === 'vcenter' || esxiMigrateVm.hostType === 'hyperv' || esxiMigrateVm.hostType === 'nutanix') {
+    if (!esxiMigrateVm) { setSourceDatastores([]); setSourceVmDetail(null); return }
+    if (esxiMigrateVm.hostType === 'hyperv' || esxiMigrateVm.hostType === 'nutanix') {
       setSourceDatastores([])
+      setSourceVmDetail(null)
       return
     }
+    const isVcenterSource = esxiMigrateVm.hostType === 'vcenter'
     setSourceDatastoresLoading(true)
     fetch(`/api/v1/vmware/${esxiMigrateVm.connId}/vms/${esxiMigrateVm.vmid}`)
       .then(r => r.json())
       .then(d => {
-        const disks = (d?.data?.disks || []) as { fileName?: string }[]
-        const names = [...new Set(disks
-          .map(disk => (disk.fileName || '').match(/^\[([^\]]+)\]/)?.[1])
-          .filter((n): n is string => !!n))]
-        setSourceDatastores(names)
+        const detail = d?.data
+        const disks = (detail?.disks || []) as { fileName?: string; diskMode?: string; sharing?: string }[]
+        if (isVcenterSource) {
+          setSourceDatastores([])
+        } else {
+          const names = [...new Set(disks
+            .map(disk => (disk.fileName || '').match(/^\[([^\]]+)\]/)?.[1])
+            .filter((n): n is string => !!n))]
+          setSourceDatastores(names)
+        }
+        setSourceVmDetail(detail ? {
+          snapshotCount: Number(detail.snapshotCount) || 0,
+          vmxVersion: String(detail.vmxVersion || ''),
+          disks,
+        } : null)
       })
-      .catch(() => setSourceDatastores([]))
+      .catch(() => { setSourceDatastores([]); setSourceVmDetail(null) })
       .finally(() => setSourceDatastoresLoading(false))
   }, [esxiMigrateVm?.connId, esxiMigrateVm?.vmid, esxiMigrateVm?.hostType])
   const sourceVsanDatastores = sourceDatastores.filter(n => n.toLowerCase().includes('vsan'))
   const vsanBlocksMigration = sourceVsanDatastores.length > 0
+
+  // Warm CBT-fallback verdict (only meaningful when migType === 'warm'): mirrors
+  // runWarmMigration's planning-time decision (`useCbt = eligible && snapshotCount
+  // === 0`). When CBT is unavailable the engine falls back to the checksum
+  // block-diff, which shuts the source down BEFORE the copy — the user must know
+  // that before launching, not from the job log at minute 0. Warning only; the
+  // launch stays enabled.
+  const warmCbtFallbackCause = React.useMemo<'Snapshot' | 'HwVersion' | 'DiskMode' | null>(() => {
+    if (!sourceVmDetail) return null
+    if (sourceVmDetail.snapshotCount > 0) return 'Snapshot'
+    const elig = cbtEligibility({ hwVersion: sourceVmDetail.vmxVersion || '', disks: sourceVmDetail.disks })
+    if (elig.eligible) return null
+    return (elig.reason || '').startsWith('hardware version') ? 'HwVersion' : 'DiskMode'
+  }, [sourceVmDetail])
 
   // Warm migration go/no-go. Probes the chosen target node for the VDDK runtime
   // the engine needs (nbdkit + vddk plugin + nbd-client + the Broadcom VDDK),
@@ -2361,6 +2394,30 @@ return
                         </Typography>
                       </Alert>
                     )
+                  )}
+
+                  {/* CBT-fallback warning: the source VM cannot use CBT (pre-existing
+                      snapshot / old hardware version / independent or multi-writer disk),
+                      so warm falls back to the checksum block-diff, which shuts the
+                      source DOWN at the start of the copy. Warning only — never blocks
+                      the launch (the fallback is lossless, just not low-downtime). */}
+                  {migType === 'warm' && warmCbtFallbackCause && (
+                    <Alert severity="warning" sx={{ fontSize: 12, '& .MuiAlert-message': { width: '100%' } }} icon={<i className="ri-error-warning-line" style={{ fontSize: 18 }} />}>
+                      <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+                        {t('inventoryPage.esxiMigration.warmCbtFallbackTitle')}
+                      </Typography>
+                      <Typography variant="body2" sx={{ mb: 0.5 }}>
+                        {t(`inventoryPage.esxiMigration.warmCbtFallbackReason${warmCbtFallbackCause}`)}
+                      </Typography>
+                      <Typography variant="body2">
+                        {t('inventoryPage.esxiMigration.warmCbtFallbackDowntime')}
+                      </Typography>
+                      {warmCbtFallbackCause === 'Snapshot' && (
+                        <Typography variant="caption" sx={{ opacity: 0.8, display: 'block', mt: 0.5 }}>
+                          {t('inventoryPage.esxiMigration.warmCbtFallbackSnapshotHint')}
+                        </Typography>
+                      )}
+                    </Alert>
                   )}
 
                   {/* sshfs not installed warning */}

--- a/frontend/src/app/api/v1/vmware/[id]/vms/[vmid]/route.test.ts
+++ b/frontend/src/app/api/v1/vmware/[id]/vms/[vmid]/route.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for GET /api/v1/vmware/[id]/vms/[vmid] — the per-VM detail the migrate
+ * dialog reads. Focused on the VirtualDisk parse loop: diskMode and sharing
+ * feed the client-side CBT-eligibility check (warm-migration fallback warning),
+ * so their extraction must survive refactors. The SOAP transport is mocked; the
+ * pure XML parsers (extractProp) stay real so the fixture exercises the actual
+ * parsing path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const h = vi.hoisted(() => ({
+  prisma: { connection: { findUnique: vi.fn() } },
+  soapText: "",
+}))
+
+vi.mock("@/lib/tenant", () => ({ getSessionPrisma: vi.fn(async () => h.prisma) }))
+vi.mock("@/lib/rbac", () => ({ checkPermission: vi.fn(async () => null), PERMISSIONS: { CONNECTION_VIEW: "connection.view" } }))
+vi.mock("@/lib/crypto/secret", () => ({ decryptSecret: vi.fn(() => "root:pass") }))
+vi.mock("@/lib/vmware/soap", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/vmware/soap")>()
+  return {
+    ...actual,
+    soapLogin: vi.fn(async () => ({
+      baseUrl: "https://esxi/sdk", cookie: "c", insecureTLS: true,
+      propertyCollector: "ha-property-collector", isVcenter: false,
+    })),
+    soapLogout: vi.fn(async () => {}),
+    soapRequest: vi.fn(async () => ({ text: h.soapText })),
+    soapResolveHostInventoryPaths: vi.fn(async () => new Map()),
+  }
+})
+
+import { GET } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+const prop = (name: string, val: string) => `<propSet><name>${name}</name><val xsi:type="x">${val}</val></propSet>`
+
+/** RetrievePropertiesEx response with three disks covering the diskMode/sharing matrix. */
+function vmXml(): string {
+  const devices =
+    `<VirtualDevice xsi:type="VirtualDisk"><label>Hard disk 1</label><capacityInBytes>10737418240</capacityInBytes>` +
+    `<fileName>[ds1] web/web.vmdk</fileName><thinProvisioned>true</thinProvisioned>` +
+    `<diskMode>persistent</diskMode><sharing>sharingNone</sharing></VirtualDevice>` +
+    `<VirtualDevice xsi:type="VirtualDisk"><label>Hard disk 2</label><capacityInBytes>2147483648</capacityInBytes>` +
+    `<fileName>[ds1] web/web_1.vmdk</fileName>` +
+    `<diskMode>independent_persistent</diskMode><sharing>sharingMultiWriter</sharing></VirtualDevice>` +
+    `<VirtualDevice xsi:type="VirtualDisk"><label>Hard disk 3</label><capacityInKB>1024</capacityInKB>` +
+    `<fileName>[ds1] web/web_2.vmdk</fileName></VirtualDevice>`
+  return [
+    prop("name", "web-01"),
+    prop("config.version", "vmx-13"),
+    prop("config.hardware.numCPU", "2"),
+    prop("config.hardware.memoryMB", "4096"),
+    prop("runtime.powerState", "poweredOn"),
+    prop("snapshot", `<currentSnapshot type="VirtualMachineSnapshot">snap-1</currentSnapshot><rootSnapshotList><snapshot type="VirtualMachineSnapshot">snap-1</snapshot></rootSnapshotList>`),
+    prop("config.hardware.device", devices),
+  ].join("")
+}
+
+beforeEach(() => {
+  h.prisma.connection.findUnique.mockReset().mockResolvedValue({
+    id: "conn-1", name: "esxi-lab", baseUrl: "https://esxi", apiTokenEnc: "enc",
+    insecureTLS: true, type: "vmware", subType: null, vmwareDatacenter: null,
+  })
+  h.soapText = vmXml()
+})
+
+describe("GET /api/v1/vmware/[id]/vms/[vmid] — disk parsing", () => {
+  it("extracts diskMode and sharing for each VirtualDisk", async () => {
+    const res = await callRoute(GET, { params: { id: "conn-1", vmid: "42" } })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body?.data?.disks).toEqual([
+      {
+        label: "Hard disk 1", capacityBytes: 10737418240, fileName: "[ds1] web/web.vmdk",
+        thinProvisioned: true, diskMode: "persistent", sharing: "sharingNone",
+      },
+      {
+        label: "Hard disk 2", capacityBytes: 2147483648, fileName: "[ds1] web/web_1.vmdk",
+        thinProvisioned: false, diskMode: "independent_persistent", sharing: "sharingMultiWriter",
+      },
+      // disks whose XML carries no diskMode/sharing degrade to empty strings
+      {
+        label: "Hard disk 3", capacityBytes: 1024 * 1024, fileName: "[ds1] web/web_2.vmdk",
+        thinProvisioned: false, diskMode: "", sharing: "",
+      },
+    ])
+  })
+
+  it("surfaces vmxVersion and snapshotCount alongside the disks (fallback-warning inputs)", async () => {
+    const res = await callRoute(GET, { params: { id: "conn-1", vmid: "42" } })
+    const body = await readJson<any>(res)
+    expect(body?.data?.vmxVersion).toBe("vmx-13")
+    expect(body?.data?.snapshotCount).toBe(1)
+  })
+
+  it("404s on a non-VMware connection", async () => {
+    h.prisma.connection.findUnique.mockResolvedValue({ id: "conn-1", type: "pve" })
+    const res = await callRoute(GET, { params: { id: "conn-1", vmid: "42" } })
+    expect(res.status).toBe(404)
+  })
+})

--- a/frontend/src/app/api/v1/vmware/[id]/vms/[vmid]/route.ts
+++ b/frontend/src/app/api/v1/vmware/[id]/vms/[vmid]/route.ts
@@ -132,11 +132,18 @@ export async function GET(
         const capacityKB = d.match(/<capacityInKB>(\d+)<\/capacityInKB>/)?.[1]
         const fileName = d.match(/<fileName>([^<]*)<\/fileName>/)?.[1] || ''
         const thinProvisioned = d.includes('<thinProvisioned>true</thinProvisioned>')
+        // diskMode/sharing feed the client-side CBT-eligibility check for the
+        // warm-migration fallback warning (independent / multi-writer disks
+        // make CBT unavailable).
+        const diskMode = d.match(/<diskMode>([^<]*)<\/diskMode>/)?.[1] || ''
+        const sharing = d.match(/<sharing>([^<]*)<\/sharing>/)?.[1] || ''
         disks.push({
           label,
           capacityBytes: capacityBytes ? Number.parseInt(capacityBytes, 10) : (capacityKB ? Number.parseInt(capacityKB, 10) * 1024 : 0),
           fileName,
           thinProvisioned,
+          diskMode,
+          sharing,
         })
       }
 

--- a/frontend/src/components/SharedTaskDetailDialog.test.tsx
+++ b/frontend/src/components/SharedTaskDetailDialog.test.tsx
@@ -131,6 +131,45 @@ describe('SharedTaskDetailDialog - cancel button visibility', () => {
 })
 
 // ------------------------------------------------------------------ //
+// 1b. Live progress readout (warm fallback UX: speed/bytes/disk were in the
+//     SharedTask payload but never rendered)
+// ------------------------------------------------------------------ //
+
+describe('SharedTaskDetailDialog - live progress readout', () => {
+  it('renders the full readout: translated step, disk counter, GB progress, speed and ETA', () => {
+    state.task = makeTask({
+      currentStep: 'full_copy',
+      currentDisk: 0, // pipelines write the 0-based loop index
+      totalDisks: 2,
+      bytesTransferred: 32 * 1073741824,
+      totalBytes: 64 * 1073741824,
+      transferSpeed: '128 MB/s',
+    })
+    renderDialog()
+    // 32 GiB to go at 128 MB/s -> 256 s -> "4m"
+    expect(screen.getByText('Full copy · Disk 1 of 2 · 32.0 / 64.0 GB · 128 MB/s · ~4m remaining')).toBeInTheDocument()
+  })
+
+  it('collapses numbered delta passes to the shared translated label', () => {
+    state.task = makeTask({ currentStep: 'delta_2', currentDisk: null, bytesTransferred: null, totalBytes: null, transferSpeed: null })
+    renderDialog()
+    expect(screen.getByText('Delta sync')).toBeInTheDocument()
+  })
+
+  it('falls back to the raw currentStep string for unknown steps', () => {
+    state.task = makeTask({ currentDisk: null, bytesTransferred: null, totalBytes: null, transferSpeed: null })
+    renderDialog()
+    expect(screen.getByText('Copying disk 1/2')).toBeInTheDocument()
+  })
+
+  it('omits the readout entirely when the task has no live fields', () => {
+    state.task = makeTask({ currentStep: null, currentDisk: null, totalDisks: null, bytesTransferred: null, totalBytes: null, transferSpeed: null })
+    renderDialog()
+    expect(screen.queryByText(/GB|remaining|Disk \d/)).not.toBeInTheDocument()
+  })
+})
+
+// ------------------------------------------------------------------ //
 // 2. Confirmation gate
 // ------------------------------------------------------------------ //
 

--- a/frontend/src/components/SharedTaskDetailDialog.tsx
+++ b/frontend/src/components/SharedTaskDetailDialog.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl'
 import { useSWRConfig } from 'swr'
 import { useSWRFetch } from '@/hooks/useSWRFetch'
 import type { SharedTask } from '@/lib/tasks/sharedTask'
+import { parseSpeedMBps, etaSeconds, formatEta, stepLabelKey } from '@/lib/tasks/taskProgressDisplay'
 
 type DetailResponse = { data: SharedTask & { logs?: unknown[] } }
 
@@ -24,6 +25,29 @@ export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: stri
   const [cancelling, setCancelling] = useState(false)
   const [cancelError, setCancelError] = useState<string | null>(null)
   const canCancel = !!task && task.kind === 'migration' && !['completed', 'failed', 'cancelled'].includes(task.status)
+
+  // Compact live readout under the progress bar, assembled from fields the
+  // SharedTask payload already carries (the warm pipeline keeps currentDisk /
+  // bytes / speed up to date). Each piece renders only when its data exists,
+  // so a task without transfer telemetry degrades to just the step label.
+  const readout: string[] = []
+  if (task) {
+    const stepKey = stepLabelKey(task.currentStep)
+    if (task.currentStep) readout.push(stepKey ? t(`tasks.steps.${stepKey}`) : task.currentStep)
+    if (task.currentDisk != null && task.totalDisks) {
+      // currentDisk is the pipeline's 0-based loop index.
+      readout.push(t('tasks.shared.diskOf', { n: task.currentDisk + 1, m: task.totalDisks }))
+    }
+    if (task.bytesTransferred != null && task.totalBytes != null) {
+      readout.push(t('tasks.shared.gbProgress', {
+        done: (task.bytesTransferred / 1073741824).toFixed(1),
+        total: (task.totalBytes / 1073741824).toFixed(1),
+      }))
+    }
+    if (task.transferSpeed) readout.push(task.transferSpeed)
+    const eta = etaSeconds(task.bytesTransferred, task.totalBytes, parseSpeedMBps(task.transferSpeed))
+    if (eta != null) readout.push(t('tasks.shared.eta', { eta: formatEta(eta) }))
+  }
 
   const handleClose = () => {
     setConfirmOpen(false)
@@ -77,7 +101,11 @@ export default function SharedTaskDetailDialog({ jobId, onClose }: { jobId: stri
               </Typography>
             </Box>
             <LinearProgress variant={task.progress > 0 ? 'determinate' : 'indeterminate'} value={task.progress} />
-            {task.currentStep && <Typography variant="body2">{task.currentStep}</Typography>}
+            {readout.length > 0 && (
+              <Typography variant="body2" sx={{ opacity: 0.7 }}>
+                {readout.join(' · ')}
+              </Typography>
+            )}
             {task.error && <Typography variant="body2" color="error">{task.error}</Typography>}
             {cancelError && <Alert severity="error">{cancelError}</Alert>}
             {Array.isArray(task.logs) && task.logs.length > 0 && (

--- a/frontend/src/lib/migration/warm/checksum-detector.test.ts
+++ b/frontend/src/lib/migration/warm/checksum-detector.test.ts
@@ -44,11 +44,21 @@ describe("buildBlockChecksumCmd", () => {
 })
 
 describe("scanBlockChecksums", () => {
-  beforeEach(() => mockSSH.mockReset())
+  // Braces matter: mockReset() returns the mock, and a function returned from
+  // beforeEach is treated by vitest as a cleanup hook and re-invoked with NO
+  // arguments after the test — which would run the mock implementation again.
+  beforeEach(() => { mockSSH.mockReset() })
   it("parses one md5 per line into an array", async () => {
     mockSSH.mockResolvedValue({ success: true, output: "aaa\nbbb\nccc\n" })
     const sums = await scanBlockChecksums("conn", "ip", "/dev/nbd3", B, 3)
     expect(sums).toEqual(["aaa", "bbb", "ccc"])
+  })
+  it("forwards inactivityMs and onData to executeSSH", async () => {
+    mockSSH.mockResolvedValue({ success: true, output: "aaa" })
+    const onData = () => {}
+    await scanBlockChecksums("conn", "ip", "/dev/nbd3", B, 1, { inactivityMs: 1234, onData })
+    expect(mockSSH).toHaveBeenCalledTimes(1)
+    expect(mockSSH.mock.calls[0][4]).toEqual({ inactivityMs: 1234, onData })
   })
   it("returns an empty list for a zero-length disk without issuing SSH", async () => {
     const sums = await scanBlockChecksums("conn", "ip", "/dev/nbd3", B, 0)
@@ -62,7 +72,10 @@ describe("scanBlockChecksums", () => {
 })
 
 describe("detectChangedExtentsByChecksum", () => {
-  beforeEach(() => mockSSH.mockReset())
+  // Braces matter: mockReset() returns the mock, and a function returned from
+  // beforeEach is treated by vitest as a cleanup hook and re-invoked with NO
+  // arguments after the test — which would run the mock implementation again.
+  beforeEach(() => { mockSSH.mockReset() })
   it("scans source + target and returns the differing extents", async () => {
     mockSSH.mockImplementation(async (...args: unknown[]) => {
       const cmd = String(args[2] ?? "")
@@ -71,5 +84,51 @@ describe("detectChangedExtentsByChecksum", () => {
     })
     const ext = await detectChangedExtentsByChecksum("conn", "ip", "/dev/nbd3", "/dev/dm-9", B, 3 * B - 1)
     expect(ext).toEqual([{ offset: B, length: B }])
+  })
+
+  it("reports scan progress by counting hash lines across both scans (2*numBlocks total)", async () => {
+    // Stream the hashes in chunks, one of them split mid-line: the partial line
+    // must not count until its newline arrives.
+    mockSSH.mockImplementation(async (...args: unknown[]) => {
+      const cmd = String(args[2] ?? "")
+      const opts = args[4] as { onData?: (c: string) => void }
+      if (cmd.includes("/dev/nbd3")) {
+        opts.onData?.("a\nb")   // 1 full line + a partial
+        opts.onData?.("\nc\n")  // completes "b", then "c"
+        return { success: true, output: "a\nb\nc" }
+      }
+      opts.onData?.("a\nX\nc\n") // 3 lines in one chunk
+      return { success: true, output: "a\nX\nc" }
+    })
+    const seen: Array<[number, number]> = []
+    await detectChangedExtentsByChecksum("conn", "ip", "/dev/nbd3", "/dev/dm-9", B, 3 * B - 1,
+      { onProgress: (scanned, total) => seen.push([scanned, total]) })
+    expect(seen.every(([, total]) => total === 6)).toBe(true)
+    // monotonic non-decreasing scanned counter…
+    for (let i = 1; i < seen.length; i++) expect(seen[i][0]).toBeGreaterThanOrEqual(seen[i - 1][0])
+    // …ending with every block of both scans counted
+    expect(seen[seen.length - 1][0]).toBe(6)
+  })
+
+  it("forwards inactivityMs to both underlying scans", async () => {
+    mockSSH.mockResolvedValue({ success: true, output: "a" })
+    await detectChangedExtentsByChecksum("conn", "ip", "/dev/nbd3", "/dev/dm-9", B, B,
+      { inactivityMs: 4321 })
+    expect(mockSSH).toHaveBeenCalledTimes(2)
+    for (const call of mockSSH.mock.calls) {
+      expect((call[4] as { inactivityMs?: number }).inactivityMs).toBe(4321)
+    }
+  })
+
+  it("stays silent (no onProgress calls) when the callback is not provided", async () => {
+    mockSSH.mockImplementation(async (...args: unknown[]) => {
+      const opts = args[4] as { onData?: (c: string) => void }
+      opts.onData?.("a\n")
+      return { success: true, output: "a" }
+    })
+    // No onProgress: the onData counters must not throw on the undefined callback.
+    await expect(
+      detectChangedExtentsByChecksum("conn", "ip", "/dev/nbd3", "/dev/dm-9", B, B),
+    ).resolves.toEqual([])
   })
 })

--- a/frontend/src/lib/migration/warm/checksum-detector.ts
+++ b/frontend/src/lib/migration/warm/checksum-detector.ts
@@ -28,6 +28,14 @@ export function buildBlockChecksumCmd(device: string, blockSize: number, numBloc
     `dd if=${shellEscape(device)} bs=${blockSize} skip=$i count=1 2>/dev/null | md5sum | cut -d' ' -f1; done`
 }
 
+/** Optional streaming controls for a scan, forwarded to executeSSH. */
+export interface ScanChecksumOpts {
+  /** Fail the scan if no output arrives for this long (see SSHExecOpts). */
+  inactivityMs?: number
+  /** Called with each raw stdout/stderr chunk as the hashes stream in. */
+  onData?: (chunk: string) => void
+}
+
 /**
  * Compute per-block checksums of a device on the PVE node. Returns one hash per
  * block (0..numBlocks-1). numBlocks <= 0 short-circuits to an empty list.
@@ -38,12 +46,13 @@ export async function scanBlockChecksums(
   device: string,
   blockSize: number,
   numBlocks: number,
+  opts: ScanChecksumOpts = {},
 ): Promise<string[]> {
   if (numBlocks <= 0) return []
   // The whole disk is scanned block-by-block, which on a multi-TB disk can run
   // for many minutes; this is the no-CBT fallback where downtime scales with
   // disk size. Give it a generous timeout.
-  const res = await executeSSH(connectionId, nodeIp, buildBlockChecksumCmd(device, blockSize, numBlocks), 6 * 60 * 60 * 1000)
+  const res = await executeSSH(connectionId, nodeIp, buildBlockChecksumCmd(device, blockSize, numBlocks), 6 * 60 * 60 * 1000, opts)
   if (!res.success) throw new Error(`block checksum scan failed on ${device}: ${res.error || res.output}`)
   return (res.output || "").split("\n").map(s => s.trim()).filter(Boolean)
 }
@@ -54,6 +63,12 @@ export async function scanBlockChecksums(
  * the applier. Universal and lossless; used when CBT is ineligible or its
  * change map is invalid. The source is stopped (snapshot) before scanning by
  * the caller so the hashes are consistent.
+ *
+ * `onProgress(scannedBlocks, totalBlocks)` reports live scan progress: each
+ * completed hash prints one line, so newlines in the SSH stream count scanned
+ * blocks (robust to a chunk splitting mid-line — a partial line has no '\n'
+ * yet and is counted when its newline arrives). Source and target are scanned
+ * in parallel, hence totalBlocks = 2 * numBlocks.
  */
 export async function detectChangedExtentsByChecksum(
   connectionId: string,
@@ -62,11 +77,22 @@ export async function detectChangedExtentsByChecksum(
   dstDevice: string,
   blockSize: number,
   diskLength: number,
+  opts: { inactivityMs?: number; onProgress?: (scannedBlocks: number, totalBlocks: number) => void } = {},
 ): Promise<Extent[]> {
   const numBlocks = Math.ceil(diskLength / blockSize)
+  let srcLines = 0
+  let dstLines = 0
+  const countLines = (chunk: string) => chunk.split("\n").length - 1
+  const report = () => opts.onProgress?.(srcLines + dstLines, 2 * numBlocks)
   const [srcSums, dstSums] = await Promise.all([
-    scanBlockChecksums(connectionId, nodeIp, srcDevice, blockSize, numBlocks),
-    scanBlockChecksums(connectionId, nodeIp, dstDevice, blockSize, numBlocks),
+    scanBlockChecksums(connectionId, nodeIp, srcDevice, blockSize, numBlocks, {
+      inactivityMs: opts.inactivityMs,
+      onData: chunk => { srcLines += countLines(chunk); report() },
+    }),
+    scanBlockChecksums(connectionId, nodeIp, dstDevice, blockSize, numBlocks, {
+      inactivityMs: opts.inactivityMs,
+      onData: chunk => { dstLines += countLines(chunk); report() },
+    }),
   ])
   return diffChecksums(srcSums, dstSums, blockSize)
 }

--- a/frontend/src/lib/migration/warm/warm-pipeline.test.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest"
-import { planPasses, buildThickZeroScript, scaleWarmProgress, ZERO_PARALLEL_CHUNKS, markVolumesCopied, requestWarmCutover, __isCutoverRequestedForTest, __awaitOperatorCutoverForTest } from "./warm-pipeline"
+import { planPasses, buildThickZeroScript, scaleWarmProgress, checksumDiskWindows, ZERO_PARALLEL_CHUNKS, markVolumesCopied, requestWarmCutover, __isCutoverRequestedForTest, __awaitOperatorCutoverForTest } from "./warm-pipeline"
 import { parseDdProgress } from "./dd-progress"
 import { volumesToFree, volumesToKeep, type AllocatedVolume } from "../pvesm-alloc"
 import { prismaTest, truncate } from "../../../__tests__/setup/prisma-test"
@@ -156,6 +156,31 @@ describe("scaleWarmProgress", () => {
 
   it("rounds to a whole percent (the job column is an Int)", () => {
     expect(scaleWarmProgress(0, 10, 1, 3)).toBe(3)
+  })
+})
+
+describe("checksumDiskWindows", () => {
+  // Checksum fallback slices of the locked 10→80 full_copy window: per disk,
+  // the first 30% of the slice is the scan, the remaining 70% the apply.
+  it("gives a single disk the whole 10→80 window, scan ending at 31", () => {
+    expect(checksumDiskWindows(0, 1)).toEqual({ scanStart: 10, scanEnd: 31, applyEnd: 80 })
+  })
+
+  it("splits multiple disks into equal contiguous slices", () => {
+    expect(checksumDiskWindows(0, 2)).toEqual({ scanStart: 10, scanEnd: 20.5, applyEnd: 45 })
+    expect(checksumDiskWindows(1, 2)).toEqual({ scanStart: 45, scanEnd: 55.5, applyEnd: 80 })
+  })
+
+  it("keeps windows contiguous and monotonic: one disk's applyEnd is the next disk's scanStart", () => {
+    for (const count of [1, 2, 3, 5]) {
+      for (let i = 0; i < count; i++) {
+        const w = checksumDiskWindows(i, count)
+        expect(w.scanStart).toBeLessThan(w.scanEnd)
+        expect(w.scanEnd).toBeLessThan(w.applyEnd)
+        if (i > 0) expect(w.scanStart).toBeCloseTo(checksumDiskWindows(i - 1, count).applyEnd, 10)
+      }
+      expect(checksumDiskWindows(count - 1, count).applyEnd).toBeCloseTo(80, 10)
+    }
   })
 })
 

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -222,6 +222,18 @@ export function scaleWarmProgress(rangeStart: number, rangeEnd: number, doneByte
   return Math.round(rangeStart + (rangeEnd - rangeStart) * fraction)
 }
 
+/**
+ * Progress windows for one disk of the checksum fallback on the locked 10→80
+ * full_copy scale. Each disk gets an equal slice (span = 70/diskCount); the
+ * first 30% of the slice is the checksum scan (reads only, nothing copied yet),
+ * the remaining 70% is the block apply. Pure — unit-tested like scaleWarmProgress.
+ */
+export function checksumDiskWindows(diskIndex: number, diskCount: number): { scanStart: number; scanEnd: number; applyEnd: number } {
+  const span = 70 / diskCount
+  const scanStart = 10 + span * diskIndex
+  return { scanStart, scanEnd: scanStart + 0.3 * span, applyEnd: 10 + span * (diskIndex + 1) }
+}
+
 /** One copy pass's slot on the locked progress scale (see scaleWarmProgress). */
 interface PassWindow {
   status: WarmStatus
@@ -516,7 +528,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         // Progress first, then the log line — appendLog stamps each entry with
         // the job's current progress, which is why the lines used to read 0 (#502).
         void (async () => {
-          await updateJobLive(jobId, pass.status, { currentStep: pass.currentStep, progress: pct, bytesTransferred: BigInt(passBytes), transferSpeed: `${(p.bytesPerSec / 1048576).toFixed(0)} MB/s` })
+          await updateJobLive(jobId, pass.status, { currentStep: pass.currentStep, currentDisk: diskIndex, progress: pct, bytesTransferred: BigInt(passBytes), transferSpeed: `${(p.bytesPerSec / 1048576).toFixed(0)} MB/s` })
           await appendLog(jobId, `Disk ${diskIndex}: copying ${(passBytes / 1073741824).toFixed(1)} GB at ${(p.bytesPerSec / 1048576).toFixed(0)} MB/s`)
         })().catch(() => {})
       }
@@ -569,6 +581,9 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         for (let i = 0; i < vmConfig.disks.length; i++) {
           if (isCancelled(jobId)) throw new Error("Migration cancelled")
           const disk = vmConfig.disks[i]
+          // Cheap live write so the task readout can say "Disk n of m" while this
+          // disk streams; keeps the pass's finer step label (e.g. delta_2).
+          await updateJobLive(jobId, window.status, { currentStep: window.currentStep, currentDisk: i })
           bytes += await readAndApply(disk, i, snapMor, extentsByDisk.get(disk.deviceKey)!, pass)
           // Correct the estimate with the disk's exact extent total: the dd
           // accumulator is conservative (see createDdProgressAccumulator).
@@ -641,13 +656,19 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
 
       // ── cutover: confirmed power-off → final delta → verify → attach → boot ──
       await updateJob(jobId, "cutover", { progress: 95 })
-      await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId)
+      await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId,
+        "Cutover: requesting clean guest shutdown (VMware Tools)…")
       await appendLog(jobId, "Source powered off (confirmed) — applying final delta", "success")
       await runCbtPass("cutover", dk => diskState.get(dk)!.currentChangeId || "*", { status: "cutover", currentStep: "cutover", rangeStart: 95, rangeEnd: 98 })
     } else {
       // ── checksum fallback: stop source, full block-diff vs the (zeroed) target ──
-      await updateJob(jobId, "cutover")
-      await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId)
+      // The early shutdown belongs to the full copy on this path, NOT the cutover:
+      // a "cutover" badge at minute 0 read as "almost done" while the whole copy
+      // was still ahead, and the generic shutdown line hid that the VM would stay
+      // off for the entire transfer (#587 field feedback).
+      await updateJob(jobId, "full_copy", { currentStep: "source_shutdown", progress: 10 })
+      await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId,
+        "Checksum fallback: requesting clean guest shutdown of the source BEFORE the copy — the VM stays powered off until the migration completes (CBT unavailable)…")
       await updateJob(jobId, "full_copy", { progress: 10 })
       const snapMor = await soapCreateSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-checksum`, "warm migration", false)
       if (!snapMor) throw new Error("CreateSnapshot (checksum) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually")
@@ -662,16 +683,38 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
           activeReaders.push(reader)
           try {
             const dev = targetDev.get(disk.deviceKey)!
-            const extents = await detectChangedExtentsByChecksum(config.targetConnectionId, nodeIp, reader.nbdDev, dev, 256 * 1024 * 1024, disk.capacityBytes)
-            // Per-disk progress window: unlike runCbtPass there is no upfront
+            // Per-disk progress windows: unlike runCbtPass there is no upfront
             // all-disk denominator here (the checksum scan needs each disk's
-            // reader), so each disk gets an equal slice of the 10→80 window.
-            const span = 70 / vmConfig.disks.length
+            // reader), so each disk gets an equal slice of the 10→80 window —
+            // the first 30% for the scan, the rest for the apply.
+            const win = checksumDiskWindows(i, vmConfig.disks.length)
+            const capGB = (disk.capacityBytes / 1073741824).toFixed(1)
+            // #587 field feedback: this scan ran ~25 min per 60 GB disk (hours on
+            // multi-TB) in total silence — no log line, no progress — and read as
+            // a hang. Announce it and stream its progress below.
+            await appendLog(jobId, `Disk ${i}: scanning source and target block checksums (${capGB} GB) — nothing is copied during this phase; it reads the whole disk and can take a long time`)
+            let lastScanFlush = 0
+            const extents = await detectChangedExtentsByChecksum(config.targetConnectionId, nodeIp, reader.nbdDev, dev, 256 * 1024 * 1024, disk.capacityBytes, {
+              inactivityMs: APPLY_INACTIVITY_MS,
+              onProgress: (scannedBlocks, totalBlocks) => {
+                const now = Date.now()
+                if (now - lastScanFlush < PROGRESS_LOG_INTERVAL_MS) return
+                lastScanFlush = now
+                const pct = scaleWarmProgress(win.scanStart, win.scanEnd, scannedBlocks, totalBlocks)
+                const scanPct = totalBlocks > 0 ? Math.round((scannedBlocks / totalBlocks) * 100) : 100
+                // Progress first, then the log line — appendLog stamps each entry
+                // with the job's current progress (#502).
+                void (async () => {
+                  await updateJobLive(jobId, "full_copy", { currentStep: "full_copy", currentDisk: i, progress: pct, transferSpeed: null })
+                  await appendLog(jobId, `Disk ${i}: checksum scan ${scanPct}% (reading source and target)`)
+                })().catch(() => {})
+              },
+            })
             await applyExtents(reader.nbdDev, dev, extents, disk.capacityBytes, "checksum apply failed", i, {
               status: "full_copy", currentStep: "full_copy",
-              rangeStart: 10 + span * i, rangeEnd: 10 + span * (i + 1),
+              rangeStart: win.scanEnd, rangeEnd: win.applyEnd,
               totalBytes: extents.reduce((s, e) => s + e.length, 0), doneBytes: 0,
-              lastPct: Math.round(10 + span * i),
+              lastPct: Math.round(win.scanEnd),
             })
           } finally {
             await stopVddkReader(config.targetConnectionId, nodeIp, reader).catch(() => {})
@@ -787,9 +830,13 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
  * Clean guest shutdown then CONFIRM the source is powered off. Mandatory for a
  * valid final delta (section 9): a delta taken while the guest still writes is
  * invalid, so there is no proceed-anyway. Aborts if the source never stops.
+ * `announce` is the log line for the shutdown request: the CBT path shuts down
+ * at cutover (seconds of downtime left) while the checksum fallback shuts down
+ * BEFORE the copy (VM off for the whole transfer) — one hardcoded "Cutover: …"
+ * line misled operators on the fallback path (#587 field feedback).
  */
-async function cleanShutdownAndConfirm(jobId: string, session: SoapSession, vmid: string): Promise<void> {
-  await appendLog(jobId, "Cutover: requesting clean guest shutdown (VMware Tools)…")
+async function cleanShutdownAndConfirm(jobId: string, session: SoapSession, vmid: string, announce: string): Promise<void> {
+  await appendLog(jobId, announce)
   await soapGuestShutdown(session, vmid).catch(async (e: any) => {
     await appendLog(jobId, `Guest shutdown could not be initiated (${e?.message || e}); waiting for manual/hard power-off`, "warn")
   })

--- a/frontend/src/lib/tasks/taskProgressDisplay.test.ts
+++ b/frontend/src/lib/tasks/taskProgressDisplay.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest"
+import { parseSpeedMBps, etaSeconds, formatEta, stepLabelKey } from "./taskProgressDisplay"
+
+describe("parseSpeedMBps", () => {
+  it("parses the bare pipeline form", () => {
+    expect(parseSpeedMBps("64 MB/s")).toBe(64)
+  })
+  it("parses prefixed forms (thick pre-zero)", () => {
+    expect(parseSpeedMBps("Zeroing: 80 MB/s")).toBe(80)
+  })
+  it("parses decimals and the MiB/s spelling", () => {
+    expect(parseSpeedMBps("12.5 MB/s")).toBe(12.5)
+    expect(parseSpeedMBps("100 MiB/s")).toBe(100)
+  })
+  it("returns null when absent", () => {
+    expect(parseSpeedMBps(null)).toBeNull()
+    expect(parseSpeedMBps("")).toBeNull()
+  })
+  it("returns null when unparseable", () => {
+    expect(parseSpeedMBps("fast")).toBeNull()
+    expect(parseSpeedMBps("64 GB/s")).toBeNull()
+  })
+})
+
+describe("etaSeconds", () => {
+  const MB = 1048576
+  it("computes remaining seconds from the byte gap and the MB/s speed", () => {
+    // 32 MiB to go at 2 MB/s -> 16 s
+    expect(etaSeconds(32 * MB, 64 * MB, 2)).toBe(16)
+  })
+  it("returns null on any missing input", () => {
+    expect(etaSeconds(null, 64 * MB, 2)).toBeNull()
+    expect(etaSeconds(32 * MB, null, 2)).toBeNull()
+    expect(etaSeconds(32 * MB, 64 * MB, null)).toBeNull()
+  })
+  it("returns null on zero or negative inputs", () => {
+    expect(etaSeconds(0, 0, 2)).toBeNull()
+    expect(etaSeconds(0, -1, 2)).toBeNull()
+    expect(etaSeconds(-1, 64 * MB, 2)).toBeNull()
+    expect(etaSeconds(0, 64 * MB, 0)).toBeNull()
+    expect(etaSeconds(0, 64 * MB, -3)).toBeNull()
+  })
+  it("returns null once the transfer caught up (transferred >= total)", () => {
+    expect(etaSeconds(64 * MB, 64 * MB, 2)).toBeNull()
+    expect(etaSeconds(65 * MB, 64 * MB, 2)).toBeNull()
+  })
+})
+
+describe("formatEta", () => {
+  it("renders sub-minute in seconds", () => {
+    expect(formatEta(45)).toBe("45s")
+    expect(formatEta(0)).toBe("0s")
+  })
+  it("clamps negatives to zero", () => {
+    expect(formatEta(-5)).toBe("0s")
+  })
+  it("renders sub-hour in whole minutes", () => {
+    expect(formatEta(720)).toBe("12m")
+    expect(formatEta(90)).toBe("1m")
+  })
+  it("renders hours with a minute remainder", () => {
+    expect(formatEta(3 * 3600 + 12 * 60)).toBe("3h 12m")
+  })
+  it("drops a zero minute remainder", () => {
+    expect(formatEta(7200)).toBe("2h")
+  })
+})
+
+describe("stepLabelKey", () => {
+  it("maps every known pipeline step to itself", () => {
+    for (const step of [
+      "planning", "enabling_cbt", "preparing_disks", "full_copy", "source_shutdown",
+      "awaiting_cutover", "cutover", "verify", "converting_disks",
+      "preflight", "transferring", "creating_vm", "configuring", "pending",
+    ]) {
+      expect(stepLabelKey(step)).toBe(step)
+    }
+  })
+  it("collapses numbered delta passes to 'delta'", () => {
+    expect(stepLabelKey("delta_1")).toBe("delta")
+    expect(stepLabelKey("delta_12")).toBe("delta")
+  })
+  it("returns null for unknown steps so the raw string can be shown", () => {
+    expect(stepLabelKey("delta_")).toBeNull()
+    expect(stepLabelKey("importing_disk_2")).toBeNull()
+    expect(stepLabelKey("Copying disk 1/2")).toBeNull()
+  })
+  it("returns null when there is no step", () => {
+    expect(stepLabelKey(null)).toBeNull()
+    expect(stepLabelKey("")).toBeNull()
+  })
+})

--- a/frontend/src/lib/tasks/taskProgressDisplay.ts
+++ b/frontend/src/lib/tasks/taskProgressDisplay.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure display helpers for the shared-task detail readout (speed parsing, ETA,
+ * step labels). Kept out of SharedTaskDetailDialog so every branch is
+ * unit-testable; the component only assembles the pieces.
+ */
+
+/**
+ * Parse the migration pipelines' transferSpeed strings into a MB/s number.
+ * Handles the bare form ("64 MB/s") and prefixed forms ("Zeroing: 80 MB/s"),
+ * plus the MiB/s spelling some fixtures use. Null when absent or unparseable.
+ */
+export function parseSpeedMBps(speed: string | null): number | null {
+  if (!speed) return null
+  const m = /(\d+(?:\.\d+)?)\s*M(?:i)?B\/s/i.exec(speed)
+  if (!m) return null
+  const v = Number.parseFloat(m[1])
+  return Number.isFinite(v) ? v : null
+}
+
+/**
+ * Remaining seconds for a transfer, from the byte counters and a MB/s speed
+ * (MB = 1048576 bytes, matching how the pipelines compute their speed strings).
+ * Null on any missing/zero/negative input or when the transfer is already done.
+ */
+export function etaSeconds(bytesTransferred: number | null, totalBytes: number | null, speedMBps: number | null): number | null {
+  if (bytesTransferred == null || totalBytes == null || speedMBps == null) return null
+  if (bytesTransferred < 0 || totalBytes <= 0 || speedMBps <= 0) return null
+  if (bytesTransferred >= totalBytes) return null
+  return (totalBytes - bytesTransferred) / (speedMBps * 1048576)
+}
+
+/** Compact duration: "45s" under a minute, "12m" under an hour, then "3h 12m". */
+export function formatEta(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds))
+  if (s < 60) return `${s}s`
+  const minutes = Math.floor(s / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  return rest > 0 ? `${hours}h ${rest}m` : `${hours}h`
+}
+
+// Steps the pipelines write to migrationJob.currentStep that have a stable
+// translation under tasks.steps.*. Warm: planning…converting_disks (delta
+// passes are numbered, see below). Cold/v2v: preflight…pending.
+const KNOWN_STEPS = new Set([
+  "planning", "enabling_cbt", "preparing_disks", "full_copy", "source_shutdown",
+  "awaiting_cutover", "cutover", "verify", "converting_disks",
+  "preflight", "transferring", "creating_vm", "configuring", "pending",
+])
+
+/**
+ * Map a job's currentStep to its tasks.steps.* key suffix. Numbered delta
+ * passes (delta_1, delta_2, …) collapse to "delta". Unknown steps return null
+ * so the caller can fall back to showing the raw string.
+ */
+export function stepLabelKey(currentStep: string | null): string | null {
+  if (!currentStep) return null
+  if (/^delta_\d+$/.test(currentStep)) return "delta"
+  return KNOWN_STEPS.has(currentStep) ? currentStep : null
+}

--- a/frontend/src/lib/vmware/cbt-eligibility.ts
+++ b/frontend/src/lib/vmware/cbt-eligibility.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure CBT eligibility check, dependency-free so client components (e.g. the
+ * migrate dialog's pre-launch fallback warning) can import it. cbt.ts
+ * transitively pulls in the server-only SOAP client and re-exports these for
+ * its existing server-side callers.
+ */
+
+export interface CbtEligibilityInput { hwVersion: string; disks: { diskMode?: string; sharing?: string }[] }
+
+/** Pure eligibility check: CBT needs hw version >= 7 and no independent / multi-writer disks. */
+export function cbtEligibility(vm: CbtEligibilityInput): { eligible: boolean; reason?: string } {
+  const ver = Number.parseInt(vm.hwVersion.replace("vmx-", ""), 10) || 0
+  if (ver < 7) return { eligible: false, reason: `hardware version ${vm.hwVersion} is below vmx-07` }
+  for (const d of vm.disks) {
+    if ((d.diskMode || "").includes("independent")) return { eligible: false, reason: "independent disk present" }
+    if (d.sharing === "sharingMultiWriter") return { eligible: false, reason: "multi-writer disk present" }
+  }
+  return { eligible: true }
+}

--- a/frontend/src/lib/vmware/cbt.ts
+++ b/frontend/src/lib/vmware/cbt.ts
@@ -42,18 +42,11 @@ export function parseSnapshotChangeIds(deviceXml: string): Map<number, string> {
   return map
 }
 
-export interface CbtEligibilityInput { hwVersion: string; disks: { diskMode?: string; sharing?: string }[] }
-
-/** Pure eligibility check: CBT needs hw version >= 7 and no independent / multi-writer disks. */
-export function cbtEligibility(vm: CbtEligibilityInput): { eligible: boolean; reason?: string } {
-  const ver = Number.parseInt(vm.hwVersion.replace("vmx-", ""), 10) || 0
-  if (ver < 7) return { eligible: false, reason: `hardware version ${vm.hwVersion} is below vmx-07` }
-  for (const d of vm.disks) {
-    if ((d.diskMode || "").includes("independent")) return { eligible: false, reason: "independent disk present" }
-    if (d.sharing === "sharingMultiWriter") return { eligible: false, reason: "multi-writer disk present" }
-  }
-  return { eligible: true }
-}
+// The pure eligibility check lives in its own dependency-free module so client
+// components can import it without dragging in the SOAP client; re-exported
+// here so existing server-side importers keep compiling unchanged.
+export { cbtEligibility } from "./cbt-eligibility"
+export type { CbtEligibilityInput } from "./cbt-eligibility"
 
 // ---- SOAP callers ----
 

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2096,6 +2096,12 @@
       "warmPreflightFailedTitle": "Zielknoten ist nicht bereit fur die Warm-Migration",
       "warmPreflightMissing": "Fehlt auf dem Knoten: {items}.",
       "warmPreflightDocsHint": "Bereiten Sie zuerst den Proxmox-Knoten vor (nbdkit, das nbdkit-VDDK-Plugin, nbd-client und das Broadcom-VDDK installieren), dann wahlen Sie den Knoten erneut aus. Siehe die <link>Anleitung zur Knotenvorbereitung fur die Warm-Migration</link>.",
+      "warmCbtFallbackTitle": "CBT nicht verfugbar: diese Warm-Migration verwendet den Prufsummen-Fallback",
+      "warmCbtFallbackReasonSnapshot": "Die Quell-VM hat einen vorhandenen VMware-Snapshot, daher kann die Anderungsverfolgung (CBT) nicht verwendet werden.",
+      "warmCbtFallbackReasonHwVersion": "Die virtuelle Hardware-Version der Quell-VM liegt unter vmx-07, daher kann die Anderungsverfolgung (CBT) nicht verwendet werden.",
+      "warmCbtFallbackReasonDiskMode": "Die Quell-VM hat eine unabhangige oder Multi-Writer-Disk, daher kann die Anderungsverfolgung (CBT) nicht verwendet werden.",
+      "warmCbtFallbackDowntime": "Mit dem Prufsummen-Fallback wird die Quell-VM zu Beginn der Kopie heruntergefahren und bleibt wahrend der gesamten Ubertragung ausgeschaltet: die Ausfallzeit skaliert mit der Gesamtgrosse der Disks.",
+      "warmCbtFallbackSnapshotHint": "Werden die VMware-Snapshots vor dem Start entfernt oder konsolidiert, bleibt die VM bis zur kurzen finalen Umschaltung online.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimentell)",
       "migrationTypeSshfsBootDesc": "Nahezu null Ausfallzeit: VM startet auf Proxmox von entfernten ESXi-Disks in Sekunden. Experimentell: der Gast muss unbeaufsichtigt auf dem Ziel-Controller booten; kann bei EFI-Windows oder Gasten fehlschlagen, die eine Treiberinjektion benotigen. Fur Produktion Live oder Offline bevorzugen.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot ist experimentell und funktioniert nur, wenn der Gast ohne Treiberanpassung auf dem Ziel korrekt bootet. Fur EFI-Windows, vCenter-VMs oder produktionskritische Systeme Live oder Offline verwenden.",
@@ -3645,6 +3651,23 @@
       "completed": "Abgeschlossen",
       "cancelled": "Abgebrochen"
     },
+    "steps": {
+      "planning": "Planung",
+      "enabling_cbt": "CBT wird aktiviert",
+      "preparing_disks": "Ziel-Disks werden vorbereitet",
+      "full_copy": "Vollständige Kopie",
+      "delta": "Delta-Synchronisierung",
+      "source_shutdown": "Quell-VM wird heruntergefahren",
+      "awaiting_cutover": "Warten auf die Umschalt-Entscheidung",
+      "cutover": "Umschaltung",
+      "verify": "Überprüfung",
+      "converting_disks": "Disks werden konvertiert",
+      "preflight": "Vorabprüfungen",
+      "transferring": "Disks werden übertragen",
+      "creating_vm": "VM wird erstellt",
+      "configuring": "VM wird konfiguriert",
+      "pending": "Ausstehend"
+    },
     "shared": {
       "detailTitle": "Migrationsaufgabe",
       "startedBy": "Gestartet von {name}",
@@ -3654,6 +3677,9 @@
       "cancelConfirmLeftovers": "Bereits kopierte Volumes und eine teilweise erstellte VMID können auf dem Zielknoten verbleiben. Bereinigen Sie sie manuell, wenn Sie sie nicht benötigen.",
       "cancelConfirmKeep": "Migration fortsetzen",
       "cancelling": "Wird abgebrochen...",
+      "diskOf": "Festplatte {n} von {m}",
+      "gbProgress": "{done} / {total} GB",
+      "eta": "~{eta} verbleibend",
       "cancelFailed": "Migration konnte nicht abgebrochen werden"
     },
     "types": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2126,6 +2126,12 @@
       "warmPreflightFailedTitle": "Target node is not ready for warm migration",
       "warmPreflightMissing": "Missing on the node: {items}.",
       "warmPreflightDocsHint": "Prepare the Proxmox node first (install nbdkit, the nbdkit VDDK plugin, nbd-client and the Broadcom VDDK), then reselect the node. See the <link>warm migration node setup guide</link>.",
+      "warmCbtFallbackTitle": "CBT unavailable: this warm migration will use the checksum fallback",
+      "warmCbtFallbackReasonSnapshot": "The source VM has an existing VMware snapshot, so Changed Block Tracking (CBT) cannot be used.",
+      "warmCbtFallbackReasonHwVersion": "The source VM's virtual hardware version is below vmx-07, so Changed Block Tracking (CBT) cannot be used.",
+      "warmCbtFallbackReasonDiskMode": "The source VM has an independent or multi-writer disk, so Changed Block Tracking (CBT) cannot be used.",
+      "warmCbtFallbackDowntime": "With the checksum fallback the source VM is shut down at the start of the copy and stays powered off for the whole transfer: downtime scales with the total disk size.",
+      "warmCbtFallbackSnapshotHint": "Removing or consolidating the VMware snapshots before starting keeps the VM online until the final short cutover.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimental)",
       "migrationTypeSshfsBootDesc": "Near-zero downtime: VM boots on Proxmox from remote ESXi disks within seconds. Experimental: the guest must boot unattended on the target controller; may fail for EFI Windows or guests needing driver injection. Prefer Live or Offline for production.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot is experimental and only works when the guest boots correctly on the target without driver adaptation. For EFI Windows, vCenter-sourced VMs, or anything production-critical, choose Live or Offline.",
@@ -3683,6 +3689,23 @@
       "completed": "Completed",
       "cancelled": "Cancelled"
     },
+    "steps": {
+      "planning": "Planning",
+      "enabling_cbt": "Enabling CBT",
+      "preparing_disks": "Preparing target disks",
+      "full_copy": "Full copy",
+      "delta": "Delta sync",
+      "source_shutdown": "Shutting down the source VM",
+      "awaiting_cutover": "Awaiting cutover decision",
+      "cutover": "Cutover",
+      "verify": "Verifying",
+      "converting_disks": "Converting disks",
+      "preflight": "Preflight checks",
+      "transferring": "Transferring disks",
+      "creating_vm": "Creating the VM",
+      "configuring": "Configuring the VM",
+      "pending": "Pending"
+    },
     "shared": {
       "detailTitle": "Migration task",
       "startedBy": "Started by {name}",
@@ -3692,6 +3715,9 @@
       "cancelConfirmLeftovers": "Volumes already copied and a partially created VMID may remain on the target node. Clean them up manually if you do not need them.",
       "cancelConfirmKeep": "Keep migrating",
       "cancelling": "Cancelling...",
+      "diskOf": "Disk {n} of {m}",
+      "gbProgress": "{done} / {total} GB",
+      "eta": "~{eta} remaining",
       "cancelFailed": "Failed to cancel the migration"
     },
     "types": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2126,6 +2126,12 @@
       "warmPreflightFailedTitle": "El nodo destino no está listo para la migración warm",
       "warmPreflightMissing": "Falta en el nodo: {items}.",
       "warmPreflightDocsHint": "Prepara primero el nodo Proxmox (instala nbdkit, el plugin nbdkit VDDK, nbd-client y Broadcom VDDK) y vuelve a seleccionar el nodo. Consulta la <link>guía de preparación del nodo para migración warm</link>.",
+      "warmCbtFallbackTitle": "CBT no disponible: esta migración warm usará el fallback por sumas de verificación",
+      "warmCbtFallbackReasonSnapshot": "La VM de origen tiene un snapshot de VMware existente, por lo que no se puede usar el seguimiento de cambios (CBT).",
+      "warmCbtFallbackReasonHwVersion": "La versión de hardware virtual de la VM de origen es inferior a vmx-07, por lo que no se puede usar el seguimiento de cambios (CBT).",
+      "warmCbtFallbackReasonDiskMode": "La VM de origen tiene un disco independiente o multi-writer, por lo que no se puede usar el seguimiento de cambios (CBT).",
+      "warmCbtFallbackDowntime": "Con el fallback por sumas de verificación, la VM de origen se apaga al inicio de la copia y permanece apagada durante toda la transferencia: la indisponibilidad depende del tamaño total de los discos.",
+      "warmCbtFallbackSnapshotHint": "Eliminar o consolidar los snapshots de VMware antes de empezar mantiene la VM online hasta el breve cutover final.",
       "migrationTypeSshfsBoot": "Arranque SSHFS (experimental)",
       "migrationTypeSshfsBootDesc": "Downtime casi nulo: la VM arranca en Proxmox desde discos ESXi remotos en segundos. Experimental: el guest debe arrancar sin intervención en la controladora destino; puede fallar con Windows EFI o guests que necesiten inyección de drivers. Usa Live u Offline en producción.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot es experimental y solo funciona si el guest arranca correctamente en el destino sin adaptar drivers. Para Windows EFI, VMs procedentes de vCenter o cualquier carga crítica de producción, elige Live u Offline.",
@@ -3683,6 +3689,23 @@
       "completed": "Completado",
       "cancelled": "Cancelado"
     },
+    "steps": {
+      "planning": "Planificación",
+      "enabling_cbt": "Habilitando CBT",
+      "preparing_disks": "Preparando los discos de destino",
+      "full_copy": "Copia completa",
+      "delta": "Sincronización delta",
+      "source_shutdown": "Apagando la VM de origen",
+      "awaiting_cutover": "Esperando la decisión de cutover",
+      "cutover": "Cutover",
+      "verify": "Verificando",
+      "converting_disks": "Convirtiendo discos",
+      "preflight": "Comprobaciones previas",
+      "transferring": "Transfiriendo discos",
+      "creating_vm": "Creando la VM",
+      "configuring": "Configurando la VM",
+      "pending": "Pendiente"
+    },
     "shared": {
       "detailTitle": "Tarea de migración",
       "startedBy": "Iniciada por {name}",
@@ -3692,6 +3715,9 @@
       "cancelConfirmLeftovers": "Los volúmenes ya copiados y un VMID creado parcialmente pueden permanecer en el nodo de destino. Límpielos manualmente si no los necesita.",
       "cancelConfirmKeep": "Seguir migrando",
       "cancelling": "Cancelando...",
+      "diskOf": "Disco {n} de {m}",
+      "gbProgress": "{done} / {total} GB",
+      "eta": "~{eta} restante",
       "cancelFailed": "No se pudo cancelar la migración"
     },
     "types": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2126,6 +2126,12 @@
       "warmPreflightFailedTitle": "Le noeud cible n'est pas pret pour la migration a chaud",
       "warmPreflightMissing": "Manquant sur le noeud : {items}.",
       "warmPreflightDocsHint": "Preparez d'abord le noeud Proxmox (installez nbdkit, le plugin VDDK de nbdkit, nbd-client et le VDDK Broadcom), puis reselectionnez le noeud. Consultez le <link>guide de preparation du noeud pour la migration a chaud</link>.",
+      "warmCbtFallbackTitle": "CBT indisponible : cette migration a chaud utilisera le repli par sommes de controle",
+      "warmCbtFallbackReasonSnapshot": "La VM source possede un snapshot VMware existant, le suivi des blocs modifies (CBT) ne peut donc pas etre utilise.",
+      "warmCbtFallbackReasonHwVersion": "La version de materiel virtuel de la VM source est inferieure a vmx-07, le suivi des blocs modifies (CBT) ne peut donc pas etre utilise.",
+      "warmCbtFallbackReasonDiskMode": "La VM source possede un disque independant ou multi-writer, le suivi des blocs modifies (CBT) ne peut donc pas etre utilise.",
+      "warmCbtFallbackDowntime": "Avec le repli par sommes de controle, la VM source est arretee au debut de la copie et reste eteinte pendant tout le transfert : l'indisponibilite depend de la taille totale des disques.",
+      "warmCbtFallbackSnapshotHint": "Supprimer ou consolider les snapshots VMware avant de lancer garde la VM en ligne jusqu'a la bascule finale courte.",
       "migrationTypeSshfsBoot": "SSHFS Boot (Experimental)",
       "migrationTypeSshfsBootDesc": "Downtime quasi-nul : la VM demarre sur Proxmox depuis les disques ESXi distants en quelques secondes. Experimental : le guest doit booter sans adaptation sur le controleur cible, peut echouer pour Windows EFI ou les guests necessitant une injection de drivers. Preferer Live ou Offline en production.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS Boot est experimental et ne fonctionne que si le guest boote correctement sur la cible sans adaptation de drivers. Pour Windows EFI, les VMs issues de vCenter, ou tout environnement critique, utilisez Live ou Offline.",
@@ -3683,6 +3689,23 @@
       "completed": "Terminé",
       "cancelled": "Annulé"
     },
+    "steps": {
+      "planning": "Planification",
+      "enabling_cbt": "Activation du CBT",
+      "preparing_disks": "Préparation des disques cibles",
+      "full_copy": "Copie complète",
+      "delta": "Synchronisation delta",
+      "source_shutdown": "Arrêt de la VM source",
+      "awaiting_cutover": "En attente de la décision de bascule",
+      "cutover": "Bascule",
+      "verify": "Vérification",
+      "converting_disks": "Conversion des disques",
+      "preflight": "Vérifications préalables",
+      "transferring": "Transfert des disques",
+      "creating_vm": "Création de la VM",
+      "configuring": "Configuration de la VM",
+      "pending": "En attente"
+    },
     "shared": {
       "detailTitle": "Tâche de migration",
       "startedBy": "Lancé par {name}",
@@ -3692,6 +3715,9 @@
       "cancelConfirmLeftovers": "Des volumes déjà copiés et un VMID partiellement créé peuvent rester sur le nœud cible. Nettoyez-les manuellement si vous n'en avez pas besoin.",
       "cancelConfirmKeep": "Continuer la migration",
       "cancelling": "Annulation...",
+      "diskOf": "Disque {n} sur {m}",
+      "gbProgress": "{done} / {total} Go",
+      "eta": "~{eta} restant",
       "cancelFailed": "Échec de l'annulation de la migration"
     },
     "types": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2126,6 +2126,12 @@
       "warmPreflightFailedTitle": "대상 노드가 웜 마이그레이션 준비가 되지 않았습니다",
       "warmPreflightMissing": "노드에 없는 항목: {items}.",
       "warmPreflightDocsHint": "먼저 Proxmox 노드를 준비한 후(nbdkit, nbdkit VDDK 플러그인, nbd-client, Broadcom VDDK 설치) 노드를 다시 선택하세요. <link>웜 마이그레이션 노드 설정 가이드</link>를 참조하세요.",
+      "warmCbtFallbackTitle": "CBT를 사용할 수 없음: 이 웜 마이그레이션은 체크섬 폴백을 사용합니다",
+      "warmCbtFallbackReasonSnapshot": "소스 VM에 기존 VMware 스냅샷이 있어 변경 추적(CBT)을 사용할 수 없습니다.",
+      "warmCbtFallbackReasonHwVersion": "소스 VM의 가상 하드웨어 버전이 vmx-07 미만이어서 변경 추적(CBT)을 사용할 수 없습니다.",
+      "warmCbtFallbackReasonDiskMode": "소스 VM에 독립(independent) 디스크 또는 multi-writer 디스크가 있어 변경 추적(CBT)을 사용할 수 없습니다.",
+      "warmCbtFallbackDowntime": "체크섬 폴백에서는 복사 시작 시점에 소스 VM이 종료되고 전송이 끝날 때까지 꺼진 상태로 유지됩니다. 중단 시간은 전체 디스크 크기에 비례합니다.",
+      "warmCbtFallbackSnapshotHint": "시작하기 전에 VMware 스냅샷을 제거하거나 통합하면 마지막 짧은 컷오버까지 VM이 온라인 상태를 유지합니다.",
       "migrationTypeSshfsBoot": "SSHFS 부팅 (실험적)",
       "migrationTypeSshfsBootDesc": "다운타임 거의 없음: VM이 몇 초 안에 원격 ESXi 디스크에서 Proxmox로 부팅됩니다. 실험적 기능: 게스트가 대상 컨트롤러에서 무인 부팅되어야 하며, EFI Windows 또는 드라이버 주입이 필요한 게스트에서는 실패할 수 있습니다. 프로덕션에서는 라이브 또는 오프라인을 사용하세요.",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS 부팅은 실험적 기능이며, 게스트가 드라이버 조정 없이 대상에서 올바르게 부팅되는 경우에만 작동합니다. EFI Windows, vCenter에서 가져온 VM, 프로덕션 크리티컬 워크로드에는 라이브 또는 오프라인을 선택하세요.",
@@ -3683,6 +3689,23 @@
       "completed": "완료됨",
       "cancelled": "취소됨"
     },
+    "steps": {
+      "planning": "계획 중",
+      "enabling_cbt": "CBT 활성화 중",
+      "preparing_disks": "대상 디스크 준비 중",
+      "full_copy": "전체 복사",
+      "delta": "델타 동기화",
+      "source_shutdown": "소스 VM 종료 중",
+      "awaiting_cutover": "컷오버 결정 대기 중",
+      "cutover": "컷오버",
+      "verify": "검증 중",
+      "converting_disks": "디스크 변환 중",
+      "preflight": "사전 점검",
+      "transferring": "디스크 전송 중",
+      "creating_vm": "VM 생성 중",
+      "configuring": "VM 구성 중",
+      "pending": "대기 중"
+    },
     "shared": {
       "detailTitle": "마이그레이션 작업",
       "startedBy": "{name}이(가) 시작함",
@@ -3692,6 +3715,9 @@
       "cancelConfirmLeftovers": "이미 복사된 볼륨과 부분적으로 생성된 VMID가 대상 노드에 남을 수 있습니다. 필요하지 않으면 수동으로 정리하십시오.",
       "cancelConfirmKeep": "마이그레이션 계속하기",
       "cancelling": "취소 중...",
+      "diskOf": "디스크 {n} / {m}",
+      "gbProgress": "{done} / {total} GB",
+      "eta": "약 {eta} 남음",
       "cancelFailed": "마이그레이션을 취소하지 못했습니다"
     },
     "types": {

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2095,6 +2095,12 @@
       "warmPreflightFailedTitle": "目标节点尚未就绪，无法进行温迁移",
       "warmPreflightMissing": "节点上缺少：{items}。",
       "warmPreflightDocsHint": "请先准备 Proxmox 节点（安装 nbdkit、nbdkit VDDK 插件、nbd-client 以及 Broadcom VDDK），然后重新选择节点。请参阅<link>温迁移节点准备指南</link>。",
+      "warmCbtFallbackTitle": "CBT 不可用：本次温迁移将使用校验和回退方式",
+      "warmCbtFallbackReasonSnapshot": "源虚拟机存在 VMware 快照，因此无法使用变更块跟踪（CBT）。",
+      "warmCbtFallbackReasonHwVersion": "源虚拟机的虚拟硬件版本低于 vmx-07，因此无法使用变更块跟踪（CBT）。",
+      "warmCbtFallbackReasonDiskMode": "源虚拟机存在独立磁盘或多写入（multi-writer）磁盘，因此无法使用变更块跟踪（CBT）。",
+      "warmCbtFallbackDowntime": "使用校验和回退时，源虚拟机会在复制开始时关机，并在整个传输期间保持关机状态：停机时间随磁盘总大小增长。",
+      "warmCbtFallbackSnapshotHint": "在开始前删除或整合 VMware 快照，可让虚拟机保持在线，直到最后的短暂切换。",
       "migrationTypeSshfsBoot": "SSHFS 启动（实验性）",
       "migrationTypeSshfsBootDesc": "近零停机：虚拟机在数秒内从远程 ESXi 磁盘启动到 Proxmox。实验性：Guest 必须能在目标控制器上无人值守地启动；可能在 EFI Windows 或需要驱动注入的 Guest 上失败。生产环境请优先使用 Live 或离线迁移。",
       "migrationTypeSshfsBootExperimentalWarning": "SSHFS 启动是实验性功能，仅当 Guest 能在目标上无需驱动适配而正确启动时才有效。对于 EFI Windows、来自 vCenter 的虚拟机或任何关键生产场景，请使用 Live 或离线模式。",
@@ -3644,6 +3650,23 @@
       "completed": "已完成",
       "cancelled": "已取消"
     },
+    "steps": {
+      "planning": "规划中",
+      "enabling_cbt": "正在启用 CBT",
+      "preparing_disks": "正在准备目标磁盘",
+      "full_copy": "全量复制",
+      "delta": "增量同步",
+      "source_shutdown": "正在关闭源虚拟机",
+      "awaiting_cutover": "等待切换决定",
+      "cutover": "切换",
+      "verify": "校验中",
+      "converting_disks": "正在转换磁盘",
+      "preflight": "预检",
+      "transferring": "正在传输磁盘",
+      "creating_vm": "正在创建虚拟机",
+      "configuring": "正在配置虚拟机",
+      "pending": "等待中"
+    },
     "shared": {
       "detailTitle": "迁移任务",
       "startedBy": "由 {name} 发起",
@@ -3653,6 +3676,9 @@
       "cancelConfirmLeftovers": "已复制的卷和部分创建的 VMID 可能会留在目标节点上。如果不需要，请手动清理。",
       "cancelConfirmKeep": "继续迁移",
       "cancelling": "正在取消...",
+      "diskOf": "磁盘 {n}/{m}",
+      "gbProgress": "{done} / {total} GB",
+      "eta": "预计剩余 {eta}",
       "cancelFailed": "取消迁移失败"
     },
     "types": {


### PR DESCRIPTION
## Summary

Field feedback from a production warm migration whose source VM carried a pre-existing VMware snapshot surfaced three UX gaps around the checksum fallback:

- Nothing warns before launch that CBT cannot be used and that the fallback shuts the source VM down at the **start** of the copy (downtime scales with total disk size).
- The checksum scan phase (a full read of both source and target, ~25 min per 60 GB disk over NBD, hours on multi-TB disks) is completely silent: no log line, no progress movement.
- The job log announces "Cutover: requesting clean guest shutdown" at minute 0 of the fallback, and the task detail dialog never rendered the live transfer fields the pipelines already persist.

## Changes

**Migrate dialog (single-VM)**
- Warning alert when the selected source VM cannot use CBT (existing snapshot / hardware below vmx-07 / independent or multi-writer disk), mirroring the engine's planning-time decision. Warning only, the launch stays enabled.
- The source-detail fetch now also runs for vCenter sources (vSAN datastore blocking is unchanged); the VM detail route additionally returns `diskMode`/`sharing` per disk.
- `cbtEligibility` moved to a dependency-free module (re-exported from `cbt.ts`) so the client component can import it without dragging in the SOAP client.

**Warm pipeline (fallback path)**
- Announce the checksum scan per disk and stream its progress (first 30% of each disk's progress slice, throttled, same inactivity guard as the copy).
- Status/step now read `full_copy`/`source_shutdown` instead of `cutover` at minute 0, with a shutdown message that says the VM stays off for the whole transfer.
- `currentDisk` is kept up to date on both the CBT and fallback paths.
- Copy semantics are unchanged: no change to snapshot handling, shutdown ordering, or the block apply.

**Task detail dialog**
- Compact live readout under the progress bar: translated step label, "Disk n of m", GB done/total, transfer speed, and an ETA computed from fields already in the SharedTask payload. Degrades gracefully when the fields are absent.
- New pure helpers (`parseSpeedMBps`, `etaSeconds`, `formatEta`, `stepLabelKey`), fully unit-tested.

**i18n**: new keys in all six locales (en, fr, de, es, ko, zh-CN).

## Tests

- 85 tests green across 6 files: new route test for the VMware VM detail endpoint, new `taskProgressDisplay` suite, extended checksum-detector suite (progress counting, option forwarding), pure `checksumDiskWindows` window math, and the detail-dialog readout.
- `npx vitest run` exit 0, `npm run build` exit 0, `tsc --noEmit` clean on touched files.
