### PR TITLE
feat(migration): pre-migration check for HA resource affinity rules

### DIFF
--- a/frontend/src/components/MigrateVmDialog.test.tsx
+++ b/frontend/src/components/MigrateVmDialog.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Component tests for MigrateVmDialog.tsx — HA resource affinity pre-check (#674).
+ *
+ * Strategy: render the dialog open on the Local migration tab, seed every MSW
+ * endpoint fired on open (nodes, VM config, storages, HA), then assert the
+ * affinity-conflict UI: node badge, alert severity, Migrate button gating,
+ * recommended-node star placement, positive-affinity notice.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import { MigrateVmDialog } from './MigrateVmDialog'
+
+const { useLicenseMock } = vi.hoisted(() => ({ useLicenseMock: vi.fn() }))
+vi.mock('@/contexts/LicenseContext', () => ({
+  useLicense: () => useLicenseMock(),
+  Features: { CROSS_CLUSTER_MIGRATION: 'cross_cluster_migration' },
+}))
+
+const CONN_ID = 'conn-1'
+const CURRENT_NODE = 'pve1'
+const VMID = '100'
+
+// pve2 scores far better than pve3 (cpuFree*0.4 + memFree*0.6), so the dialog
+// auto-selects pve2 on load — which is exactly where the conflicting peer runs.
+const nodesFixture = [
+  { node: 'pve1', status: 'online', cpu: 0.1, maxcpu: 16, mem: 20e9, maxmem: 100e9 },
+  { node: 'pve2', status: 'online', cpu: 0.05, maxcpu: 16, mem: 10e9, maxmem: 100e9 },
+  { node: 'pve3', status: 'online', cpu: 0.6, maxcpu: 16, mem: 80e9, maxmem: 100e9 },
+]
+
+const sharedStorages = [
+  { storage: 'ceph', type: 'rbd', shared: 1, content: 'images,rootdir', avail: 1e12, total: 2e12 },
+]
+
+const haStatus = (peerState: string) => [
+  { id: 'quorum', type: 'quorum', node: 'pve1' },
+  { id: 'service:vm:100', type: 'service', sid: 'vm:100', node: 'pve1', state: 'started' },
+  { id: 'service:vm:200', type: 'service', sid: 'vm:200', node: 'pve2', state: peerState },
+  { id: 'service:ct:300', type: 'service', sid: 'ct:300', node: 'pve3', state: 'started' },
+]
+
+const negativeRule = { rule: 'keep-apart', type: 'resource-affinity', affinity: 'negative', resources: 'vm:100,vm:200' }
+const positiveRule = { rule: 'keep-together', type: 'resource-affinity', affinity: 'positive', resources: 'vm:100,ct:300' }
+
+function seedHandlers({
+  haResources = [{ sid: 'vm:100', state: 'started' }, { sid: 'vm:200', state: 'started' }],
+  rules = [] as any[],
+  status = [] as any[],
+} = {}) {
+  server.use(
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes`, () =>
+      HttpResponse.json({ data: nodesFixture }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/guests/qemu/${CURRENT_NODE}/${VMID}/config`, () =>
+      HttpResponse.json({ data: { scsi0: 'ceph:vm-100-disk-0,size=10G', cpu: 'x86-64-v2-AES' } }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/nodes/:node/storages`, () =>
+      HttpResponse.json({ data: sharedStorages }),
+    ),
+    http.get(`*/api/v1/connections/${CONN_ID}/ha`, () =>
+      HttpResponse.json({
+        data: {
+          resources: haResources,
+          groups: [],
+          rules,
+          status,
+          pveVersion: '9.0.3',
+          majorVersion: 9,
+          rulesSupported: true,
+        },
+      }),
+    ),
+  )
+}
+
+function makeProps() {
+  return {
+    open: true,
+    onClose: vi.fn(),
+    onMigrate: vi.fn().mockResolvedValue(undefined),
+    connId: CONN_ID,
+    currentNode: CURRENT_NODE,
+    vmName: 'web',
+    vmid: VMID,
+    vmStatus: 'running',
+    vmType: 'qemu' as const,
+    isCluster: true,
+  }
+}
+
+async function waitForNodesLoaded() {
+  await screen.findByText('pve2')
+  await screen.findByText('pve3')
+}
+
+beforeEach(() => {
+  useLicenseMock.mockReturnValue({ hasFeature: () => false, loading: false })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MigrateVmDialog - HA negative affinity conflict (running peer)', () => {
+  beforeEach(() => {
+    seedHandlers({ rules: [negativeRule, positiveRule], status: haStatus('started') })
+  })
+
+  it('flags the conflicting node, blocks Migrate and moves the recommendation', async () => {
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+
+    // pve2 is auto-selected (best score) and hosts vm:200 -> blocking alert
+    await screen.findByText('HA affinity conflict')
+    expect(
+      screen.getByText(/vm:200 is running on pve2 and rule "keep-apart"/),
+    ).toBeInTheDocument()
+
+    // Shield badge on the conflicting node row + alert icon
+    await waitFor(() => {
+      expect(document.querySelectorAll('.ri-shield-cross-line').length).toBeGreaterThanOrEqual(2)
+    })
+
+    // Migrate is blocked while the peer runs on the selected node
+    expect(screen.getByRole('button', { name: /migrate/i })).toBeDisabled()
+
+    // The recommended star skips the conflicting node: it sits on pve3's row
+    const star = document.querySelector('.ri-star-fill')
+    expect(star).not.toBeNull()
+    let el: HTMLElement | null = star as HTMLElement
+    while (el && !el.textContent?.includes('pve3')) el = el.parentElement
+    expect(el?.textContent).toContain('pve3')
+    expect(el?.textContent).not.toContain('pve2')
+  })
+
+  it('shows the positive-affinity co-migration notice', async () => {
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+
+    expect(
+      await screen.findByText(/positive HA affinity with ct:300/),
+    ).toBeInTheDocument()
+  })
+
+  it('selecting a conflict-free node clears the alert and unblocks Migrate', async () => {
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+    await screen.findByText('HA affinity conflict')
+
+    fireEvent.click(screen.getByText('pve3'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('HA affinity conflict')).not.toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /migrate/i })).not.toBeDisabled()
+  })
+})
+
+describe('MigrateVmDialog - HA negative affinity with a stopped peer', () => {
+  beforeEach(() => {
+    seedHandlers({ rules: [negativeRule], status: haStatus('stopped') })
+  })
+
+  it('warns without blocking the migration', async () => {
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+
+    await screen.findByText('HA affinity conflict')
+    expect(screen.getByText(/currently not running/)).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /migrate/i })).not.toBeDisabled()
+    })
+  })
+})
+
+describe('MigrateVmDialog - no affinity involvement', () => {
+  it('renders nothing affinity-related for a non-HA guest', async () => {
+    seedHandlers({ haResources: [{ sid: 'vm:999', state: 'started' }], rules: [negativeRule], status: haStatus('started') })
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /migrate/i })).not.toBeDisabled()
+    })
+    expect(screen.queryByText('HA affinity conflict')).not.toBeInTheDocument()
+    expect(document.querySelector('.ri-shield-cross-line')).toBeNull()
+  })
+
+  it('renders nothing affinity-related for an HA guest without rules (PVE 8)', async () => {
+    seedHandlers({ rules: [], status: [] })
+    renderWithProviders(<MigrateVmDialog {...makeProps()} />)
+    await waitForNodesLoaded()
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /migrate/i })).not.toBeDisabled()
+    })
+    expect(screen.queryByText('HA affinity conflict')).not.toBeInTheDocument()
+    expect(document.querySelector('.ri-shield-cross-line')).toBeNull()
+  })
+})

--- a/frontend/src/components/MigrateVmDialog.tsx
+++ b/frontend/src/components/MigrateVmDialog.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 import { isSharedStorage } from '@/lib/proxmox/storage'
+import { computeNegativeAffinityConflicts, getAffinityPeers, type AffinityPeer, type HaRule, type HaStatusEntry } from '@/lib/proxmox/haAffinity'
 
 import {
   Dialog,
@@ -222,7 +223,9 @@ export function MigrateVmDialog({
   const [haGroup, setHaGroup] = useState<string>('')
   const [haLoading, setHaLoading] = useState(false)
   const [haRemoving, setHaRemoving] = useState(false)
-  
+  const [haRules, setHaRules] = useState<HaRule[]>([])
+  const [haStatusEntries, setHaStatusEntries] = useState<HaStatusEntry[]>([])
+
   // ========== PRE-MIGRATION VALIDATION ==========
   type ValidationIssue = {
     type: 'error' | 'warning'
@@ -244,7 +247,26 @@ export function MigrateVmDialog({
   const hasLocalDisks = useMemo(() => {
     return vmDisks.some(d => d.isLocal)
   }, [vmDisks])
-  
+
+  const vmSid = `${vmType === 'lxc' ? 'ct' : 'vm'}:${vmid}`
+
+  // Nœuds hébergeant une ressource en affinité négative avec cette VM (règles HA PVE 9)
+  const affinityConflictsByNode = useMemo(() => {
+    if (!isHaManaged) return new Map<string, AffinityPeer[]>()
+
+    return computeNegativeAffinityConflicts(vmSid, haRules, haStatusEntries)
+  }, [isHaManaged, vmSid, haRules, haStatusEntries])
+
+  // Ressources en affinité positive : le HA manager les co-migre avec la VM
+  const positiveAffinityPeers = useMemo(() => {
+    if (!isHaManaged) return [] as AffinityPeer[]
+
+    return getAffinityPeers(vmSid, haRules, 'positive', haStatusEntries)
+  }, [isHaManaged, vmSid, haRules, haStatusEntries])
+
+  const selectedNodeConflicts = selectedNode ? (affinityConflictsByNode.get(selectedNode) || []) : []
+  const selectedNodeBlocked = selectedNodeConflicts.some(p => p.running)
+
   // Reset states when dialog opens
   useEffect(() => {
     if (open) {
@@ -262,6 +284,8 @@ export function MigrateVmDialog({
       setIsHaManaged(false)
       setHaState('')
       setHaGroup('')
+      setHaRules([])
+      setHaStatusEntries([])
       setValidationIssues([])
       setValidationDone(false)
     }
@@ -414,12 +438,14 @@ export function MigrateVmDialog({
         
         const json = await res.json()
         const resources = json.data?.resources || []
-        
+
+        setHaRules(Array.isArray(json.data?.rules) ? json.data.rules : [])
+        setHaStatusEntries(Array.isArray(json.data?.status) ? json.data.status : [])
+
         // Chercher si cette VM est dans les ressources HA
         // Le format du sid est "vm:VMID" ou "ct:VMID"
-        const vmSid = `${vmType === 'lxc' ? 'ct' : 'vm'}:${vmid}`
         const haResource = resources.find((r: any) => r.sid === vmSid)
-        
+
         if (haResource) {
           setIsHaManaged(true)
           setHaState(haResource.state || 'unknown')
@@ -662,8 +688,12 @@ export function MigrateVmDialog({
   
   const isRecommended = (node: NodeInfo): boolean => {
     if (nodes.length === 0) return false
-    const recommended = getRecommendedNode(nodes)
-    return recommended.node === node.node
+
+    // Ne jamais recommander un nœud que le HA manager refusera
+    const eligible = nodes.filter(n => !(affinityConflictsByNode.get(n.node) || []).some(p => p.running))
+    const pool = eligible.length > 0 ? eligible : nodes
+
+    return getRecommendedNode(pool).node === node.node
   }
   
   // Handle local migration
@@ -728,9 +758,8 @@ export function MigrateVmDialog({
     setError(null)
     
     try {
-      const sid = `${vmType === 'lxc' ? 'ct' : 'vm'}:${vmid}`
       const res = await fetch(
-        `/api/v1/connections/${encodeURIComponent(connId)}/ha/${encodeURIComponent(sid)}`,
+        `/api/v1/connections/${encodeURIComponent(connId)}/ha/${encodeURIComponent(vmSid)}`,
         { method: 'DELETE' }
       )
       
@@ -747,7 +776,6 @@ export function MigrateVmDialog({
       if (haRes.ok) {
         const haJson = await haRes.json()
         const resources = haJson.data?.resources || []
-        const vmSid = `${vmType === 'lxc' ? 'ct' : 'vm'}:${vmid}`
         const haResource = resources.find((r: any) => r.sid === vmSid)
         
         if (haResource) {
@@ -974,6 +1002,18 @@ export function MigrateVmDialog({
                           </Box>
                         </Tooltip>
                       )}
+                      {(affinityConflictsByNode.get(node.node) || []).length > 0 && (
+                        <Tooltip
+                          title={t('hardware.haAffinity.nodeTooltip', {
+                            peers: (affinityConflictsByNode.get(node.node) || []).map(p => p.sid).join(', ')
+                          })}
+                          arrow
+                        >
+                          <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', color: 'error.main' }}>
+                            <i className="ri-shield-cross-line" style={{ fontSize: 12 }} />
+                          </Box>
+                        </Tooltip>
+                      )}
 
                       <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center', gap: 1.5 }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
@@ -997,6 +1037,33 @@ export function MigrateVmDialog({
               </Stack>
             )}
             
+            {/* Conflits d'affinité HA (PVE 9, règles « keep separated ») */}
+            {selectedNodeConflicts.length > 0 && (
+              <Alert
+                severity={selectedNodeBlocked ? 'error' : 'warning'}
+                icon={<i className="ri-shield-cross-line" />}
+              >
+                <Typography variant="body2" fontWeight={600} sx={{ mb: 0.5 }}>
+                  {t('hardware.haAffinity.conflictTitle')}
+                </Typography>
+                {selectedNodeConflicts.map((peer) => (
+                  <Typography key={peer.sid} variant="caption" component="div" sx={{ opacity: 0.9 }}>
+                    {peer.running
+                      ? t('hardware.haAffinity.conflictBlocked', { peer: peer.sid, node: selectedNode, rule: peer.rule })
+                      : t('hardware.haAffinity.conflictStopped', { peer: peer.sid, node: selectedNode, rule: peer.rule })}
+                  </Typography>
+                ))}
+              </Alert>
+            )}
+
+            {positiveAffinityPeers.length > 0 && (
+              <Alert severity="info" icon={<i className="ri-links-line" />}>
+                <Typography variant="caption">
+                  {t('hardware.haAffinity.positiveInfo', { peers: positiveAffinityPeers.map(p => p.sid).join(', ') })}
+                </Typography>
+              </Alert>
+            )}
+
             {/* Storage selector */}
             {nodes.length > 0 && selectedNode && (
               <>
@@ -1553,7 +1620,7 @@ export function MigrateVmDialog({
           <Button 
             variant="contained" 
             onClick={handleLocalMigrate} 
-            disabled={migrating || !selectedNode || nodes.length === 0}
+            disabled={migrating || !selectedNode || nodes.length === 0 || selectedNodeBlocked}
             startIcon={migrating ? <CircularProgress size={16} /> : <i className="ri-swap-box-line" />}
           >
             {migrating ? t('hardware.migrating') : t('hardware.migrate')}

--- a/frontend/src/lib/proxmox/haAffinity.test.ts
+++ b/frontend/src/lib/proxmox/haAffinity.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  parseRuleResources,
+  getServicePlacements,
+  getAffinityPeers,
+  computeNegativeAffinityConflicts,
+  type HaRule,
+  type HaStatusEntry,
+} from './haAffinity'
+
+const status: HaStatusEntry[] = [
+  { id: 'quorum', type: 'quorum', node: 'pve1' },
+  { id: 'master', type: 'master', node: 'pve1' },
+  { id: 'lrm:pve2', type: 'lrm', node: 'pve2' },
+  { id: 'service:vm:20026', type: 'service', sid: 'vm:20026', node: 'pve1', state: 'started' },
+  { id: 'service:vm:20027', type: 'service', sid: 'vm:20027', node: 'pve2', state: 'started' },
+  { id: 'service:ct:300', type: 'service', sid: 'ct:300', node: 'pve3', state: 'stopped' },
+]
+
+const rules: HaRule[] = [
+  { rule: 'keep-apart', type: 'resource-affinity', affinity: 'negative', resources: 'vm:20026, vm:20027' },
+  { rule: 'keep-together', type: 'resource-affinity', affinity: 'positive', resources: 'vm:20026,ct:300' },
+  { rule: 'pin-nodes', type: 'node-affinity', resources: 'vm:20026' },
+]
+
+describe('parseRuleResources', () => {
+  it('splits and trims a comma-separated sid list', () => {
+    expect(parseRuleResources('vm:100, ct:101,vm:102')).toEqual(['vm:100', 'ct:101', 'vm:102'])
+  })
+
+  it('returns an empty list for non-string input', () => {
+    expect(parseRuleResources(undefined)).toEqual([])
+    expect(parseRuleResources(42)).toEqual([])
+    expect(parseRuleResources('')).toEqual([])
+  })
+})
+
+describe('getServicePlacements', () => {
+  it('maps service sids to their current node and state', () => {
+    const placements = getServicePlacements(status)
+
+    expect(placements.get('vm:20027')).toEqual({ node: 'pve2', state: 'started' })
+    expect(placements.get('ct:300')).toEqual({ node: 'pve3', state: 'stopped' })
+  })
+
+  it('ignores non-service entries', () => {
+    const placements = getServicePlacements(status)
+
+    expect(placements.has('quorum')).toBe(false)
+    expect(placements.size).toBe(3)
+  })
+
+  it('falls back to parsing the id when sid is missing', () => {
+    const placements = getServicePlacements([{ id: 'service:vm:9', type: 'service', node: 'pveX', state: 'started' }])
+
+    expect(placements.get('vm:9')).toEqual({ node: 'pveX', state: 'started' })
+  })
+
+  it('handles null and undefined input', () => {
+    expect(getServicePlacements(null).size).toBe(0)
+    expect(getServicePlacements(undefined).size).toBe(0)
+  })
+})
+
+describe('getAffinityPeers', () => {
+  it('returns negative-affinity peers with their placement', () => {
+    expect(getAffinityPeers('vm:20026', rules, 'negative', status)).toEqual([
+      { sid: 'vm:20027', rule: 'keep-apart', node: 'pve2', state: 'started', running: true },
+    ])
+  })
+
+  it('returns positive-affinity peers, flagging non-running ones', () => {
+    expect(getAffinityPeers('vm:20026', rules, 'positive', status)).toEqual([
+      { sid: 'ct:300', rule: 'keep-together', node: 'pve3', state: 'stopped', running: false },
+    ])
+  })
+
+  it('ignores disabled rules', () => {
+    const disabled = [{ ...rules[0], disable: 1 }]
+
+    expect(getAffinityPeers('vm:20026', disabled, 'negative', status)).toEqual([])
+  })
+
+  it('ignores rules that do not include the vm', () => {
+    expect(getAffinityPeers('vm:999', rules, 'negative', status)).toEqual([])
+  })
+
+  it('ignores node-affinity rules', () => {
+    const nodeOnly = [{ rule: 'pin', type: 'node-affinity', resources: 'vm:20026,vm:20027' }]
+
+    expect(getAffinityPeers('vm:20026', nodeOnly, 'negative', status)).toEqual([])
+  })
+
+  it('reports peers without a known placement', () => {
+    expect(getAffinityPeers('vm:20026', rules, 'negative', [])).toEqual([
+      { sid: 'vm:20027', rule: 'keep-apart', node: null, state: null, running: false },
+    ])
+  })
+
+  it('dedupes a peer paired through several rules', () => {
+    const twoRules = [
+      rules[0],
+      { rule: 'keep-apart-bis', type: 'resource-affinity', affinity: 'negative', resources: 'vm:20026,vm:20027' },
+    ]
+
+    expect(getAffinityPeers('vm:20026', twoRules, 'negative', status)).toHaveLength(1)
+  })
+})
+
+describe('computeNegativeAffinityConflicts', () => {
+  it('groups conflicting peers by their current node', () => {
+    const conflicts = computeNegativeAffinityConflicts('vm:20026', rules, status)
+
+    expect([...conflicts.keys()]).toEqual(['pve2'])
+    expect(conflicts.get('pve2')).toEqual([
+      { sid: 'vm:20027', rule: 'keep-apart', node: 'pve2', state: 'started', running: true },
+    ])
+  })
+
+  it('sees the conflict from the other resource of the pair too', () => {
+    const conflicts = computeNegativeAffinityConflicts('vm:20027', rules, status)
+
+    expect(conflicts.get('pve1')?.[0]?.sid).toBe('vm:20026')
+  })
+
+  it('skips peers without a placement', () => {
+    expect(computeNegativeAffinityConflicts('vm:20026', rules, []).size).toBe(0)
+  })
+
+  it('returns an empty map when there are no rules', () => {
+    expect(computeNegativeAffinityConflicts('vm:20026', [], status).size).toBe(0)
+    expect(computeNegativeAffinityConflicts('vm:20026', undefined, status).size).toBe(0)
+  })
+})

--- a/frontend/src/lib/proxmox/haAffinity.ts
+++ b/frontend/src/lib/proxmox/haAffinity.ts
@@ -1,0 +1,107 @@
+// Évaluation pré-migration des règles d'affinité HA de PVE 9 (/cluster/ha/rules).
+// Le ha-manager refuse de migrer une ressource HA vers un nœud hébergeant une
+// ressource en affinité négative avec elle ; ce module permet à l'UI de le
+// détecter avant d'envoyer la migration.
+
+export type HaRule = {
+  rule: string
+  type?: string // 'resource-affinity' | 'node-affinity'
+  affinity?: string // 'positive' | 'negative' (resource-affinity uniquement)
+  resources?: string // "vm:100,ct:101"
+  disable?: number | boolean
+}
+
+export type HaStatusEntry = {
+  id?: string // "service:vm:100" pour les services
+  type?: string // 'service' | 'quorum' | 'master' | 'lrm'
+  sid?: string // "vm:100"
+  node?: string
+  state?: string
+}
+
+export type AffinityPeer = {
+  sid: string
+  rule: string
+  node: string | null
+  state: string | null
+  running: boolean
+}
+
+// États CRM où la ressource occupe effectivement son nœud
+const ACTIVE_STATES = new Set(['started', 'starting', 'migrate', 'relocate', 'recovery', 'error', 'fence'])
+
+export function parseRuleResources(resources: unknown): string[] {
+  if (typeof resources !== 'string') return []
+
+  return resources.split(',').map(s => s.trim()).filter(Boolean)
+}
+
+// Map sid -> placement courant, à partir de /cluster/ha/status/current
+export function getServicePlacements(status: HaStatusEntry[] | null | undefined): Map<string, { node: string | null; state: string | null }> {
+  const placements = new Map<string, { node: string | null; state: string | null }>()
+
+  for (const entry of status || []) {
+    if (entry?.type !== 'service') continue
+    const sid = entry.sid || (typeof entry.id === 'string' ? entry.id.replace(/^service:/, '') : '')
+
+    if (!sid) continue
+    placements.set(sid, { node: entry.node || null, state: entry.state || null })
+  }
+
+  return placements
+}
+
+// Pairs de vmSid dans les règles resource-affinity actives du type demandé
+export function getAffinityPeers(
+  vmSid: string,
+  rules: HaRule[] | null | undefined,
+  affinity: 'negative' | 'positive',
+  status?: HaStatusEntry[] | null
+): AffinityPeer[] {
+  const placements = getServicePlacements(status)
+  const peers: AffinityPeer[] = []
+  const seen = new Set<string>()
+
+  for (const rule of rules || []) {
+    if (rule?.type !== 'resource-affinity' || rule.affinity !== affinity || rule.disable) continue
+    const sids = parseRuleResources(rule.resources)
+
+    if (!sids.includes(vmSid)) continue
+
+    for (const sid of sids) {
+      if (sid === vmSid || seen.has(sid)) continue
+      seen.add(sid)
+      const placement = placements.get(sid)
+      const state = placement?.state ?? null
+
+      peers.push({
+        sid,
+        rule: rule.rule,
+        node: placement?.node ?? null,
+        state,
+        running: state !== null && ACTIVE_STATES.has(state),
+      })
+    }
+  }
+
+  return peers
+}
+
+// nœud -> ressources en affinité négative avec vmSid placées sur ce nœud
+export function computeNegativeAffinityConflicts(
+  vmSid: string,
+  rules: HaRule[] | null | undefined,
+  status: HaStatusEntry[] | null | undefined
+): Map<string, AffinityPeer[]> {
+  const byNode = new Map<string, AffinityPeer[]>()
+
+  for (const peer of getAffinityPeers(vmSid, rules, 'negative', status)) {
+    if (!peer.node) continue
+    const list = byNode.get(peer.node)
+
+    if (list) list.push(peer)
+    else byNode.set(peer.node, [peer])
+  }
+
+  return byNode
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4837,6 +4837,13 @@
     "vmIdOutOfRange": "Die VMID muss innerhalb Ihres Bereichs {start}-{end} liegen",
     "fullCopyDescription": "Erstellt eine vollständige und unabhängige Kopie der Disk",
     "migrateTitle": "Migrieren: {vmName} ({vmid})",
+    "haAffinity": {
+      "conflictTitle": "HA-Affinitätskonflikt",
+      "conflictBlocked": "PVE wird diese Migration ablehnen: {peer} läuft auf {node} und Regel \"{rule}\" verlangt die Trennung von dieser VM.",
+      "conflictStopped": "{peer} ist {node} zugewiesen (derzeit gestoppt) und Regel \"{rule}\" verlangt die Trennung von dieser VM. Der HA-Manager kann diese Migration dennoch ablehnen.",
+      "nodeTooltip": "Negative HA-Affinität mit {peers}",
+      "positiveInfo": "Diese VM hat eine positive HA-Affinität mit {peers} (werden zusammengehalten): Der HA-Manager migriert sie mit."
+    },
     "currentNode": "aktuell node:",
     "noNodeAvailable": "Kein anderer Node im Cluster für die Migration verfügbar.",
     "targetStorageLabel": "Ziel-Storage:",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4875,6 +4875,13 @@
     "vmIdOutOfRange": "VMID must be within your tenant range {start}-{end}",
     "fullCopyDescription": "Creates a complete and independent copy of the disk",
     "migrateTitle": "Migrate: {vmName} ({vmid})",
+    "haAffinity": {
+      "conflictTitle": "HA affinity conflict",
+      "conflictBlocked": "PVE will reject this migration: {peer} is running on {node} and rule \"{rule}\" requires it to stay separated from this VM.",
+      "conflictStopped": "{peer} is assigned to {node} (currently not running) and rule \"{rule}\" requires it to stay separated from this VM. The HA manager may still reject this migration.",
+      "nodeTooltip": "Negative HA affinity with {peers}",
+      "positiveInfo": "This VM is in positive HA affinity with {peers} (kept together): the HA manager will migrate them along."
+    },
     "currentNode": "Current node:",
     "noNodeAvailable": "No other node available in the cluster for migration.",
     "targetStorageLabel": "Target storage:",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4875,6 +4875,13 @@
     "vmIdOutOfRange": "El VMID debe estar dentro de su rango {start}-{end}",
     "fullCopyDescription": "Crea una copia completa e independiente del disco",
     "migrateTitle": "Migrar: {vmName} ({vmid})",
+    "haAffinity": {
+      "conflictTitle": "Conflicto de afinidad HA",
+      "conflictBlocked": "PVE rechazará esta migración: {peer} se ejecuta en {node} y la regla \"{rule}\" exige mantenerlo separado de esta VM.",
+      "conflictStopped": "{peer} está asignado a {node} (actualmente detenido) y la regla \"{rule}\" exige mantenerlo separado de esta VM. El gestor HA aún puede rechazar esta migración.",
+      "nodeTooltip": "Afinidad HA negativa con {peers}",
+      "positiveInfo": "Esta VM tiene afinidad HA positiva con {peers} (se mantienen juntas): el gestor HA también las migrará."
+    },
     "currentNode": "Nodo actual:",
     "noNodeAvailable": "No hay otro nodo disponible en el clúster para la migración.",
     "targetStorageLabel": "Almacenamiento de destino:",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4875,6 +4875,13 @@
     "vmIdOutOfRange": "Le VMID doit être dans votre plage {start}-{end}",
     "fullCopyDescription": "Crée une copie complète et indépendante du disque",
     "migrateTitle": "Migrer: {vmName} ({vmid})",
+    "haAffinity": {
+      "conflictTitle": "Conflit d'affinité HA",
+      "conflictBlocked": "PVE refusera cette migration : {peer} s'exécute sur {node} et la règle « {rule} » impose de le garder séparé de cette VM.",
+      "conflictStopped": "{peer} est assigné à {node} (actuellement arrêté) et la règle « {rule} » impose de le garder séparé de cette VM. Le gestionnaire HA peut malgré tout rejeter cette migration.",
+      "nodeTooltip": "Affinité HA négative avec {peers}",
+      "positiveInfo": "Cette VM est en affinité HA positive avec {peers} (maintenus ensemble) : le gestionnaire HA les migrera également."
+    },
     "currentNode": "Node actuel:",
     "noNodeAvailable": "Aucun autre node disponible dans le cluster pour la migration.",
     "targetStorageLabel": "Stockage cible:",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4875,6 +4875,13 @@
     "vmIdOutOfRange": "VMID는 테넌트 범위 {start}-{end} 내에 있어야 합니다",
     "fullCopyDescription": "디스크의 완전하고 독립적인 복사본을 생성합니다",
     "migrateTitle": "마이그레이션: {vmName} ({vmid})",
+    "haAffinity": {
+      "conflictTitle": "HA 어피니티 충돌",
+      "conflictBlocked": "PVE가 이 마이그레이션을 거부합니다: {peer}이(가) {node}에서 실행 중이며 규칙 \"{rule}\"에 따라 이 VM과 분리되어야 합니다.",
+      "conflictStopped": "{peer}이(가) {node}에 할당되어 있으며(현재 중지됨) 규칙 \"{rule}\"에 따라 이 VM과 분리되어야 합니다. HA 관리자가 이 마이그레이션을 거부할 수 있습니다.",
+      "nodeTooltip": "{peers}와(과) 부정적 HA 어피니티",
+      "positiveInfo": "이 VM은 {peers}와(과) 긍정적 HA 어피니티(함께 유지) 관계입니다. HA 관리자가 함께 마이그레이션합니다."
+    },
     "currentNode": "현재 노드:",
     "noNodeAvailable": "클러스터에 마이그레이션 가능한 다른 노드가 없습니다.",
     "targetStorageLabel": "대상 스토리지:",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4836,6 +4836,13 @@
     "vmIdOutOfRange": "VMID 必须在租户范围 {start}-{end} 内",
     "fullCopyDescription": "创建磁盘的完整独立副本",
     "migrateTitle": "迁移：{vmName}（{vmid}）",
+    "haAffinity": {
+      "conflictTitle": "HA 亲和性冲突",
+      "conflictBlocked": "PVE 将拒绝此迁移:{peer} 正在 {node} 上运行,规则\"{rule}\"要求其与此虚拟机保持分离。",
+      "conflictStopped": "{peer} 已分配到 {node}(当前已停止),规则\"{rule}\"要求其与此虚拟机保持分离。HA 管理器仍可能拒绝此迁移。",
+      "nodeTooltip": "与 {peers} 存在负 HA 亲和性",
+      "positiveInfo": "此虚拟机与 {peers} 存在正 HA 亲和性(保持在一起):HA 管理器会将它们一并迁移。"
+    },
     "currentNode": "当前节点：",
     "noNodeAvailable": "集群中没有其他可用节点进行迁移。",
     "targetStorageLabel": "目标存储：",


### PR DESCRIPTION
## Summary

Implements the pre-migration validation requested in #674: when migrating an HA-managed guest, the local migration dialog now checks the cluster's HA resource affinity rules ("keep separated") before the request is sent, instead of letting the HA manager reject it afterwards in the task log.

- New pure helper `lib/proxmox/haAffinity.ts` evaluating `/cluster/ha/rules` and `/cluster/ha/status/current` (both already returned by the existing connection HA endpoint, so no backend change).
- Target nodes hosting a resource in negative affinity with the guest are flagged in the node picker (shield badge + tooltip listing the peers).
- Selecting such a node shows a PVE-style explanation (peer resource, node, rule name) and disables the Migrate button while the peer is running there; a stopped peer only raises a warning since the HA manager may still allow it.
- The "recommended node" star skips conflicting nodes.
- Positive affinity ("keep together") peers are listed as an info notice, since the HA manager co-migrates them.
- Fails open: PVE 8 clusters (no rules API), non-HA guests, or a failed rules fetch keep the current behavior.
- i18n keys added for all 6 locales.

Closes #674

## Test plan

- 17 unit tests on the helper (`src/lib/proxmox/haAffinity.test.ts`): rule parsing, disabled rules, placement fallback, negative/positive peers, conflict grouping by node.
- Manually verified on a PVE 9 cluster with a negative resource affinity rule between two HA VMs: the node hosting the peer VM is flagged, the migration is blocked with the rule name shown, and the recommendation moves to a conflict-free node. Non-HA guests and clusters without the rules API are unchanged.
