### PR TITLE
fix(site-recovery): deterministic VM names across clusters and persistent test-failover state

### DIFF
--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -68,6 +68,7 @@ export default function SiteRecoveryPage() {
 
   // Execution tracking
   const [activeExecution, setActiveExecution] = useState<RecoveryExecution | null>(null)
+  const [failoverError, setFailoverError] = useState<string | null>(null)
 
   // Cleanup state
   const [cleanupLoading, setCleanupLoading] = useState(false)
@@ -128,10 +129,14 @@ export default function SiteRecoveryPage() {
     }))
   , [allVMsData])
 
-  // VM name map for display (vmid → name)
-  const vmNameMap = useMemo(() => {
-    const m: Record<number, string> = {}
-    for (const vm of allVMs) if (vm.vmid && vm.name) m[vm.vmid] = vm.name
+  // VM names scoped per connection (connId → vmid → name): the same VMID can
+  // exist on both sites, so a flat map resolves nondeterministically.
+  const vmNamesByConn = useMemo(() => {
+    const m: Record<string, Record<number, string>> = {}
+    for (const vm of allVMs) {
+      if (!vm.vmid || !vm.name || !vm.connId) continue
+      ;(m[vm.connId] ??= {})[vm.vmid] = vm.name
+    }
     return m
   }, [allVMs])
 
@@ -236,7 +241,21 @@ export default function SiteRecoveryPage() {
     setActiveExecution(null)
     setCleanupResult(null)
     setCleanupLoading(false)
-  }, [])
+    setFailoverError(null)
+
+    // Rehydration: a test failover started before a reload has no in-memory
+    // `activeExecution` — refetch it from its id on the plan so the dialog
+    // can land directly on the Cleanup block instead of showing "confirm".
+    if (type === 'test') {
+      const plan = (plans || []).find((p: RecoveryPlan) => p.id === planId)
+      if (plan?.active_test_execution_id) {
+        fetch(`/api/v1/orchestrator/replication/executions/${plan.active_test_execution_id}`)
+          .then(res => (res.ok ? res.json() : null))
+          .then(data => { if (data) setActiveExecution(data) })
+          .catch(() => { /* ignore — dialog shows the warning banner instead */ })
+      }
+    }
+  }, [plans])
 
   const handleFailoverConfirm = useCallback(async () => {
     if (!failoverDialog.planId) return
@@ -252,14 +271,19 @@ export default function SiteRecoveryPage() {
         headers: body ? { 'Content-Type': 'application/json' } : {},
         body
       })
-      const data = await res.json()
-
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setFailoverError(data?.error || t('siteRecovery.failover.testConflict'))
+        mutatePlans()
+        return
+      }
+      setFailoverError(null)
       setActiveExecution(data)
       mutatePlans()
     } catch (e) {
       console.error('Failed to execute:', e)
     }
-  }, [failoverDialog, mutatePlans])
+  }, [failoverDialog, mutatePlans, t])
 
   const handleCleanupTest = useCallback(async () => {
     if (!failoverDialog.planId) return
@@ -391,7 +415,7 @@ export default function SiteRecoveryPage() {
 
         {/* Tab Content */}
         {tab === 0 && hasEnoughCephClusters && (
-          <DashboardTab health={health} loading={healthLoading} jobs={jobs || []} connections={connections} vmNameMap={vmNameMap} onSyncJob={handleSyncJob} />
+          <DashboardTab health={health} loading={healthLoading} jobs={jobs || []} connections={connections} vmNamesByConn={vmNamesByConn} onSyncJob={handleSyncJob} />
         )}
 
         {tab === 1 && hasEnoughCephClusters && (
@@ -401,7 +425,7 @@ export default function SiteRecoveryPage() {
             logs={jobLogs || []}
             logsLoading={logsLoading}
             connections={connections}
-            vmNameMap={vmNameMap}
+            vmNamesByConn={vmNamesByConn}
             onSyncJob={handleSyncJob}
             onPauseJob={handlePauseJob}
             onResumeJob={handleResumeJob}
@@ -413,7 +437,7 @@ export default function SiteRecoveryPage() {
         )}
 
         {tab === 2 && hasEnoughCephClusters && (
-          <SnapshotsTab connections={connections} vmNameMap={vmNameMap} />
+          <SnapshotsTab connections={connections} vmNamesByConn={vmNamesByConn} />
         )}
 
         {tab === 3 && hasEnoughCephClusters && (
@@ -428,6 +452,7 @@ export default function SiteRecoveryPage() {
             onFailover={(id) => openFailoverDialog(id, 'failover')}
             onFailback={(id) => openFailoverDialog(id, 'failback')}
             onDeletePlan={handleDeletePlan}
+            onCleanupTest={(id) => openFailoverDialog(id, 'test')}
             connections={connections}
           />
         )}
@@ -438,7 +463,7 @@ export default function SiteRecoveryPage() {
             plans={plans || []}
             loading={jobsLoading || plansLoading}
             connections={connections}
-            vmNameMap={vmNameMap}
+            vmNamesByConn={vmNamesByConn}
             onStartVM={handleStartDRVM}
             onExecuteFailover={(planId) => openFailoverDialog(planId, 'failover')}
             onExecuteFailback={(planId) => openFailoverDialog(planId, 'failback')}
@@ -485,9 +510,10 @@ export default function SiteRecoveryPage() {
           cleanupLoading={cleanupLoading}
           cleanupResult={cleanupResult}
           execution={activeExecution}
+          errorMessage={failoverError}
           targetConnId={failoverPlan?.target_cluster}
           connections={connections}
-          vmNameMap={vmNameMap}
+          vmNameMap={failoverPlan ? vmNamesByConn[failoverPlan.source_cluster] : undefined}
         />
       </Box>
     </EnterpriseGuard>

--- a/frontend/src/components/automation/site-recovery/DashboardTab.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.tsx
@@ -827,9 +827,9 @@ const ReplicationFlow = ({ sites, connectivity, latencyMs, jobs, connections, t 
 
 // ── Failed jobs widget ─────────────────────────────────────────────────
 
-const FailedJobsWidget = ({ jobs, vmNameMap, onSyncJob, t }: {
+const FailedJobsWidget = ({ jobs, vmNamesByConn, onSyncJob, t }: {
   jobs: ReplicationJob[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob?: (id: string) => void
   t: any
 }) => {
@@ -855,7 +855,7 @@ const FailedJobsWidget = ({ jobs, vmNameMap, onSyncJob, t }: {
             const label = j.name || (
               j.tags?.length
                 ? j.tags.map(tag => `#${tag}`).join(', ')
-                : (j.vm_ids || []).slice(0, 2).map(id => vmNameMap?.[id] || `VM ${id}`).join(', ')
+                : (j.vm_ids || []).slice(0, 2).map(id => vmNamesByConn?.[j.source_cluster]?.[id] || `VM ${id}`).join(', ')
             )
             const retryInfo = j.next_retry_at && (j.retry_count || 0) < 3
               ? t('siteRecovery.dashboard.retryIn', { in: Math.max(0, Math.round((new Date(j.next_retry_at).getTime() - Date.now()) / 1000 / 60)) })
@@ -903,11 +903,11 @@ interface DashboardTabProps {
   loading: boolean
   jobs?: ReplicationJob[]
   connections?: { id: string; name: string }[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob?: (id: string) => void
 }
 
-export default function DashboardTab({ health, loading, jobs, connections, vmNameMap, onSyncJob }: DashboardTabProps) {
+export default function DashboardTab({ health, loading, jobs, connections, vmNamesByConn, onSyncJob }: DashboardTabProps) {
   const t = useTranslations()
   const theme = useTheme()
 
@@ -1001,7 +1001,7 @@ export default function DashboardTab({ health, loading, jobs, connections, vmNam
       </Box>
 
       {/* Failed jobs (only when error_count > 0) */}
-      <FailedJobsWidget jobs={jobs || []} vmNameMap={vmNameMap} onSyncJob={onSyncJob} t={t} />
+      <FailedJobsWidget jobs={jobs || []} vmNamesByConn={vmNamesByConn} onSyncJob={onSyncJob} t={t} />
 
       {/* Charts Row */}
       <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' } }}>

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
@@ -61,7 +61,7 @@ interface EmergencyDRTabProps {
   plans: RecoveryPlan[]
   loading: boolean
   connections: Array<{ id: string; name: string }>
-  vmNameMap: Record<number, string>
+  vmNamesByConn: Record<string, Record<number, string>>
   onStartVM: (vmId: number, targetCluster: string, jobId: string) => Promise<void>
   onExecuteFailover: (planId: string) => void
   onExecuteFailback: (planId: string) => void
@@ -69,7 +69,7 @@ interface EmergencyDRTabProps {
 }
 
 export default function EmergencyDRTab({
-  jobs, plans, loading, connections, vmNameMap, onStartVM, onExecuteFailover, onExecuteFailback, onDeletePlan
+  jobs, plans, loading, connections, vmNamesByConn, onStartVM, onExecuteFailover, onExecuteFailback, onDeletePlan
 }: EmergencyDRTabProps) {
   const t = useTranslations('siteRecovery')
   const tc = useTranslations('common')
@@ -93,7 +93,7 @@ export default function EmergencyDRTab({
       for (const vmId of (job.vm_ids || [])) {
         allDRVMs.push({
           vmId,
-          vmName: vmNameMap[vmId] || `VM ${vmId}`,
+          vmName: vmNamesByConn[job.source_cluster]?.[vmId] || `VM ${vmId}`,
           targetVmId: destinationVMID(job.vmid_prefix, vmId),
           sourceCluster: job.source_cluster,
           targetCluster: job.target_cluster,
@@ -110,7 +110,7 @@ export default function EmergencyDRTab({
     for (const plan of plans) {
       for (const pvm of (plan.vms || [])) {
         vmInPlan.add(pvm.vm_id)
-        const drvm = allDRVMs.find(v => v.vmId === pvm.vm_id)
+        const drvm = allDRVMs.find(v => v.vmId === pvm.vm_id && v.sourceCluster === plan.source_cluster)
         if (drvm) {
           drvm.planId = plan.id
           drvm.planName = plan.name
@@ -140,7 +140,7 @@ export default function EmergencyDRTab({
     }
 
     return { planVMs: pVMs, standaloneVMs: sVMs, planGroups: groups }
-  }, [jobs, plans, vmNameMap])
+  }, [jobs, plans, vmNamesByConn])
 
   const totalDR = planVMs.length + standaloneVMs.length
   const healthyJobs = jobs.filter(j => j.status === 'synced' || j.status === 'syncing').length

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Component tests for FailoverDialog's persistent "test failover active" UI
+ * (issue #664, point 4).
+ *
+ * Before this fix, the dialog kept both the "confirm" and the "Cleanup"
+ * blocks visible once a test execution had completed (`!isExecuting` stayed
+ * true for any non-running status). It must now show exactly one of the two,
+ * driven by whether an execution is known at all — which also covers the
+ * reload case, where the execution is rehydrated from
+ * `plan.active_test_execution_id` instead of living only in React state.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import type { RecoveryPlan, RecoveryExecution } from '@/lib/orchestrator/site-recovery.types'
+
+import FailoverDialog from './FailoverDialog'
+
+afterEach(cleanup)
+
+function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
+  return {
+    id: 'plan-1',
+    name: 'Prod DR',
+    description: '',
+    status: 'ready',
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    vms: [{ vm_id: 100, vm_name: 'web-01', replication_job_id: 'job-1', tier: 1, boot_order: 1 }],
+    last_test: null,
+    last_failover: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function execution(overrides: Partial<RecoveryExecution> = {}): RecoveryExecution {
+  return {
+    id: 'exec-1',
+    plan_id: 'plan-1',
+    type: 'test',
+    status: 'completed',
+    started_at: '2026-01-01T00:00:00Z',
+    vm_results: [],
+    ...overrides,
+  }
+}
+
+type Props = Parameters<typeof FailoverDialog>[0]
+
+function renderDialog(overrides: Partial<Props> = {}) {
+  const onConfirm = vi.fn()
+  const onClose = vi.fn()
+
+  renderWithProviders(
+    <FailoverDialog
+      open
+      onClose={onClose}
+      plan={plan()}
+      type='test'
+      onConfirm={onConfirm}
+      execution={null}
+      {...overrides}
+    />,
+  )
+
+  return { onConfirm, onClose }
+}
+
+describe('FailoverDialog', () => {
+  it('hides Confirm and shows Cleanup once a test execution is known (completed)', () => {
+    renderDialog({ execution: execution(), onCleanup: vi.fn() })
+
+    expect(screen.queryByRole('button', { name: 'Test Failover' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cleanup test' })).toBeInTheDocument()
+  })
+
+  it('shows the Confirm button when there is no execution at all', () => {
+    renderDialog({ execution: null })
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+
+  it('renders the error alert when errorMessage is set', () => {
+    const message = 'A test failover is already active for this plan. Clean it up first.'
+    renderDialog({ errorMessage: message })
+
+    expect(screen.getByText(message)).toBeInTheDocument()
+  })
+
+  it('disables Confirm and shows the warning banner when the plan has an unresolved active test', () => {
+    renderDialog({
+      plan: plan({ active_test_execution_id: 'exec-1', last_test: '2026-08-01T10:00:00Z' }),
+      execution: null,
+    })
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+    expect(screen.getByText(/awaiting cleanup/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -22,12 +22,13 @@ interface FailoverDialogProps {
   cleanupLoading?: boolean
   cleanupResult?: { vms_stopped: number; disks_rolled: number; jobs_resumed: number; errors: string[] } | null
   execution: RecoveryExecution | null
+  errorMessage?: string | null
   targetConnId?: string
   connections?: { id: string; name: string }[]
   vmNameMap?: Record<number, string>
 }
 
-export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, targetConnId, connections, vmNameMap }: FailoverDialogProps) {
+export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap }: FailoverDialogProps) {
   const t = useTranslations()
   const [confirmText, setConfirmText] = useState('')
   const isDestructive = type === 'failover' || type === 'failback'
@@ -40,7 +41,11 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   if (!plan) return null
 
   const confirmRequired = isDestructive ? plan.name : null
-  const canConfirm = !isDestructive || confirmText === confirmRequired
+  // A test failover started before this page load has no in-memory
+  // `execution` yet — the rehydration fetch on open is still in flight or
+  // failed. Block a second test-failover attempt until it resolves.
+  const testActiveUnresolved = type === 'test' && !!plan.active_test_execution_id && !execution
+  const canConfirm = (!isDestructive || confirmText === confirmRequired) && !testActiveUnresolved
 
   const typeConfig = {
     test: {
@@ -77,6 +82,14 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
       <DialogContent>
         <Stack spacing={2}>
           <Alert severity={config.severity}>{config.description}</Alert>
+
+          {testActiveUnresolved && (
+            <Alert severity='warning'>
+              {t('siteRecovery.failover.testActiveBanner', {
+                date: plan.last_test ? new Date(plan.last_test).toLocaleString() : ''
+              })}
+            </Alert>
+          )}
 
           {type === 'test' && (
             <Chip
@@ -252,8 +265,9 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           )}
         </Stack>
       </DialogContent>
+      {errorMessage && <Alert severity='error' sx={{ mx: 3 }}>{errorMessage}</Alert>}
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        {!isExecuting && (
+        {!execution && (
           <>
             <Button onClick={onClose}>{t('common.cancel')}</Button>
             <Button

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -337,7 +337,7 @@ interface ProtectionTabProps {
   logs: ReplicationJobLog[]
   logsLoading: boolean
   connections: Connection[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob: (id: string) => void
   onPauseJob: (id: string) => void
   onResumeJob: (id: string) => void
@@ -348,7 +348,7 @@ interface ProtectionTabProps {
 }
 
 export default function ProtectionTab({
-  jobs, loading, logs, logsLoading, connections, vmNameMap,
+  jobs, loading, logs, logsLoading, connections, vmNamesByConn,
   onSyncJob, onPauseJob, onResumeJob, onDeleteJob, onEditJob,
   selectedJobId, onSelectJob
 }: ProtectionTabProps) {
@@ -451,14 +451,14 @@ export default function ProtectionTab({
     const qq = q.trim().toLowerCase()
 
     return (jobs || []).filter(j => {
-      const label = jobLabel(j, vmNameMap)
+      const label = jobLabel(j, vmNamesByConn?.[j.source_cluster])
       const matchQ = !qq || label.toLowerCase().includes(qq) ||
         (j.name || '').toLowerCase().includes(qq) ||
         connName(j.source_cluster).toLowerCase().includes(qq) || connName(j.target_cluster).toLowerCase().includes(qq)
 
       return matchQ && (statusFilter === 'all' || j.status === statusFilter)
     })
-  }, [jobs, q, statusFilter, connName, vmNameMap])
+  }, [jobs, q, statusFilter, connName, vmNamesByConn])
 
   const grouped = useMemo(() => {
     const map = new Map<string, ReplicationJob[]>()
@@ -614,7 +614,7 @@ export default function ProtectionTab({
                 {/* Group jobs */}
                 <Stack spacing={1}>
                   {groupJobs.map(j => (
-                    <JobCard key={j.id} job={j} onClick={() => openJob(j.id)} onEdit={() => onEditJob(j.id)} vmNameMap={vmNameMap} throughputHistory={throughputHistoryRef.current.get(j.id)} t={t} />
+                    <JobCard key={j.id} job={j} onClick={() => openJob(j.id)} onEdit={() => onEditJob(j.id)} vmNameMap={vmNamesByConn?.[j.source_cluster]} throughputHistory={throughputHistoryRef.current.get(j.id)} t={t} />
                   ))}
                 </Stack>
               </Box>
@@ -638,16 +638,16 @@ export default function ProtectionTab({
                 </Tooltip>
                 <Box sx={{ minWidth: 0, flex: 1 }}>
                   <Typography variant='h6' sx={{ fontWeight: 700, mb: 0.25 }}>
-                    {selected.name || jobLabel(selected, vmNameMap)}
+                    {selected.name || jobLabel(selected, vmNamesByConn?.[selected.source_cluster])}
                   </Typography>
                   {selected.name && (
                     <Typography variant='body2' sx={{ color: 'text.primary', fontWeight: 500, mb: 0.25 }}>
-                      {jobLabel(selected, vmNameMap)}
+                      {jobLabel(selected, vmNamesByConn?.[selected.source_cluster])}
                     </Typography>
                   )}
                   <Typography variant='caption' sx={{ color: 'text.secondary' }}>
                     {(selected.vm_ids || []).length} VM(s) — {(selected.vm_ids || []).map(id => {
-                      const name = vmNameMap?.[id]
+                      const name = vmNamesByConn?.[selected.source_cluster]?.[id]
                       return name ? `${id} - ${name}` : `${id}`
                     }).join(', ')}
                   </Typography>

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Component tests for RecoveryPlansTab's "test failover active" indicators
+ * (issue #664, point 4).
+ *
+ * `active_test_execution_id` is set by the backend while a test failover's
+ * cleanup is still pending and survives a page reload (unlike the old
+ * React-only `activeExecution` state). The row must show a warning chip and
+ * the drawer must block a second test failover until cleanup runs.
+ */
+
+import { useState } from 'react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import type { RecoveryPlan } from '@/lib/orchestrator/site-recovery.types'
+
+import RecoveryPlansTab from './RecoveryPlansTab'
+
+afterEach(cleanup)
+
+function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
+  return {
+    id: 'plan-1',
+    name: 'Prod DR',
+    description: '',
+    status: 'ready',
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    vms: [{ vm_id: 100, vm_name: 'web-01', replication_job_id: 'job-1', tier: 1, boot_order: 1 }],
+    last_test: null,
+    last_failover: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// RecoveryPlansTab is controlled: the drawer's open/closed state lives in the
+// component, but which plan is selected is driven by the parent. This small
+// harness plays the parent's role so clicking a row actually opens the drawer.
+function Harness({
+  plans,
+  onTestFailover,
+  onCleanupTest,
+}: {
+  plans: RecoveryPlan[]
+  onTestFailover: (id: string) => void
+  onCleanupTest: (id: string) => void
+}) {
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
+
+  return (
+    <RecoveryPlansTab
+      plans={plans}
+      loading={false}
+      history={[]}
+      historyLoading={false}
+      selectedPlanId={selectedPlanId}
+      onSelectPlan={setSelectedPlanId}
+      onTestFailover={onTestFailover}
+      onFailover={vi.fn()}
+      onFailback={vi.fn()}
+      onDeletePlan={vi.fn()}
+      onCleanupTest={onCleanupTest}
+      connections={[]}
+    />
+  )
+}
+
+function renderTab(plans: RecoveryPlan[]) {
+  const onTestFailover = vi.fn()
+  const onCleanupTest = vi.fn()
+
+  renderWithProviders(
+    <Harness plans={plans} onTestFailover={onTestFailover} onCleanupTest={onCleanupTest} />,
+  )
+
+  return { onTestFailover, onCleanupTest }
+}
+
+const openDrawer = async () => userEvent.click(screen.getByText('Prod DR'))
+
+describe('RecoveryPlansTab — cleanup pending indicators', () => {
+  it('shows the "Cleanup pending" chip and a disabled Test Failover + Cleanup button when a test is active', async () => {
+    const { onCleanupTest } = renderTab([plan({ active_test_execution_id: 'exec-1' })])
+
+    expect(screen.getByText('Cleanup pending')).toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+
+    const cleanupButton = screen.getByRole('button', { name: 'Cleanup test' })
+    await userEvent.click(cleanupButton)
+    expect(onCleanupTest).toHaveBeenCalledWith('plan-1')
+  })
+
+  it('shows no chip, an enabled Test Failover button and no Cleanup button when no test is active', async () => {
+    renderTab([plan({ active_test_execution_id: null })])
+
+    expect(screen.queryByText('Cleanup pending')).not.toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).not.toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl'
 
 import {
   Alert, Box, Button, Card, CardContent, Chip, Collapse, Divider, Drawer,
-  IconButton, Stack, Typography, alpha, useTheme
+  IconButton, Stack, Tooltip, Typography, alpha, useTheme
 } from '@mui/material'
 
 import EmptyState from '@/components/EmptyState'
@@ -110,6 +110,16 @@ const PlanRow = ({ plan, onClick, t, connName }: { plan: RecoveryPlan; onClick: 
         )}
       </Box>
 
+      {/* Cleanup pending warning */}
+      {plan.active_test_execution_id && (
+        <Box sx={{ flex: '0 0 auto' }}>
+          <Chip size='small' color='warning' variant='outlined'
+            icon={<i className='ri-eraser-line' />}
+            label={t('siteRecovery.plans.cleanupPending')}
+            sx={{ height: 22, fontSize: '0.65rem' }} />
+        </Box>
+      )}
+
       {/* Status */}
       <Box sx={{ flex: '0 0 auto' }}>
         <PlanStatusBadge status={plan.status} t={t} />
@@ -131,13 +141,14 @@ interface RecoveryPlansTabProps {
   onFailover: (id: string) => void
   onFailback: (id: string) => void
   onDeletePlan: (id: string) => void
+  onCleanupTest: (id: string) => void
   connections?: Array<{ id: string; name: string }>
 }
 
 export default function RecoveryPlansTab({
   plans, loading, history, historyLoading,
   selectedPlanId, onSelectPlan,
-  onTestFailover, onFailover, onFailback, onDeletePlan,
+  onTestFailover, onFailover, onFailback, onDeletePlan, onCleanupTest,
   connections
 }: RecoveryPlansTabProps) {
   const t = useTranslations()
@@ -336,13 +347,31 @@ export default function RecoveryPlansTab({
                   {t('siteRecovery.plans.actions')}
                 </Typography>
                 <Stack spacing={1}>
-                  <Button
-                    variant='outlined' size='small' fullWidth
-                    startIcon={<i className='ri-test-tube-line' />}
-                    onClick={() => onTestFailover(selected.id)}
+                  {selected.active_test_execution_id && (
+                    <Button
+                      variant='contained' size='small' color='warning' fullWidth
+                      startIcon={<i className='ri-eraser-line' />}
+                      onClick={() => onCleanupTest(selected.id)}
+                    >
+                      {t('siteRecovery.failover.cleanup')}
+                    </Button>
+                  )}
+                  <Tooltip
+                    title={t('siteRecovery.plans.testActiveTooltip')}
+                    disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing')}
+                    arrow
                   >
-                    {t('siteRecovery.plans.testFailover')}
-                  </Button>
+                    <span style={{ display: 'block' }}>
+                      <Button
+                        variant='outlined' size='small' fullWidth
+                        startIcon={<i className='ri-test-tube-line' />}
+                        onClick={() => onTestFailover(selected.id)}
+                        disabled={!!selected.active_test_execution_id || selected.status === 'executing'}
+                      >
+                        {t('siteRecovery.plans.testFailover')}
+                      </Button>
+                    </span>
+                  </Tooltip>
                   <Button
                     variant='contained' size='small' color='warning' fullWidth
                     startIcon={<i className='ri-shield-star-line' />}

--- a/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
+++ b/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
@@ -34,7 +34,7 @@ interface Connection {
 
 interface Props {
   connections: Connection[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
 }
 
 function formatBytes(b: number | undefined | null): string {
@@ -53,7 +53,7 @@ function formatAge(ts: number): string {
   return `${Math.floor(diff / 86400)}d`
 }
 
-export default function SnapshotsTab({ connections, vmNameMap }: Props) {
+export default function SnapshotsTab({ connections, vmNamesByConn }: Props) {
   const t = useTranslations()
 
   const [snaps, setSnaps] = useState<MirrorSnapshot[] | null>(null)
@@ -105,7 +105,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
       if (statusFilter === 'orphan' && !s.is_orphan) return false
       if (statusFilter === 'active' && s.is_orphan) return false
       if (!qq) return true
-      const vmName = s.vmid ? vmNameMap?.[s.vmid] : undefined
+      const vmName = s.vmid ? vmNamesByConn?.[s.cluster_id]?.[s.vmid] : undefined
       return (
         s.cluster_name?.toLowerCase().includes(qq) ||
         s.pool?.toLowerCase().includes(qq) ||
@@ -115,7 +115,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
         (vmName?.toLowerCase().includes(qq) ?? false)
       )
     })
-  }, [snaps, q, clusterFilter, statusFilter, vmNameMap])
+  }, [snaps, q, clusterFilter, statusFilter, vmNamesByConn])
 
   // Reset page when filters change and current page would be out of range
   useEffect(() => {
@@ -340,7 +340,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
             <TableBody>
               {paged.map(s => {
                 const k = key(s)
-                const vmName = s.vmid ? vmNameMap?.[s.vmid] : undefined
+                const vmName = s.vmid ? vmNamesByConn?.[s.cluster_id]?.[s.vmid] : undefined
                 return (
                   <TableRow key={k} hover selected={selected.has(k)}>
                     <TableCell padding='checkbox'>
@@ -438,7 +438,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
               {!!detail.vmid && (
                 <Box>
                   <Typography variant='caption' color='text.secondary'>{t('siteRecovery.snapshots.vm')}</Typography>
-                  <Typography variant='body2'>{detail.vmid}{vmNameMap?.[detail.vmid] ? ` · ${vmNameMap[detail.vmid]}` : ''}</Typography>
+                  <Typography variant='body2'>{detail.vmid}{vmNamesByConn?.[detail.cluster_id]?.[detail.vmid] ? ` · ${vmNamesByConn[detail.cluster_id][detail.vmid]}` : ''}</Typography>
                 </Box>
               )}
               <Box>

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -105,6 +105,7 @@ export interface RecoveryPlan {
   vms: RecoveryPlanVM[]
   last_test: string | null
   last_failover: string | null
+  active_test_execution_id?: string | null
   created_at: string
   updated_at: string
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4140,7 +4140,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Wiederherstellungsplan löschen",
-      "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+      "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "cleanupPending": "Bereinigung ausstehend",
+      "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten."
     },
     "rpoTargetLabel": "RPO-Ziel",
     "createJob": {
@@ -4258,7 +4260,9 @@
       "cleanupDone": "Cleanup abgeschlossen",
       "stopped": "Gestoppt",
       "disksRolledBack": "RBD-Festplatte(n) zurückgesetzt",
-      "jobsResumed": "Replikation job(s) resumed"
+      "jobsResumed": "Replikation job(s) resumed",
+      "testActiveBanner": "Ein am {date} gestarteter Test-Failover wartet auf die Bereinigung. Test-VMs könnten noch auf dem DR-Standort laufen.",
+      "testConflict": "Für diesen Plan ist bereits ein Test-Failover aktiv. Bereinigen Sie ihn zuerst."
     },
     "emergencyDR": {
       "title": "Notfall-DR",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Delete Recovery Plan",
-      "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone."
+      "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone.",
+      "cleanupPending": "Cleanup pending",
+      "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test."
     },
     "rpoTargetLabel": "RPO target",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Cleanup completed",
       "stopped": "stopped",
       "disksRolledBack": "RBD disk(s) rolled back",
-      "jobsResumed": "replication job(s) resumed"
+      "jobsResumed": "replication job(s) resumed",
+      "testActiveBanner": "A test failover started {date} is awaiting cleanup. Test VMs may still be running on the DR site.",
+      "testConflict": "A test failover is already active for this plan. Clean it up first."
     },
     "emergencyDR": {
       "title": "Emergency DR",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Eliminar plan de recuperación",
-      "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer."
+      "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer.",
+      "cleanupPending": "Limpieza pendiente",
+      "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba."
     },
     "rpoTargetLabel": "RPO objetivo",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Limpieza completada",
       "stopped": "detenida",
       "disksRolledBack": "disco(s) RBD revertido(s)",
-      "jobsResumed": "trabajo(s) de replicación reanudado(s)"
+      "jobsResumed": "trabajo(s) de replicación reanudado(s)",
+      "testActiveBanner": "Un failover de prueba iniciado el {date} está esperando limpieza. Las VMs de prueba pueden seguir ejecutándose en el sitio DR.",
+      "testConflict": "Ya hay un failover de prueba activo para este plan. Límpialo primero."
     },
     "emergencyDR": {
       "title": "DR de emergencia",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Supprimer le plan de reprise",
-      "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible."
+      "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible.",
+      "cleanupPending": "Nettoyage en attente",
+      "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test."
     },
     "rpoTargetLabel": "RPO cible",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Nettoyage terminé",
       "stopped": "arrêtée(s)",
       "disksRolledBack": "disque(s) RBD restauré(s)",
-      "jobsResumed": "job(s) de réplication repris"
+      "jobsResumed": "job(s) de réplication repris",
+      "testActiveBanner": "Un test de bascule démarré le {date} attend son nettoyage. Des VM de test peuvent encore tourner sur le site de secours.",
+      "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord."
     },
     "emergencyDR": {
       "title": "DR d'urgence",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4178,7 +4178,9 @@
       "failover": "페일오버",
       "failback": "페일백",
       "deletePlan": "복구 계획 삭제",
-      "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+      "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "cleanupPending": "정리 대기 중",
+      "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요."
     },
     "rpoTargetLabel": "RPO 목표",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "정리 완료",
       "stopped": "중지됨",
       "disksRolledBack": "RBD 디스크 롤백됨",
-      "jobsResumed": "복제 작업 재개됨"
+      "jobsResumed": "복제 작업 재개됨",
+      "testActiveBanner": "{date}에 시작된 테스트 페일오버가 정리를 기다리고 있습니다. 테스트 VM이 DR 사이트에서 계속 실행 중일 수 있습니다.",
+      "testConflict": "이 계획에 대해 테스트 페일오버가 이미 진행 중입니다. 먼저 정리하세요."
     },
     "emergencyDR": {
       "title": "긴급 DR",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4139,7 +4139,9 @@
       "failover": "故障转移",
       "failback": "故障回切",
       "deletePlan": "删除恢复计划",
-      "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。"
+      "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。",
+      "cleanupPending": "待清理",
+      "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。"
     },
     "rpoTargetLabel": "RPO 目标",
     "createJob": {
@@ -4257,7 +4259,9 @@
       "cleanupDone": "清理完成",
       "stopped": "已停止",
       "disksRolledBack": "RBD 磁盘已回滚",
-      "jobsResumed": "复制任务已恢复"
+      "jobsResumed": "复制任务已恢复",
+      "testActiveBanner": "于 {date} 启动的测试故障转移正在等待清理。测试 VM 可能仍在灾备站点上运行。",
+      "testConflict": "此计划已有一个测试故障转移正在进行。请先清理它。"
     },
     "emergencyDR": {
       "title": "紧急灾难恢复",


### PR DESCRIPTION
## Summary

Short-term fixes for the first two field-feedback points of #664.

### VM names resolved per cluster (point 3)
When the same VMID exists on both sites, every Site Recovery view that resolved names through a flat `vmid -> name` map picked a nondeterministic winner (Go map iteration order server-side, fetch order client-side), so the recovery-plan picker visibly flipped between the replicated VM and an unrelated DR VM on each refresh. VM names are now resolved strictly against the cluster the VM belongs to, across the whole bug class: plan picker, protection tab, dashboard failed-jobs widget, emergency DR tab (including plan-to-job matching), snapshots tab and failover dialog. An unreachable cluster now degrades to `VM <id>` instead of borrowing another cluster's name.

### Test failover state survives reloads (point 4)
The pending-cleanup state after a test failover only lived in React state. The recovery plan now carries `active_test_execution_id` (set when a test starts, cleared by cleanup or a real failover), so after a reload the plan row shows a Cleanup pending chip, Test Failover stays disabled until cleanup, the dialog rehydrates the finished execution (per-VM results and console links) and starting a second test while one is active returns 409 and is surfaced in the dialog.

Requires the matching orchestrator update (deployed together; each side degrades gracefully without the other).

## Tests
- New component tests: RecoveryPlansTab gating/chip, FailoverDialog action blocks.
- Full suite green: 417 files / 4183 tests, build and lint clean.

Closes points 3 and 4 of #664.