### PR TITLE
fix: show custom CPU models and check their availability before cross-cluster migration

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
@@ -115,6 +115,12 @@ function seedAllHandlers() {
     http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/storage/local-vm/content`, () =>
       HttpResponse.json({ data: [] }),
     ),
+
+    // 9. Custom CPU models (cpu-models.conf) for connection + node (#665).
+    //    Empty list = no Custom section, the static CPU type options stand.
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/${NODE_NAME}/cpu-models`, () =>
+      HttpResponse.json({ data: [] }),
+    ),
   )
 }
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from 'next-intl'
 import { useRBAC } from '@/contexts/RBACContext'
 import { useTenant } from '@/contexts/TenantContext'
 import { getOsSvgIcon } from '@/lib/utils/osIcons'
+import { extractCustomCpuModels } from '@/lib/inventory/cpuModels'
+import { cpuGroupHeaderSx } from './cpuSelectStyles'
 
 import {
   Alert,
@@ -143,6 +145,7 @@ function CreateVmDialog({
   // Données dynamiques
   const [connections, setConnections] = useState<any[]>([])
   const [nodes, setNodes] = useState<any[]>([])
+  const [customCpuModels, setCustomCpuModels] = useState<string[]>([])
   const [storages, setStorages] = useState<any[]>([])
   const [isoImages, setIsoImages] = useState<any[]>([])
   const [networks, setNetworks] = useState<any[]>([])
@@ -289,6 +292,24 @@ function CreateVmDialog({
     }
   }
 
+  // Charge les modèles CPU custom du cluster (cpu-models.conf) pour le Select
+  // CPU Type, sinon impossible de créer une VM avec un modèle custom (#665)
+  const loadCustomCpuModels = async (connId: string, node: string) => {
+    try {
+      const res = await fetch(
+        `/api/v1/connections/${encodeURIComponent(connId)}/nodes/${encodeURIComponent(node)}/cpu-models`
+      )
+      if (res.ok) {
+        const json = await res.json()
+        setCustomCpuModels(extractCustomCpuModels(json?.data))
+        return
+      }
+      setCustomCpuModels([])
+    } catch {
+      setCustomCpuModels([])
+    }
+  }
+
   // Disk array helpers
   const addDisk = () => {
     setDisks(prev => {
@@ -375,6 +396,13 @@ function CreateVmDialog({
   useEffect(() => {
     if (selectedConnection && resolvedNode) {
       loadBridges(selectedConnection, resolvedNode)
+    }
+  }, [selectedConnection, resolvedNode])
+
+  // Charger les modèles CPU custom quand un node est sélectionné
+  useEffect(() => {
+    if (selectedConnection && resolvedNode) {
+      loadCustomCpuModels(selectedConnection, resolvedNode)
     }
   }, [selectedConnection, resolvedNode])
 
@@ -1665,19 +1693,23 @@ return
                 <FormControl fullWidth size="small" sx={{ gridColumn: '1 / -1' }}>
                   <InputLabel>{t('inventory.createVm.cpuType')}</InputLabel>
                   <Select value={cpuType} onChange={(e) => setCpuType(e.target.value)} label={t('inventory.createVm.cpuType')}>
-                    <ListSubheader>Special</ListSubheader>
+                    {customCpuModels.length > 0 && <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Custom</ListSubheader>}
+                    {customCpuModels.map((m: string) => (
+                      <MenuItem key={m} value={m}>{m}</MenuItem>
+                    ))}
+                    <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Special</ListSubheader>
                     <MenuItem value="host">host</MenuItem>
                     <MenuItem value="max">max</MenuItem>
                     <MenuItem value="kvm64">kvm64</MenuItem>
                     <MenuItem value="kvm32">kvm32</MenuItem>
                     <MenuItem value="qemu64">qemu64</MenuItem>
                     <MenuItem value="qemu32">qemu32</MenuItem>
-                    <ListSubheader>x86-64 Levels</ListSubheader>
+                    <ListSubheader disableSticky sx={cpuGroupHeaderSx}>x86-64 Levels</ListSubheader>
                     <MenuItem value="x86-64-v2">x86-64-v2</MenuItem>
                     <MenuItem value="x86-64-v2-AES">x86-64-v2-AES (Recommended)</MenuItem>
                     <MenuItem value="x86-64-v3">x86-64-v3</MenuItem>
                     <MenuItem value="x86-64-v4">x86-64-v4</MenuItem>
-                    <ListSubheader>Intel</ListSubheader>
+                    <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Intel</ListSubheader>
                     <MenuItem value="Conroe">Conroe</MenuItem>
                     <MenuItem value="Penryn">Penryn</MenuItem>
                     <MenuItem value="Nehalem">Nehalem</MenuItem>
@@ -1693,7 +1725,7 @@ return
                     <MenuItem value="Icelake-Server">Icelake-Server</MenuItem>
                     <MenuItem value="SapphireRapids">SapphireRapids</MenuItem>
                     <MenuItem value="GraniteRapids">GraniteRapids</MenuItem>
-                    <ListSubheader>AMD</ListSubheader>
+                    <ListSubheader disableSticky sx={cpuGroupHeaderSx}>AMD</ListSubheader>
                     <MenuItem value="Opteron_G5">Opteron G5</MenuItem>
                     <MenuItem value="EPYC">EPYC</MenuItem>
                     <MenuItem value="EPYC-Rome">EPYC-Rome</MenuItem>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/cpuSelectStyles.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/cpuSelectStyles.ts
@@ -1,0 +1,13 @@
+import type { SxProps } from '@mui/material'
+
+// En-têtes de groupes des Select "CPU Type" (Custom, Special, Intel, ...) :
+// mis en évidence pour trancher visuellement sur les items de la liste (#665).
+export const cpuGroupHeaderSx: SxProps = {
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.8px',
+  lineHeight: '30px',
+  color: 'primary.main',
+  bgcolor: 'action.hover',
+}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -83,6 +83,8 @@ import InventorySummary from '../components/InventorySummary'
 import { SaveIcon, AddIcon, CloseIcon } from '../components/IconWrappers'
 import VdcQuotaBanner from '@/components/inventory/VdcQuotaBanner'
 import NumericTextField from '@/components/ui/NumericTextField'
+import { extractCustomCpuModels, isKnownCpuType } from '@/lib/inventory/cpuModels'
+import { cpuGroupHeaderSx } from '../cpuSelectStyles'
 
 export default function VmDetailTabs(props: any) {
   const t = useTranslations()
@@ -102,6 +104,25 @@ export default function VmDetailTabs(props: any) {
   const [hwQuotaBlocked, setHwQuotaBlocked] = useState(false)
   const vmConnId = props.selection?.id ? parseVmId(props.selection.id).connId : undefined
   const { getColor: getTagColor } = useTagColors(vmConnId)
+
+  // Modèles CPU custom du cluster (cpu-models.conf). Le Select "CPU Type" est
+  // statique : sans cette liste, une VM configurée en "custom-*" affiche un
+  // champ vide (#665).
+  const [customCpuModels, setCustomCpuModels] = useState<string[]>([])
+  useEffect(() => {
+    const { connId, node, type } = props.selection?.id ? parseVmId(props.selection.id) : { connId: '', node: '', type: '' }
+    if (!connId || !node || type !== 'qemu') { setCustomCpuModels([]); return }
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(`/api/v1/connections/${encodeURIComponent(connId)}/nodes/${encodeURIComponent(node)}/cpu-models`)
+        if (!res.ok) return
+        const json = await res.json()
+        if (!cancelled) setCustomCpuModels(extractCustomCpuModels(json?.data))
+      } catch { /* on retombe sur la liste statique */ }
+    })()
+    return () => { cancelled = true }
+  }, [props.selection?.id])
 
   // Fetch vDC quota+usage for the connection that hosts this VM. Skipped
   // for the provider (no vDC mapping → API returns nothing). Refreshed
@@ -957,19 +978,28 @@ export default function VmDetailTabs(props: any) {
                               label={t('inventory.cpuType')}
                               onChange={(e) => setCpuType(e.target.value)}
                             >
-                              <ListSubheader>Special</ListSubheader>
+                              {(customCpuModels.length > 0 || Boolean(cpuType && !isKnownCpuType(cpuType) && !customCpuModels.includes(cpuType))) && (
+                                <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Custom</ListSubheader>
+                              )}
+                              {customCpuModels.map((m: string) => (
+                                <MenuItem key={m} value={m}>{m}</MenuItem>
+                              ))}
+                              {Boolean(cpuType && !isKnownCpuType(cpuType) && !customCpuModels.includes(cpuType)) && (
+                                <MenuItem value={cpuType}>{cpuType}</MenuItem>
+                              )}
+                              <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Special</ListSubheader>
                               <MenuItem value="host">host ({t('inventory.maxPerformance')})</MenuItem>
                               <MenuItem value="max">max</MenuItem>
                               <MenuItem value="kvm64">kvm64 ({t('inventory.compatible')})</MenuItem>
                               <MenuItem value="kvm32">kvm32</MenuItem>
                               <MenuItem value="qemu64">qemu64 ({t('inventory.emulation')})</MenuItem>
                               <MenuItem value="qemu32">qemu32</MenuItem>
-                              <ListSubheader>x86-64 Microarchitecture Levels</ListSubheader>
+                              <ListSubheader disableSticky sx={cpuGroupHeaderSx}>x86-64 Microarchitecture Levels</ListSubheader>
                               <MenuItem value="x86-64-v2">x86-64-v2</MenuItem>
                               <MenuItem value="x86-64-v2-AES">x86-64-v2-AES (Recommended)</MenuItem>
                               <MenuItem value="x86-64-v3">x86-64-v3</MenuItem>
                               <MenuItem value="x86-64-v4">x86-64-v4</MenuItem>
-                              <ListSubheader>Intel</ListSubheader>
+                              <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Intel</ListSubheader>
                               <MenuItem value="486">486</MenuItem>
                               <MenuItem value="pentium">Pentium</MenuItem>
                               <MenuItem value="pentium2">Pentium 2</MenuItem>
@@ -1020,7 +1050,7 @@ export default function VmDetailTabs(props: any) {
                               <MenuItem value="SapphireRapids-v2">SapphireRapids-v2</MenuItem>
                               <MenuItem value="GraniteRapids">GraniteRapids</MenuItem>
                               <MenuItem value="KnightsMill">KnightsMill</MenuItem>
-                              <ListSubheader>AMD</ListSubheader>
+                              <ListSubheader disableSticky sx={cpuGroupHeaderSx}>AMD</ListSubheader>
                               <MenuItem value="athlon">Athlon</MenuItem>
                               <MenuItem value="phenom">Phenom</MenuItem>
                               <MenuItem value="Opteron_G1">Opteron G1</MenuItem>
@@ -1039,7 +1069,7 @@ export default function VmDetailTabs(props: any) {
                               <MenuItem value="EPYC-Milan">EPYC-Milan</MenuItem>
                               <MenuItem value="EPYC-Milan-v2">EPYC-Milan-v2</MenuItem>
                               <MenuItem value="EPYC-Genoa">EPYC-Genoa</MenuItem>
-                              <ListSubheader>Legacy</ListSubheader>
+                              <ListSubheader disableSticky sx={cpuGroupHeaderSx}>Legacy</ListSubheader>
                               <MenuItem value="coreduo">Core Duo</MenuItem>
                               <MenuItem value="core2duo">Core 2 Duo</MenuItem>
                             </Select>

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/check/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/check/route.test.ts
@@ -75,3 +75,92 @@ describe("POST .../remote-migrate/check — snapshot pre-flight", () => {
     expect(json.issues.some((i: any) => i.code === "SNAPSHOTS_PRESENT")).toBe(false)
   })
 })
+
+// Route pveFetch responses for the CPU-type-on-target check. `vmCpu` feeds the
+// VM config, `targetCpus` the target node's /capabilities/qemu/cpu response.
+function wireCpuPveFetch(opts: { vmCpu?: string; targetCpus?: any }) {
+  pveFetchMock.mockImplementation((_conn: any, path: string) => {
+    if (path.endsWith("/config")) return Promise.resolve(opts.vmCpu ? { cpu: opts.vmCpu } : {})
+    if (path.includes("/capabilities/qemu/cpu")) {
+      if (opts.targetCpus instanceof Error) return Promise.reject(opts.targetCpus)
+      return Promise.resolve(opts.targetCpus)
+    }
+    if (path.includes("/snapshot")) return Promise.resolve([])
+    if (path.includes("/cluster/ha/resources")) return Promise.resolve([])
+    // Benign target-side data so no unrelated blocking issue pollutes `valid`.
+    if (path === "/nodes") return Promise.resolve([{ node: BODY.targetNode, status: "online" }])
+    if (path.endsWith("/storage")) return Promise.resolve([{ storage: BODY.targetStorage, content: "images", avail: 100 * 1024 * 1024 * 1024 }])
+    if (path.endsWith("/network")) return Promise.resolve([{ iface: BODY.targetBridge, type: "bridge" }])
+    return Promise.resolve([])
+  })
+}
+
+describe("POST .../remote-migrate/check — CPU type availability on target", () => {
+  it("flags a blocking CPU_TYPE_NOT_ON_TARGET error when a custom model is missing on the target", async () => {
+    wireCpuPveFetch({
+      vmCpu: "custom-migration-safe,flags=+aes",
+      targetCpus: [{ name: "kvm64" }, { name: "x86-64-v2-AES" }],
+    })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    const issue = json.issues.find((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")
+    expect(issue).toBeDefined()
+    expect(issue.type).toBe("error")
+    expect(issue.message).toContain("custom-migration-safe")
+    expect(issue.details).toContain("cpu-models.conf")
+    expect(json.valid).toBe(false)
+  })
+
+  it("does NOT flag when the custom model exists on the target", async () => {
+    wireCpuPveFetch({
+      vmCpu: "custom-migration-safe",
+      targetCpus: [{ name: "kvm64" }, { name: "custom-migration-safe", custom: 1 }],
+    })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    expect(json.issues.some((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")).toBe(false)
+  })
+
+  it("flags a builtin CPU type absent from a non-empty capability list", async () => {
+    wireCpuPveFetch({ vmCpu: "SapphireRapids", targetCpus: [{ name: "kvm64" }] })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    const issue = json.issues.find((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")
+    expect(issue).toBeDefined()
+    expect(issue.type).toBe("error")
+  })
+
+  it("does NOT conclude anything from an empty capability list", async () => {
+    wireCpuPveFetch({ vmCpu: "SapphireRapids", targetCpus: [] })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    expect(json.issues.some((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")).toBe(false)
+  })
+
+  it("degrades to a CPU_TYPE_CHECK_FAILED warning (not a block) when the capability fetch throws", async () => {
+    wireCpuPveFetch({ vmCpu: "custom-migration-safe", targetCpus: new Error("nope") })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    const issue = json.issues.find((i: any) => i.code === "CPU_TYPE_CHECK_FAILED")
+    expect(issue).toBeDefined()
+    expect(issue.type).toBe("warning")
+    expect(json.issues.some((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")).toBe(false)
+    expect(json.valid).toBe(true)
+  })
+
+  it("does not apply the availability check to CPU type 'host' (CPU_HOST warning still fires)", async () => {
+    wireCpuPveFetch({ vmCpu: "host", targetCpus: [] })
+    const POST = (await import("./route")).POST as Parameters<typeof callRoute>[0]
+    const res = await callRoute(POST, { method: "POST", params: PARAMS, body: BODY })
+    const json = await res.json()
+    expect(json.issues.some((i: any) => i.code === "CPU_TYPE_NOT_ON_TARGET")).toBe(false)
+    const hostIssue = json.issues.find((i: any) => i.code === "CPU_HOST")
+    expect(hostIssue).toBeDefined()
+    expect(hostIssue.type).toBe("warning")
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/check/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/[vmid]/remote-migrate/check/route.ts
@@ -186,6 +186,34 @@ export async function POST(
       }
     }
 
+    // 5b. Type CPU nommé (builtin ou custom-*) : vérifier qu'il existe sur la
+    // cible. Les modèles custom vivent dans /etc/pve/virtual-guest/cpu-models.conf
+    // de chaque cluster ; absent de la cible, remote-migrate échoue après coup (#665).
+    if (cpuTypeRaw && cpuTypeRaw !== 'host' && cpuTypeRaw !== 'max') {
+      const cpuTypeName = String(vmConfig.cpu).split(',')[0].trim()
+      try {
+        const targetCpus = await pveFetch<any[]>(targetConn, `/nodes/${encodeURIComponent(targetNode)}/capabilities/qemu/cpu`)
+        const available = new Set((Array.isArray(targetCpus) ? targetCpus : []).map((c: any) => String(c?.name || '').toLowerCase()))
+        if (available.size > 0 && !available.has(cpuTypeRaw)) {
+          issues.push({
+            type: 'error',
+            code: 'CPU_TYPE_NOT_ON_TARGET',
+            message: `CPU type "${cpuTypeName}" is not available on target node "${targetNode}"`,
+            details: cpuTypeRaw.startsWith('custom-')
+              ? `"${cpuTypeName}" is a custom CPU model defined on the source cluster (/etc/pve/virtual-guest/cpu-models.conf). Define the same model on the target cluster before migrating, or switch the VM to a built-in CPU type.`
+              : `The target node does not report this CPU type in its QEMU capabilities. Switch the VM to a CPU type available on the target (e.g. "x86-64-v2-AES") before migrating.`
+          })
+        }
+      } catch (e: any) {
+        issues.push({
+          type: 'warning',
+          code: 'CPU_TYPE_CHECK_FAILED',
+          message: `Could not verify that CPU type "${cpuTypeName}" is available on the target`,
+          details: e?.message || String(e)
+        })
+      }
+    }
+
     // ========== VÉRIFICATIONS CIBLE ==========
 
     // 6. Vérifier que le nœud cible existe et est online

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute } from "@/__tests__/setup/route-test"
+
+const { checkPermissionMock, getConnectionByIdMock, pveFetchMock } = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn(),
+  getConnectionByIdMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  buildNodeResourceId: (id: string, node: string) => `${id}/${node}`,
+  PERMISSIONS: { NODE_VIEW: "node.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: (...a: any[]) => getConnectionByIdMock(...a),
+}))
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...a: any[]) => pveFetchMock(...a),
+}))
+
+const PARAMS = { id: "conn-1", node: "pve1" }
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: "c", baseUrl: "https://x:8006", apiToken: "t" })
+  pveFetchMock.mockReset()
+})
+
+describe("GET .../nodes/[node]/cpu-models", () => {
+  it("returns the CPU model list from the node's QEMU capabilities", async () => {
+    const models = [{ name: "kvm64" }, { name: "custom-foo", custom: 1 }]
+    pveFetchMock.mockResolvedValue(models)
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS })
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual(models)
+    expect(pveFetchMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("/capabilities/qemu/cpu")
+    )
+  })
+
+  it("returns an empty list when PVE responds with a non-array payload", async () => {
+    pveFetchMock.mockResolvedValue(null)
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS })
+    const json = await res.json()
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual([])
+  })
+
+  it("returns the RBAC denial without calling PVE when permission is denied", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS })
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("returns 500 with an error message when the PVE call fails", async () => {
+    pveFetchMock.mockRejectedValue(new Error("boom"))
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS })
+    const json = await res.json()
+    expect(res.status).toBe(500)
+    expect(json.error).toBeDefined()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server"
+
+import { pveFetch } from "@/lib/proxmox/client"
+import { getConnectionById } from "@/lib/connections/getConnection"
+import { checkPermission, buildNodeResourceId, PERMISSIONS } from "@/lib/rbac"
+
+export const runtime = "nodejs"
+
+// GET /api/v1/connections/{id}/nodes/{node}/cpu-models
+// Liste les modèles CPU QEMU disponibles sur un node (builtin + modèles custom
+// du cluster définis dans /etc/pve/virtual-guest/cpu-models.conf).
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ id: string; node: string }> }
+) {
+  try {
+    const { id, node } = await ctx.params
+
+    const resourceId = buildNodeResourceId(id, node)
+    const denied = await checkPermission(PERMISSIONS.NODE_VIEW, "node", resourceId)
+    if (denied) return denied
+
+    const conn = await getConnectionById(id)
+
+    const models = await pveFetch<any[]>(
+      conn,
+      `/nodes/${encodeURIComponent(node)}/capabilities/qemu/cpu`
+    )
+
+    return NextResponse.json({ data: Array.isArray(models) ? models : [] })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/frontend/src/lib/inventory/cpuModels.test.ts
+++ b/frontend/src/lib/inventory/cpuModels.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { extractCustomCpuModels, isKnownCpuType } from "./cpuModels"
+
+describe("isKnownCpuType", () => {
+  it("returns true for built-in CPU types offered by the static Selects", () => {
+    expect(isKnownCpuType("host")).toBe(true)
+    expect(isKnownCpuType("x86-64-v2-AES")).toBe(true)
+    expect(isKnownCpuType("EPYC-Milan")).toBe(true)
+  })
+
+  it("returns false for custom models and unknown names", () => {
+    expect(isKnownCpuType("custom-foo")).toBe(false)
+    expect(isKnownCpuType("Denverton")).toBe(false)
+  })
+})
+
+describe("extractCustomCpuModels", () => {
+  it("prefixes custom models reported without the custom- prefix", () => {
+    const data = [{ name: "migration-safe", custom: 1 }]
+    expect(extractCustomCpuModels(data)).toEqual(["custom-migration-safe"])
+  })
+
+  it("keeps models already carrying the custom- prefix unchanged", () => {
+    const data = [{ name: "custom-migration-safe", custom: 1 }]
+    expect(extractCustomCpuModels(data)).toEqual(["custom-migration-safe"])
+  })
+
+  it("ignores builtin entries", () => {
+    const data = [{ name: "kvm64" }, { name: "x86-64-v3", custom: 0 }]
+    expect(extractCustomCpuModels(data)).toEqual([])
+  })
+
+  it("deduplicates and sorts the result", () => {
+    const data = [
+      { name: "zeta", custom: 1 },
+      { name: "custom-alpha" },
+      { name: "custom-zeta", custom: 1 },
+      { name: "alpha", custom: true },
+    ]
+    expect(extractCustomCpuModels(data)).toEqual(["custom-alpha", "custom-zeta"])
+  })
+
+  it("skips invalid entries", () => {
+    const data = [null, {}, { name: 42, custom: 1 }, { name: "   ", custom: 1 }]
+    expect(extractCustomCpuModels(data)).toEqual([])
+  })
+
+  it("returns [] for non-array input", () => {
+    expect(extractCustomCpuModels(null)).toEqual([])
+    expect(extractCustomCpuModels(undefined)).toEqual([])
+    expect(extractCustomCpuModels({ name: "custom-foo" })).toEqual([])
+    expect(extractCustomCpuModels("custom-foo")).toEqual([])
+  })
+})

--- a/frontend/src/lib/inventory/cpuModels.ts
+++ b/frontend/src/lib/inventory/cpuModels.ts
@@ -1,0 +1,46 @@
+// Valeurs proposées par les Select statiques "CPU Type" de l'UI (VmDetailTabs,
+// CreateVmDialog). Une valeur de config hors de cette liste (ex: modèle
+// "custom-*" du cluster) rendrait le Select MUI vide — voir issue #665.
+const KNOWN_VM_CPU_TYPES = new Set([
+  'host', 'max', 'kvm64', 'kvm32', 'qemu64', 'qemu32',
+  'x86-64-v2', 'x86-64-v2-AES', 'x86-64-v3', 'x86-64-v4',
+  '486', 'pentium', 'pentium2', 'pentium3',
+  'Conroe', 'Penryn', 'Nehalem', 'Nehalem-IBRS', 'Westmere', 'Westmere-IBRS',
+  'SandyBridge', 'SandyBridge-IBRS', 'IvyBridge', 'IvyBridge-IBRS',
+  'Haswell', 'Haswell-IBRS', 'Haswell-noTSX', 'Haswell-noTSX-IBRS',
+  'Broadwell', 'Broadwell-IBRS', 'Broadwell-noTSX', 'Broadwell-noTSX-IBRS',
+  'Skylake-Client', 'Skylake-Client-IBRS', 'Skylake-Client-noTSX-IBRS', 'Skylake-Client-v4',
+  'Skylake-Server', 'Skylake-Server-IBRS', 'Skylake-Server-noTSX-IBRS', 'Skylake-Server-v4', 'Skylake-Server-v5',
+  'Cascadelake-Server', 'Cascadelake-Server-noTSX', 'Cascadelake-Server-v2', 'Cascadelake-Server-v4', 'Cascadelake-Server-v5',
+  'Cooperlake', 'Cooperlake-v2',
+  'Icelake-Client', 'Icelake-Client-noTSX',
+  'Icelake-Server', 'Icelake-Server-noTSX', 'Icelake-Server-v3', 'Icelake-Server-v4', 'Icelake-Server-v5', 'Icelake-Server-v6',
+  'SapphireRapids', 'SapphireRapids-v2', 'GraniteRapids', 'KnightsMill',
+  'athlon', 'phenom',
+  'Opteron_G1', 'Opteron_G2', 'Opteron_G3', 'Opteron_G4', 'Opteron_G5',
+  'EPYC', 'EPYC-IBPB', 'EPYC-v3', 'EPYC-v4',
+  'EPYC-Rome', 'EPYC-Rome-v2', 'EPYC-Rome-v3', 'EPYC-Rome-v4',
+  'EPYC-Milan', 'EPYC-Milan-v2', 'EPYC-Genoa',
+  'coreduo', 'core2duo',
+])
+
+export function isKnownCpuType(value: string): boolean {
+  return KNOWN_VM_CPU_TYPES.has(value)
+}
+
+// Extrait les modèles CPU custom d'une réponse /nodes/{node}/capabilities/qemu/cpu.
+// PVE marque les modèles custom avec custom=1 ; la config VM les référence
+// toujours sous la forme préfixée "custom-<nom>", normalisée ici par sécurité.
+export function extractCustomCpuModels(data: unknown): string[] {
+  if (!Array.isArray(data)) return []
+  const models: string[] = []
+  for (const raw of data) {
+    const entry = raw as { name?: unknown; custom?: unknown } | null
+    const name = typeof entry?.name === 'string' ? entry.name.trim() : ''
+    if (!name) continue
+    const isCustom = entry?.custom === 1 || entry?.custom === true || name.startsWith('custom-')
+    if (!isCustom) continue
+    models.push(name.startsWith('custom-') ? name : `custom-${name}`)
+  }
+  return [...new Set(models)].sort((a, b) => a.localeCompare(b))
+}


### PR DESCRIPTION
## Problem

Proxmox custom CPU models (`custom-*`, defined cluster-wide in `/etc/pve/virtual-guest/cpu-models.conf`) were not handled (#665):

- The CPU Type selects (VM Hardware tab, Create VM dialog) only contained a hardcoded list of built-in types, so a VM configured with a custom model rendered an **empty** CPU Type field, and custom models could not be selected at all.
- Cross-cluster migration started without checking that the VM's CPU type exists on the destination, so a VM using a custom model not defined on the target cluster failed mid-migration instead of being warned upfront.

## Fix

- New `GET /api/v1/connections/{id}/nodes/{node}/cpu-models` route proxying PVE `/nodes/{node}/capabilities/qemu/cpu` (RBAC `node.view`).
- `lib/inventory/cpuModels.ts`: `extractCustomCpuModels()` (normalizes the `custom-` prefix PVE uses in VM configs) and `isKnownCpuType()`.
- VM Hardware tab and Create VM dialog: a **Custom** section at the top of the CPU Type select lists the cluster's custom models. On the Hardware tab, a current value unknown to every list is injected into the select as a fallback, so the field can never render empty again (e.g. when the capabilities call fails).
- Remote-migrate pre-check: blocking `CPU_TYPE_NOT_ON_TARGET` error when the VM's CPU type (custom or built-in) is absent from the target node's QEMU capabilities, `CPU_TYPE_CHECK_FAILED` warning when the capabilities call itself fails, and no conclusion drawn from an empty capability list to avoid false positives.
- The group headers of both CPU Type selects (Custom / Special / Intel / AMD / ...) are now visually emphasized to mark the sections.

## Tests

- New unit tests for the `cpu-models` route, the `cpuModels` lib and the pre-check (29 tests green across 4 files).
- `CreateVmDialog` jsdom suite extended with the new MSW handler (37/37 green).
- Verified on a lab cluster: custom model visible and selectable on the Hardware tab and in the Create VM dialog; pre-check error raised when the model is missing on the target cluster.

Fixes #665
