### PR TITLE
feat(inventory): show PVE node in filtered flat VM lists

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -1040,6 +1040,10 @@ export default function InventoryDetails({
   // VMs sans templates (pour affichage dans les modes vms, tree, hosts, pools, tags)
   const displayVms = useMemo(() => allVms.filter(vm => !vm.template), [allVms])
 
+  // #666: node status lookup for the VmsTable node column pastille, keyed
+  // like HostItem.key (`${connId}:${node}`).
+  const nodeStatuses = useMemo(() => new Map(hosts.map(h => [h.key, h.status])), [hosts])
+
   // Mapping vmid → name pour affichage dans storage content
   const vmNamesMap = useMemo(() => {
     const map: Record<string, string> = {}
@@ -2646,6 +2650,7 @@ return vm?.isCluster ?? false
                     }))}
                     expanded
                     showNode
+                    nodeStatuses={nodeStatuses}
                     showTrends
                     showActions
                     showIpSnap={showIpSnap}
@@ -2694,6 +2699,7 @@ return vm?.isCluster ?? false
             favorites={favorites}
             onToggleFavorite={toggleFavorite}
             migratingVmIds={migratingVmIds}
+            nodeStatuses={nodeStatuses}
           />
         ) : viewMode === 'pools' && pools.length > 0 ? (
           <GroupedVmsView
@@ -2713,6 +2719,7 @@ return vm?.isCluster ?? false
             favorites={favorites}
             onToggleFavorite={toggleFavorite}
             migratingVmIds={migratingVmIds}
+            nodeStatuses={nodeStatuses}
           />
         ) : viewMode === 'tags' && tags.length > 0 ? (
           <GroupedVmsView
@@ -2733,6 +2740,7 @@ return vm?.isCluster ?? false
             favorites={favorites}
             onToggleFavorite={toggleFavorite}
             migratingVmIds={migratingVmIds}
+            nodeStatuses={nodeStatuses}
           />
         ) : viewMode === 'templates' ? (
 
@@ -2786,6 +2794,7 @@ return vm?.isCluster ?? false
                     }))}
                     expanded
                     showNode
+                    nodeStatuses={nodeStatuses}
                     showActions
                     onVmAction={handleTableVmAction}
                     onNodeClick={handleNodeClick}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -1850,6 +1850,25 @@ return next
   // (same gate as the detail-header node chip in InventoryDetails).
   const showNodeCaption = isFullClusterView && search.trim().length > 0
 
+  // Node status for the flat-list captions (NodeIcon pastille) — keyed like
+  // hostsList entries, from the same clusters data.
+  const nodeStatusByKey = useMemo(() => {
+    const m = new Map<string, string | undefined>()
+    clusters.forEach(clu => {
+      clu.nodes.forEach(n => m.set(`${clu.connId}:${n.node}`, n.status))
+    })
+    return m
+  }, [clusters])
+
+  // Clusters that are genuinely single-node (standalone host, or tenant
+  // scoped to one node) — the tree flattens only those. A multi-node
+  // cluster reduced to one visible node by the search filter keeps its
+  // full cluster → node → VM hierarchy.
+  const singleNodeConnIds = useMemo(
+    () => new Set(clusters.filter(c => c.nodes.length === 1).map(c => c.connId)),
+    [clusters]
+  )
+
   useEffect(() => {
     const timer = setTimeout(() => setSearch(searchInput), 300)
     return () => clearTimeout(timer)
@@ -2876,6 +2895,7 @@ return favorites.has(vmKey)
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
                       showNode={showNodeCaption}
+                      nodeStatus={nodeStatusByKey.get(`${vm.connId}:${vm.node}`)}
                       lock={vm.lock}
                     />
                   </Box>
@@ -2943,6 +2963,7 @@ return favorites.has(vmKey)
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
                       showNode={showNodeCaption}
+                      nodeStatus={nodeStatusByKey.get(`${vm.connId}:${vm.node}`)}
                       lock={vm.lock}
                     />
                   </Box>
@@ -3288,6 +3309,7 @@ return (
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
                       showNode={showNodeCaption}
+                      nodeStatus={nodeStatusByKey.get(`${vm.connId}:${vm.node}`)}
                       lock={vm.lock}
                     />
                   </Box>
@@ -3394,7 +3416,7 @@ return (
           // Flatten when only 1 node is visible (standalone host, or tenant
           // scoped to a single node of a cluster) — no intermediate cluster
           // root in either case.
-          if (clu.nodes.length === 1) {
+          if (singleNodeConnIds.has(clu.connId)) {
             const n = clu.nodes[0]
 
             

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -1845,6 +1845,11 @@ return next
   const [searchInput, setSearchInput] = useState('')
   const [search, setSearch] = useState('')
 
+  // #666: reveal each guest's PVE node in the flat lists while a search
+  // filter is active — provider/MSP only, vDC tenants never see node names
+  // (same gate as the detail-header node chip in InventoryDetails).
+  const showNodeCaption = isFullClusterView && search.trim().length > 0
+
   useEffect(() => {
     const timer = setTimeout(() => setSearch(searchInput), 300)
     return () => clearTimeout(timer)
@@ -2870,6 +2875,7 @@ return favorites.has(vmKey)
                       t={t}
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
+                      showNode={showNodeCaption}
                       lock={vm.lock}
                     />
                   </Box>
@@ -2936,6 +2942,7 @@ return favorites.has(vmKey)
                       t={t}
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
+                      showNode={showNodeCaption}
                       lock={vm.lock}
                     />
                   </Box>
@@ -3280,6 +3287,7 @@ return (
                       t={t}
                       tags={vm.tags ? String(vm.tags).split(';').filter(Boolean) : undefined}
                       showVmId={showVmId}
+                      showNode={showNodeCaption}
                       lock={vm.lock}
                     />
                   </Box>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/GroupedVmsView.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/GroupedVmsView.tsx
@@ -38,9 +38,10 @@ type GroupedVmsViewProps = {
   favorites?: Set<string>
   onToggleFavorite?: (vm: VmRow) => void
   migratingVmIds?: Set<string>
+  nodeStatuses?: Map<string, string | undefined>  // #666: node column pastille, keyed `${connId}:${node}`
 }
 
-function GroupedVmsView({ title, icon, groups, allVms, onVmClick, onVmAction, onMigrate, onLoadTrendsBatch, onSelect, favorites, onToggleFavorite, migratingVmIds }: GroupedVmsViewProps) {
+function GroupedVmsView({ title, icon, groups, allVms, onVmClick, onVmAction, onMigrate, onLoadTrendsBatch, onSelect, favorites, onToggleFavorite, migratingVmIds, nodeStatuses }: GroupedVmsViewProps) {
   const t = useTranslations()
   // Par défaut, TOUS les groupes sont repliés
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
@@ -184,6 +185,7 @@ return next
                         compact
                         showTrends
                         showActions
+                        nodeStatuses={nodeStatuses}
                         onLoadTrendsBatch={onLoadTrendsBatch}
                         onVmClick={onVmClick}
                         onVmAction={onVmAction}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { useTranslations } from 'next-intl'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import { VmItem, type VmItemProps } from './VmItem'
+
+// The jsdom lane has no RTL auto-cleanup; without this, the negative
+// assertions below would match leftovers from the previous render.
+afterEach(cleanup)
+
+// VmItem takes `t` as a prop (typed as useTranslations' return), so a tiny
+// harness sources it from the provider renderWithProviders already mounts.
+function Harness(props: Omit<VmItemProps, 't'>) {
+  const t = useTranslations()
+  return <VmItem {...props} t={t} />
+}
+
+const baseProps: Omit<VmItemProps, 't' | 'variant'> = {
+  vmKey: 'conn1:pve-2-2:qemu:100',
+  connId: 'conn1',
+  connName: 'Cluster1',
+  node: 'pve-2-2',
+  vmType: 'qemu',
+  vmid: '100',
+  name: 'web-01',
+  status: 'running',
+  isSelected: false,
+  isMigrating: false,
+  isPendingAction: false,
+  isFavorite: false,
+  onFavoriteToggle: vi.fn(),
+  onClick: vi.fn(),
+  onContextMenu: vi.fn(),
+}
+
+describe('VmItem node caption (issue #666)', () => {
+  it.each(['flat', 'favorite', 'template'] as const)(
+    'shows the node caption on the %s variant when showNode is set',
+    variant => {
+      renderWithProviders(<Harness {...baseProps} variant={variant} showNode />)
+      expect(screen.getByText('· pve-2-2')).toBeInTheDocument()
+    },
+  )
+
+  it('does not show the node caption without showNode', () => {
+    renderWithProviders(<Harness {...baseProps} variant="flat" />)
+    expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()
+  })
+
+  it('does not show the node caption on the grouped variant even with showNode', () => {
+    renderWithProviders(<Harness {...baseProps} variant="grouped" showNode />)
+    expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()
+  })
+
+  it('still renders the VM name alongside the caption', () => {
+    renderWithProviders(<Harness {...baseProps} variant="flat" showNode />)
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
@@ -57,4 +57,15 @@ describe('VmItem node caption (issue #666)', () => {
     renderWithProviders(<Harness {...baseProps} variant="flat" showNode />)
     expect(screen.getByText('web-01')).toBeInTheDocument()
   })
+
+  it('reacts to showNode flipping on an already-mounted instance (exercises the memo comparator)', () => {
+    const { rerender } = renderWithProviders(<Harness {...baseProps} variant="flat" />)
+    expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()
+
+    rerender(<Harness {...baseProps} variant="flat" showNode />)
+    expect(screen.getByText('· pve-2-2')).toBeInTheDocument()
+
+    rerender(<Harness {...baseProps} variant="flat" showNode={false} />)
+    expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.test.tsx
@@ -39,7 +39,7 @@ describe('VmItem node caption (issue #666)', () => {
     'shows the node caption on the %s variant when showNode is set',
     variant => {
       renderWithProviders(<Harness {...baseProps} variant={variant} showNode />)
-      expect(screen.getByText('· pve-2-2')).toBeInTheDocument()
+      expect(screen.getByText('pve-2-2')).toBeInTheDocument()
     },
   )
 
@@ -63,7 +63,7 @@ describe('VmItem node caption (issue #666)', () => {
     expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()
 
     rerender(<Harness {...baseProps} variant="flat" showNode />)
-    expect(screen.getByText('· pve-2-2')).toBeInTheDocument()
+    expect(screen.getByText('pve-2-2')).toBeInTheDocument()
 
     rerender(<Harness {...baseProps} variant="flat" showNode={false} />)
     expect(screen.queryByText(/pve-2-2/)).not.toBeInTheDocument()

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.tsx
@@ -94,6 +94,7 @@ export type VmItemProps = {
   tags?: string[]
   showVmId?: boolean
   lock?: string
+  showNode?: boolean
 }
 
 /* ------------------------------------------------------------------ */
@@ -127,6 +128,7 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
     tags,
     showVmId,
     lock,
+    showNode,
   } = props
   const { getColor, getShape } = useTagColors(connId)
   const shape = getShape(connId)
@@ -168,6 +170,15 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
       />
     )
   }) : null
+
+  // #666 — PVE placement readable from the flat lists while a search
+  // filter is active. Never rendered for vDC tenants (call sites gate on
+  // isFullClusterView, same rule as the detail-header node chip).
+  const nodeCaption = showNode ? (
+    <Typography variant="caption" sx={{ fontSize: 11, color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
+      {`· ${node}`}
+    </Typography>
+  ) : null
 
   if (variant === 'tree') {
     const cpuPct = getCpuPct(cpu)
@@ -338,6 +349,7 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
           <Typography variant="body2" sx={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {showVmId ? `${vmid} - ${name}` : name}
           </Typography>
+          {nodeCaption}
           <Chip label={vmType === 'lxc' ? 'LXC' : 'VM'} size="small" sx={{ height: 16, fontSize: 10 }} />
         </Box>
       </Box>
@@ -385,6 +397,7 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
           <Typography variant="body2" sx={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {showVmId ? `${vmid} - ${name}` : name}
           </Typography>
+          {nodeCaption}
           {template && (
             <Chip label={t('inventory.template')} size="small" sx={{ height: 16, fontSize: 10, ml: 0.5 }} />
           )}
@@ -461,6 +474,7 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
           <Typography variant="body2" sx={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {showVmId ? `${vmid} - ${name}` : name}
           </Typography>
+          {nodeCaption}
           {template && (
             <Chip label={t('inventory.template')} size="small" sx={{ height: 16, fontSize: 10, ml: 0.5 }} />
           )}
@@ -495,5 +509,6 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
   prev.template === next.template &&
   prev.tags?.join(';') === next.tags?.join(';') &&
   prev.showVmId === next.showVmId &&
-  prev.lock === next.lock
+  prev.lock === next.lock &&
+  prev.showNode === next.showNode
 )

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/VmItem.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material'
 
 import { useTagColors } from '@/contexts/TagColorContext'
-import { StatusIcon } from './TreeIcons'
+import { NodeIcon, StatusIcon } from './TreeIcons'
 
 // Re-export getVmIcon for consumers that import from VmItem
 export { getVmIcon } from './TreeIcons'
@@ -95,6 +95,7 @@ export type VmItemProps = {
   showVmId?: boolean
   lock?: string
   showNode?: boolean
+  nodeStatus?: string
 }
 
 /* ------------------------------------------------------------------ */
@@ -129,6 +130,7 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
     showVmId,
     lock,
     showNode,
+    nodeStatus,
   } = props
   const { getColor, getShape } = useTagColors(connId)
   const shape = getShape(connId)
@@ -175,9 +177,13 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
   // filter is active. Never rendered for vDC tenants (call sites gate on
   // isFullClusterView, same rule as the detail-header node chip).
   const nodeCaption = showNode ? (
-    <Typography variant="caption" sx={{ fontSize: 11, color: 'text.secondary', whiteSpace: 'nowrap', flexShrink: 0 }}>
-      {`· ${node}`}
-    </Typography>
+    <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+      <Typography variant="body2" sx={{ fontSize: 13, color: 'text.secondary' }}>-</Typography>
+      <NodeIcon status={nodeStatus} size={14} />
+      <Typography variant="body2" sx={{ fontSize: 13, color: 'text.secondary', whiteSpace: 'nowrap' }}>
+        {node}
+      </Typography>
+    </Box>
   ) : null
 
   if (variant === 'tree') {
@@ -510,5 +516,6 @@ export const VmItem = React.memo(function VmItem(props: VmItemProps) {
   prev.tags?.join(';') === next.tags?.join(';') &&
   prev.showVmId === next.showVmId &&
   prev.lock === next.lock &&
-  prev.showNode === next.showNode
+  prev.showNode === next.showNode &&
+  prev.nodeStatus === next.nodeStatus
 )

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -335,7 +335,7 @@ export default function NodeTabs(props: any) {
   // #666: node status lookup for the VmsTable node column pastille (full
   // view), reusing the `hosts` prop InventoryDetails already passes down.
   const nodeStatuses = useMemo(
-    () => new Map((hosts || []).map((h: any) => [h.key, h.status])),
+    () => new Map<string, string | undefined>((hosts || []).map((h: any) => [h.key as string, h.status as string | undefined])),
     [hosts]
   )
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/NodeTabs.tsx
@@ -332,6 +332,13 @@ export default function NodeTabs(props: any) {
     return tags ? String(tags).split(';').filter(Boolean) : []
   }, [hostsData, nodeNodeName])
 
+  // #666: node status lookup for the VmsTable node column pastille (full
+  // view), reusing the `hosts` prop InventoryDetails already passes down.
+  const nodeStatuses = useMemo(
+    () => new Map((hosts || []).map((h: any) => [h.key, h.status])),
+    [hosts]
+  )
+
   // Fetch Ceph OSD flags when on OSD sub-tab
   useEffect(() => {
     if (nodeTab !== 8 || nodeCephSubTab !== 2 || !nodeConnId || !data.clusterName) return
@@ -1170,6 +1177,7 @@ export default function NodeTabs(props: any) {
                           vms={data.vmsData as VmRow[]}
                           compact={!expandedVmsTable}
                           expanded={expandedVmsTable}
+                          nodeStatuses={nodeStatuses}
                           maxHeight="100%"
                           autoPageSize
                           showTrends

--- a/frontend/src/components/VmsTable.test.tsx
+++ b/frontend/src/components/VmsTable.test.tsx
@@ -101,6 +101,31 @@ describe('VmsTable - basic render', () => {
     // When showNode=false no .node-name elements exist
     expect(container.querySelectorAll('.node-name').length).toBe(0)
   })
+
+  it('shows the NodeIcon pastille (not the bare logo) in the node cell when nodeStatuses has an entry (#666)', () => {
+    const row = vmRowsFixture[0]
+    const nodeStatuses = new Map([[`${row.connId}:${row.node}`, 'online']])
+    const { container } = renderWithProviders(
+      <VmsTable vms={[row]} showNode nodeStatuses={nodeStatuses} />,
+    )
+    const nodeNameEl = container.querySelector('.node-name')
+    expect(nodeNameEl).not.toBeNull()
+    expect(nodeNameEl!.textContent).toBe('pve1')
+    // NodeIcon wraps its <img> + status dot in a <span>; the bare-logo
+    // fallback (no nodeStatuses entry) is a lone <img> sibling instead.
+    const iconWrapper = nodeNameEl!.previousElementSibling
+    expect(iconWrapper?.tagName).toBe('SPAN')
+    expect(iconWrapper?.querySelector('img')).toBeInTheDocument()
+  })
+
+  it('falls back to the bare Proxmox logo in the node cell when nodeStatuses has no entry for this node (#666)', () => {
+    const { container } = renderWithProviders(
+      <VmsTable vms={[vmRowsFixture[0]]} showNode />,
+    )
+    const nodeNameEl = container.querySelector('.node-name')
+    const iconWrapper = nodeNameEl!.previousElementSibling
+    expect(iconWrapper?.tagName).toBe('IMG')
+  })
 })
 
 // ------------------------------------------------------------------ //

--- a/frontend/src/components/VmsTable.tsx
+++ b/frontend/src/components/VmsTable.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { getOsSvgIcon } from '@/lib/utils/osIcons'
 import { useTagColors } from '@/contexts/TagColorContext'
 import { vmIconOpacity } from '@/app/(dashboard)/infrastructure/inventory/helpers'
+import { NodeIcon } from '@/app/(dashboard)/infrastructure/inventory/components/TreeIcons'
 import { useTenant } from '@/contexts/TenantContext'
 
 import { createPortal } from 'react-dom'
@@ -467,6 +468,7 @@ type VmsTableProps = {
   expanded?: boolean
   maxHeight?: number | string
   showNode?: boolean
+  nodeStatuses?: Map<string, string | undefined>  // #666: node column pastille, keyed `${connId}:${node}`
   showTrends?: boolean
   showActions?: boolean
   showIpSnap?: boolean  // Afficher les colonnes IP et Snapshots
@@ -502,6 +504,7 @@ function VmsTable({
   expanded = false,
   maxHeight = 400,
   showNode = false,
+  nodeStatuses,
   showTrends = false,
   showActions = false,
   showIpSnap = false,
@@ -972,7 +975,14 @@ return (
         minWidth: 80,
         maxWidth: 150,
         renderHeader: headerWithIcon('ri-server-line', 'Node'),
-        renderCell: (params) => (
+        renderCell: (params) => {
+          // #666: same NodeIcon (logo + status pastille) vocabulary as the
+          // inventory tree/flat lists. Falls back to the bare logo when the
+          // node's status isn't known here — a pastille with no real status
+          // would default to red and lie.
+          const nodeSt = nodeStatuses?.get(`${params.row.connId}:${params.row.node}`)
+
+          return (
           <Box
             sx={{
               display: 'flex',
@@ -989,13 +999,17 @@ return (
               }
             }}
           >
-            <img
-              src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'}
-              alt=""
-              width={14}
-              height={14}
-              style={{ opacity: 0.7, flexShrink: 0 }}
-            />
+            {nodeSt ? (
+              <NodeIcon status={nodeSt} size={14} />
+            ) : (
+              <img
+                src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'}
+                alt=""
+                width={14}
+                height={14}
+                style={{ opacity: 0.7, flexShrink: 0 }}
+              />
+            )}
             <Typography
               className="node-name"
               variant='body2'
@@ -1010,10 +1024,11 @@ return (
               {params.row.node}
             </Typography>
           </Box>
-        )
+          )
+        }
       })
     }
-    
+
     // Colonne HA - toujours inclus quand expanded et qu'il y a des VMs cluster
     if (showNode || expanded) {
       const hasClusterVms = vms.some(vm => vm.isCluster)
@@ -1687,7 +1702,7 @@ return true
       // MUI re-runs flex layout on every columns-prop change and ignores width.
       return { ...col, width: saved, flex: undefined }
     })
-  }, [isCompact, expanded, showNode, showTrends, showActions, showIpSnap, onVmAction, onMigrate, canMigrate, onNodeClick, primaryColor, trendsData, trendsLoading, vms, isMobile, isTablet, isSmallDesktop, isLargeDesktop, favorites, onToggleFavorite, visibleColumns, columnWidths])
+  }, [isCompact, expanded, showNode, nodeStatuses, showTrends, showActions, showIpSnap, onVmAction, onMigrate, canMigrate, onNodeClick, primaryColor, trendsData, trendsLoading, vms, isMobile, isTablet, isSmallDesktop, isLargeDesktop, favorites, onToggleFavorite, visibleColumns, columnWidths])
 
   return (
     <Box sx={{


### PR DESCRIPTION
## Summary

When a search filter is active in the inventory sidebar, the flat VM lists (VMs, Favorites, Templates view modes) now show which PVE node each guest runs on, right after the VM name: `TSEStore01-W2022 - <logo+status dot> PVE-2-2`, using the same node icon (Proxmox logo + status pastille) as everywhere else in the UI. Without a search filter, rows are unchanged.

The tree view also keeps its full cluster → node → VM hierarchy while searching, and the VMs table's Node column gains the node status pastille.

## Details

- New optional `showNode`/`nodeStatus` props on `VmItem`, rendered in its `flat`, `favorite` and `template` variants (the `grouped` variant already sits under a host header, and the tree shows nodes natively). The `React.memo` comparator includes the new props.
- The caption is only shown to provider/MSP viewers (`isFullClusterView`): vDC tenants never see PVE node names, matching the existing node chip rule in the detail-panel header.
- Tree view: the single-node flatten shortcut now only applies to genuinely single-node connections (standalone host, tenant scoped to one node). A multi-node cluster reduced to one visible node by the search filter keeps the cluster → node → VM hierarchy, so the node stays visible (auto-expanded during search).
- `VmsTable` Node column: renders the shared `NodeIcon` (logo + green/red status dot) when the node's status is known — wired from the `hosts` data in the root VMs/Templates tables and the node detail table — and keeps the bare logo as fallback when it isn't.
- No new i18n keys.

## Tests

- `VmItem.test.tsx` (new): caption present on the three flat variants with `showNode`, absent without it, absent on `grouped`, plus a mount-then-`rerender` case exercising the memo comparator both ways.
- `VmsTable.test.tsx`: node column shows the status pastille when `nodeStatuses` is provided, bare logo fallback otherwise.
- 42/42 passing across both suites; eslint clean.

Closes #666
