### PR TITLE
Site Recovery: configurable retention, point-in-time recovery, failback and DR hardening

### DIFF
--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -68,6 +68,7 @@ export default function SiteRecoveryPage() {
 
   // Execution tracking
   const [activeExecution, setActiveExecution] = useState<RecoveryExecution | null>(null)
+  const [failoverError, setFailoverError] = useState<string | null>(null)
 
   // Cleanup state
   const [cleanupLoading, setCleanupLoading] = useState(false)
@@ -128,10 +129,14 @@ export default function SiteRecoveryPage() {
     }))
   , [allVMsData])
 
-  // VM name map for display (vmid → name)
-  const vmNameMap = useMemo(() => {
-    const m: Record<number, string> = {}
-    for (const vm of allVMs) if (vm.vmid && vm.name) m[vm.vmid] = vm.name
+  // VM names scoped per connection (connId → vmid → name): the same VMID can
+  // exist on both sites, so a flat map resolves nondeterministically.
+  const vmNamesByConn = useMemo(() => {
+    const m: Record<string, Record<number, string>> = {}
+    for (const vm of allVMs) {
+      if (!vm.vmid || !vm.name || !vm.connId) continue
+      ;(m[vm.connId] ??= {})[vm.vmid] = vm.name
+    }
     return m
   }, [allVMs])
 
@@ -236,7 +241,21 @@ export default function SiteRecoveryPage() {
     setActiveExecution(null)
     setCleanupResult(null)
     setCleanupLoading(false)
-  }, [])
+    setFailoverError(null)
+
+    // Rehydration: a test failover started before a reload has no in-memory
+    // `activeExecution` — refetch it from its id on the plan so the dialog
+    // can land directly on the Cleanup block instead of showing "confirm".
+    if (type === 'test') {
+      const plan = (plans || []).find((p: RecoveryPlan) => p.id === planId)
+      if (plan?.active_test_execution_id) {
+        fetch(`/api/v1/orchestrator/replication/executions/${plan.active_test_execution_id}`)
+          .then(res => (res.ok ? res.json() : null))
+          .then(data => { if (data) setActiveExecution(data) })
+          .catch(() => { /* ignore — dialog shows the warning banner instead */ })
+      }
+    }
+  }, [plans])
 
   const handleFailoverConfirm = useCallback(async () => {
     if (!failoverDialog.planId) return
@@ -252,14 +271,19 @@ export default function SiteRecoveryPage() {
         headers: body ? { 'Content-Type': 'application/json' } : {},
         body
       })
-      const data = await res.json()
-
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setFailoverError(data?.error || t('siteRecovery.failover.testConflict'))
+        mutatePlans()
+        return
+      }
+      setFailoverError(null)
       setActiveExecution(data)
       mutatePlans()
     } catch (e) {
       console.error('Failed to execute:', e)
     }
-  }, [failoverDialog, mutatePlans])
+  }, [failoverDialog, mutatePlans, t])
 
   const handleCleanupTest = useCallback(async () => {
     if (!failoverDialog.planId) return
@@ -391,7 +415,7 @@ export default function SiteRecoveryPage() {
 
         {/* Tab Content */}
         {tab === 0 && hasEnoughCephClusters && (
-          <DashboardTab health={health} loading={healthLoading} jobs={jobs || []} connections={connections} vmNameMap={vmNameMap} onSyncJob={handleSyncJob} />
+          <DashboardTab health={health} loading={healthLoading} jobs={jobs || []} connections={connections} vmNamesByConn={vmNamesByConn} onSyncJob={handleSyncJob} />
         )}
 
         {tab === 1 && hasEnoughCephClusters && (
@@ -401,7 +425,7 @@ export default function SiteRecoveryPage() {
             logs={jobLogs || []}
             logsLoading={logsLoading}
             connections={connections}
-            vmNameMap={vmNameMap}
+            vmNamesByConn={vmNamesByConn}
             onSyncJob={handleSyncJob}
             onPauseJob={handlePauseJob}
             onResumeJob={handleResumeJob}
@@ -413,7 +437,7 @@ export default function SiteRecoveryPage() {
         )}
 
         {tab === 2 && hasEnoughCephClusters && (
-          <SnapshotsTab connections={connections} vmNameMap={vmNameMap} />
+          <SnapshotsTab connections={connections} vmNamesByConn={vmNamesByConn} />
         )}
 
         {tab === 3 && hasEnoughCephClusters && (
@@ -428,6 +452,7 @@ export default function SiteRecoveryPage() {
             onFailover={(id) => openFailoverDialog(id, 'failover')}
             onFailback={(id) => openFailoverDialog(id, 'failback')}
             onDeletePlan={handleDeletePlan}
+            onCleanupTest={(id) => openFailoverDialog(id, 'test')}
             connections={connections}
           />
         )}
@@ -438,7 +463,7 @@ export default function SiteRecoveryPage() {
             plans={plans || []}
             loading={jobsLoading || plansLoading}
             connections={connections}
-            vmNameMap={vmNameMap}
+            vmNamesByConn={vmNamesByConn}
             onStartVM={handleStartDRVM}
             onExecuteFailover={(planId) => openFailoverDialog(planId, 'failover')}
             onExecuteFailback={(planId) => openFailoverDialog(planId, 'failback')}
@@ -485,9 +510,10 @@ export default function SiteRecoveryPage() {
           cleanupLoading={cleanupLoading}
           cleanupResult={cleanupResult}
           execution={activeExecution}
+          errorMessage={failoverError}
           targetConnId={failoverPlan?.target_cluster}
           connections={connections}
-          vmNameMap={vmNameMap}
+          vmNameMap={failoverPlan ? vmNamesByConn[failoverPlan.source_cluster] : undefined}
         />
       </Box>
     </EnterpriseGuard>

--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -86,12 +86,20 @@ export default function SiteRecoveryPage() {
   const { data: allVMsData } = useSWR<{ data: { vms: any[] } }>('/api/v1/vms', fetcher)
 
   // Restore points for the plan currently open in the failover dialog (test/failover only — failback has no selector)
-  const { data: restorePoints, error: restorePointsError, isLoading: restorePointsLoading } = useSWR(
+  const { data: restorePoints, error: restorePointsError, isLoading: restorePointsLoading, mutate: mutateRestorePoints } = useSWR(
     failoverDialog.open && failoverDialog.planId && failoverDialog.type !== 'failback'
       ? `/api/v1/orchestrator/replication/plans/${failoverDialog.planId}/restore-points`
       : null,
     (url: string) => fetch(url).then(r => { if (!r.ok) throw new Error(String(r.status)); return r.json() })
   )
+
+  // Drop the cached list on every dialog open: RBD snapshots move with each
+  // sync, and a reopened dialog must never offer points from a previous look.
+  useEffect(() => {
+    if (failoverDialog.open && failoverDialog.planId && failoverDialog.type !== 'failback') {
+      mutateRestorePoints(undefined, { revalidate: true })
+    }
+  }, [failoverDialog.open, failoverDialog.planId, failoverDialog.type, mutateRestorePoints])
 
   // Page title
   useEffect(() => {

--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -271,6 +271,20 @@ export default function SiteRecoveryPage() {
           .catch(() => { /* ignore — dialog shows the warning banner instead */ })
       }
     }
+
+    // Same rehydration for a failback in progress: a failing_back plan
+    // carries the running execution's id so reopening the dialog (or
+    // reloading the page) lands back on the reverse-sync/cutover view
+    // instead of the initial confirm screen.
+    if (type === 'failback') {
+      const plan = (plans || []).find((p: RecoveryPlan) => p.id === planId)
+      if (plan?.active_failback_execution_id) {
+        fetch(`/api/v1/orchestrator/replication/executions/${plan.active_failback_execution_id}`)
+          .then(res => (res.ok ? res.json() : null))
+          .then(data => { if (data) setActiveExecution(data) })
+          .catch(() => { /* ignore — dialog shows the initial confirm screen instead */ })
+      }
+    }
   }, [plans])
 
   const handleFailoverConfirm = useCallback(async (options?: { restorePoints?: Record<number, string> }) => {
@@ -318,6 +332,47 @@ export default function SiteRecoveryPage() {
       setCleanupLoading(false)
     }
   }, [failoverDialog.planId, mutateJobs, mutatePlans])
+
+  const handleFailbackCutover = useCallback(async (planId: string) => {
+    try {
+      const res = await fetch(`/api/v1/orchestrator/replication/plans/${planId}/failback-cutover`, { method: 'POST' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setFailoverError(data?.error || 'Failed to execute failback cutover')
+        mutatePlans()
+        return
+      }
+      setFailoverError(null)
+      // Refetch the execution so the dialog picks up the 'cutover' phase
+      // right away instead of waiting for the next poll tick.
+      if (activeExecution) {
+        const execRes = await fetch(`/api/v1/orchestrator/replication/executions/${activeExecution.id}`)
+        const execData = await execRes.json().catch(() => null)
+        if (execData) setActiveExecution(execData)
+      }
+      mutatePlans()
+    } catch (e) {
+      console.error('Failed to execute failback cutover:', e)
+    }
+  }, [activeExecution, mutatePlans])
+
+  const handleFailbackCancel = useCallback(async (planId: string) => {
+    try {
+      const res = await fetch(`/api/v1/orchestrator/replication/plans/${planId}/failback-cancel`, { method: 'POST' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setFailoverError(data?.error || 'Failed to cancel failback')
+        mutatePlans()
+        return
+      }
+      setFailoverError(null)
+      setActiveExecution(null)
+      setFailoverDialog({ open: false, planId: null, type: 'test' })
+      mutatePlans()
+    } catch (e) {
+      console.error('Failed to cancel failback:', e)
+    }
+  }, [mutatePlans])
 
   const handleStartDRVM = useCallback(async (vmId: number, targetCluster: string, jobId: string) => {
     const res = await fetch('/api/v1/orchestrator/replication/emergency/start-vm', {
@@ -536,6 +591,8 @@ export default function SiteRecoveryPage() {
           restorePoints={restorePoints}
           restorePointsLoading={restorePointsLoading}
           restorePointsError={!!restorePointsError}
+          onFailbackCutover={handleFailbackCutover}
+          onFailbackCancel={handleFailbackCancel}
         />
       </Box>
     </EnterpriseGuard>

--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -85,6 +85,14 @@ export default function SiteRecoveryPage() {
   const { data: connectionsData } = useSWR<{ data: any[] }>('/api/v1/connections?type=pve', fetcher)
   const { data: allVMsData } = useSWR<{ data: { vms: any[] } }>('/api/v1/vms', fetcher)
 
+  // Restore points for the plan currently open in the failover dialog (test/failover only — failback has no selector)
+  const { data: restorePoints, error: restorePointsError, isLoading: restorePointsLoading } = useSWR(
+    failoverDialog.open && failoverDialog.planId && failoverDialog.type !== 'failback'
+      ? `/api/v1/orchestrator/replication/plans/${failoverDialog.planId}/restore-points`
+      : null,
+    (url: string) => fetch(url).then(r => { if (!r.ok) throw new Error(String(r.status)); return r.json() })
+  )
+
   // Page title
   useEffect(() => {
     setPageInfo(t('siteRecovery.title'), t('siteRecovery.subtitle'), 'ri-shield-star-line')
@@ -257,13 +265,15 @@ export default function SiteRecoveryPage() {
     }
   }, [plans])
 
-  const handleFailoverConfirm = useCallback(async () => {
+  const handleFailoverConfirm = useCallback(async (options?: { restorePoints?: Record<number, string> }) => {
     if (!failoverDialog.planId) return
     const endpoint = failoverDialog.type === 'test' ? 'test-failover' : failoverDialog.type
 
     const body = failoverDialog.type === 'test'
-      ? JSON.stringify({ network_isolated: true })
-      : undefined
+      ? JSON.stringify({ network_isolated: true, ...(options?.restorePoints ? { restore_points: options.restorePoints } : {}) })
+      : failoverDialog.type === 'failover'
+        ? (options?.restorePoints ? JSON.stringify({ restore_points: options.restorePoints }) : undefined)
+        : undefined
 
     try {
       const res = await fetch(`/api/v1/orchestrator/replication/plans/${failoverDialog.planId}/${endpoint}`, {
@@ -514,6 +524,9 @@ export default function SiteRecoveryPage() {
           targetConnId={failoverPlan?.target_cluster}
           connections={connections}
           vmNameMap={failoverPlan ? vmNamesByConn[failoverPlan.source_cluster] : undefined}
+          restorePoints={restorePoints}
+          restorePointsLoading={restorePointsLoading}
+          restorePointsError={!!restorePointsError}
         />
       </Box>
     </EnterpriseGuard>

--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -79,7 +79,7 @@ export default function SiteRecoveryPage() {
   const { data: jobs, isLoading: jobsLoading, mutate: mutateJobs } = useReplicationJobs(isEnterprise)
   const { data: plans, isLoading: plansLoading, mutate: mutatePlans } = useRecoveryPlans(isEnterprise)
   const { data: jobLogs, isLoading: logsLoading } = useReplicationJobLogs(selectedJobId, !!selectedJobId)
-  const { data: planHistory, isLoading: historyLoading } = useRecoveryHistory(selectedPlanId)
+  const { data: planHistory, isLoading: historyLoading, mutate: mutateHistory } = useRecoveryHistory(selectedPlanId)
 
   // Real data: PVE connections and all VMs
   const { data: connectionsData } = useSWR<{ data: any[] }>('/api/v1/connections?type=pve', fetcher)
@@ -471,6 +471,7 @@ export default function SiteRecoveryPage() {
             onFailback={(id) => openFailoverDialog(id, 'failback')}
             onDeletePlan={handleDeletePlan}
             onCleanupTest={(id) => openFailoverDialog(id, 'test')}
+            onHistoryCleared={() => mutateHistory()}
             connections={connections}
           />
         )}

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/route.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn()
+const getExecutionMock = vi.fn()
+const getRecoveryPlanMock = vi.fn()
+const getTenantConnectionIdsMock = vi.fn()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: { AUTOMATION_VIEW: 'automation.view' },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: () => getTenantConnectionIdsMock(),
+}))
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getExecution: (...args: unknown[]) => getExecutionMock(...args),
+    getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+  }),
+}))
+
+import { GET } from './route'
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getTenantConnectionIdsMock.mockReset().mockResolvedValue(new Set(['conn-src', 'conn-dst']))
+  getExecutionMock.mockReset().mockResolvedValue({ data: { id: 'exec-1', plan_id: 'plan-1', status: 'completed' } })
+  getRecoveryPlanMock.mockReset().mockResolvedValue({ data: { source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/v1/orchestrator/replication/executions/[id]', () => {
+  it('returns the denied response when permission is refused', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+
+    const res = await callRoute(GET, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(403)
+    expect(getExecutionMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the execution passthrough for an in-tenant execution', async () => {
+    const res = await callRoute(GET, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ id: 'exec-1', plan_id: 'plan-1', status: 'completed' })
+  })
+
+  it('404s when the execution traces back to a plan outside the tenant scope', async () => {
+    getRecoveryPlanMock.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const res = await callRoute(GET, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Not found' })
+  })
+
+  it('returns a 500 with the error message when the orchestrator call fails', async () => {
+    getExecutionMock.mockRejectedValue(new Error('boom'))
+
+    const res = await callRoute(GET, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'boom' })
+  })
+
+  it('falls back to a generic message when the error has none of its own', async () => {
+    getExecutionMock.mockRejectedValue({})
+
+    const res = await callRoute(GET, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to fetch execution' })
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { checkExecutionTenantScope } from "@/lib/orchestrator/executionScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
@@ -13,35 +12,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
-    const response = await client.getExecution(id)
-    const execution = response.data
+    const { denied: scopeDenied, execution } = await checkExecutionTenantScope(id)
 
-    // Verify ownership: check execution's cluster fields or trace back via plan
-    const tenantConnectionIds = await getTenantConnectionIds()
-
-    if (execution?.plan_id) {
-      try {
-        const planResponse = await client.getRecoveryPlan(execution.plan_id)
-        const plan = planResponse.data
-
-        if (
-          plan &&
-          ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-          (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-        ) {
-          return NextResponse.json({ error: "Not found" }, { status: 404 })
-        }
-      } catch {
-        // Plan may have been deleted; fall through to return the execution
-      }
-    } else if (
-      execution &&
-      ((execution.source_cluster && !tenantConnectionIds.has(execution.source_cluster)) ||
-      (execution.target_cluster && !tenantConnectionIds.has(execution.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
+    if (scopeDenied) return scopeDenied
 
     return NextResponse.json(execution)
   } catch (e: any) {

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/[vmid]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/[vmid]/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { denyExecutionOutsideTenant } from "@/lib/orchestrator/executionScope"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+
+export const runtime = "nodejs"
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string; vmid: string }> }) {
+  try {
+    const denied = await checkPermission(PERMISSIONS.AUTOMATION_VIEW, "global", "*")
+
+    if (denied) return denied
+
+    const { id, vmid } = await params
+
+    if (!/^\d+$/.test(vmid)) {
+      return NextResponse.json({ error: "Invalid vmid" }, { status: 400 })
+    }
+
+    const scopeDenied = await denyExecutionOutsideTenant(id)
+
+    if (scopeDenied) return scopeDenied
+
+    // The orchestrator client is JSON-only; fetch the PNG directly and pass
+    // the bytes through untouched.
+    const headers: Record<string, string> = {}
+
+    if (process.env.ORCHESTRATOR_API_KEY) headers["X-API-Key"] = process.env.ORCHESTRATOR_API_KEY
+
+    const upstream = await fetch(
+      `${process.env.ORCHESTRATOR_URL || "http://localhost:8080"}/api/v1/replication/executions/${encodeURIComponent(id)}/screenshots/${vmid}`,
+      { headers }
+    )
+
+    if (!upstream.ok) {
+      return NextResponse.json({ error: "Screenshot not found" }, { status: 404 })
+    }
+
+    const png = await upstream.arrayBuffer()
+
+    return new NextResponse(png, {
+      status: 200,
+      headers: { "Content-Type": "image/png", "Cache-Control": "private, max-age=86400" },
+    })
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Failed to fetch screenshot" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/[vmid]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/[vmid]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 
-import { denyExecutionOutsideTenant } from "@/lib/orchestrator/executionScope"
+import { checkExecutionTenantScope } from "@/lib/orchestrator/executionScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Invalid vmid" }, { status: 400 })
     }
 
-    const scopeDenied = await denyExecutionOutsideTenant(id)
+    const { denied: scopeDenied } = await checkExecutionTenantScope(id)
 
     if (scopeDenied) return scopeDenied
 

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
-import { denyExecutionOutsideTenant } from "@/lib/orchestrator/executionScope"
+import { checkExecutionTenantScope } from "@/lib/orchestrator/executionScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
@@ -13,7 +13,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const scopeDenied = await denyExecutionOutsideTenant(id)
+    const { denied: scopeDenied } = await checkExecutionTenantScope(id)
 
     if (scopeDenied) return scopeDenied
 

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { denyExecutionOutsideTenant } from "@/lib/orchestrator/executionScope"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+
+export const runtime = "nodejs"
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const denied = await checkPermission(PERMISSIONS.AUTOMATION_VIEW, "global", "*")
+
+    if (denied) return denied
+
+    const { id } = await params
+    const scopeDenied = await denyExecutionOutsideTenant(id)
+
+    if (scopeDenied) return scopeDenied
+
+    const response = await getOrchestratorClient().getExecutionScreenshots(id)
+
+    return NextResponse.json(response.data ?? [])
+  } catch (e: any) {
+    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
+      console.error("Error listing execution screenshots:", e)
+    }
+
+    return NextResponse.json(
+      { error: e?.message || "Failed to list screenshots" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/screenshotsRoutes.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/screenshotsRoutes.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute } from '@/__tests__/setup/route-test'
+
+const checkPermission = vi.fn()
+const getExecution = vi.fn()
+const getRecoveryPlan = vi.fn()
+const getExecutionScreenshots = vi.fn()
+const getTenantConnectionIds = vi.fn()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermission(...args),
+  PERMISSIONS: { AUTOMATION_VIEW: 'automation.view' },
+}))
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: () => getTenantConnectionIds(),
+}))
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({ getExecution, getRecoveryPlan, getExecutionScreenshots }),
+}))
+
+import { GET as listScreenshots } from './route'
+import { GET as getScreenshotPng } from './[vmid]/route'
+
+beforeEach(() => {
+  checkPermission.mockResolvedValue(null)
+  getTenantConnectionIds.mockResolvedValue(new Set(['conn-src', 'conn-dst']))
+  getExecution.mockResolvedValue({ data: { id: 'exec-1', plan_id: 'plan-1' } })
+  getRecoveryPlan.mockResolvedValue({ data: { source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
+  getExecutionScreenshots.mockResolvedValue({ data: [{ vm_id: 100, target_vmid: 9100, captured_at: '2026-08-10T20:00:00Z' }] })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('GET /replication/executions/[id]/screenshots', () => {
+  it('returns the metadata list for an in-tenant execution', async () => {
+    const res = await callRoute(listScreenshots, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ vm_id: 100, target_vmid: 9100, captured_at: '2026-08-10T20:00:00Z' }])
+  })
+
+  it('404s when the plan belongs to another tenant', async () => {
+    getRecoveryPlan.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const res = await callRoute(listScreenshots, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(404)
+    expect(getExecutionScreenshots).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /replication/executions/[id]/screenshots/[vmid]', () => {
+  it('passes the PNG through with image headers', async () => {
+    const png = new Uint8Array([137, 80, 78, 71])
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(png, { status: 200 })))
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('image/png')
+    expect(res.headers.get('cache-control')).toBe('private, max-age=86400')
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(png)
+  })
+
+  it('rejects a non-numeric vmid before any upstream call', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: 'abc' } })
+
+    expect(res.status).toBe(400)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('maps an upstream miss to 404', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 404 })))
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/screenshotsRoutes.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/executions/[id]/screenshots/screenshotsRoutes.test.ts
@@ -52,6 +52,24 @@ describe('GET /replication/executions/[id]/screenshots', () => {
     expect(res.status).toBe(404)
     expect(getExecutionScreenshots).not.toHaveBeenCalled()
   })
+
+  it('returns the denied response when permission is refused', async () => {
+    checkPermission.mockResolvedValue(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }))
+
+    const res = await callRoute(listScreenshots, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(403)
+    expect(getExecutionScreenshots).not.toHaveBeenCalled()
+  })
+
+  it('returns a 500 with the error message when the orchestrator call fails', async () => {
+    getExecutionScreenshots.mockRejectedValue(new Error('boom'))
+
+    const res = await callRoute(listScreenshots, { params: { id: 'exec-1' } })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'boom' })
+  })
 })
 
 describe('GET /replication/executions/[id]/screenshots/[vmid]', () => {
@@ -83,5 +101,36 @@ describe('GET /replication/executions/[id]/screenshots/[vmid]', () => {
     const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
 
     expect(res.status).toBe(404)
+  })
+
+  it('returns the denied response when permission is refused', async () => {
+    checkPermission.mockResolvedValue(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }))
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
+
+    expect(res.status).toBe(403)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('404s when the execution belongs to another tenant', async () => {
+    getRecoveryPlan.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
+
+    expect(res.status).toBe(404)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns a 500 with the error message when the upstream fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unreachable')))
+
+    const res = await callRoute(getScreenshotPng, { params: { id: 'exec-1', vmid: '100' } })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'network unreachable' })
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cancel/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cancel/route.ts
@@ -28,12 +28,12 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Not found" }, { status: 404 })
     }
 
-    const response = await client.executeFailback(id)
+    const response = await client.failbackCancel(id)
 
     return NextResponse.json(response.data)
   } catch (e: any) {
     if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error executing failback:", e)
+      console.error("Error cancelling failback:", e)
     }
 
     const upstream = parseOrchestratorError(e)
@@ -43,7 +43,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     }
 
     return NextResponse.json(
-      { error: e?.message || "Failed to execute failback" },
+      { error: e?.message || "Failed to cancel failback" },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cancel/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cancel/route.ts
@@ -1,50 +1,13 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest } from "next/server"
 
-import { getOrchestratorClient, parseOrchestratorError } from "@/lib/orchestrator/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
+import { proxyPlanFailbackAction } from "@/lib/orchestrator/planFailbackProxy"
 
 export const runtime = "nodejs"
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
-
-    if (denied) return denied
-
-    const { id } = await params
-    const client = getOrchestratorClient()
-
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
-
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.failbackCancel(id)
-
-    return NextResponse.json(response.data)
-  } catch (e: any) {
-    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error cancelling failback:", e)
-    }
-
-    const upstream = parseOrchestratorError(e)
-
-    if (upstream) {
-      return NextResponse.json({ error: upstream.message }, { status: upstream.status })
-    }
-
-    return NextResponse.json(
-      { error: e?.message || "Failed to cancel failback" },
-      { status: 500 }
-    )
-  }
+  return proxyPlanFailbackAction(params, {
+    action: (client, id) => client.failbackCancel(id),
+    logLabel: "Error cancelling failback:",
+    fallbackMessage: "Failed to cancel failback",
+  })
 }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/failbackRoutes.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/failbackRoutes.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn()
+const getTenantConnectionIdsMock = vi.fn()
+const getRecoveryPlanMock = vi.fn()
+const executeFailbackMock = vi.fn()
+const failbackCutoverMock = vi.fn()
+const failbackCancelMock = vi.fn()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: { AUTOMATION_MANAGE: 'automation.manage' },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: () => getTenantConnectionIdsMock(),
+}))
+
+// Keep the real parseOrchestratorError so the 409-passthrough behaviour is
+// exercised for real; only stub the network-facing client factory.
+vi.mock('@/lib/orchestrator/client', async importActual => {
+  const actual = await importActual<typeof import('@/lib/orchestrator/client')>()
+
+  return {
+    ...actual,
+    getOrchestratorClient: () => ({
+      getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+      executeFailback: (...args: unknown[]) => executeFailbackMock(...args),
+      failbackCutover: (...args: unknown[]) => failbackCutoverMock(...args),
+      failbackCancel: (...args: unknown[]) => failbackCancelMock(...args),
+    }),
+  }
+})
+
+import { POST as failbackPOST } from '../failback/route'
+import { POST as failbackCancelPOST } from '../failback-cancel/route'
+import { POST as failbackCutoverPOST } from './route'
+
+const fakePlan = {
+  id: 'plan-1',
+  source_cluster: 'conn-src',
+  target_cluster: 'conn-dst',
+}
+
+// The exact shape orchestratorFetch throws for a non-OK upstream response:
+// `Orchestrator ${status}: ${rawBody}`.
+function upstreamConflict(message: string) {
+  return new Error(`Orchestrator 409: ${JSON.stringify({ error: message })}`)
+}
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getTenantConnectionIdsMock.mockReset().mockResolvedValue(new Set(['conn-src', 'conn-dst']))
+  getRecoveryPlanMock.mockReset().mockResolvedValue({ data: fakePlan })
+  executeFailbackMock.mockReset().mockResolvedValue({ data: { id: 'exec-1', status: 'running' } })
+  failbackCutoverMock.mockReset().mockResolvedValue({ data: { status: 'cutover_started' } })
+  failbackCancelMock.mockReset().mockResolvedValue({ data: { status: 'cancelled' } })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe.each([
+  {
+    name: 'POST /replication/plans/[id]/failback',
+    handler: () => failbackPOST as Parameters<typeof callRoute>[0],
+    actionMock: () => executeFailbackMock,
+    expectedData: { id: 'exec-1', status: 'running' },
+  },
+  {
+    name: 'POST /replication/plans/[id]/failback-cutover',
+    handler: () => failbackCutoverPOST as Parameters<typeof callRoute>[0],
+    actionMock: () => failbackCutoverMock,
+    expectedData: { status: 'cutover_started' },
+  },
+  {
+    name: 'POST /replication/plans/[id]/failback-cancel',
+    handler: () => failbackCancelPOST as Parameters<typeof callRoute>[0],
+    actionMock: () => failbackCancelMock,
+    expectedData: { status: 'cancelled' },
+  },
+])('$name', ({ handler, actionMock, expectedData }) => {
+  it('returns the denied response when permission is refused', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+
+    const res = await callRoute(handler(), { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(403)
+    expect(getRecoveryPlanMock).not.toHaveBeenCalled()
+    expect(actionMock()).not.toHaveBeenCalled()
+  })
+
+  it('404s when the plan belongs to another tenant', async () => {
+    getRecoveryPlanMock.mockResolvedValue({ data: { ...fakePlan, source_cluster: 'foreign' } })
+
+    const res = await callRoute(handler(), { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Not found' })
+    expect(actionMock()).not.toHaveBeenCalled()
+  })
+
+  it('passes through an upstream 409 conflict with the same error message', async () => {
+    actionMock().mockRejectedValue(upstreamConflict('a failback is already in progress for this plan'))
+
+    const res = await callRoute(handler(), { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'a failback is already in progress for this plan' })
+  })
+
+  it('returns the upstream success payload on 200', async () => {
+    const res = await callRoute(handler(), { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(200)
+    expect(actionMock()).toHaveBeenCalledWith('plan-1')
+    expect(await res.json()).toEqual(expectedData)
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/route.ts
@@ -28,12 +28,12 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Not found" }, { status: 404 })
     }
 
-    const response = await client.executeFailback(id)
+    const response = await client.failbackCutover(id)
 
     return NextResponse.json(response.data)
   } catch (e: any) {
     if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error executing failback:", e)
+      console.error("Error executing failback cutover:", e)
     }
 
     const upstream = parseOrchestratorError(e)
@@ -43,7 +43,7 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
     }
 
     return NextResponse.json(
-      { error: e?.message || "Failed to execute failback" },
+      { error: e?.message || "Failed to execute failback cutover" },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback-cutover/route.ts
@@ -1,50 +1,13 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest } from "next/server"
 
-import { getOrchestratorClient, parseOrchestratorError } from "@/lib/orchestrator/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
+import { proxyPlanFailbackAction } from "@/lib/orchestrator/planFailbackProxy"
 
 export const runtime = "nodejs"
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
-
-    if (denied) return denied
-
-    const { id } = await params
-    const client = getOrchestratorClient()
-
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
-
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.failbackCutover(id)
-
-    return NextResponse.json(response.data)
-  } catch (e: any) {
-    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error executing failback cutover:", e)
-    }
-
-    const upstream = parseOrchestratorError(e)
-
-    if (upstream) {
-      return NextResponse.json({ error: upstream.message }, { status: upstream.status })
-    }
-
-    return NextResponse.json(
-      { error: e?.message || "Failed to execute failback cutover" },
-      { status: 500 }
-    )
-  }
+  return proxyPlanFailbackAction(params, {
+    action: (client, id) => client.failbackCutover(id),
+    logLabel: "Error executing failback cutover:",
+    fallbackMessage: "Failed to execute failback cutover",
+  })
 }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failback/route.ts
@@ -1,50 +1,13 @@
-import { NextRequest, NextResponse } from "next/server"
+import { NextRequest } from "next/server"
 
-import { getOrchestratorClient, parseOrchestratorError } from "@/lib/orchestrator/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
+import { proxyPlanFailbackAction } from "@/lib/orchestrator/planFailbackProxy"
 
 export const runtime = "nodejs"
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  try {
-    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
-
-    if (denied) return denied
-
-    const { id } = await params
-    const client = getOrchestratorClient()
-
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
-
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.executeFailback(id)
-
-    return NextResponse.json(response.data)
-  } catch (e: any) {
-    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error executing failback:", e)
-    }
-
-    const upstream = parseOrchestratorError(e)
-
-    if (upstream) {
-      return NextResponse.json({ error: upstream.message }, { status: upstream.status })
-    }
-
-    return NextResponse.json(
-      { error: e?.message || "Failed to execute failback" },
-      { status: 500 }
-    )
-  }
+  return proxyPlanFailbackAction(params, {
+    action: (client, id) => client.executeFailback(id),
+    logLabel: "Error executing failback:",
+    fallbackMessage: "Failed to execute failback",
+  })
 }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { callRoute } from '@/__tests__/setup/route-test'
+
+const getRecoveryPlanMock = vi.fn()
+const executeFailoverMock = vi.fn()
+const checkPermissionMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+    executeFailover: (...args: unknown[]) => executeFailoverMock(...args),
+  }),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: {
+    AUTOMATION_VIEW: 'automation.view',
+    AUTOMATION_MANAGE: 'automation.manage',
+  },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>(['conn-src', 'conn-dst'])),
+}))
+
+import { POST } from './route'
+
+const fakePlan = {
+  id: 'plan-1',
+  name: 'Prod DR',
+  source_cluster: 'conn-src',
+  target_cluster: 'conn-dst',
+}
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getRecoveryPlanMock.mockReset().mockResolvedValue({ data: fakePlan })
+  executeFailoverMock.mockReset().mockResolvedValue({ data: { id: 'exec-1', status: 'running' } })
+})
+
+describe('POST /api/v1/orchestrator/replication/plans/[id]/failover', () => {
+  it('forwards a restore_points body to client.executeFailover', async () => {
+    const restorePoints = { 100: 'snap-1' }
+    await callRoute(POST as Parameters<typeof callRoute>[0], {
+      params: { id: 'plan-1' },
+      body: { restore_points: restorePoints },
+    })
+    expect(executeFailoverMock).toHaveBeenCalledWith('plan-1', { restore_points: restorePoints })
+  })
+
+  it('still succeeds with an empty body, calling executeFailover with undefined', async () => {
+    const res = await callRoute(POST as Parameters<typeof callRoute>[0], {
+      params: { id: 'plan-1' },
+      method: 'POST',
+    })
+    expect(res.status).toBe(200)
+    expect(executeFailoverMock).toHaveBeenCalledWith('plan-1', undefined)
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { checkPlanTenantScope } from "@/lib/orchestrator/planTenantScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
@@ -13,23 +13,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
 
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
-
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
+    if (scopeDenied) return scopeDenied
 
     const body = await request.json().catch(() => undefined)
-    const response = await client.executeFailover(id, body)
+    const response = await getOrchestratorClient().executeFailover(id, body)
 
     return NextResponse.json(response.data)
   } catch (e: any) {

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/failover/route.ts
@@ -6,7 +6,7 @@ import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
-export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
 
@@ -28,7 +28,8 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       return NextResponse.json({ error: "Not found" }, { status: 404 })
     }
 
-    const response = await client.executeFailover(id)
+    const body = await request.json().catch(() => undefined)
+    const response = await client.executeFailover(id, body)
 
     return NextResponse.json(response.data)
   } catch (e: any) {

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.test.ts
@@ -5,6 +5,7 @@ import { callRoute } from '@/__tests__/setup/route-test'
 const checkPermission = vi.fn()
 const getRecoveryPlan = vi.fn()
 const clearRecoveryHistory = vi.fn()
+const getRecoveryHistory = vi.fn()
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: (...args: unknown[]) => checkPermission(...args),
@@ -14,15 +15,16 @@ vi.mock('@/lib/tenant', () => ({
   getTenantConnectionIds: vi.fn().mockResolvedValue(new Set(['conn-src', 'conn-dst'])),
 }))
 vi.mock('@/lib/orchestrator/client', () => ({
-  getOrchestratorClient: () => ({ getRecoveryPlan, clearRecoveryHistory }),
+  getOrchestratorClient: () => ({ getRecoveryPlan, clearRecoveryHistory, getRecoveryHistory }),
 }))
 
-import { DELETE } from './route'
+import { DELETE, GET } from './route'
 
 beforeEach(() => {
   checkPermission.mockReset().mockResolvedValue(null)
   getRecoveryPlan.mockReset().mockResolvedValue({ data: { source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
   clearRecoveryHistory.mockReset().mockResolvedValue({ data: { deleted: 3 } })
+  getRecoveryHistory.mockReset().mockResolvedValue({ data: [{ id: 'exec-1', status: 'completed' }] })
 })
 
 afterEach(() => {
@@ -55,5 +57,50 @@ describe('DELETE /api/v1/orchestrator/replication/plans/[id]/history', () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ deleted: 3 })
     expect(clearRecoveryHistory).toHaveBeenCalledWith('plan-1')
+  })
+
+  it('returns a 500 with the error message when clearing history fails', async () => {
+    clearRecoveryHistory.mockRejectedValue(new Error('orchestrator down'))
+
+    const res = await callRoute(DELETE, { params: { id: 'plan-1' }, method: 'DELETE' })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'orchestrator down' })
+  })
+})
+
+describe('GET /api/v1/orchestrator/replication/plans/[id]/history', () => {
+  it('denies the call when permission is missing', async () => {
+    checkPermission.mockResolvedValue(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }))
+
+    const res = await callRoute(GET, { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(403)
+    expect(getRecoveryHistory).not.toHaveBeenCalled()
+  })
+
+  it('404s when the plan belongs to another tenant', async () => {
+    getRecoveryPlan.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const res = await callRoute(GET, { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(404)
+    expect(getRecoveryHistory).not.toHaveBeenCalled()
+  })
+
+  it('returns the history list for an in-tenant plan', async () => {
+    const res = await callRoute(GET, { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([{ id: 'exec-1', status: 'completed' }])
+  })
+
+  it('swallows orchestrator errors and returns an empty list', async () => {
+    getRecoveryHistory.mockRejectedValue(new Error('orchestrator down'))
+
+    const res = await callRoute(GET, { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual([])
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute } from '@/__tests__/setup/route-test'
+
+const checkPermission = vi.fn()
+const getRecoveryPlan = vi.fn()
+const clearRecoveryHistory = vi.fn()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermission(...args),
+  PERMISSIONS: { AUTOMATION_VIEW: 'automation.view', AUTOMATION_MANAGE: 'automation.manage' },
+}))
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set(['conn-src', 'conn-dst'])),
+}))
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({ getRecoveryPlan, clearRecoveryHistory }),
+}))
+
+import { DELETE } from './route'
+
+beforeEach(() => {
+  checkPermission.mockReset().mockResolvedValue(null)
+  getRecoveryPlan.mockReset().mockResolvedValue({ data: { source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
+  clearRecoveryHistory.mockReset().mockResolvedValue({ data: { deleted: 3 } })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('DELETE /api/v1/orchestrator/replication/plans/[id]/history', () => {
+  it('denies the call when permission is missing', async () => {
+    const denial = new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 })
+    checkPermission.mockResolvedValue(denial)
+
+    const res = await callRoute(DELETE, { params: { id: 'plan-1' }, method: 'DELETE' })
+
+    expect(res.status).toBe(403)
+    expect(clearRecoveryHistory).not.toHaveBeenCalled()
+  })
+
+  it('404s when the plan belongs to another tenant', async () => {
+    getRecoveryPlan.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const res = await callRoute(DELETE, { params: { id: 'plan-1' }, method: 'DELETE' })
+
+    expect(res.status).toBe(404)
+    expect(clearRecoveryHistory).not.toHaveBeenCalled()
+  })
+
+  it('clears the history for an in-tenant plan', async () => {
+    const res = await callRoute(DELETE, { params: { id: 'plan-1' }, method: 'DELETE' })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ deleted: 3 })
+    expect(clearRecoveryHistory).toHaveBeenCalledWith('plan-1')
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { checkPlanTenantScope } from "@/lib/orchestrator/planTenantScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
@@ -13,22 +13,11 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
 
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
+    if (scopeDenied) return scopeDenied
 
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.getRecoveryHistory(id)
+    const response = await getOrchestratorClient().getRecoveryHistory(id)
 
     return NextResponse.json(response.data || [])
   } catch (e: any) {
@@ -47,22 +36,11 @@ export async function DELETE(_request: NextRequest, { params }: { params: Promis
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
 
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
+    if (scopeDenied) return scopeDenied
 
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.clearRecoveryHistory(id)
+    const response = await getOrchestratorClient().clearRecoveryHistory(id)
 
     return NextResponse.json(response.data)
   } catch (e: any) {

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/history/route.ts
@@ -39,3 +39,40 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json([])
   }
 }
+
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
+
+    if (denied) return denied
+
+    const { id } = await params
+    const client = getOrchestratorClient()
+
+    // Verify plan ownership
+    const tenantConnectionIds = await getTenantConnectionIds()
+    const planResponse = await client.getRecoveryPlan(id)
+    const plan = planResponse.data
+
+    if (
+      plan &&
+      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
+      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
+    ) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+
+    const response = await client.clearRecoveryHistory(id)
+
+    return NextResponse.json(response.data)
+  } catch (e: any) {
+    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
+      console.error("Error clearing recovery history:", e)
+    }
+
+    return NextResponse.json(
+      { error: e?.message || "Failed to clear recovery history" },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.test.ts
@@ -67,4 +67,11 @@ describe('GET /api/v1/orchestrator/replication/plans/[id]/restore-points', () =>
     expect(res.status).toBe(404)
     expect(getPlanRestorePointsMock).not.toHaveBeenCalled()
   })
+
+  it('returns a 500 with the error message when the orchestrator call fails', async () => {
+    getPlanRestorePointsMock.mockRejectedValue(new Error('boom'))
+    const res = await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+    expect(res.status).toBe(500)
+    expect(await readJson(res)).toEqual({ error: 'boom' })
+  })
 })

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const getRecoveryPlanMock = vi.fn()
+const getPlanRestorePointsMock = vi.fn()
+const checkPermissionMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+    getPlanRestorePoints: (...args: unknown[]) => getPlanRestorePointsMock(...args),
+  }),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: {
+    AUTOMATION_VIEW: 'automation.view',
+    AUTOMATION_MANAGE: 'automation.manage',
+  },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>(['conn-src', 'conn-dst'])),
+}))
+
+import { GET } from './route'
+
+const fakePlan = {
+  id: 'plan-1',
+  source_cluster: 'conn-src',
+  target_cluster: 'conn-dst',
+}
+
+const fakeRestorePoints = {
+  plan_id: 'plan-1',
+  target_cluster: 'conn-dst',
+  vms: [
+    { vm_id: 100, vm_name: 'web-01', target_vmid: 9100, disk_count: 1, restore_points: [{ snapshot: 'snap-2', created_ts: 2, created_iso: '2026-01-02T00:00:00Z' }] },
+  ],
+}
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getRecoveryPlanMock.mockReset().mockResolvedValue({ data: fakePlan })
+  getPlanRestorePointsMock.mockReset().mockResolvedValue({ data: fakeRestorePoints })
+})
+
+describe('GET /api/v1/orchestrator/replication/plans/[id]/restore-points', () => {
+  it('returns the restore points passthrough on 200', async () => {
+    const res = await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual(fakeRestorePoints)
+    expect(getPlanRestorePointsMock).toHaveBeenCalledWith('plan-1')
+  })
+
+  it('returns denied response when permission check fails', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    const res = await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+    expect(res.status).toBe(403)
+    expect(getPlanRestorePointsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the plan belongs to a connection outside the tenant scope', async () => {
+    getRecoveryPlanMock.mockResolvedValue({ data: { ...fakePlan, source_cluster: 'conn-other' } })
+    const res = await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+    expect(res.status).toBe(404)
+    expect(getPlanRestorePointsMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.ts
@@ -6,9 +6,9 @@ import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
-export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
-    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
+    const denied = await checkPermission(PERMISSIONS.AUTOMATION_VIEW, "global", "*")
 
     if (denied) return denied
 
@@ -28,18 +28,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       return NextResponse.json({ error: "Not found" }, { status: 404 })
     }
 
-    let body: { network_isolated?: boolean; restore_points?: Record<number, string> } | undefined
-    try { body = await request.json() } catch { /* empty body is fine */ }
-    const response = await client.testFailover(id, body)
+    const response = await client.getPlanRestorePoints(id)
 
     return NextResponse.json(response.data)
   } catch (e: any) {
     if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
-      console.error("Error executing test failover:", e)
+      console.error("Error fetching restore points:", e)
     }
 
     return NextResponse.json(
-      { error: e?.message || "Failed to execute test failover" },
+      { error: e?.message || "Failed to fetch restore points" },
       { status: 500 }
     )
   }

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/restore-points/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { checkPlanTenantScope } from "@/lib/orchestrator/planTenantScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
@@ -13,22 +13,11 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
 
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
+    if (scopeDenied) return scopeDenied
 
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
-
-    const response = await client.getPlanRestorePoints(id)
+    const response = await getOrchestratorClient().getPlanRestorePoints(id)
 
     return NextResponse.json(response.data)
   } catch (e: any) {

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/test-failover/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/test-failover/route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { callRoute, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const getRecoveryPlanMock = vi.fn()
+const testFailoverMock = vi.fn()
+const checkPermissionMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+    testFailover: (...args: unknown[]) => testFailoverMock(...args),
+  }),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: {
+    AUTOMATION_VIEW: 'automation.view',
+    AUTOMATION_MANAGE: 'automation.manage',
+  },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>(['conn-src', 'conn-dst'])),
+}))
+
+import { POST } from './route'
+
+const fakePlan = {
+  id: 'plan-1',
+  source_cluster: 'conn-src',
+  target_cluster: 'conn-dst',
+}
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getRecoveryPlanMock.mockReset().mockResolvedValue({ data: fakePlan })
+  testFailoverMock.mockReset().mockResolvedValue({ data: { id: 'exec-1', status: 'running' } })
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('POST /api/v1/orchestrator/replication/plans/[id]/test-failover', () => {
+  it('returns the denied response when permission is refused', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+
+    const res = await callRoute(POST as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(403)
+    expect(testFailoverMock).not.toHaveBeenCalled()
+  })
+
+  it('404s when the plan belongs to another tenant', async () => {
+    getRecoveryPlanMock.mockResolvedValue({ data: { ...fakePlan, source_cluster: 'foreign' } })
+
+    const res = await callRoute(POST as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(404)
+    expect(testFailoverMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards a restore_points body to client.testFailover', async () => {
+    const restorePoints = { 100: 'snap-1' }
+
+    await callRoute(POST as Parameters<typeof callRoute>[0], {
+      params: { id: 'plan-1' },
+      body: { restore_points: restorePoints },
+    })
+
+    expect(testFailoverMock).toHaveBeenCalledWith('plan-1', { restore_points: restorePoints })
+  })
+
+  it('still succeeds with an empty body, calling testFailover with undefined', async () => {
+    const res = await callRoute(POST as Parameters<typeof callRoute>[0], {
+      params: { id: 'plan-1' },
+      method: 'POST',
+    })
+
+    expect(res.status).toBe(200)
+    expect(testFailoverMock).toHaveBeenCalledWith('plan-1', undefined)
+  })
+
+  it('returns a 500 with the error message when the orchestrator call fails', async () => {
+    testFailoverMock.mockRejectedValue(new Error('boom'))
+
+    const res = await callRoute(POST as Parameters<typeof callRoute>[0], { params: { id: 'plan-1' } })
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'boom' })
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/test-failover/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/plans/[id]/test-failover/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { checkPlanTenantScope } from "@/lib/orchestrator/planTenantScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
-import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
@@ -13,24 +13,13 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (denied) return denied
 
     const { id } = await params
-    const client = getOrchestratorClient()
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
 
-    // Verify plan ownership
-    const tenantConnectionIds = await getTenantConnectionIds()
-    const planResponse = await client.getRecoveryPlan(id)
-    const plan = planResponse.data
-
-    if (
-      plan &&
-      ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
-      (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
-    ) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 })
-    }
+    if (scopeDenied) return scopeDenied
 
     let body: { network_isolated?: boolean; restore_points?: Record<number, string> } | undefined
     try { body = await request.json() } catch { /* empty body is fine */ }
-    const response = await client.testFailover(id, body)
+    const response = await getOrchestratorClient().testFailover(id, body)
 
     return NextResponse.json(response.data)
   } catch (e: any) {

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
@@ -13,6 +13,7 @@
 
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import { SWRConfig } from 'swr'
 
 import { renderWithProviders, screen, userEvent, fireEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
 
@@ -100,16 +101,22 @@ describe('CreateJobDialog snapshot retention (issue #664)', () => {
 
     const onSubmit = vi.fn()
     renderWithProviders(
-      <CreateJobDialog
-        open
-        onClose={vi.fn()}
-        onSubmit={onSubmit}
-        connections={[
-          { id: 'src', name: 'Source', hasCeph: true },
-          { id: 'dst', name: 'Target', hasCeph: true },
-        ]}
-        allVMs={[{ vmid: 100, name: 'web-01', node: 'node1', connId: 'src', type: 'qemu', status: 'running', tags: [], diskGb: 10 }]}
-      />,
+      // renderWithProviders's own SWRConfig sets revalidateOnMount:false (to
+      // keep other tests from triggering background fetches); this dialog's
+      // VM list depends on a real SWR fetch resolving, so override it back
+      // on for this one render — SWRConfig context merges when nested.
+      <SWRConfig value={{ revalidateOnMount: true }}>
+        <CreateJobDialog
+          open
+          onClose={vi.fn()}
+          onSubmit={onSubmit}
+          connections={[
+            { id: 'src', name: 'Source', hasCeph: true },
+            { id: 'dst', name: 'Target', hasCeph: true },
+          ]}
+          allVMs={[{ vmid: 100, name: 'web-01', node: 'node1', connId: 'src', type: 'qemu', status: 'running', tags: [], diskGb: 10 }]}
+        />
+      </SWRConfig>,
     )
 
     // Source cluster

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
@@ -34,8 +34,10 @@ function renderDialog() {
 // DOM order: retention-source, retention-target, VMID prefix.
 const prefix = () => screen.getAllByRole('spinbutton').at(-1) as HTMLInputElement
 const blur = () => userEvent.click(screen.getByText('VMID Prefix'))
-const retentionSource = () => screen.getByLabelText('Keep on source') as HTMLInputElement
-const retentionTarget = () => screen.getByLabelText('Keep on target (DR)') as HTMLInputElement
+// getByRole('spinbutton'): the sliders now carry the same accessible name, so
+// getByLabelText would match two elements per retention setting.
+const retentionSource = () => screen.getByRole('spinbutton', { name: 'Keep on source' }) as HTMLInputElement
+const retentionTarget = () => screen.getByRole('spinbutton', { name: 'Keep on target (DR)' }) as HTMLInputElement
 
 describe('CreateJobDialog VMID prefix', () => {
   it('renders blank rather than 0 when no prefix is set', () => {

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
@@ -14,11 +14,14 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
-import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import { renderWithProviders, screen, userEvent, fireEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
 
 import CreateJobDialog from './CreateJobDialog'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 function renderDialog() {
   renderWithProviders(
@@ -26,10 +29,12 @@ function renderDialog() {
   )
 }
 
-// No bandwidth window and no cluster selected, so the VMID prefix is the only
-// number input on the dialog.
-const prefix = () => screen.getByRole('spinbutton') as HTMLInputElement
+// No bandwidth window and no cluster selected, so the numeric inputs are, in
+// DOM order: retention-source, retention-target, VMID prefix.
+const prefix = () => screen.getAllByRole('spinbutton').at(-1) as HTMLInputElement
 const blur = () => userEvent.click(screen.getByText('VMID Prefix'))
+const retentionSource = () => screen.getByLabelText('Keep on source') as HTMLInputElement
+const retentionTarget = () => screen.getByLabelText('Keep on target (DR)') as HTMLInputElement
 
 describe('CreateJobDialog VMID prefix', () => {
   it('renders blank rather than 0 when no prefix is set', () => {
@@ -58,5 +63,78 @@ describe('CreateJobDialog VMID prefix', () => {
     await userEvent.clear(prefix())
     await blur()
     expect(prefix().value).toBe('')
+  })
+})
+
+describe('CreateJobDialog snapshot retention (issue #664)', () => {
+  it('shows the default retention of 3 on both source and target', () => {
+    renderDialog()
+    expect(retentionSource().value).toBe('3')
+    expect(retentionTarget().value).toBe('3')
+  })
+
+  it('includes snapshot_keep_source/target in the submitted payload', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/api/v1/connections/src/ceph-vms') {
+        return new Response(JSON.stringify({ data: [{ vmid: 100, cephDiskGb: 10 }] }), { status: 200 })
+      }
+      if (url === '/api/v1/orchestrator/replication/check-ssh' && init?.method === 'POST') {
+        return new Response(
+          JSON.stringify({ connected: true, source_node: 'node1', target_ip: '10.0.0.1' }),
+          { status: 200 },
+        )
+      }
+      if (url === '/api/v1/connections/dst/ceph') {
+        return new Response(
+          JSON.stringify({
+            data: { pools: { list: [{ name: 'rbd', percentUsed: 0.1, bytesUsed: 100, maxAvail: 900, bytesUsedFormatted: '100 MB', maxAvailFormatted: '900 MB' }] } },
+          }),
+          { status: 200 },
+        )
+      }
+      if (url === '/api/v1/orchestrator/replication/preflight' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ checks: [], can_create: true }), { status: 200 })
+      }
+      return new Response('{}', { status: 200 })
+    }))
+
+    const onSubmit = vi.fn()
+    renderWithProviders(
+      <CreateJobDialog
+        open
+        onClose={vi.fn()}
+        onSubmit={onSubmit}
+        connections={[
+          { id: 'src', name: 'Source', hasCeph: true },
+          { id: 'dst', name: 'Target', hasCeph: true },
+        ]}
+        allVMs={[{ vmid: 100, name: 'web-01', node: 'node1', connId: 'src', type: 'qemu', status: 'running', tags: [], diskGb: 10 }]}
+      />,
+    )
+
+    // Source cluster
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+    await userEvent.click(await screen.findByRole('option', { name: 'Source' }))
+
+    // Select the only VM (its ceph-vms entry must resolve first)
+    await userEvent.click(await screen.findByRole('checkbox', { name: /web-01/ }))
+
+    // Target cluster
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[1])
+    await userEvent.click(await screen.findByRole('option', { name: 'Target' }))
+
+    // Target pool (Select enables once the Ceph pools fetch resolves)
+    await waitFor(() => expect(screen.getAllByRole('combobox')[2]).not.toHaveAttribute('aria-disabled', 'true'))
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[2])
+    await userEvent.click(await screen.findByRole('option', { name: /rbd/ }))
+
+    // The Create button only enables once the SSH check succeeds
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create Job' })).not.toBeDisabled())
+    await userEvent.click(screen.getByRole('button', { name: 'Create Job' }))
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      snapshot_keep_source: 3,
+      snapshot_keep_target: 3,
+    }))
   })
 })

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
@@ -73,6 +73,8 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
   const [vmidPrefix, setVmidPrefix] = useState<number>(0)
   const [installPv, setInstallPv] = useState(true)
   const [bandwidthWindows, setBandwidthWindows] = useState<BandwidthWindow[]>([])
+  const [keepSource, setKeepSource] = useState(3)
+  const [keepTarget, setKeepTarget] = useState(3)
 
   // Ceph VM IDs for the source cluster (only VMs with disks on RBD storage)
   const { data: cephVMsData } = useSWR(
@@ -280,6 +282,8 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
       vmid_prefix: vmidPrefix || undefined,
       install_pv: installPv || undefined,
       network_mapping: {},
+      snapshot_keep_source: keepSource,
+      snapshot_keep_target: keepTarget,
     }
     if (scheduleValue.mode === 'rpo') {
       onSubmit({ ...base, rpo_target: scheduleValue.rpoTargetSeconds })
@@ -310,6 +314,8 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
     setVmidPrefix(0)
     setInstallPv(true)
     setBandwidthWindows([])
+    setKeepSource(3)
+    setKeepTarget(3)
     setVmSearch('')
     setSshCheck('idle')
     setSshError('')
@@ -714,6 +720,43 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
           <ScheduleBuilder value={scheduleValue} onChange={setScheduleValue} />
 
           <BandwidthWindowsEditor value={bandwidthWindows} onChange={setBandwidthWindows} staticRateMbps={0} />
+
+          {/* Snapshot retention */}
+          <Box>
+            <Typography variant='subtitle2' sx={{ mb: 0.5 }}>{t('siteRecovery.createJob.snapshotRetention')}</Typography>
+            <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
+              {t('siteRecovery.createJob.snapshotRetentionHelp')}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ flex: 1 }}>
+                <NumericTextField
+                  type='number'
+                  value={keepSource}
+                  onChange={setKeepSource}
+                  fallback={3}
+                  min={2}
+                  max={500}
+                  size='small'
+                  fullWidth
+                  label={t('siteRecovery.createJob.retentionSource')}
+                />
+              </Box>
+              <Box sx={{ flex: 1 }}>
+                <NumericTextField
+                  type='number'
+                  value={keepTarget}
+                  onChange={setKeepTarget}
+                  fallback={3}
+                  min={2}
+                  max={500}
+                  size='small'
+                  fullWidth
+                  label={t('siteRecovery.createJob.retentionTarget')}
+                  helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+                />
+              </Box>
+            </Box>
+          </Box>
 
           {/* VMID Prefix */}
           <Box>

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
@@ -15,6 +15,7 @@ import type { BandwidthWindow, CreateReplicationJobRequest } from '@/lib/orchest
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
+import RetentionSlider from './RetentionSlider'
 import NumericTextField from '@/components/ui/NumericTextField'
 
 // ── Types ───────────────────────────────────────────────────────────────
@@ -727,35 +728,19 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
             <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
               {t('siteRecovery.createJob.snapshotRetentionHelp')}
             </Typography>
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Box sx={{ flex: 1 }}>
-                <NumericTextField
-                  type='number'
-                  value={keepSource}
-                  onChange={setKeepSource}
-                  fallback={3}
-                  min={2}
-                  max={500}
-                  size='small'
-                  fullWidth
-                  label={t('siteRecovery.createJob.retentionSource')}
-                />
-              </Box>
-              <Box sx={{ flex: 1 }}>
-                <NumericTextField
-                  type='number'
-                  value={keepTarget}
-                  onChange={setKeepTarget}
-                  fallback={3}
-                  min={2}
-                  max={500}
-                  size='small'
-                  fullWidth
-                  label={t('siteRecovery.createJob.retentionTarget')}
-                  helperText={t('siteRecovery.createJob.retentionTargetHelp')}
-                />
-              </Box>
-            </Box>
+            <Stack spacing={1}>
+              <RetentionSlider
+                label={t('siteRecovery.createJob.retentionSource')}
+                value={keepSource}
+                onChange={setKeepSource}
+              />
+              <RetentionSlider
+                label={t('siteRecovery.createJob.retentionTarget')}
+                value={keepTarget}
+                onChange={setKeepTarget}
+                helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+              />
+            </Stack>
           </Box>
 
           {/* VMID Prefix */}

--- a/frontend/src/components/automation/site-recovery/DashboardTab.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.tsx
@@ -827,9 +827,9 @@ const ReplicationFlow = ({ sites, connectivity, latencyMs, jobs, connections, t 
 
 // ── Failed jobs widget ─────────────────────────────────────────────────
 
-const FailedJobsWidget = ({ jobs, vmNameMap, onSyncJob, t }: {
+const FailedJobsWidget = ({ jobs, vmNamesByConn, onSyncJob, t }: {
   jobs: ReplicationJob[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob?: (id: string) => void
   t: any
 }) => {
@@ -855,7 +855,7 @@ const FailedJobsWidget = ({ jobs, vmNameMap, onSyncJob, t }: {
             const label = j.name || (
               j.tags?.length
                 ? j.tags.map(tag => `#${tag}`).join(', ')
-                : (j.vm_ids || []).slice(0, 2).map(id => vmNameMap?.[id] || `VM ${id}`).join(', ')
+                : (j.vm_ids || []).slice(0, 2).map(id => vmNamesByConn?.[j.source_cluster]?.[id] || `VM ${id}`).join(', ')
             )
             const retryInfo = j.next_retry_at && (j.retry_count || 0) < 3
               ? t('siteRecovery.dashboard.retryIn', { in: Math.max(0, Math.round((new Date(j.next_retry_at).getTime() - Date.now()) / 1000 / 60)) })
@@ -903,11 +903,11 @@ interface DashboardTabProps {
   loading: boolean
   jobs?: ReplicationJob[]
   connections?: { id: string; name: string }[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob?: (id: string) => void
 }
 
-export default function DashboardTab({ health, loading, jobs, connections, vmNameMap, onSyncJob }: DashboardTabProps) {
+export default function DashboardTab({ health, loading, jobs, connections, vmNamesByConn, onSyncJob }: DashboardTabProps) {
   const t = useTranslations()
   const theme = useTheme()
 
@@ -1001,7 +1001,7 @@ export default function DashboardTab({ health, loading, jobs, connections, vmNam
       </Box>
 
       {/* Failed jobs (only when error_count > 0) */}
-      <FailedJobsWidget jobs={jobs || []} vmNameMap={vmNameMap} onSyncJob={onSyncJob} t={t} />
+      <FailedJobsWidget jobs={jobs || []} vmNamesByConn={vmNamesByConn} onSyncJob={onSyncJob} t={t} />
 
       {/* Charts Row */}
       <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', md: 'repeat(3, 1fr)' } }}>

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
@@ -62,8 +62,10 @@ function renderDialog(overrides: Partial<ReplicationJob> = {}) {
 // window exists, so role alone identifies it.
 const rateLimit = () => screen.getAllByRole('spinbutton')[0] as HTMLInputElement
 const save = () => screen.getByRole('button', { name: 'Save changes' })
-const retentionSource = () => screen.getByLabelText('Keep on source') as HTMLInputElement
-const retentionTarget = () => screen.getByLabelText('Keep on target (DR)') as HTMLInputElement
+// getByRole('spinbutton'): the sliders now carry the same accessible name, so
+// getByLabelText would match two elements per retention setting.
+const retentionSource = () => screen.getByRole('spinbutton', { name: 'Keep on source' }) as HTMLInputElement
+const retentionTarget = () => screen.getByRole('spinbutton', { name: 'Keep on target (DR)' }) as HTMLInputElement
 
 describe('EditJobDialog rate limit', () => {
   it('shows the job rate limit', () => {

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.test.tsx
@@ -62,6 +62,8 @@ function renderDialog(overrides: Partial<ReplicationJob> = {}) {
 // window exists, so role alone identifies it.
 const rateLimit = () => screen.getAllByRole('spinbutton')[0] as HTMLInputElement
 const save = () => screen.getByRole('button', { name: 'Save changes' })
+const retentionSource = () => screen.getByLabelText('Keep on source') as HTMLInputElement
+const retentionTarget = () => screen.getByLabelText('Keep on target (DR)') as HTMLInputElement
 
 describe('EditJobDialog rate limit', () => {
   it('shows the job rate limit', () => {
@@ -93,5 +95,35 @@ describe('EditJobDialog rate limit', () => {
     await userEvent.click(save())
     expect(rateLimit().value).toBe('0')
     expect(onSubmit).toHaveBeenCalledWith('job-1', expect.objectContaining({ rate_limit_mbps: 0 }))
+  })
+})
+
+describe('EditJobDialog snapshot retention (issue #664)', () => {
+  it('prefills 3 when the job has no retention fields (old backend)', () => {
+    renderDialog({ snapshot_keep_source: undefined, snapshot_keep_target: undefined })
+    expect(retentionSource().value).toBe('3')
+    expect(retentionTarget().value).toBe('3')
+  })
+
+  it('prefills the job effective retention values when present', () => {
+    renderDialog({ snapshot_keep_source: 5, snapshot_keep_target: 10 })
+    expect(retentionSource().value).toBe('5')
+    expect(retentionTarget().value).toBe('10')
+  })
+
+  it('submits edited retention values', async () => {
+    const { onSubmit } = renderDialog({ snapshot_keep_source: 3, snapshot_keep_target: 3 })
+
+    await userEvent.clear(retentionSource())
+    await userEvent.type(retentionSource(), '7')
+    await userEvent.clear(retentionTarget())
+    await userEvent.type(retentionTarget(), '20')
+
+    await userEvent.click(save())
+
+    expect(onSubmit).toHaveBeenCalledWith('job-1', expect.objectContaining({
+      snapshot_keep_source: 7,
+      snapshot_keep_target: 20,
+    }))
   })
 })

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
@@ -33,6 +33,8 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
   })
   const [rateLimit, setRateLimit] = useState(0)
   const [bandwidthWindows, setBandwidthWindows] = useState<BandwidthWindow[]>([])
+  const [keepSource, setKeepSource] = useState(3)
+  const [keepTarget, setKeepTarget] = useState(3)
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [is409, setIs409] = useState(false)
@@ -48,6 +50,8 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
     })
     setRateLimit(job.rate_limit_mbps || 0)
     setBandwidthWindows(job.bandwidth_windows || [])
+    setKeepSource(job.snapshot_keep_source || 3)
+    setKeepTarget(job.snapshot_keep_target || 3)
     setError('')
     setIs409(false)
   }, [job])
@@ -65,6 +69,8 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
         name: name.trim(),
         rate_limit_mbps: rateLimit,
         bandwidth_windows: bandwidthWindows,
+        snapshot_keep_source: keepSource,
+        snapshot_keep_target: keepTarget,
       }
       if (scheduleValue.mode === 'scheduled' && scheduleValue.scheduleSpec) {
         req.schedule_spec = scheduleValue.scheduleSpec
@@ -143,6 +149,43 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
               min={0}
               helperText={t('siteRecovery.editJob.rateLimitHelp')}
             />
+          </Box>
+
+          {/* Snapshot retention */}
+          <Box>
+            <Typography variant='subtitle2' sx={{ mb: 0.5 }}>{t('siteRecovery.createJob.snapshotRetention')}</Typography>
+            <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
+              {t('siteRecovery.createJob.snapshotRetentionHelp')}
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ flex: 1 }}>
+                <NumericTextField
+                  type='number'
+                  value={keepSource}
+                  onChange={setKeepSource}
+                  fallback={3}
+                  min={2}
+                  max={500}
+                  size='small'
+                  fullWidth
+                  label={t('siteRecovery.createJob.retentionSource')}
+                />
+              </Box>
+              <Box sx={{ flex: 1 }}>
+                <NumericTextField
+                  type='number'
+                  value={keepTarget}
+                  onChange={setKeepTarget}
+                  fallback={3}
+                  min={2}
+                  max={500}
+                  size='small'
+                  fullWidth
+                  label={t('siteRecovery.createJob.retentionTarget')}
+                  helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+                />
+              </Box>
+            </Box>
           </Box>
 
           <BandwidthWindowsEditor value={bandwidthWindows} onChange={setBandwidthWindows} staticRateMbps={rateLimit} />

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
@@ -9,6 +9,7 @@ import {
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
+import RetentionSlider from './RetentionSlider'
 import NumericTextField from '@/components/ui/NumericTextField'
 import type { BandwidthWindow, ReplicationJob, UpdateReplicationJobRequest } from '@/lib/orchestrator/site-recovery.types'
 
@@ -157,35 +158,19 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
             <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block', mb: 1 }}>
               {t('siteRecovery.createJob.snapshotRetentionHelp')}
             </Typography>
-            <Box sx={{ display: 'flex', gap: 2 }}>
-              <Box sx={{ flex: 1 }}>
-                <NumericTextField
-                  type='number'
-                  value={keepSource}
-                  onChange={setKeepSource}
-                  fallback={3}
-                  min={2}
-                  max={500}
-                  size='small'
-                  fullWidth
-                  label={t('siteRecovery.createJob.retentionSource')}
-                />
-              </Box>
-              <Box sx={{ flex: 1 }}>
-                <NumericTextField
-                  type='number'
-                  value={keepTarget}
-                  onChange={setKeepTarget}
-                  fallback={3}
-                  min={2}
-                  max={500}
-                  size='small'
-                  fullWidth
-                  label={t('siteRecovery.createJob.retentionTarget')}
-                  helperText={t('siteRecovery.createJob.retentionTargetHelp')}
-                />
-              </Box>
-            </Box>
+            <Stack spacing={1}>
+              <RetentionSlider
+                label={t('siteRecovery.createJob.retentionSource')}
+                value={keepSource}
+                onChange={setKeepSource}
+              />
+              <RetentionSlider
+                label={t('siteRecovery.createJob.retentionTarget')}
+                value={keepTarget}
+                onChange={setKeepTarget}
+                helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+              />
+            </Stack>
           </Box>
 
           <BandwidthWindowsEditor value={bandwidthWindows} onChange={setBandwidthWindows} staticRateMbps={rateLimit} />

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
@@ -61,7 +61,7 @@ interface EmergencyDRTabProps {
   plans: RecoveryPlan[]
   loading: boolean
   connections: Array<{ id: string; name: string }>
-  vmNameMap: Record<number, string>
+  vmNamesByConn: Record<string, Record<number, string>>
   onStartVM: (vmId: number, targetCluster: string, jobId: string) => Promise<void>
   onExecuteFailover: (planId: string) => void
   onExecuteFailback: (planId: string) => void
@@ -69,7 +69,7 @@ interface EmergencyDRTabProps {
 }
 
 export default function EmergencyDRTab({
-  jobs, plans, loading, connections, vmNameMap, onStartVM, onExecuteFailover, onExecuteFailback, onDeletePlan
+  jobs, plans, loading, connections, vmNamesByConn, onStartVM, onExecuteFailover, onExecuteFailback, onDeletePlan
 }: EmergencyDRTabProps) {
   const t = useTranslations('siteRecovery')
   const tc = useTranslations('common')
@@ -93,7 +93,7 @@ export default function EmergencyDRTab({
       for (const vmId of (job.vm_ids || [])) {
         allDRVMs.push({
           vmId,
-          vmName: vmNameMap[vmId] || `VM ${vmId}`,
+          vmName: vmNamesByConn[job.source_cluster]?.[vmId] || `VM ${vmId}`,
           targetVmId: destinationVMID(job.vmid_prefix, vmId),
           sourceCluster: job.source_cluster,
           targetCluster: job.target_cluster,
@@ -110,7 +110,7 @@ export default function EmergencyDRTab({
     for (const plan of plans) {
       for (const pvm of (plan.vms || [])) {
         vmInPlan.add(pvm.vm_id)
-        const drvm = allDRVMs.find(v => v.vmId === pvm.vm_id)
+        const drvm = allDRVMs.find(v => v.vmId === pvm.vm_id && v.sourceCluster === plan.source_cluster)
         if (drvm) {
           drvm.planId = plan.id
           drvm.planName = plan.name
@@ -140,7 +140,7 @@ export default function EmergencyDRTab({
     }
 
     return { planVMs: pVMs, standaloneVMs: sVMs, planGroups: groups }
-  }, [jobs, plans, vmNameMap])
+  }, [jobs, plans, vmNamesByConn])
 
   const totalDR = planVMs.length + standaloneVMs.length
   const healthyJobs = jobs.filter(j => j.status === 'synced' || j.status === 'syncing').length

--- a/frontend/src/components/automation/site-recovery/ExecutionScreenshots.test.tsx
+++ b/frontend/src/components/automation/site-recovery/ExecutionScreenshots.test.tsx
@@ -13,9 +13,13 @@ afterEach(() => {
 
 // Distinct execution ids per test: SWR caches by key across renders.
 function stubList(shots: unknown[]) {
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+  const fetchMock = vi.fn().mockResolvedValue(
     new Response(JSON.stringify(shots), { status: 200, headers: { 'content-type': 'application/json' } })
-  ))
+  )
+
+  vi.stubGlobal('fetch', fetchMock)
+
+  return fetchMock
 }
 
 describe('ExecutionScreenshots', () => {
@@ -45,12 +49,20 @@ describe('ExecutionScreenshots', () => {
   })
 
   it('renders nothing when the execution has no screenshots', async () => {
-    stubList([])
+    const fetchMock = stubList([])
 
-    const { container } = renderWithProviders(<ExecutionScreenshots executionId='exec-empty' />)
+    const { container } = renderWithProviders(
+      // Same override as above: renderWithProviders disables revalidateOnMount,
+      // so without this the fetch never fires and the assertion below would
+      // pass for the wrong reason (never-fetched, not empty-after-fetch).
+      <SWRConfig value={{ revalidateOnMount: true }}>
+        <ExecutionScreenshots executionId='exec-empty' />
+      </SWRConfig>
+    )
 
-    // Give SWR a tick to resolve, then assert emptiness.
-    await new Promise(r => setTimeout(r, 10))
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled()
+    })
     expect(container.innerHTML).toBe('')
   })
 })

--- a/frontend/src/components/automation/site-recovery/ExecutionScreenshots.test.tsx
+++ b/frontend/src/components/automation/site-recovery/ExecutionScreenshots.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, waitFor } from '@testing-library/react'
+import { SWRConfig } from 'swr'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+
+import ExecutionScreenshots from './ExecutionScreenshots'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+// Distinct execution ids per test: SWR caches by key across renders.
+function stubList(shots: unknown[]) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(shots), { status: 200, headers: { 'content-type': 'application/json' } })
+  ))
+}
+
+describe('ExecutionScreenshots', () => {
+  it('renders one clickable thumbnail per screenshot', async () => {
+    stubList([
+      { vm_id: 100, target_vmid: 9100, captured_at: '2026-08-10T20:00:00Z' },
+      { vm_id: 101, target_vmid: 9101, captured_at: '2026-08-10T20:00:05Z' },
+    ])
+
+    renderWithProviders(
+      // renderWithProviders's own SWRConfig sets revalidateOnMount:false (to keep
+      // other tests from triggering background fetches); this component's thumbnail
+      // list depends on a real SWR fetch resolving, so override it back on here —
+      // SWRConfig context merges when nested (see CreateJobDialog.test.tsx).
+      <SWRConfig value={{ revalidateOnMount: true }}>
+        <ExecutionScreenshots executionId='exec-thumbs' vmNameMap={{ 100: 'web-01' }} />
+      </SWRConfig>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByAltText('web-01')).toBeInTheDocument()
+    })
+    expect(screen.getByAltText('VM 101')).toBeInTheDocument()
+    expect(screen.getByAltText('web-01').getAttribute('src')).toBe(
+      '/api/v1/orchestrator/replication/executions/exec-thumbs/screenshots/100'
+    )
+  })
+
+  it('renders nothing when the execution has no screenshots', async () => {
+    stubList([])
+
+    const { container } = renderWithProviders(<ExecutionScreenshots executionId='exec-empty' />)
+
+    // Give SWR a tick to resolve, then assert emptiness.
+    await new Promise(r => setTimeout(r, 10))
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/frontend/src/components/automation/site-recovery/ExecutionScreenshots.tsx
+++ b/frontend/src/components/automation/site-recovery/ExecutionScreenshots.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useState } from 'react'
+import useSWR from 'swr'
+import { useTranslations } from 'next-intl'
+
+import { Box, Dialog, DialogContent, DialogTitle, Tooltip, Typography } from '@mui/material'
+
+export interface ScreenshotMeta {
+  vm_id: number
+  target_vmid: number
+  captured_at: string
+}
+
+const fetcher = (url: string) => fetch(url).then(r => {
+  if (!r.ok) throw new Error(String(r.status))
+  return r.json()
+})
+
+/** Boot screenshot metadata of one execution; empty while loading or on error. */
+export function useExecutionScreenshots(executionId: string | null): ScreenshotMeta[] {
+  const { data } = useSWR<ScreenshotMeta[]>(
+    executionId ? `/api/v1/orchestrator/replication/executions/${executionId}/screenshots` : null,
+    fetcher
+  )
+
+  return Array.isArray(data) ? data : []
+}
+
+const screenshotUrl = (executionId: string, vmId: number) =>
+  `/api/v1/orchestrator/replication/executions/${executionId}/screenshots/${vmId}`
+
+export function ScreenshotPreviewDialog({ executionId, shot, label, onClose }: {
+  executionId: string
+  shot: ScreenshotMeta | null
+  label: string
+  onClose: () => void
+}) {
+  const t = useTranslations()
+
+  return (
+    <Dialog open={!!shot} onClose={onClose} maxWidth='md' fullWidth>
+      {shot && (
+        <>
+          <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <i className='ri-computer-line' style={{ fontSize: 18, opacity: 0.7 }} />
+            {label}
+            <Typography variant='caption' sx={{ color: 'text.secondary', ml: 'auto' }}>
+              {t('siteRecovery.screenshots.capturedAt')} {new Date(shot.captured_at).toLocaleString()}
+            </Typography>
+          </DialogTitle>
+          <DialogContent>
+            <Box
+              component='img'
+              src={screenshotUrl(executionId, shot.vm_id)}
+              alt={label}
+              sx={{ maxWidth: '100%', display: 'block', borderRadius: 1, mx: 'auto' }}
+            />
+          </DialogContent>
+        </>
+      )}
+    </Dialog>
+  )
+}
+
+/** Thumbnails row for one execution's boot screenshots (test failovers). */
+export default function ExecutionScreenshots({ executionId, vmNameMap }: {
+  executionId: string
+  vmNameMap?: Record<number, string>
+}) {
+  const t = useTranslations()
+  const shots = useExecutionScreenshots(executionId)
+  const [preview, setPreview] = useState<ScreenshotMeta | null>(null)
+
+  if (shots.length === 0) return null
+
+  const label = (s: ScreenshotMeta) => vmNameMap?.[s.vm_id] || `VM ${s.vm_id}`
+
+  return (
+    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap', mt: 0.75 }}>
+      {shots.map(s => (
+        <Tooltip
+          key={s.vm_id}
+          title={`${label(s)} · ${t('siteRecovery.screenshots.capturedAt')} ${new Date(s.captured_at).toLocaleString()}`}
+          arrow
+        >
+          <Box
+            component='img'
+            src={screenshotUrl(executionId, s.vm_id)}
+            alt={label(s)}
+            onClick={() => setPreview(s)}
+            sx={{
+              height: 40,
+              borderRadius: 0.5,
+              border: '1px solid',
+              borderColor: 'divider',
+              cursor: 'pointer',
+              display: 'block',
+              '&:hover': { borderColor: 'primary.main' }
+            }}
+          />
+        </Tooltip>
+      ))}
+      <ScreenshotPreviewDialog
+        executionId={executionId}
+        shot={preview}
+        label={preview ? label(preview) : ''}
+        onClose={() => setPreview(null)}
+      />
+    </Box>
+  )
+}

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -13,8 +13,8 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
-import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
-import type { RecoveryPlan, RecoveryExecution } from '@/lib/orchestrator/site-recovery.types'
+import { renderWithProviders, screen, userEvent, fireEvent } from '@/__tests__/setup/renderWithProviders'
+import type { RecoveryPlan, RecoveryExecution, PlanRestorePoints } from '@/lib/orchestrator/site-recovery.types'
 
 import FailoverDialog from './FailoverDialog'
 
@@ -45,6 +45,26 @@ function execution(overrides: Partial<RecoveryExecution> = {}): RecoveryExecutio
     status: 'completed',
     started_at: '2026-01-01T00:00:00Z',
     vm_results: [],
+    ...overrides,
+  }
+}
+
+function restorePoints(overrides: Partial<PlanRestorePoints> = {}): PlanRestorePoints {
+  return {
+    plan_id: 'plan-1',
+    target_cluster: 'dst',
+    vms: [
+      {
+        vm_id: 100,
+        vm_name: 'web-01',
+        target_vmid: 9100,
+        disk_count: 1,
+        restore_points: [
+          { snapshot: 'snap-2', created_ts: 2, created_iso: '2026-06-15T12:00:00Z' },
+          { snapshot: 'snap-1', created_ts: 1, created_iso: '2026-06-10T12:00:00Z' },
+        ],
+      },
+    ],
     ...overrides,
   }
 }
@@ -100,5 +120,56 @@ describe('FailoverDialog', () => {
 
     expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
     expect(screen.getByText(/awaiting cleanup/)).toBeInTheDocument()
+  })
+})
+
+describe('FailoverDialog restore-point selection (issue #664)', () => {
+  it('renders a restore-point selector per VM, defaulting to Latest', () => {
+    renderDialog({ type: 'test', restorePoints: restorePoints() })
+
+    const select = screen.getByRole('combobox')
+    expect(select).toHaveTextContent('Latest (default)')
+  })
+
+  it('shows a muted caption instead of a selector when a VM has no restore points', () => {
+    renderDialog({
+      type: 'test',
+      restorePoints: restorePoints({ vms: [{ vm_id: 100, vm_name: 'web-01', target_vmid: 9100, disk_count: 1, restore_points: [] }] }),
+    })
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByText('No restore points')).toBeInTheDocument()
+  })
+
+  it('sends onConfirm only the non-latest selection', async () => {
+    const { onConfirm } = renderDialog({
+      type: 'failover',
+      restorePoints: restorePoints(),
+    })
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    const options = await screen.findAllByRole('option')
+    // options[0] is "Latest (default)"; options[1] is the newest restore point (snap-2).
+    await userEvent.click(options[1])
+
+    await userEvent.type(screen.getByPlaceholderText('Prod DR'), 'Prod DR')
+    await userEvent.click(screen.getByRole('button', { name: 'Execute Failover' }))
+
+    expect(onConfirm).toHaveBeenCalledWith({ restorePoints: { 100: 'snap-2' } })
+  })
+
+  it('falls back to onConfirm() with no options when Latest stays selected', async () => {
+    const { onConfirm } = renderDialog({ type: 'test', restorePoints: restorePoints() })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Test Failover' }))
+
+    expect(onConfirm).toHaveBeenCalledWith(undefined)
+  })
+
+  it('hides selectors and shows the info alert in degraded mode (restore points failed to load)', () => {
+    renderDialog({ type: 'test', restorePointsError: true })
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+    expect(screen.getByText(/Restore points could not be loaded/)).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -242,6 +242,40 @@ describe('FailoverDialog stabilization countdown (issue #664 follow-up)', () => 
   })
 })
 
+describe('FailoverDialog real-failover per-VM steps and completion summary (issue #664 follow-up)', () => {
+  it('shows the translated step caption while a failover VM is running a known step', () => {
+    renderDialog({
+      type: 'failover',
+      execution: execution({
+        type: 'failover',
+        status: 'running',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 40, step: 'fencing' },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Stopping the source VM')).toBeInTheDocument()
+  })
+
+  it('shows a completion summary alert and hides the confirm input once a failover execution has completed', () => {
+    renderDialog({
+      type: 'failover',
+      execution: execution({
+        type: 'failover',
+        status: 'completed',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'completed', progress_percent: 100 },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Failover complete')).toBeInTheDocument()
+    expect(screen.getByText(/1\/1/)).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Prod DR')).not.toBeInTheDocument()
+  })
+})
+
 describe('FailoverDialog camera button on rehydrated results (issue #664 follow-up)', () => {
   it('shows the camera button in the Plan Summary rows for a rehydrated (non-running) execution, and opens the preview dialog on click', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -276,6 +276,115 @@ describe('FailoverDialog real-failover per-VM steps and completion summary (issu
   })
 })
 
+describe('FailoverDialog failback reverse-sync monitor (issue #664 failback)', () => {
+  it('renders the per-VM sync table and both action buttons during reverse_sync', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z', last_reverse_sync_bytes: 5242880 },
+        ],
+      }),
+    })
+
+    // "web-01" appears both in the Plan Summary list above and in the new
+    // reverse-sync table — assert both are present rather than picking one.
+    expect(screen.getAllByText('web-01').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText(new Date('2026-08-10T10:00:00Z').toLocaleString())).toBeInTheDocument()
+    expect(screen.getByText('5 MiB')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel failback' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cutover' })).toBeInTheDocument()
+  })
+
+  it('shows "No reverse sync yet" for a VM that has not synced back, and its error caption when set', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, error: 'disk offline' },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('No reverse sync yet')).toBeInTheDocument()
+    expect(screen.getByText('disk offline')).toBeInTheDocument()
+  })
+
+  it('opens a confirm dialog before calling onFailbackCutover, passing the plan id', async () => {
+    const onFailbackCutover = vi.fn()
+    renderDialog({
+      type: 'failback',
+      execution: execution({ type: 'failback', status: 'running', phase: 'reverse_sync', vm_results: [] }),
+      onFailbackCutover,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cutover' }))
+    expect(onFailbackCutover).not.toHaveBeenCalled()
+    expect(screen.getByText('Stop the DR VMs, apply the final delta and start the source VMs?')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    expect(onFailbackCutover).toHaveBeenCalledWith('plan-1')
+  })
+
+  it('opens a confirm dialog before calling onFailbackCancel, passing the plan id', async () => {
+    const onFailbackCancel = vi.fn()
+    renderDialog({
+      type: 'failback',
+      execution: execution({ type: 'failback', status: 'running', phase: 'reverse_sync', vm_results: [] }),
+      onFailbackCancel,
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel failback' }))
+    expect(onFailbackCancel).not.toHaveBeenCalled()
+    expect(screen.getByText('Stop reverse replication and return the plan to failed over? Nothing is changed on the VMs.')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    expect(onFailbackCancel).toHaveBeenCalledWith('plan-1')
+  })
+})
+
+describe('FailoverDialog failback cutover phase (issue #664 failback)', () => {
+  it('shows the translated step caption for the final_sync step', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'cutover',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 60, step: 'final_sync' },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Applying the final delta')).toBeInTheDocument()
+  })
+})
+
+describe('FailoverDialog failback completion summary (issue #664 failback)', () => {
+  it('shows the failback completion summary once the execution has completed', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'completed',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'completed', progress_percent: 100 },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Failback complete')).toBeInTheDocument()
+    expect(screen.getByText('Source VMs are running and replication protects them again in the original direction.')).toBeInTheDocument()
+  })
+})
+
 describe('FailoverDialog camera button on rehydrated results (issue #664 follow-up)', () => {
   it('shows the camera button in the Plan Summary rows for a rehydrated (non-running) execution, and opens the preview dialog on click', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -12,13 +12,17 @@
 
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import { SWRConfig } from 'swr'
 
 import { renderWithProviders, screen, userEvent, fireEvent } from '@/__tests__/setup/renderWithProviders'
 import type { RecoveryPlan, RecoveryExecution, PlanRestorePoints } from '@/lib/orchestrator/site-recovery.types'
 
 import FailoverDialog from './FailoverDialog'
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
   return {
@@ -204,5 +208,75 @@ describe('FailoverDialog boot screenshot step checklist (issue #664 follow-up)',
     const stabilizeRow = screen.getByText('Letting guests settle').closest('div')
 
     expect(stabilizeRow?.querySelector('.ri-check-line')).toBeInTheDocument()
+  })
+})
+
+describe('FailoverDialog stabilization countdown (issue #664 follow-up)', () => {
+  it('appends a live countdown to the stabilize label when phase_ends_at is set', () => {
+    renderDialog({
+      execution: execution({
+        status: 'running',
+        phase: 'stabilizing',
+        phase_ends_at: new Date(Date.now() + 30500).toISOString(),
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'completed', progress_percent: 100 },
+        ],
+      }),
+    })
+
+    expect(screen.getByText(/Letting guests settle \(3?\d s\)/)).toBeInTheDocument()
+  })
+
+  it('does not append a countdown when phase_ends_at is absent', () => {
+    renderDialog({
+      execution: execution({
+        status: 'running',
+        phase: 'stabilizing',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'completed', progress_percent: 100 },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Letting guests settle')).toBeInTheDocument()
+  })
+})
+
+describe('FailoverDialog camera button on rehydrated results (issue #664 follow-up)', () => {
+  it('shows the camera button in the Plan Summary rows for a rehydrated (non-running) execution, and opens the preview dialog on click', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([
+        { vm_id: 100, target_vmid: 9100, captured_at: '2026-08-11T07:47:35Z' },
+      ]), { status: 200, headers: { 'content-type': 'application/json' } })
+    ))
+
+    renderWithProviders(
+      // renderWithProviders's own SWRConfig sets revalidateOnMount:false; the
+      // camera button depends on the screenshots list SWR fetch actually
+      // resolving, so override it back on here (same pattern as
+      // ExecutionScreenshots.test.tsx).
+      <SWRConfig value={{ revalidateOnMount: true }}>
+        <FailoverDialog
+          open
+          onClose={vi.fn()}
+          plan={plan()}
+          type='test'
+          onConfirm={vi.fn()}
+          execution={execution({
+            status: 'completed',
+            vm_results: [
+              { vm_id: 100, vm_name: 'web-01', status: 'completed', progress_percent: 100, target_node: 'dr-1', target_vmid: 9100 },
+            ],
+          })}
+        />
+      </SWRConfig>,
+    )
+
+    const cameraButton = await screen.findByRole('button', { name: 'View boot screenshot' })
+
+    await userEvent.click(cameraButton)
+
+    const previewImg = await screen.findByRole('img')
+    expect(previewImg).toHaveAttribute('src', '/api/v1/orchestrator/replication/executions/exec-1/screenshots/100')
   })
 })

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -299,6 +299,68 @@ describe('FailoverDialog failback reverse-sync monitor (issue #664 failback)', (
     expect(screen.getByRole('button', { name: 'Cutover' })).toBeInTheDocument()
   })
 
+  it('shows the phase1Title heading and the table header row instead of the generic "Operation in progress" text', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+        ],
+      }),
+    })
+
+    expect(screen.getByText('Reverse replication in progress')).toBeInTheDocument()
+    expect(screen.queryByText('Operation in progress...')).not.toBeInTheDocument()
+    expect(screen.getByText('VM')).toBeInTheDocument()
+    expect(screen.getByText('Last reverse sync')).toBeInTheDocument()
+    expect(screen.getByText('Transferred')).toBeInTheDocument()
+  })
+
+  it('renders the animated data-flow banner with the DR and source endpoint labels', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+        ],
+      }),
+    })
+
+    // No `connections` prop passed here, so both endpoints fall back to
+    // their generic labels ("DR" / "Source") rather than a resolved cluster
+    // name — covered separately below.
+    const banner = screen.getByTestId('failback-flow-banner')
+    expect(banner).toBeInTheDocument()
+    expect(banner).toHaveTextContent('DR')
+    expect(banner).toHaveTextContent('Source')
+  })
+
+  it('resolves the DR and source endpoint labels from the connections list when available', () => {
+    renderDialog({
+      type: 'failback',
+      plan: plan({ source_cluster: 'src', target_cluster: 'dst' }),
+      connections: [{ id: 'src', name: 'Paris-Prod' }, { id: 'dst', name: 'Lyon-DR' }],
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+        ],
+      }),
+    })
+
+    const banner = screen.getByTestId('failback-flow-banner')
+    expect(banner).toHaveTextContent('Lyon-DR')
+    expect(banner).toHaveTextContent('Paris-Prod')
+  })
+
   it('shows "No reverse sync yet" for a VM that has not synced back, and its error caption when set', () => {
     renderDialog({
       type: 'failback',

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Component tests for FailoverDialog's persistent "test failover active" UI
+ * (issue #664, point 4).
+ *
+ * Before this fix, the dialog kept both the "confirm" and the "Cleanup"
+ * blocks visible once a test execution had completed (`!isExecuting` stayed
+ * true for any non-running status). It must now show exactly one of the two,
+ * driven by whether an execution is known at all — which also covers the
+ * reload case, where the execution is rehydrated from
+ * `plan.active_test_execution_id` instead of living only in React state.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import type { RecoveryPlan, RecoveryExecution } from '@/lib/orchestrator/site-recovery.types'
+
+import FailoverDialog from './FailoverDialog'
+
+afterEach(cleanup)
+
+function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
+  return {
+    id: 'plan-1',
+    name: 'Prod DR',
+    description: '',
+    status: 'ready',
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    vms: [{ vm_id: 100, vm_name: 'web-01', replication_job_id: 'job-1', tier: 1, boot_order: 1 }],
+    last_test: null,
+    last_failover: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function execution(overrides: Partial<RecoveryExecution> = {}): RecoveryExecution {
+  return {
+    id: 'exec-1',
+    plan_id: 'plan-1',
+    type: 'test',
+    status: 'completed',
+    started_at: '2026-01-01T00:00:00Z',
+    vm_results: [],
+    ...overrides,
+  }
+}
+
+type Props = Parameters<typeof FailoverDialog>[0]
+
+function renderDialog(overrides: Partial<Props> = {}) {
+  const onConfirm = vi.fn()
+  const onClose = vi.fn()
+
+  renderWithProviders(
+    <FailoverDialog
+      open
+      onClose={onClose}
+      plan={plan()}
+      type='test'
+      onConfirm={onConfirm}
+      execution={null}
+      {...overrides}
+    />,
+  )
+
+  return { onConfirm, onClose }
+}
+
+describe('FailoverDialog', () => {
+  it('hides Confirm and shows Cleanup once a test execution is known (completed)', () => {
+    renderDialog({ execution: execution(), onCleanup: vi.fn() })
+
+    expect(screen.queryByRole('button', { name: 'Test Failover' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cleanup test' })).toBeInTheDocument()
+  })
+
+  it('shows the Confirm button when there is no execution at all', () => {
+    renderDialog({ execution: null })
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+
+  it('renders the error alert when errorMessage is set', () => {
+    const message = 'A test failover is already active for this plan. Clean it up first.'
+    renderDialog({ errorMessage: message })
+
+    expect(screen.getByText(message)).toBeInTheDocument()
+  })
+
+  it('disables Confirm and shows the warning banner when the plan has an unresolved active test', () => {
+    renderDialog({
+      plan: plan({ active_test_execution_id: 'exec-1', last_test: '2026-08-01T10:00:00Z' }),
+      execution: null,
+    })
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+    expect(screen.getByText(/awaiting cleanup/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -316,6 +316,59 @@ describe('FailoverDialog failback reverse-sync monitor (issue #664 failback)', (
     expect(screen.getByText('disk offline')).toBeInTheDocument()
   })
 
+  it('shows a Close button during reverse_sync (issue: dialog unclosable for days) and calls onClose when clicked', async () => {
+    const { onClose } = renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+        ],
+      }),
+    })
+
+    const closeButton = screen.getByRole('button', { name: 'Close' })
+    expect(closeButton).toBeInTheDocument()
+    await userEvent.click(closeButton)
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables Cutover while any VM has not completed a reverse sync yet', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+          { vm_id: 200, vm_name: 'web-02', status: 'running', progress_percent: 0 },
+        ],
+      }),
+    })
+
+    expect(screen.getByRole('button', { name: 'Cutover' })).toBeDisabled()
+  })
+
+  it('enables Cutover once every VM has completed at least one reverse sync', () => {
+    renderDialog({
+      type: 'failback',
+      execution: execution({
+        type: 'failback',
+        status: 'running',
+        phase: 'reverse_sync',
+        vm_results: [
+          { vm_id: 100, vm_name: 'web-01', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:00:00Z' },
+          { vm_id: 200, vm_name: 'web-02', status: 'running', progress_percent: 0, last_reverse_sync_at: '2026-08-10T10:05:00Z' },
+        ],
+      }),
+    })
+
+    expect(screen.getByRole('button', { name: 'Cutover' })).not.toBeDisabled()
+  })
+
   it('opens a confirm dialog before calling onFailbackCutover, passing the plan id', async () => {
     const onFailbackCutover = vi.fn()
     renderDialog({

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -173,3 +173,36 @@ describe('FailoverDialog restore-point selection (issue #664)', () => {
     expect(screen.getByText(/Restore points could not be loaded/)).toBeInTheDocument()
   })
 })
+
+describe('FailoverDialog boot screenshot step checklist (issue #664 follow-up)', () => {
+  const runningVMResults = [
+    { vm_id: 100, vm_name: 'web-01', status: 'completed' as const, progress_percent: 100 },
+  ]
+
+  it('shows the stabilize step spinning while the execution phase is stabilizing', () => {
+    renderDialog({
+      execution: execution({ status: 'running', phase: 'stabilizing', vm_results: runningVMResults }),
+    })
+
+    const label = screen.getByText('Letting guests settle')
+    const row = label.closest('div')
+
+    expect(row?.querySelector('.ri-loader-4-line')).toBeInTheDocument()
+  })
+
+  it('shows the capture step spinning while the execution phase is capturing', () => {
+    renderDialog({
+      execution: execution({ status: 'running', phase: 'capturing', vm_results: runningVMResults }),
+    })
+
+    const label = screen.getByText('Capturing boot screenshots')
+    const row = label.closest('div')
+
+    expect(row?.querySelector('.ri-loader-4-line')).toBeInTheDocument()
+
+    // The stabilize step is done by the time we're capturing.
+    const stabilizeRow = screen.getByText('Letting guests settle').closest('div')
+
+    expect(stabilizeRow?.querySelector('.ri-check-line')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -152,11 +152,9 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                           variant='outlined'
                           sx={{ height: 18, fontSize: '0.6rem', minWidth: 32 }}
                         />
+                        <i className='ri-computer-line' style={{ fontSize: 14, opacity: 0.65 }} />
                         <Typography variant='body2' sx={{ fontWeight: 500, fontSize: '0.8rem', flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                           {vmNameMap?.[vm.vm_id] || (vm.vm_name && !vm.vm_name.startsWith('VM ') ? vm.vm_name : `VM ${vm.vm_id}`)}
-                        </Typography>
-                        <Typography variant='caption' sx={{ color: 'text.secondary', fontFamily: 'monospace', fontSize: '0.65rem' }}>
-                          {vm.vm_id}
                         </Typography>
                         {showRestoreSelector && !restorePointsError && (
                           restorePointsLoading ? (
@@ -171,28 +169,34 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                               )
                             }
                             return (
-                              <Select
-                                size='small'
-                                displayEmpty
-                                value={selectedPoints[vm.vm_id] || ''}
-                                onChange={e => {
-                                  const val = e.target.value
-                                  setSelectedPoints(prev => {
-                                    const next = { ...prev }
-                                    if (val) next[vm.vm_id] = val
-                                    else delete next[vm.vm_id]
-                                    return next
-                                  })
-                                }}
-                                sx={{ minWidth: 170, fontSize: '0.75rem' }}
-                              >
-                                <MenuItem value=''>{t('siteRecovery.failover.restorePointLatest')}</MenuItem>
-                                {vmRestore.restore_points.map(rp => (
-                                  <MenuItem key={rp.snapshot} value={rp.snapshot}>
-                                    {new Date(rp.created_iso).toLocaleString()}
-                                  </MenuItem>
-                                ))}
-                              </Select>
+                              <>
+                                <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.65rem' }}>
+                                  {t('siteRecovery.failover.restorePointChoose')}
+                                </Typography>
+                                <Select
+                                  size='small'
+                                  displayEmpty
+                                  value={selectedPoints[vm.vm_id] || ''}
+                                  onChange={e => {
+                                    const val = e.target.value
+                                    setSelectedPoints(prev => {
+                                      const next = { ...prev }
+                                      if (val) next[vm.vm_id] = val
+                                      else delete next[vm.vm_id]
+                                      return next
+                                    })
+                                  }}
+                                  sx={{ minWidth: 170, fontSize: '0.75rem' }}
+                                >
+                                  <MenuItem value=''>{t('siteRecovery.failover.restorePointLatest')}</MenuItem>
+                                  {vmRestore.restore_points.map(rp => (
+                                    <MenuItem key={rp.snapshot} value={rp.snapshot}>
+                                      <i className='ri-camera-line' style={{ fontSize: 13, marginRight: 6, opacity: 0.7 }} />
+                                      {new Date(rp.created_iso).toLocaleString()}
+                                    </MenuItem>
+                                  ))}
+                                </Select>
+                              </>
                             )
                           })()
                         )}

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -222,6 +222,17 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                             </IconButton>
                           </Tooltip>
                         )}
+                        {type === 'test' && (() => {
+                          const shot = screenshots.find(s => s.vm_id === vm.vm_id)
+                          if (!shot) return null
+                          return (
+                            <Tooltip title={t('siteRecovery.screenshots.view')}>
+                              <IconButton size='small' onClick={() => setScreenshotPreview(shot)} sx={{ color: 'text.secondary' }}>
+                                <i className='ri-camera-line' />
+                              </IconButton>
+                            </Tooltip>
+                          )
+                        })()}
                       </Box>
                     )
                   })}
@@ -338,6 +349,45 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                   </Box>
                 ))}
               </Stack>
+              {type === 'test' && (() => {
+                const allTerminal = (execution.vm_results || []).length > 0
+                  && (execution.vm_results || []).every((vm: RecoveryVMResult) => vm.status === 'completed' || vm.status === 'failed')
+                const steps = [
+                  {
+                    key: 'boot',
+                    label: t('siteRecovery.screenshots.stepBoot'),
+                    state: (execution.phase === 'stabilizing' || execution.phase === 'capturing' || allTerminal) ? 'done' : 'active'
+                  },
+                  {
+                    key: 'stabilize',
+                    label: t('siteRecovery.screenshots.stepStabilize'),
+                    state: execution.phase === 'capturing' ? 'done' : execution.phase === 'stabilizing' ? 'active' : 'pending'
+                  },
+                  {
+                    key: 'capture',
+                    label: t('siteRecovery.screenshots.stepCapture'),
+                    state: execution.phase === 'capturing' ? 'active' : 'pending'
+                  }
+                ] as const
+                return (
+                  <Stack spacing={0.75} sx={{ mt: 1.5 }}>
+                    {steps.map(step => {
+                      const stepIcon = step.state === 'done' ? { icon: 'ri-check-line', color: 'success.main' }
+                        : step.state === 'active' ? { icon: 'ri-loader-4-line', color: 'primary.main' }
+                        : { icon: 'ri-time-line', color: 'text.disabled' }
+                      return (
+                        <Box key={step.key} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Box sx={{ width: 16, textAlign: 'center', color: stepIcon.color, fontSize: 14, display: 'inline-flex', justifyContent: 'center' }}>
+                            <i className={stepIcon.icon} style={{ animation: stepIcon.icon === 'ri-loader-4-line' ? 'spin 1.5s linear infinite' : 'none' }} />
+                            <Box sx={{ '@keyframes spin': { '0%': { transform: 'rotate(0deg)' }, '100%': { transform: 'rotate(360deg)' } } }} />
+                          </Box>
+                          <Typography variant='caption' sx={{ color: 'text.secondary' }}>{step.label}</Typography>
+                        </Box>
+                      )
+                    })}
+                  </Stack>
+                )
+              })()}
             </Box>
           )}
         </Stack>

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -8,6 +8,8 @@ import {
   IconButton, LinearProgress, MenuItem, Select, Stack, TextField, Tooltip, Typography
 } from '@mui/material'
 
+import { ScreenshotPreviewDialog, useExecutionScreenshots, type ScreenshotMeta } from './ExecutionScreenshots'
+
 import type { RecoveryPlan, RecoveryExecution, RecoveryVMResult, PlanRestorePoints } from '@/lib/orchestrator/site-recovery.types'
 
 // ── Main Component ─────────────────────────────────────────────────────
@@ -35,6 +37,8 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   const t = useTranslations()
   const [confirmText, setConfirmText] = useState('')
   const [selectedPoints, setSelectedPoints] = useState<Record<number, string>>({})
+  const screenshots = useExecutionScreenshots(execution && type === 'test' ? execution.id : null)
+  const [screenshotPreview, setScreenshotPreview] = useState<ScreenshotMeta | null>(null)
   const isDestructive = type === 'failover' || type === 'failback'
   const isExecuting = !!execution && execution.status === 'running'
 
@@ -316,6 +320,21 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                         </IconButton>
                       </Tooltip>
                     )}
+                    {(() => {
+                      const shot = screenshots.find(s => s.vm_id === vm.vm_id)
+                      if (!shot) return null
+                      return (
+                        <Tooltip title={t('siteRecovery.screenshots.view')}>
+                          <IconButton
+                            size='small'
+                            onClick={() => setScreenshotPreview(shot)}
+                            sx={{ color: 'text.secondary' }}
+                          >
+                            <i className='ri-camera-line' />
+                          </IconButton>
+                        </Tooltip>
+                      )
+                    })()}
                   </Box>
                 ))}
               </Stack>
@@ -359,6 +378,14 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           </>
         )}
       </DialogActions>
+      {execution && (
+        <ScreenshotPreviewDialog
+          executionId={execution.id}
+          shot={screenshotPreview}
+          label={screenshotPreview ? (vmNameMap?.[screenshotPreview.vm_id] || `VM ${screenshotPreview.vm_id}`) : ''}
+          onClose={() => setScreenshotPreview(null)}
+        />
+      )}
     </Dialog>
   )
 }

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -173,6 +173,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                             return (
                               <Select
                                 size='small'
+                                displayEmpty
                                 value={selectedPoints[vm.vm_id] || ''}
                                 onChange={e => {
                                   const val = e.target.value

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -262,7 +262,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           )}
 
           {/* Confirm field for destructive operations */}
-          {isDestructive && !isExecuting && (
+          {isDestructive && !isExecuting && !execution && (
             <Box>
               <Typography variant='body2' sx={{ mb: 1 }}>
                 {t('siteRecovery.failover.typeToConfirm', { name: plan.name })}
@@ -298,6 +298,27 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
             )
           })()}
 
+          {/* Failover completion summary */}
+          {execution && execution.status === 'completed' && type === 'failover' && (() => {
+            const results = execution.vm_results || []
+            const total = results.length
+            const okCount = results.filter(r => r.status === 'completed').length
+            const allOk = total > 0 && okCount === total
+            return (
+              <Alert severity={allOk ? 'success' : 'warning'}>
+                <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+                  {t('siteRecovery.failover.completeTitle')}
+                </Typography>
+                <Typography variant='caption' component='div'>
+                  {okCount}/{total} {t('siteRecovery.failover.completeVMs')}
+                </Typography>
+                <Typography variant='caption' component='div'>
+                  {t('siteRecovery.failover.completeLocked')}
+                </Typography>
+              </Alert>
+            )
+          })()}
+
           {/* Execution progress */}
           {isExecuting && execution && (
             <Box>
@@ -326,6 +347,12 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                       />
                       {vm.error && (
                         <Typography variant='caption' sx={{ color: 'error.main', fontSize: '0.65rem' }}>{vm.error}</Typography>
+                      )}
+                      {!vm.error && vm.status === 'running' && vm.step && t.has(`siteRecovery.failover.step.${vm.step}`) && (
+                        <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.65rem', display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                          <i className='ri-loader-4-line' style={{ fontSize: 11, animation: 'spin 1.5s linear infinite' }} />
+                          {t(`siteRecovery.failover.step.${vm.step}`)}
+                        </Typography>
                       )}
                     </Box>
                     {type === 'test' && targetConnId && vm.target_node && vm.target_vmid != null &&

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -4,11 +4,11 @@ import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle,
-  IconButton, LinearProgress, Stack, TextField, Tooltip, Typography
+  Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+  IconButton, LinearProgress, MenuItem, Select, Stack, TextField, Tooltip, Typography
 } from '@mui/material'
 
-import type { RecoveryPlan, RecoveryExecution, RecoveryVMResult } from '@/lib/orchestrator/site-recovery.types'
+import type { RecoveryPlan, RecoveryExecution, RecoveryVMResult, PlanRestorePoints } from '@/lib/orchestrator/site-recovery.types'
 
 // ── Main Component ─────────────────────────────────────────────────────
 
@@ -17,7 +17,7 @@ interface FailoverDialogProps {
   onClose: () => void
   plan: RecoveryPlan | null
   type: 'test' | 'failover' | 'failback'
-  onConfirm: () => void
+  onConfirm: (options?: { restorePoints?: Record<number, string> }) => void
   onCleanup?: () => void
   cleanupLoading?: boolean
   cleanupResult?: { vms_stopped: number; disks_rolled: number; jobs_resumed: number; errors: string[] } | null
@@ -26,16 +26,23 @@ interface FailoverDialogProps {
   targetConnId?: string
   connections?: { id: string; name: string }[]
   vmNameMap?: Record<number, string>
+  restorePoints?: PlanRestorePoints | null
+  restorePointsLoading?: boolean
+  restorePointsError?: boolean
 }
 
-export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap }: FailoverDialogProps) {
+export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap, restorePoints, restorePointsLoading, restorePointsError }: FailoverDialogProps) {
   const t = useTranslations()
   const [confirmText, setConfirmText] = useState('')
+  const [selectedPoints, setSelectedPoints] = useState<Record<number, string>>({})
   const isDestructive = type === 'failover' || type === 'failback'
   const isExecuting = !!execution && execution.status === 'running'
 
   useEffect(() => {
-    if (!open) setConfirmText('')
+    if (!open) {
+      setConfirmText('')
+      setSelectedPoints({})
+    }
   }, [open])
 
   if (!plan) return null
@@ -83,6 +90,10 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
         <Stack spacing={2}>
           <Alert severity={config.severity}>{config.description}</Alert>
 
+          {restorePointsError && !execution && type !== 'failback' && (
+            <Alert severity='info'>{t('siteRecovery.failover.restorePointsLoadFailed')}</Alert>
+          )}
+
           {testActiveUnresolved && (
             <Alert severity='warning'>
               {t('siteRecovery.failover.testActiveBanner', {
@@ -109,6 +120,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
               const resultsByVMID: Record<number, RecoveryVMResult> = {}
               for (const r of (execution?.vm_results || [])) resultsByVMID[r.vm_id] = r
               const sortedVMs = [...plan.vms].sort((a, b) => (a.boot_order || 0) - (b.boot_order || 0))
+              const showRestoreSelector = !execution && type !== 'failback'
               return (
                 <Stack spacing={0.5} sx={{ maxHeight: 260, overflow: 'auto' }}>
                   {sortedVMs.map(vm => {
@@ -146,6 +158,43 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                         <Typography variant='caption' sx={{ color: 'text.secondary', fontFamily: 'monospace', fontSize: '0.65rem' }}>
                           {vm.vm_id}
                         </Typography>
+                        {showRestoreSelector && !restorePointsError && (
+                          restorePointsLoading ? (
+                            <CircularProgress size={14} />
+                          ) : (() => {
+                            const vmRestore = restorePoints?.vms.find(v => v.vm_id === vm.vm_id)
+                            if (!vmRestore || vmRestore.error || vmRestore.restore_points.length === 0) {
+                              return (
+                                <Typography variant='caption' sx={{ color: 'text.disabled', fontSize: '0.65rem', minWidth: 170, textAlign: 'right' }}>
+                                  {t('siteRecovery.failover.restorePointsNone')}
+                                </Typography>
+                              )
+                            }
+                            return (
+                              <Select
+                                size='small'
+                                value={selectedPoints[vm.vm_id] || ''}
+                                onChange={e => {
+                                  const val = e.target.value
+                                  setSelectedPoints(prev => {
+                                    const next = { ...prev }
+                                    if (val) next[vm.vm_id] = val
+                                    else delete next[vm.vm_id]
+                                    return next
+                                  })
+                                }}
+                                sx={{ minWidth: 170, fontSize: '0.75rem' }}
+                              >
+                                <MenuItem value=''>{t('siteRecovery.failover.restorePointLatest')}</MenuItem>
+                                {vmRestore.restore_points.map(rp => (
+                                  <MenuItem key={rp.snapshot} value={rp.snapshot}>
+                                    {new Date(rp.created_iso).toLocaleString()}
+                                  </MenuItem>
+                                ))}
+                              </Select>
+                            )
+                          })()
+                        )}
                         {canConsole && (
                           <Tooltip title={t('siteRecovery.failover.openConsole')} arrow>
                             <IconButton
@@ -171,6 +220,10 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
               )
             })()}
           </Box>
+
+          {type === 'failover' && Object.keys(selectedPoints).length > 0 && (
+            <Alert severity='warning'>{t('siteRecovery.failover.restorePointRebaseWarning')}</Alert>
+          )}
 
           {/* Confirm field for destructive operations */}
           {isDestructive && !isExecuting && (
@@ -273,7 +326,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
             <Button
               variant='contained'
               color={config.color}
-              onClick={onConfirm}
+              onClick={() => onConfirm(Object.keys(selectedPoints).length ? { restorePoints: selectedPoints } : undefined)}
               disabled={!canConfirm}
               startIcon={<i className={config.icon} />}
             >

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -4,11 +4,13 @@ import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogTitle,
+  Alert, Box, Button, Chip, CircularProgress, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle,
   IconButton, LinearProgress, MenuItem, Select, Stack, TextField, Tooltip, Typography
 } from '@mui/material'
 
 import { ScreenshotPreviewDialog, useExecutionScreenshots, type ScreenshotMeta } from './ExecutionScreenshots'
+
+import { formatBytes } from '@/utils/format'
 
 import type { RecoveryPlan, RecoveryExecution, RecoveryVMResult, PlanRestorePoints } from '@/lib/orchestrator/site-recovery.types'
 
@@ -31,9 +33,11 @@ interface FailoverDialogProps {
   restorePoints?: PlanRestorePoints | null
   restorePointsLoading?: boolean
   restorePointsError?: boolean
+  onFailbackCutover?: (planId: string) => void
+  onFailbackCancel?: (planId: string) => void
 }
 
-export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap, restorePoints, restorePointsLoading, restorePointsError }: FailoverDialogProps) {
+export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap, restorePoints, restorePointsLoading, restorePointsError, onFailbackCutover, onFailbackCancel }: FailoverDialogProps) {
   const t = useTranslations()
   const [confirmText, setConfirmText] = useState('')
   const [selectedPoints, setSelectedPoints] = useState<Record<number, string>>({})
@@ -42,11 +46,15 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   const isDestructive = type === 'failover' || type === 'failback'
   const isExecuting = !!execution && execution.status === 'running'
   const [stabilizeRemainingSeconds, setStabilizeRemainingSeconds] = useState<number | null>(null)
+  const [confirmCancelFailback, setConfirmCancelFailback] = useState(false)
+  const [confirmCutover, setConfirmCutover] = useState(false)
 
   useEffect(() => {
     if (!open) {
       setConfirmText('')
       setSelectedPoints({})
+      setConfirmCancelFailback(false)
+      setConfirmCutover(false)
     }
   }, [open])
 
@@ -73,6 +81,10 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   // failed. Block a second test-failover attempt until it resolves.
   const testActiveUnresolved = type === 'test' && !!plan.active_test_execution_id && !execution
   const canConfirm = (!isDestructive || confirmText === confirmRequired) && !testActiveUnresolved
+  // The two-phase failback flow: while reverse replication converges, the
+  // dialog shows a dedicated per-VM sync table (not the generic progress
+  // rows) and its own Cutover/Cancel actions instead of the default ones.
+  const isReverseSyncPhase = type === 'failback' && !!execution && execution.phase === 'reverse_sync'
 
   const typeConfig = {
     test: {
@@ -319,8 +331,54 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
             )
           })()}
 
+          {/* Failback completion summary */}
+          {execution && execution.status === 'completed' && type === 'failback' && (
+            <Alert severity='success'>
+              <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
+                {t('siteRecovery.failback.completeTitle')}
+              </Typography>
+              <Typography variant='caption' component='div'>
+                {t('siteRecovery.failback.completeReprotected')}
+              </Typography>
+            </Alert>
+          )}
+
+          {/* Failback reverse-sync monitor — dedicated per-VM sync table
+              instead of the generic progress rows below, since there is no
+              percent/step progress to show while the loop just converges */}
+          {isExecuting && execution && isReverseSyncPhase && (
+            <Box>
+              <Typography variant='subtitle2' sx={{ mb: 1.5 }}>
+                {t('siteRecovery.failover.inProgress')}
+              </Typography>
+              <Stack spacing={1}>
+                {(execution.vm_results || []).map((vm: RecoveryVMResult) => (
+                  <Box key={vm.vm_id} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography variant='body2' sx={{ fontWeight: 500, fontSize: '0.8rem' }}>
+                        {vmNameMap?.[vm.vm_id] || vm.vm_name}
+                      </Typography>
+                      {vm.error && (
+                        <Typography variant='caption' sx={{ color: 'error.main', fontSize: '0.65rem' }}>{vm.error}</Typography>
+                      )}
+                    </Box>
+                    <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.7rem', textAlign: 'right' }}>
+                      {vm.last_reverse_sync_at ? new Date(vm.last_reverse_sync_at).toLocaleString() : t('siteRecovery.failback.neverSynced')}
+                    </Typography>
+                    {typeof vm.last_reverse_sync_bytes === 'number' && vm.last_reverse_sync_bytes > 0 && (
+                      <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.7rem', minWidth: 70, textAlign: 'right' }}>
+                        {formatBytes(vm.last_reverse_sync_bytes)}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+              </Stack>
+              <Alert severity='info' sx={{ mt: 1.5 }}>{t('siteRecovery.failback.phase1Help')}</Alert>
+            </Box>
+          )}
+
           {/* Execution progress */}
-          {isExecuting && execution && (
+          {isExecuting && execution && !isReverseSyncPhase && (
             <Box>
               <Typography variant='subtitle2' sx={{ mb: 1.5 }}>
                 {t('siteRecovery.failover.inProgress')}
@@ -453,6 +511,16 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
             </Button>
           </>
         )}
+        {isReverseSyncPhase && (
+          <>
+            <Button variant='outlined' onClick={() => setConfirmCancelFailback(true)}>
+              {t('siteRecovery.failback.cancelFailback')}
+            </Button>
+            <Button variant='contained' color='warning' onClick={() => setConfirmCutover(true)}>
+              {t('siteRecovery.failback.cutover')}
+            </Button>
+          </>
+        )}
         {execution && execution.status !== 'running' && (
           <>
             {type === 'test' && onCleanup && !cleanupResult && (
@@ -473,6 +541,43 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           </>
         )}
       </DialogActions>
+
+      {/* Nested confirm: cancel failback */}
+      <Dialog open={confirmCancelFailback} onClose={() => setConfirmCancelFailback(false)} maxWidth='sm' fullWidth>
+        <DialogTitle>{t('siteRecovery.failback.cancelFailback')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('siteRecovery.failback.cancelConfirm')}</DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setConfirmCancelFailback(false)}>{t('common.cancel')}</Button>
+          <Button
+            variant='contained'
+            color='error'
+            onClick={() => { setConfirmCancelFailback(false); onFailbackCancel?.(plan.id) }}
+          >
+            {t('common.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Nested confirm: cutover */}
+      <Dialog open={confirmCutover} onClose={() => setConfirmCutover(false)} maxWidth='sm' fullWidth>
+        <DialogTitle>{t('siteRecovery.failback.cutover')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('siteRecovery.failback.cutoverConfirm')}</DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setConfirmCutover(false)}>{t('common.cancel')}</Button>
+          <Button
+            variant='contained'
+            color='warning'
+            onClick={() => { setConfirmCutover(false); onFailbackCutover?.(plan.id) }}
+          >
+            {t('common.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       {execution && (
         <ScreenshotPreviewDialog
           executionId={execution.id}

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -90,6 +90,12 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   // disable the button rather than let the operator hit that failure.
   const cutoverNotReady = isReverseSyncPhase
     && (execution?.vm_results || []).some(vm => vm.status !== 'completed' && !vm.last_reverse_sync_at)
+  // Endpoint labels for the reverse-sync flow banner: DR (plan's target
+  // cluster) on the left, source on the right — the reverse of
+  // CreateJobDialog's source→target connector, since failback copies data
+  // back from the DR site to the original source.
+  const drClusterName = connections?.find(c => c.id === plan.target_cluster)?.name || 'DR'
+  const sourceClusterName = connections?.find(c => c.id === plan.source_cluster)?.name || t('siteRecovery.protection.source')
 
   const typeConfig = {
     test: {
@@ -354,8 +360,66 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           {isExecuting && execution && isReverseSyncPhase && (
             <Box>
               <Typography variant='subtitle2' sx={{ mb: 1.5 }}>
-                {t('siteRecovery.failover.inProgress')}
+                {t('siteRecovery.failback.phase1Title')}
               </Typography>
+
+              {/* Animated data-flow banner — a purely visual cue (no
+                  byte-level telemetry backs it): DR on the left, source on
+                  the right, with an animated dashed line flowing between
+                  them. Reuses the exact dashed-flow CSS technique from
+                  CreateJobDialog's SSH connectivity connector
+                  (repeating-linear-gradient + a backgroundPosition
+                  keyframe), just relabeled endpoints — DR → source here,
+                  the reverse of that dialog's source → target. */}
+              <Box
+                data-testid='failback-flow-banner'
+                sx={{
+                  display: 'flex', alignItems: 'center', gap: 1,
+                  height: 48, px: 1.5, mb: 1.5,
+                  borderRadius: 1, border: '1px solid', borderColor: 'divider',
+                  bgcolor: 'action.hover'
+                }}
+              >
+                <Typography
+                  variant='caption'
+                  sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontWeight: 600, fontSize: '0.7rem', flexShrink: 0, maxWidth: '35%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  <i className='ri-server-line' style={{ fontSize: 15, opacity: 0.75 }} />
+                  {drClusterName}
+                </Typography>
+                <Box sx={{
+                  flex: 1, height: 2, borderRadius: 1, minWidth: 24,
+                  background: theme => `repeating-linear-gradient(90deg, ${theme.palette.warning.main} 0 6px, transparent 6px 12px)`,
+                  backgroundSize: '12px 2px',
+                  animation: 'failbackFlow 1.2s linear infinite',
+                  '@keyframes failbackFlow': {
+                    '0%': { backgroundPosition: '0 0' },
+                    '100%': { backgroundPosition: '12px 0' },
+                  },
+                }} />
+                <i className='ri-arrow-right-line' style={{ fontSize: 15, opacity: 0.6, flexShrink: 0 }} />
+                <Typography
+                  variant='caption'
+                  sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontWeight: 600, fontSize: '0.7rem', flexShrink: 0, maxWidth: '35%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                >
+                  {sourceClusterName}
+                  <i className='ri-server-line' style={{ fontSize: 15, opacity: 0.75 }} />
+                </Typography>
+              </Box>
+
+              {/* Header row */}
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, px: 0.75, pb: 0.5 }}>
+                <Typography variant='caption' sx={{ flex: 1, minWidth: 0, color: 'text.secondary', fontWeight: 600, fontSize: '0.65rem', textTransform: 'uppercase' }}>
+                  {t('siteRecovery.snapshots.vm')}
+                </Typography>
+                <Typography variant='caption' sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.65rem', textTransform: 'uppercase', textAlign: 'right' }}>
+                  {t('siteRecovery.failback.colLastSync')}
+                </Typography>
+                <Typography variant='caption' sx={{ color: 'text.secondary', fontWeight: 600, fontSize: '0.65rem', textTransform: 'uppercase', textAlign: 'right', minWidth: 70 }}>
+                  {t('siteRecovery.failback.colTransferred')}
+                </Typography>
+              </Box>
+
               <Stack spacing={1}>
                 {(execution.vm_results || []).map((vm: RecoveryVMResult) => (
                   <Box key={vm.vm_id} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
@@ -370,11 +434,11 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                     <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.7rem', textAlign: 'right' }}>
                       {vm.last_reverse_sync_at ? new Date(vm.last_reverse_sync_at).toLocaleString() : t('siteRecovery.failback.neverSynced')}
                     </Typography>
-                    {typeof vm.last_reverse_sync_bytes === 'number' && vm.last_reverse_sync_bytes > 0 && (
-                      <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.7rem', minWidth: 70, textAlign: 'right' }}>
-                        {formatBytes(vm.last_reverse_sync_bytes)}
-                      </Typography>
-                    )}
+                    <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.7rem', minWidth: 70, textAlign: 'right' }}>
+                      {typeof vm.last_reverse_sync_bytes === 'number' && vm.last_reverse_sync_bytes > 0
+                        ? formatBytes(vm.last_reverse_sync_bytes)
+                        : '—'}
+                    </Typography>
                   </Box>
                 ))}
               </Stack>

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -41,6 +41,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   const [screenshotPreview, setScreenshotPreview] = useState<ScreenshotMeta | null>(null)
   const isDestructive = type === 'failover' || type === 'failback'
   const isExecuting = !!execution && execution.status === 'running'
+  const [stabilizeRemainingSeconds, setStabilizeRemainingSeconds] = useState<number | null>(null)
 
   useEffect(() => {
     if (!open) {
@@ -48,6 +49,21 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
       setSelectedPoints({})
     }
   }, [open])
+
+  // Live countdown for the 'stabilizing' phase, ticking every second while
+  // it's active — so the ~45-60s post-boot wait shows a deadline instead of
+  // an indefinite spinner.
+  useEffect(() => {
+    if (execution?.phase !== 'stabilizing' || !execution.phase_ends_at) {
+      setStabilizeRemainingSeconds(null)
+      return
+    }
+    const endsAt = new Date(execution.phase_ends_at).getTime()
+    const tick = () => setStabilizeRemainingSeconds(Math.max(0, Math.ceil((endsAt - Date.now()) / 1000)))
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [execution?.phase, execution?.phase_ends_at])
 
   if (!plan) return null
 
@@ -360,7 +376,9 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
                   },
                   {
                     key: 'stabilize',
-                    label: t('siteRecovery.screenshots.stepStabilize'),
+                    label: execution.phase === 'stabilizing' && stabilizeRemainingSeconds != null
+                      ? `${t('siteRecovery.screenshots.stepStabilize')} (${stabilizeRemainingSeconds} s)`
+                      : t('siteRecovery.screenshots.stepStabilize'),
                     state: execution.phase === 'capturing' ? 'done' : execution.phase === 'stabilizing' ? 'active' : 'pending'
                   },
                   {

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -22,12 +22,13 @@ interface FailoverDialogProps {
   cleanupLoading?: boolean
   cleanupResult?: { vms_stopped: number; disks_rolled: number; jobs_resumed: number; errors: string[] } | null
   execution: RecoveryExecution | null
+  errorMessage?: string | null
   targetConnId?: string
   connections?: { id: string; name: string }[]
   vmNameMap?: Record<number, string>
 }
 
-export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, targetConnId, connections, vmNameMap }: FailoverDialogProps) {
+export default function FailoverDialog({ open, onClose, plan, type, onConfirm, onCleanup, cleanupLoading, cleanupResult, execution, errorMessage, targetConnId, connections, vmNameMap }: FailoverDialogProps) {
   const t = useTranslations()
   const [confirmText, setConfirmText] = useState('')
   const isDestructive = type === 'failover' || type === 'failback'
@@ -40,7 +41,11 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   if (!plan) return null
 
   const confirmRequired = isDestructive ? plan.name : null
-  const canConfirm = !isDestructive || confirmText === confirmRequired
+  // A test failover started before this page load has no in-memory
+  // `execution` yet — the rehydration fetch on open is still in flight or
+  // failed. Block a second test-failover attempt until it resolves.
+  const testActiveUnresolved = type === 'test' && !!plan.active_test_execution_id && !execution
+  const canConfirm = (!isDestructive || confirmText === confirmRequired) && !testActiveUnresolved
 
   const typeConfig = {
     test: {
@@ -77,6 +82,14 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
       <DialogContent>
         <Stack spacing={2}>
           <Alert severity={config.severity}>{config.description}</Alert>
+
+          {testActiveUnresolved && (
+            <Alert severity='warning'>
+              {t('siteRecovery.failover.testActiveBanner', {
+                date: plan.last_test ? new Date(plan.last_test).toLocaleString() : ''
+              })}
+            </Alert>
+          )}
 
           {type === 'test' && (
             <Chip
@@ -252,8 +265,9 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           )}
         </Stack>
       </DialogContent>
+      {errorMessage && <Alert severity='error' sx={{ mx: 3 }}>{errorMessage}</Alert>}
       <DialogActions sx={{ px: 3, pb: 2 }}>
-        {!isExecuting && (
+        {!execution && (
           <>
             <Button onClick={onClose}>{t('common.cancel')}</Button>
             <Button

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -85,6 +85,11 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   // dialog shows a dedicated per-VM sync table (not the generic progress
   // rows) and its own Cutover/Cancel actions instead of the default ones.
   const isReverseSyncPhase = type === 'failback' && !!execution && execution.phase === 'reverse_sync'
+  // Cutover must never fence a VM that has not completed even one reverse
+  // sync yet (backend guard: ExecuteFailbackCutover refuses it outright) —
+  // disable the button rather than let the operator hit that failure.
+  const cutoverNotReady = isReverseSyncPhase
+    && (execution?.vm_results || []).some(vm => vm.status !== 'completed' && !vm.last_reverse_sync_at)
 
   const typeConfig = {
     test: {
@@ -113,7 +118,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
   const config = typeConfig[type]
 
   return (
-    <Dialog open={open} onClose={isExecuting ? undefined : onClose} maxWidth='sm' fullWidth>
+    <Dialog open={open} onClose={isExecuting && !isReverseSyncPhase ? undefined : onClose} maxWidth='sm' fullWidth>
       <DialogTitle sx={{ fontWeight: 700, display: 'flex', alignItems: 'center', gap: 1 }}>
         <i className={config.icon} />
         {config.title}
@@ -513,12 +518,17 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
         )}
         {isReverseSyncPhase && (
           <>
+            <Button onClick={onClose}>{t('common.close')}</Button>
             <Button variant='outlined' onClick={() => setConfirmCancelFailback(true)}>
               {t('siteRecovery.failback.cancelFailback')}
             </Button>
-            <Button variant='contained' color='warning' onClick={() => setConfirmCutover(true)}>
-              {t('siteRecovery.failback.cutover')}
-            </Button>
+            <Tooltip title={t('siteRecovery.failback.cutoverNotReady')} disableHoverListener={!cutoverNotReady} arrow>
+              <span>
+                <Button variant='contained' color='warning' onClick={() => setConfirmCutover(true)} disabled={cutoverNotReady}>
+                  {t('siteRecovery.failback.cutover')}
+                </Button>
+              </span>
+            </Tooltip>
           </>
         )}
         {execution && execution.status !== 'running' && (

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Component tests for ProtectionTab's "failed over" lockdown (issue #664
+ * follow-up): once a recovery plan fails over, its replication jobs are
+ * marked "failed_over" on the backend. The job card must show a distinct
+ * chip and its Sync now / Resume / Edit actions must be disabled — a
+ * "Sync now" or resume on a failed-over job would rbd import-diff over
+ * what is now the production copy.
+ */
+
+import { useState } from 'react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import type { ReplicationJob } from '@/lib/orchestrator/site-recovery.types'
+
+import ProtectionTab from './ProtectionTab'
+
+afterEach(cleanup)
+
+function job(overrides: Partial<ReplicationJob> = {}): ReplicationJob {
+  return {
+    id: 'job-1',
+    name: '',
+    vm_ids: [100],
+    vm_names: ['web-01'],
+    tags: [],
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    target_pool: 'rbd',
+    vmid_prefix: 0,
+    status: 'pending',
+    schedule: '*/15 * * * *',
+    schedule_spec: null,
+    timezone: '',
+    rpo_target: 900,
+    last_sync: null,
+    next_sync: null,
+    retry_count: 0,
+    next_retry_at: null,
+    throughput_bps: 0,
+    rate_limit_mbps: 0,
+    bandwidth_windows: [],
+    network_mapping: {},
+    progress_percent: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// ProtectionTab is controlled: which job is selected (drawer open/closed)
+// lives with the parent. This harness plays that role so clicking a card
+// actually opens the drawer, matching RecoveryPlansTab.test.tsx's pattern.
+function Harness({ jobs }: { jobs: ReplicationJob[] }) {
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null)
+
+  return (
+    <ProtectionTab
+      jobs={jobs}
+      loading={false}
+      logs={[]}
+      logsLoading={false}
+      connections={[]}
+      onSyncJob={vi.fn()}
+      onPauseJob={vi.fn()}
+      onResumeJob={vi.fn()}
+      onDeleteJob={vi.fn()}
+      onEditJob={vi.fn()}
+      selectedJobId={selectedJobId}
+      onSelectJob={setSelectedJobId}
+    />
+  )
+}
+
+function renderTab(jobs: ReplicationJob[]) {
+  renderWithProviders(<Harness jobs={jobs} />)
+}
+
+// Opening the drawer triggers a throughput fetch unconditionally (and a
+// per-VM status fetch for multi-VM jobs, not used here since every fixture
+// job has a single VM). Stub it so the drawer renders without an unhandled
+// MSW request failing the test.
+function stubThroughputFetch() {
+  server.use(
+    http.get('/api/v1/orchestrator/replication/jobs/:id/throughput', () => HttpResponse.json([])),
+  )
+}
+
+const openDrawer = async (label: string) => userEvent.click(screen.getByText(label))
+
+describe('ProtectionTab — failed-over job lockdown', () => {
+  it('shows a distinct "Failed over" chip with the warning color and shield icon', () => {
+    renderTab([job({ status: 'failed_over' })])
+
+    const chipLabel = screen.getByText('Failed over')
+    const chip = chipLabel.closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorWarning')
+    expect(chip?.querySelector('.ri-shield-star-line')).toBeInTheDocument()
+  })
+
+  it('disables the card-level Edit button for a failed-over job but not for a pending job', () => {
+    renderTab([job({ status: 'failed_over' })])
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
+
+    cleanup()
+
+    renderTab([job({ status: 'pending' })])
+    expect(screen.getByRole('button', { name: 'Edit' })).not.toBeDisabled()
+  })
+
+  it('disables Sync now, Resume and Edit in the drawer for a failed-over job, keeps Delete enabled', async () => {
+    stubThroughputFetch()
+    renderTab([job({ status: 'failed_over' })])
+
+    await openDrawer('100 - web-01')
+
+    expect(await screen.findByRole('button', { name: 'Sync Now' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Resume' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled()
+  })
+
+  it('keeps Sync now and Resume enabled in the drawer for a paused (not failed-over) job', async () => {
+    stubThroughputFetch()
+    renderTab([job({ status: 'paused' })])
+
+    await openDrawer('100 - web-01')
+
+    expect(await screen.findByRole('button', { name: 'Sync Now' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Resume' })).not.toBeDisabled()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -67,17 +67,26 @@ function jobLabel(job: ReplicationJob, vmNameMap?: Record<number, string>): stri
 // ── Sub-components ─────────────────────────────────────────────────────
 
 const StatusChip = ({ status, t }: { status: ReplicationJobStatus; t: any }) => {
-  const config: Record<ReplicationJobStatus, { label: string; color: 'success' | 'primary' | 'error' | 'default' | 'warning' }> = {
+  const config: Record<ReplicationJobStatus, { label: string; color: 'success' | 'primary' | 'error' | 'default' | 'warning'; icon?: string }> = {
     synced: { label: t('siteRecovery.status.synced'), color: 'success' },
     syncing: { label: t('siteRecovery.status.syncing'), color: 'primary' },
     error: { label: t('siteRecovery.status.error'), color: 'error' },
     paused: { label: t('siteRecovery.status.paused'), color: 'default' },
-    pending: { label: t('siteRecovery.status.pending'), color: 'warning' }
+    pending: { label: t('siteRecovery.status.pending'), color: 'warning' },
+    failed_over: { label: t('siteRecovery.jobs.failedOver'), color: 'warning', icon: 'ri-shield-star-line' }
   }
 
   const c = config[status] || config.paused
 
-  return <Chip size='small' label={c.label} color={c.color} variant={status === 'paused' ? 'outlined' : 'filled'} />
+  return (
+    <Chip
+      size='small'
+      label={c.label}
+      color={c.color}
+      variant={status === 'paused' ? 'outlined' : 'filled'}
+      icon={c.icon ? <i className={c.icon} /> : undefined}
+    />
+  )
 }
 
 const DetailRow = ({ icon, label, value, mono }: { icon: string; label: string; value: string; mono?: boolean }) => (
@@ -153,6 +162,7 @@ const JobCard = ({ job, onClick, onEdit, vmNameMap, throughputHistory, t }: { jo
   const progress = job.progress_percent || 0
   const isError = job.status === 'error'
   const isSyncing = job.status === 'syncing'
+  const isFailedOver = job.status === 'failed_over'
   const rpoActual = computeRpoActual(job.last_sync)
   const rpoOk = rpoActual != null && rpoActual <= job.rpo_target
 
@@ -300,14 +310,18 @@ const JobCard = ({ job, onClick, onEdit, vmNameMap, throughputHistory, t }: { jo
           </Box>
 
           {/* Edit (does not open the drawer) */}
-          <Tooltip title={t('common.edit')} arrow>
-            <IconButton
-              size='small'
-              onClick={e => { e.stopPropagation(); onEdit() }}
-              sx={{ p: 0.5, color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
-            >
-              <i className='ri-edit-line' style={{ fontSize: 16 }} />
-            </IconButton>
+          <Tooltip title={isFailedOver ? t('siteRecovery.jobs.failedOverTooltip') : t('common.edit')} arrow>
+            <span>
+              <IconButton
+                size='small'
+                disabled={isFailedOver}
+                aria-label={t('common.edit')}
+                onClick={e => { e.stopPropagation(); onEdit() }}
+                sx={{ p: 0.5, color: 'text.secondary', '&:hover': { color: 'primary.main' } }}
+              >
+                <i className='ri-edit-line' style={{ fontSize: 16 }} />
+              </IconButton>
+            </span>
           </Tooltip>
         </Box>
       </CardContent>
@@ -661,10 +675,27 @@ export default function ProtectionTab({
 
               {/* Actions — top placement for visibility, full-width equal split */}
               <Box sx={{ display: 'flex', gap: 1, mb: 2, '& > *': { flex: 1, minWidth: 0 } }}>
-                <Button variant='contained' size='small' startIcon={<i className='ri-refresh-line' />} onClick={() => onSyncJob(selected.id)}>
-                  {t('siteRecovery.protection.syncNow')}
-                </Button>
-                {selected.status === 'paused' ? (
+                <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} disableHoverListener={selected.status !== 'failed_over'} arrow>
+                  <span style={{ display: 'block' }}>
+                    <Button
+                      variant='contained' size='small' fullWidth
+                      startIcon={<i className='ri-refresh-line' />}
+                      onClick={() => onSyncJob(selected.id)}
+                      disabled={selected.status === 'failed_over'}
+                    >
+                      {t('siteRecovery.protection.syncNow')}
+                    </Button>
+                  </span>
+                </Tooltip>
+                {selected.status === 'failed_over' ? (
+                  <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} arrow>
+                    <span style={{ display: 'block' }}>
+                      <Button variant='outlined' size='small' fullWidth startIcon={<i className='ri-play-circle-line' />} disabled>
+                        {t('siteRecovery.protection.resume')}
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : selected.status === 'paused' ? (
                   <Button variant='outlined' size='small' startIcon={<i className='ri-play-circle-line' />} onClick={() => onResumeJob(selected.id)}>
                     {t('siteRecovery.protection.resume')}
                   </Button>
@@ -673,9 +704,18 @@ export default function ProtectionTab({
                     {t('siteRecovery.protection.pause')}
                   </Button>
                 )}
-                <Button variant='outlined' size='small' startIcon={<i className='ri-edit-line' />} onClick={() => onEditJob(selected.id)}>
-                  {t('common.edit')}
-                </Button>
+                <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} disableHoverListener={selected.status !== 'failed_over'} arrow>
+                  <span style={{ display: 'block' }}>
+                    <Button
+                      variant='outlined' size='small' fullWidth
+                      startIcon={<i className='ri-edit-line' />}
+                      onClick={() => onEditJob(selected.id)}
+                      disabled={selected.status === 'failed_over'}
+                    >
+                      {t('common.edit')}
+                    </Button>
+                  </span>
+                </Tooltip>
                 <Button variant='outlined' size='small' color='error' startIcon={<i className='ri-delete-bin-line' />} onClick={() => setConfirmDeleteJob(selected)}>
                   {t('common.delete')}
                 </Button>

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -337,7 +337,7 @@ interface ProtectionTabProps {
   logs: ReplicationJobLog[]
   logsLoading: boolean
   connections: Connection[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
   onSyncJob: (id: string) => void
   onPauseJob: (id: string) => void
   onResumeJob: (id: string) => void
@@ -348,7 +348,7 @@ interface ProtectionTabProps {
 }
 
 export default function ProtectionTab({
-  jobs, loading, logs, logsLoading, connections, vmNameMap,
+  jobs, loading, logs, logsLoading, connections, vmNamesByConn,
   onSyncJob, onPauseJob, onResumeJob, onDeleteJob, onEditJob,
   selectedJobId, onSelectJob
 }: ProtectionTabProps) {
@@ -451,14 +451,14 @@ export default function ProtectionTab({
     const qq = q.trim().toLowerCase()
 
     return (jobs || []).filter(j => {
-      const label = jobLabel(j, vmNameMap)
+      const label = jobLabel(j, vmNamesByConn?.[j.source_cluster])
       const matchQ = !qq || label.toLowerCase().includes(qq) ||
         (j.name || '').toLowerCase().includes(qq) ||
         connName(j.source_cluster).toLowerCase().includes(qq) || connName(j.target_cluster).toLowerCase().includes(qq)
 
       return matchQ && (statusFilter === 'all' || j.status === statusFilter)
     })
-  }, [jobs, q, statusFilter, connName, vmNameMap])
+  }, [jobs, q, statusFilter, connName, vmNamesByConn])
 
   const grouped = useMemo(() => {
     const map = new Map<string, ReplicationJob[]>()
@@ -614,7 +614,7 @@ export default function ProtectionTab({
                 {/* Group jobs */}
                 <Stack spacing={1}>
                   {groupJobs.map(j => (
-                    <JobCard key={j.id} job={j} onClick={() => openJob(j.id)} onEdit={() => onEditJob(j.id)} vmNameMap={vmNameMap} throughputHistory={throughputHistoryRef.current.get(j.id)} t={t} />
+                    <JobCard key={j.id} job={j} onClick={() => openJob(j.id)} onEdit={() => onEditJob(j.id)} vmNameMap={vmNamesByConn?.[j.source_cluster]} throughputHistory={throughputHistoryRef.current.get(j.id)} t={t} />
                   ))}
                 </Stack>
               </Box>
@@ -638,16 +638,16 @@ export default function ProtectionTab({
                 </Tooltip>
                 <Box sx={{ minWidth: 0, flex: 1 }}>
                   <Typography variant='h6' sx={{ fontWeight: 700, mb: 0.25 }}>
-                    {selected.name || jobLabel(selected, vmNameMap)}
+                    {selected.name || jobLabel(selected, vmNamesByConn?.[selected.source_cluster])}
                   </Typography>
                   {selected.name && (
                     <Typography variant='body2' sx={{ color: 'text.primary', fontWeight: 500, mb: 0.25 }}>
-                      {jobLabel(selected, vmNameMap)}
+                      {jobLabel(selected, vmNamesByConn?.[selected.source_cluster])}
                     </Typography>
                   )}
                   <Typography variant='caption' sx={{ color: 'text.secondary' }}>
                     {(selected.vm_ids || []).length} VM(s) — {(selected.vm_ids || []).map(id => {
-                      const name = vmNameMap?.[id]
+                      const name = vmNamesByConn?.[selected.source_cluster]?.[id]
                       return name ? `${id} - ${name}` : `${id}`
                     }).join(', ')}
                   </Typography>

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -10,10 +10,10 @@
 
 import { useState } from 'react'
 import { describe, expect, it, vi, afterEach } from 'vitest'
-import { cleanup } from '@testing-library/react'
+import { cleanup, waitFor } from '@testing-library/react'
 
 import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
-import type { RecoveryPlan } from '@/lib/orchestrator/site-recovery.types'
+import type { RecoveryExecution, RecoveryPlan } from '@/lib/orchestrator/site-recovery.types'
 
 import RecoveryPlansTab from './RecoveryPlansTab'
 
@@ -41,12 +41,16 @@ function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
 // harness plays the parent's role so clicking a row actually opens the drawer.
 function Harness({
   plans,
+  history = [],
   onTestFailover,
   onCleanupTest,
+  onHistoryCleared,
 }: {
   plans: RecoveryPlan[]
+  history?: RecoveryExecution[]
   onTestFailover: (id: string) => void
   onCleanupTest: (id: string) => void
+  onHistoryCleared?: () => void
 }) {
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
 
@@ -54,7 +58,7 @@ function Harness({
     <RecoveryPlansTab
       plans={plans}
       loading={false}
-      history={[]}
+      history={history}
       historyLoading={false}
       selectedPlanId={selectedPlanId}
       onSelectPlan={setSelectedPlanId}
@@ -63,23 +67,42 @@ function Harness({
       onFailback={vi.fn()}
       onDeletePlan={vi.fn()}
       onCleanupTest={onCleanupTest}
+      onHistoryCleared={onHistoryCleared}
       connections={[]}
     />
   )
 }
 
-function renderTab(plans: RecoveryPlan[]) {
+function renderTab(plans: RecoveryPlan[], history: RecoveryExecution[] = []) {
   const onTestFailover = vi.fn()
   const onCleanupTest = vi.fn()
+  const onHistoryCleared = vi.fn()
 
   renderWithProviders(
-    <Harness plans={plans} onTestFailover={onTestFailover} onCleanupTest={onCleanupTest} />,
+    <Harness
+      plans={plans}
+      history={history}
+      onTestFailover={onTestFailover}
+      onCleanupTest={onCleanupTest}
+      onHistoryCleared={onHistoryCleared}
+    />,
   )
 
-  return { onTestFailover, onCleanupTest }
+  return { onTestFailover, onCleanupTest, onHistoryCleared }
 }
 
 const openDrawer = async () => userEvent.click(screen.getByText('Prod DR'))
+
+function execution(overrides: Partial<RecoveryExecution> = {}): RecoveryExecution {
+  return {
+    id: 'exec-1',
+    plan_id: 'plan-1',
+    type: 'failover',
+    status: 'completed',
+    started_at: '2026-01-02T00:00:00Z',
+    ...overrides,
+  }
+}
 
 describe('RecoveryPlansTab — cleanup pending indicators', () => {
   it('shows the "Cleanup pending" chip and a disabled Test Failover + Cleanup button when a test is active', async () => {
@@ -117,5 +140,53 @@ describe('RecoveryPlansTab — cleanup pending indicators', () => {
 
     expect(screen.getByRole('button', { name: 'Test Failover' })).not.toBeDisabled()
     expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+})
+
+describe('RecoveryPlansTab — clear execution history', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows the clear-history button when history has entries', async () => {
+    renderTab([plan()], [execution()])
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Clear history' })).toBeInTheDocument()
+  })
+
+  it('hides the clear-history button when history is empty', async () => {
+    renderTab([plan()], [])
+
+    await openDrawer()
+
+    expect(screen.queryByRole('button', { name: 'Clear history' })).not.toBeInTheDocument()
+  })
+
+  it('opens a confirm dialog on click', async () => {
+    renderTab([plan()], [execution()])
+
+    await openDrawer()
+    await userEvent.click(screen.getByRole('button', { name: 'Clear history' }))
+
+    expect(screen.getByText(/Delete all past executions of this plan/)).toBeInTheDocument()
+  })
+
+  it('calls DELETE on the plan history endpoint and notifies the parent on confirm', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(JSON.stringify({ deleted: 2 }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    const { onHistoryCleared } = renderTab([plan()], [execution()])
+
+    await openDrawer()
+    await userEvent.click(screen.getByRole('button', { name: 'Clear history' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/v1/orchestrator/replication/plans/plan-1/history',
+      { method: 'DELETE' },
+    )
+    await waitFor(() => expect(onHistoryCleared).toHaveBeenCalled())
   })
 })

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Component tests for RecoveryPlansTab's "test failover active" indicators
+ * (issue #664, point 4).
+ *
+ * `active_test_execution_id` is set by the backend while a test failover's
+ * cleanup is still pending and survives a page reload (unlike the old
+ * React-only `activeExecution` state). The row must show a warning chip and
+ * the drawer must block a second test failover until cleanup runs.
+ */
+
+import { useState } from 'react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import type { RecoveryPlan } from '@/lib/orchestrator/site-recovery.types'
+
+import RecoveryPlansTab from './RecoveryPlansTab'
+
+afterEach(cleanup)
+
+function plan(overrides: Partial<RecoveryPlan> = {}): RecoveryPlan {
+  return {
+    id: 'plan-1',
+    name: 'Prod DR',
+    description: '',
+    status: 'ready',
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    vms: [{ vm_id: 100, vm_name: 'web-01', replication_job_id: 'job-1', tier: 1, boot_order: 1 }],
+    last_test: null,
+    last_failover: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// RecoveryPlansTab is controlled: the drawer's open/closed state lives in the
+// component, but which plan is selected is driven by the parent. This small
+// harness plays the parent's role so clicking a row actually opens the drawer.
+function Harness({
+  plans,
+  onTestFailover,
+  onCleanupTest,
+}: {
+  plans: RecoveryPlan[]
+  onTestFailover: (id: string) => void
+  onCleanupTest: (id: string) => void
+}) {
+  const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
+
+  return (
+    <RecoveryPlansTab
+      plans={plans}
+      loading={false}
+      history={[]}
+      historyLoading={false}
+      selectedPlanId={selectedPlanId}
+      onSelectPlan={setSelectedPlanId}
+      onTestFailover={onTestFailover}
+      onFailover={vi.fn()}
+      onFailback={vi.fn()}
+      onDeletePlan={vi.fn()}
+      onCleanupTest={onCleanupTest}
+      connections={[]}
+    />
+  )
+}
+
+function renderTab(plans: RecoveryPlan[]) {
+  const onTestFailover = vi.fn()
+  const onCleanupTest = vi.fn()
+
+  renderWithProviders(
+    <Harness plans={plans} onTestFailover={onTestFailover} onCleanupTest={onCleanupTest} />,
+  )
+
+  return { onTestFailover, onCleanupTest }
+}
+
+const openDrawer = async () => userEvent.click(screen.getByText('Prod DR'))
+
+describe('RecoveryPlansTab — cleanup pending indicators', () => {
+  it('shows the "Cleanup pending" chip and a disabled Test Failover + Cleanup button when a test is active', async () => {
+    const { onCleanupTest } = renderTab([plan({ active_test_execution_id: 'exec-1' })])
+
+    expect(screen.getByText('Cleanup pending')).toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+
+    const cleanupButton = screen.getByRole('button', { name: 'Cleanup test' })
+    await userEvent.click(cleanupButton)
+    expect(onCleanupTest).toHaveBeenCalledWith('plan-1')
+  })
+
+  it('shows no chip, an enabled Test Failover button and no Cleanup button when no test is active', async () => {
+    renderTab([plan({ active_test_execution_id: null })])
+
+    expect(screen.queryByText('Cleanup pending')).not.toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).not.toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -96,6 +96,18 @@ describe('RecoveryPlansTab — cleanup pending indicators', () => {
     expect(onCleanupTest).toHaveBeenCalledWith('plan-1')
   })
 
+  it('shows the "Test failover in progress" chip and no Cleanup button while the test is still executing', async () => {
+    renderTab([plan({ active_test_execution_id: 'exec-1', status: 'executing' })])
+
+    expect(screen.getByText('Test failover in progress')).toBeInTheDocument()
+    expect(screen.queryByText('Cleanup pending')).not.toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+    expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
+  })
+
   it('shows no chip, an enabled Test Failover button and no Cleanup button when no test is active', async () => {
     renderTab([plan({ active_test_execution_id: null })])
 

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -45,12 +45,14 @@ function Harness({
   onTestFailover,
   onCleanupTest,
   onHistoryCleared,
+  onFailback,
 }: {
   plans: RecoveryPlan[]
   history?: RecoveryExecution[]
   onTestFailover: (id: string) => void
   onCleanupTest: (id: string) => void
   onHistoryCleared?: () => void
+  onFailback?: (id: string) => void
 }) {
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
 
@@ -64,7 +66,7 @@ function Harness({
       onSelectPlan={setSelectedPlanId}
       onTestFailover={onTestFailover}
       onFailover={vi.fn()}
-      onFailback={vi.fn()}
+      onFailback={onFailback || vi.fn()}
       onDeletePlan={vi.fn()}
       onCleanupTest={onCleanupTest}
       onHistoryCleared={onHistoryCleared}
@@ -163,6 +165,41 @@ describe('RecoveryPlansTab — failed-over lockdown', () => {
 
     expect(screen.getByRole('button', { name: 'Test Failover' })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: 'Failover' })).not.toBeDisabled()
+  })
+})
+
+describe('RecoveryPlansTab — failing-back lockdown (issue #664 failback)', () => {
+  it('shows only the Open failback action (enabled) and a disabled Delete with tooltip', async () => {
+    renderTab([plan({ status: 'failing_back' })])
+
+    expect(screen.getByText('Failing back')).toBeInTheDocument()
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Open failback' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDisabled()
+
+    expect(screen.queryByRole('button', { name: 'Test Failover' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Failover' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Failback' })).not.toBeInTheDocument()
+  })
+
+  it('calls onFailback with the plan id when Open failback is clicked', async () => {
+    const onFailback = vi.fn()
+
+    renderWithProviders(
+      <Harness
+        plans={[plan({ status: 'failing_back' })]}
+        onTestFailover={vi.fn()}
+        onCleanupTest={vi.fn()}
+        onFailback={onFailback}
+      />,
+    )
+
+    await openDrawer()
+    await userEvent.click(screen.getByRole('button', { name: 'Open failback' }))
+
+    expect(onFailback).toHaveBeenCalledWith('plan-1')
   })
 })
 

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.test.tsx
@@ -143,6 +143,29 @@ describe('RecoveryPlansTab — cleanup pending indicators', () => {
   })
 })
 
+describe('RecoveryPlansTab — failed-over lockdown', () => {
+  it('disables Test Failover and Failover but keeps Failback enabled and Delete present', async () => {
+    renderTab([plan({ status: 'failed_over' })])
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Failover' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Failback' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete' })).not.toBeDisabled()
+  })
+
+  it('leaves Test Failover and Failover enabled for a ready plan', async () => {
+    renderTab([plan({ status: 'ready' })])
+
+    await openDrawer()
+
+    expect(screen.getByRole('button', { name: 'Test Failover' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Failover' })).not.toBeDisabled()
+  })
+})
+
 describe('RecoveryPlansTab — clear execution history', () => {
   afterEach(() => {
     vi.unstubAllGlobals()

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -110,13 +110,21 @@ const PlanRow = ({ plan, onClick, t, connName }: { plan: RecoveryPlan; onClick: 
         )}
       </Box>
 
-      {/* Cleanup pending warning */}
+      {/* Active test: while the plan is executing the test is still running;
+          once it finishes, active_test_execution_id alone means cleanup is due */}
       {plan.active_test_execution_id && (
         <Box sx={{ flex: '0 0 auto' }}>
-          <Chip size='small' color='warning' variant='outlined'
-            icon={<i className='ri-eraser-line' />}
-            label={t('siteRecovery.plans.cleanupPending')}
-            sx={{ height: 22, fontSize: '0.65rem' }} />
+          {plan.status === 'executing' ? (
+            <Chip size='small' color='info' variant='outlined'
+              icon={<i className='ri-test-tube-line' />}
+              label={t('siteRecovery.plans.testRunning')}
+              sx={{ height: 22, fontSize: '0.65rem' }} />
+          ) : (
+            <Chip size='small' color='warning' variant='outlined'
+              icon={<i className='ri-eraser-line' />}
+              label={t('siteRecovery.plans.cleanupPending')}
+              sx={{ height: 22, fontSize: '0.65rem' }} />
+          )}
         </Box>
       )}
 
@@ -347,7 +355,9 @@ export default function RecoveryPlansTab({
                   {t('siteRecovery.plans.actions')}
                 </Typography>
                 <Stack spacing={1}>
-                  {selected.active_test_execution_id && (
+                  {/* Cleanup only once the test finished — the orchestrator
+                      refuses it while the plan is still executing */}
+                  {selected.active_test_execution_id && selected.status !== 'executing' && (
                     <Button
                       variant='contained' size='small' color='warning' fullWidth
                       startIcon={<i className='ri-eraser-line' />}

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl'
 
 import {
   Alert, Box, Button, Card, CardContent, Chip, Collapse, Divider, Drawer,
-  IconButton, Stack, Typography, alpha, useTheme
+  IconButton, Stack, Tooltip, Typography, alpha, useTheme
 } from '@mui/material'
 
 import EmptyState from '@/components/EmptyState'
@@ -110,6 +110,16 @@ const PlanRow = ({ plan, onClick, t, connName }: { plan: RecoveryPlan; onClick: 
         )}
       </Box>
 
+      {/* Cleanup pending warning */}
+      {plan.active_test_execution_id && (
+        <Box sx={{ flex: '0 0 auto' }}>
+          <Chip size='small' color='warning' variant='outlined'
+            icon={<i className='ri-eraser-line' />}
+            label={t('siteRecovery.plans.cleanupPending')}
+            sx={{ height: 22, fontSize: '0.65rem' }} />
+        </Box>
+      )}
+
       {/* Status */}
       <Box sx={{ flex: '0 0 auto' }}>
         <PlanStatusBadge status={plan.status} t={t} />
@@ -131,13 +141,14 @@ interface RecoveryPlansTabProps {
   onFailover: (id: string) => void
   onFailback: (id: string) => void
   onDeletePlan: (id: string) => void
+  onCleanupTest: (id: string) => void
   connections?: Array<{ id: string; name: string }>
 }
 
 export default function RecoveryPlansTab({
   plans, loading, history, historyLoading,
   selectedPlanId, onSelectPlan,
-  onTestFailover, onFailover, onFailback, onDeletePlan,
+  onTestFailover, onFailover, onFailback, onDeletePlan, onCleanupTest,
   connections
 }: RecoveryPlansTabProps) {
   const t = useTranslations()
@@ -336,13 +347,31 @@ export default function RecoveryPlansTab({
                   {t('siteRecovery.plans.actions')}
                 </Typography>
                 <Stack spacing={1}>
-                  <Button
-                    variant='outlined' size='small' fullWidth
-                    startIcon={<i className='ri-test-tube-line' />}
-                    onClick={() => onTestFailover(selected.id)}
+                  {selected.active_test_execution_id && (
+                    <Button
+                      variant='contained' size='small' color='warning' fullWidth
+                      startIcon={<i className='ri-eraser-line' />}
+                      onClick={() => onCleanupTest(selected.id)}
+                    >
+                      {t('siteRecovery.failover.cleanup')}
+                    </Button>
+                  )}
+                  <Tooltip
+                    title={t('siteRecovery.plans.testActiveTooltip')}
+                    disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing')}
+                    arrow
                   >
-                    {t('siteRecovery.plans.testFailover')}
-                  </Button>
+                    <span style={{ display: 'block' }}>
+                      <Button
+                        variant='outlined' size='small' fullWidth
+                        startIcon={<i className='ri-test-tube-line' />}
+                        onClick={() => onTestFailover(selected.id)}
+                        disabled={!!selected.active_test_execution_id || selected.status === 'executing'}
+                      >
+                        {t('siteRecovery.plans.testFailover')}
+                      </Button>
+                    </span>
+                  </Tooltip>
                   <Button
                     variant='contained' size='small' color='warning' fullWidth
                     startIcon={<i className='ri-shield-star-line' />}

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -10,6 +10,8 @@ import {
 
 import EmptyState from '@/components/EmptyState'
 
+import ExecutionScreenshots from './ExecutionScreenshots'
+
 import type { RecoveryPlan, RecoveryExecution, RecoveryPlanStatus } from '@/lib/orchestrator/site-recovery.types'
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -320,7 +322,6 @@ export default function RecoveryPlansTab({
                     <Stack spacing={0.5}>
                       {history.slice(0, 10).map(exec => (
                         <Box key={exec.id} sx={{
-                          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
                           py: 0.75, px: 1, borderRadius: 1,
                           bgcolor: alpha(
                             exec.status === 'completed' ? theme.palette.success.main :
@@ -328,20 +329,28 @@ export default function RecoveryPlansTab({
                             theme.palette.info.main, 0.05
                           )
                         }}>
-                          <Box>
-                            <Typography variant='body2' sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'capitalize' }}>
-                              {exec.type}
-                            </Typography>
-                            <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.65rem' }}>
-                              {new Date(exec.started_at).toLocaleString()}
-                            </Typography>
+                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                            <Box>
+                              <Typography variant='body2' sx={{ fontWeight: 600, fontSize: '0.8rem', textTransform: 'capitalize' }}>
+                                {exec.type}
+                              </Typography>
+                              <Typography variant='caption' sx={{ color: 'text.secondary', fontSize: '0.65rem' }}>
+                                {new Date(exec.started_at).toLocaleString()}
+                              </Typography>
+                            </Box>
+                            <Chip
+                              size='small'
+                              label={exec.status}
+                              color={exec.status === 'completed' ? 'success' : exec.status === 'failed' ? 'error' : 'info'}
+                              sx={{ height: 20, fontSize: '0.65rem' }}
+                            />
                           </Box>
-                          <Chip
-                            size='small'
-                            label={exec.status}
-                            color={exec.status === 'completed' ? 'success' : exec.status === 'failed' ? 'error' : 'info'}
-                            sx={{ height: 20, fontSize: '0.65rem' }}
-                          />
+                          {exec.type === 'test' && (
+                            <ExecutionScreenshots
+                              executionId={exec.id}
+                              vmNameMap={Object.fromEntries((selected.vms || []).map(v => [v.vm_id, v.vm_name]))}
+                            />
+                          )}
                         </Box>
                       ))}
                     </Stack>

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Alert, Box, Button, Card, CardContent, Chip, Collapse, Divider, Drawer,
+  Alert, Box, Button, Card, CardContent, Chip, Collapse, Dialog, DialogActions, DialogContent,
+  DialogContentText, DialogTitle, Divider, Drawer,
   IconButton, Stack, Tooltip, Typography, alpha, useTheme
 } from '@mui/material'
 
@@ -152,19 +153,21 @@ interface RecoveryPlansTabProps {
   onFailback: (id: string) => void
   onDeletePlan: (id: string) => void
   onCleanupTest: (id: string) => void
+  onHistoryCleared?: () => void
   connections?: Array<{ id: string; name: string }>
 }
 
 export default function RecoveryPlansTab({
   plans, loading, history, historyLoading,
   selectedPlanId, onSelectPlan,
-  onTestFailover, onFailover, onFailback, onDeletePlan, onCleanupTest,
+  onTestFailover, onFailover, onFailback, onDeletePlan, onCleanupTest, onHistoryCleared,
   connections
 }: RecoveryPlansTabProps) {
   const t = useTranslations()
   const theme = useTheme()
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [expandedTiers, setExpandedTiers] = useState<Set<number>>(new Set([1, 2, 3]))
+  const [confirmClearHistory, setConfirmClearHistory] = useState(false)
 
   const selected = useMemo(() => (plans || []).find(p => p.id === selectedPlanId), [plans, selectedPlanId])
 
@@ -192,6 +195,15 @@ export default function RecoveryPlansTab({
 
       return next
     })
+  }
+
+  const handleClearHistory = async () => {
+    setConfirmClearHistory(false)
+
+    if (!selected) return
+
+    await fetch(`/api/v1/orchestrator/replication/plans/${selected.id}/history`, { method: 'DELETE' })
+    onHistoryCleared?.()
   }
 
   if (loading) {
@@ -316,9 +328,20 @@ export default function RecoveryPlansTab({
                 {history && history.length > 0 && (
                   <>
                     <Divider sx={{ my: 2 }} />
-                    <Typography variant='overline' sx={{ color: 'text.secondary', fontWeight: 600, mb: 1, display: 'block' }}>
-                      {t('siteRecovery.plans.executionHistory')}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                      <Typography variant='overline' sx={{ color: 'text.secondary', fontWeight: 600, display: 'block' }}>
+                        {t('siteRecovery.plans.executionHistory')}
+                      </Typography>
+                      <IconButton
+                        size='small'
+                        color='inherit'
+                        aria-label={t('siteRecovery.plans.clearHistory')}
+                        onClick={() => setConfirmClearHistory(true)}
+                        sx={{ color: 'text.secondary', '&:hover': { color: 'error.main' } }}
+                      >
+                        <i className='ri-delete-bin-line' />
+                      </IconButton>
+                    </Box>
                     <Stack spacing={0.5}>
                       {history.slice(0, 10).map(exec => (
                         <Box key={exec.id} sx={{
@@ -418,6 +441,20 @@ export default function RecoveryPlansTab({
           )}
         </Box>
       </Drawer>
+
+      {/* Clear history confirmation */}
+      <Dialog open={confirmClearHistory} onClose={() => setConfirmClearHistory(false)} maxWidth='sm' fullWidth>
+        <DialogTitle>{t('siteRecovery.plans.clearHistory')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('siteRecovery.plans.clearHistoryConfirm')}</DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setConfirmClearHistory(false)}>{t('common.cancel')}</Button>
+          <Button variant='contained' color='error' onClick={handleClearHistory}>
+            {t('common.confirm')}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -399,8 +399,8 @@ export default function RecoveryPlansTab({
                     </Button>
                   )}
                   <Tooltip
-                    title={t('siteRecovery.plans.testActiveTooltip')}
-                    disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing')}
+                    title={selected.status === 'failed_over' ? t('siteRecovery.plans.failedOverTooltip') : t('siteRecovery.plans.testActiveTooltip')}
+                    disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over')}
                     arrow
                   >
                     <span style={{ display: 'block' }}>
@@ -408,19 +408,28 @@ export default function RecoveryPlansTab({
                         variant='outlined' size='small' fullWidth
                         startIcon={<i className='ri-test-tube-line' />}
                         onClick={() => onTestFailover(selected.id)}
-                        disabled={!!selected.active_test_execution_id || selected.status === 'executing'}
+                        disabled={!!selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over'}
                       >
                         {t('siteRecovery.plans.testFailover')}
                       </Button>
                     </span>
                   </Tooltip>
-                  <Button
-                    variant='contained' size='small' color='warning' fullWidth
-                    startIcon={<i className='ri-shield-star-line' />}
-                    onClick={() => onFailover(selected.id)}
+                  <Tooltip
+                    title={t('siteRecovery.plans.failedOverTooltip')}
+                    disableHoverListener={selected.status !== 'failed_over'}
+                    arrow
                   >
-                    {t('siteRecovery.plans.failover')}
-                  </Button>
+                    <span style={{ display: 'block' }}>
+                      <Button
+                        variant='contained' size='small' color='warning' fullWidth
+                        startIcon={<i className='ri-shield-star-line' />}
+                        onClick={() => onFailover(selected.id)}
+                        disabled={selected.status === 'failed_over'}
+                      >
+                        {t('siteRecovery.plans.failover')}
+                      </Button>
+                    </span>
+                  </Tooltip>
                   <Button
                     variant='outlined' size='small' fullWidth
                     startIcon={<i className='ri-arrow-go-back-line' />}

--- a/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
+++ b/frontend/src/components/automation/site-recovery/RecoveryPlansTab.tsx
@@ -32,12 +32,14 @@ const PlanStatusBadge = ({ status, t }: { status: RecoveryPlanStatus; t: any }) 
     executing: { color: 'info' },
     failed: { color: 'error' },
     not_ready: { color: 'default' },
-    failed_over: { color: 'error' }
+    failed_over: { color: 'error' },
+    failing_back: { color: 'info' }
   }
 
   const c = config[status] || config.not_ready
+  const label = status === 'failing_back' ? t('siteRecovery.plans.statusFailingBack') : t(`siteRecovery.planStatus.${status}`)
 
-  return <Chip size='small' label={t(`siteRecovery.planStatus.${status}`)} color={c.color} />
+  return <Chip size='small' label={label} color={c.color} />
 }
 
 const TierSummary = ({ vms, t }: { vms: RecoveryPlan['vms']; t: any }) => {
@@ -387,63 +389,88 @@ export default function RecoveryPlansTab({
                   {t('siteRecovery.plans.actions')}
                 </Typography>
                 <Stack spacing={1}>
-                  {/* Cleanup only once the test finished — the orchestrator
-                      refuses it while the plan is still executing */}
-                  {selected.active_test_execution_id && selected.status !== 'executing' && (
-                    <Button
-                      variant='contained' size='small' color='warning' fullWidth
-                      startIcon={<i className='ri-eraser-line' />}
-                      onClick={() => onCleanupTest(selected.id)}
-                    >
-                      {t('siteRecovery.failover.cleanup')}
-                    </Button>
-                  )}
-                  <Tooltip
-                    title={selected.status === 'failed_over' ? t('siteRecovery.plans.failedOverTooltip') : t('siteRecovery.plans.testActiveTooltip')}
-                    disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over')}
-                    arrow
-                  >
-                    <span style={{ display: 'block' }}>
+                  {selected.status === 'failing_back' ? (
+                    <>
+                      <Button
+                        variant='contained' size='small' color='info' fullWidth
+                        startIcon={<i className='ri-arrow-go-back-line' />}
+                        onClick={() => onFailback(selected.id)}
+                      >
+                        {t('siteRecovery.plans.openFailback')}
+                      </Button>
+                      <Tooltip title={t('siteRecovery.plans.failingBackTooltip')} arrow>
+                        <span style={{ display: 'block' }}>
+                          <Button
+                            variant='outlined' size='small' color='error' fullWidth
+                            startIcon={<i className='ri-delete-bin-line' />}
+                            disabled
+                          >
+                            {t('common.delete')}
+                          </Button>
+                        </span>
+                      </Tooltip>
+                    </>
+                  ) : (
+                    <>
+                      {/* Cleanup only once the test finished — the orchestrator
+                          refuses it while the plan is still executing */}
+                      {selected.active_test_execution_id && selected.status !== 'executing' && (
+                        <Button
+                          variant='contained' size='small' color='warning' fullWidth
+                          startIcon={<i className='ri-eraser-line' />}
+                          onClick={() => onCleanupTest(selected.id)}
+                        >
+                          {t('siteRecovery.failover.cleanup')}
+                        </Button>
+                      )}
+                      <Tooltip
+                        title={selected.status === 'failed_over' ? t('siteRecovery.plans.failedOverTooltip') : t('siteRecovery.plans.testActiveTooltip')}
+                        disableHoverListener={!(selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over')}
+                        arrow
+                      >
+                        <span style={{ display: 'block' }}>
+                          <Button
+                            variant='outlined' size='small' fullWidth
+                            startIcon={<i className='ri-test-tube-line' />}
+                            onClick={() => onTestFailover(selected.id)}
+                            disabled={!!selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over'}
+                          >
+                            {t('siteRecovery.plans.testFailover')}
+                          </Button>
+                        </span>
+                      </Tooltip>
+                      <Tooltip
+                        title={t('siteRecovery.plans.failedOverTooltip')}
+                        disableHoverListener={selected.status !== 'failed_over'}
+                        arrow
+                      >
+                        <span style={{ display: 'block' }}>
+                          <Button
+                            variant='contained' size='small' color='warning' fullWidth
+                            startIcon={<i className='ri-shield-star-line' />}
+                            onClick={() => onFailover(selected.id)}
+                            disabled={selected.status === 'failed_over'}
+                          >
+                            {t('siteRecovery.plans.failover')}
+                          </Button>
+                        </span>
+                      </Tooltip>
                       <Button
                         variant='outlined' size='small' fullWidth
-                        startIcon={<i className='ri-test-tube-line' />}
-                        onClick={() => onTestFailover(selected.id)}
-                        disabled={!!selected.active_test_execution_id || selected.status === 'executing' || selected.status === 'failed_over'}
+                        startIcon={<i className='ri-arrow-go-back-line' />}
+                        onClick={() => onFailback(selected.id)}
                       >
-                        {t('siteRecovery.plans.testFailover')}
+                        {t('siteRecovery.plans.failback')}
                       </Button>
-                    </span>
-                  </Tooltip>
-                  <Tooltip
-                    title={t('siteRecovery.plans.failedOverTooltip')}
-                    disableHoverListener={selected.status !== 'failed_over'}
-                    arrow
-                  >
-                    <span style={{ display: 'block' }}>
                       <Button
-                        variant='contained' size='small' color='warning' fullWidth
-                        startIcon={<i className='ri-shield-star-line' />}
-                        onClick={() => onFailover(selected.id)}
-                        disabled={selected.status === 'failed_over'}
+                        variant='outlined' size='small' color='error' fullWidth
+                        startIcon={<i className='ri-delete-bin-line' />}
+                        onClick={() => { onDeletePlan(selected.id); closeDrawer() }}
                       >
-                        {t('siteRecovery.plans.failover')}
+                        {t('common.delete')}
                       </Button>
-                    </span>
-                  </Tooltip>
-                  <Button
-                    variant='outlined' size='small' fullWidth
-                    startIcon={<i className='ri-arrow-go-back-line' />}
-                    onClick={() => onFailback(selected.id)}
-                  >
-                    {t('siteRecovery.plans.failback')}
-                  </Button>
-                  <Button
-                    variant='outlined' size='small' color='error' fullWidth
-                    startIcon={<i className='ri-delete-bin-line' />}
-                    onClick={() => { onDeletePlan(selected.id); closeDrawer() }}
-                  >
-                    {t('common.delete')}
-                  </Button>
+                    </>
+                  )}
                 </Stack>
               </Box>
             </>

--- a/frontend/src/components/automation/site-recovery/RetentionSlider.tsx
+++ b/frontend/src/components/automation/site-recovery/RetentionSlider.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Box, Slider, Typography } from '@mui/material'
+
+import NumericTextField from '@/components/ui/NumericTextField'
+
+// The slider covers the practical range; the field stays authoritative up to
+// the backend cap of 500 and pins the slider at its max beyond SLIDER_MAX.
+const SLIDER_MAX = 50
+
+const MARKS = [2, 10, 25, 50].map(v => ({ value: v, label: String(v) }))
+
+interface RetentionSliderProps {
+  label: string
+  value: number
+  onChange: (value: number) => void
+  helperText?: string
+}
+
+export default function RetentionSlider({ label, value, onChange, helperText }: RetentionSliderProps) {
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, mb: 0.5 }}>
+        <Typography variant='body2' sx={{ fontWeight: 500 }}>{label}</Typography>
+        <NumericTextField
+          type='number'
+          size='small'
+          value={value}
+          onChange={onChange}
+          fallback={3}
+          min={2}
+          max={500}
+          sx={{ width: 120 }}
+          inputProps={{ min: 2, max: 500, 'aria-label': label }}
+        />
+      </Box>
+      <Slider
+        aria-label={label}
+        value={Math.min(value, SLIDER_MAX)}
+        onChange={(_, val) => onChange(val as number)}
+        min={2}
+        max={SLIDER_MAX}
+        step={1}
+        marks={MARKS}
+        valueLabelDisplay='auto'
+        sx={{ '& .MuiSlider-markLabel': { fontSize: '0.65rem' } }}
+      />
+      {helperText && (
+        <Typography variant='caption' sx={{ color: 'text.secondary', display: 'block' }}>{helperText}</Typography>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
+++ b/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
@@ -34,7 +34,7 @@ interface Connection {
 
 interface Props {
   connections: Connection[]
-  vmNameMap?: Record<number, string>
+  vmNamesByConn?: Record<string, Record<number, string>>
 }
 
 function formatBytes(b: number | undefined | null): string {
@@ -53,7 +53,7 @@ function formatAge(ts: number): string {
   return `${Math.floor(diff / 86400)}d`
 }
 
-export default function SnapshotsTab({ connections, vmNameMap }: Props) {
+export default function SnapshotsTab({ connections, vmNamesByConn }: Props) {
   const t = useTranslations()
 
   const [snaps, setSnaps] = useState<MirrorSnapshot[] | null>(null)
@@ -105,7 +105,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
       if (statusFilter === 'orphan' && !s.is_orphan) return false
       if (statusFilter === 'active' && s.is_orphan) return false
       if (!qq) return true
-      const vmName = s.vmid ? vmNameMap?.[s.vmid] : undefined
+      const vmName = s.vmid ? vmNamesByConn?.[s.cluster_id]?.[s.vmid] : undefined
       return (
         s.cluster_name?.toLowerCase().includes(qq) ||
         s.pool?.toLowerCase().includes(qq) ||
@@ -115,7 +115,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
         (vmName?.toLowerCase().includes(qq) ?? false)
       )
     })
-  }, [snaps, q, clusterFilter, statusFilter, vmNameMap])
+  }, [snaps, q, clusterFilter, statusFilter, vmNamesByConn])
 
   // Reset page when filters change and current page would be out of range
   useEffect(() => {
@@ -340,7 +340,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
             <TableBody>
               {paged.map(s => {
                 const k = key(s)
-                const vmName = s.vmid ? vmNameMap?.[s.vmid] : undefined
+                const vmName = s.vmid ? vmNamesByConn?.[s.cluster_id]?.[s.vmid] : undefined
                 return (
                   <TableRow key={k} hover selected={selected.has(k)}>
                     <TableCell padding='checkbox'>
@@ -438,7 +438,7 @@ export default function SnapshotsTab({ connections, vmNameMap }: Props) {
               {!!detail.vmid && (
                 <Box>
                   <Typography variant='caption' color='text.secondary'>{t('siteRecovery.snapshots.vm')}</Typography>
-                  <Typography variant='body2'>{detail.vmid}{vmNameMap?.[detail.vmid] ? ` · ${vmNameMap[detail.vmid]}` : ''}</Typography>
+                  <Typography variant='body2'>{detail.vmid}{vmNamesByConn?.[detail.cluster_id]?.[detail.vmid] ? ` · ${vmNamesByConn[detail.cluster_id][detail.vmid]}` : ''}</Typography>
                 </Box>
               )}
               <Box>

--- a/frontend/src/lib/orchestrator/client.test.ts
+++ b/frontend/src/lib/orchestrator/client.test.ts
@@ -215,4 +215,109 @@ describe('OrchestratorClient axios-style wrapper', () => {
     const [url] = fetchMock.mock.calls[0]
     expect(url).toBe('http://localhost:8080/api/v1/drs/recommendations?validate=true')
   })
+
+  it('getPlanRestorePoints hits /replication/plans/<id>/restore-points with GET', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ vms: [] }))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().getPlanRestorePoints('plan-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/plans/plan-1/restore-points')
+    expect(init.method).toBe('GET')
+  })
+
+  it('executeFailover forwards the restore_points body on POST', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 'exec-1' }))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().executeFailover('plan-1', { restore_points: { 100: 'snap-1' } })
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/plans/plan-1/failover')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ restore_points: { 100: 'snap-1' } }))
+  })
+
+  it('failbackCutover hits /replication/plans/<id>/failback-cutover with POST', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'cutover_started' }))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().failbackCutover('plan-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/plans/plan-1/failback-cutover')
+    expect(init.method).toBe('POST')
+  })
+
+  it('failbackCancel hits /replication/plans/<id>/failback-cancel with POST', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'cancelled' }))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().failbackCancel('plan-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/plans/plan-1/failback-cancel')
+    expect(init.method).toBe('POST')
+  })
+
+  it('clearRecoveryHistory hits /replication/plans/<id>/history with DELETE', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ deleted: 3 }))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().clearRecoveryHistory('plan-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/plans/plan-1/history')
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('getExecutionScreenshots hits /replication/executions/<id>/screenshots with GET', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().getExecutionScreenshots('exec-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/executions/exec-1/screenshots')
+    expect(init.method).toBe('GET')
+  })
+})
+
+describe('parseOrchestratorError', () => {
+  it('returns null when the error message does not match the Orchestrator <status>: <body> shape', async () => {
+    const { parseOrchestratorError } = await import('./client')
+
+    expect(parseOrchestratorError(new Error('TLS handshake failed'))).toBeNull()
+    expect(parseOrchestratorError('a plain string')).toBeNull()
+    expect(parseOrchestratorError(undefined)).toBeNull()
+  })
+
+  it('extracts the status and message from a JSON error body', async () => {
+    const { parseOrchestratorError } = await import('./client')
+    const error = new Error(`Orchestrator 409: ${JSON.stringify({ error: 'a failback is already in progress' })}`)
+
+    expect(parseOrchestratorError(error)).toEqual({ status: 409, message: 'a failback is already in progress' })
+  })
+
+  it('falls back to the raw body text when the JSON has no error field', async () => {
+    const { parseOrchestratorError } = await import('./client')
+    const error = new Error(`Orchestrator 500: ${JSON.stringify({ code: 'internal' })}`)
+
+    expect(parseOrchestratorError(error)).toEqual({ status: 500, message: JSON.stringify({ code: 'internal' }) })
+  })
+
+  it('falls back to the raw body text when the body is not JSON', async () => {
+    const { parseOrchestratorError } = await import('./client')
+    const error = new Error('Orchestrator 502: bad gateway upstream')
+
+    expect(parseOrchestratorError(error)).toEqual({ status: 502, message: 'bad gateway upstream' })
+  })
+
+  it('falls back to a generic message when the body is empty', async () => {
+    const { parseOrchestratorError } = await import('./client')
+    const error = new Error('Orchestrator 503: ')
+
+    expect(parseOrchestratorError(error)).toEqual({ status: 503, message: 'Orchestrator error 503' })
+  })
 })

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -534,6 +534,10 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
     return this.get<any[]>(`/replication/plans/${planId}/history`)
   }
 
+  clearRecoveryHistory(planId: string) {
+    return this.delete<any>(`/replication/plans/${planId}/history`)
+  }
+
   getExecution(id: string) {
     return this.get<any>(`/replication/executions/${id}`)
   }

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -537,6 +537,10 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
   getExecution(id: string) {
     return this.get<any>(`/replication/executions/${id}`)
   }
+
+  getExecutionScreenshots(id: string) {
+    return this.get<{ vm_id: number; target_vmid: number; captured_at: string }[]>(`/replication/executions/${id}/screenshots`)
+  }
 }
 
 // ============================================

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -86,6 +86,38 @@ export async function orchestratorFetch<T>(
   }
 }
 
+/**
+ * Extract the upstream HTTP status and error message from an Error thrown by
+ * orchestratorFetch on a non-OK response (message shape:
+ * `Orchestrator ${status}: ${rawBody}`). Route handlers use this to pass an
+ * upstream conflict/validation response (e.g. 409 `{error: "..."}`) straight
+ * through instead of collapsing everything to a generic 500.
+ *
+ * Returns null when the error doesn't match that shape (timeouts, connection
+ * failures, etc.) — callers should fall back to a 500 in that case.
+ */
+export function parseOrchestratorError(error: unknown): { status: number; message: string } | null {
+  const raw = error instanceof Error ? error.message : typeof error === 'string' ? error : ''
+  const match = /^Orchestrator (\d+): ([\s\S]*)$/.exec(raw)
+
+  if (!match) return null
+
+  const status = Number(match[1])
+  const body = match[2].trim()
+
+  try {
+    const parsed = JSON.parse(body)
+
+    if (parsed && typeof parsed.error === 'string' && parsed.error) {
+      return { status, message: parsed.error }
+    }
+  } catch {
+    // Not JSON — fall through to the raw body text below
+  }
+
+  return { status, message: body || `Orchestrator error ${status}` }
+}
+
 // ============================================
 // Types DRS
 // ============================================
@@ -516,6 +548,14 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
 
   executeFailback(planId: string) {
     return this.post<any>(`/replication/plans/${planId}/failback`)
+  }
+
+  failbackCutover(planId: string) {
+    return this.post<any>(`/replication/plans/${planId}/failback-cutover`)
+  }
+
+  failbackCancel(planId: string) {
+    return this.post<any>(`/replication/plans/${planId}/failback-cancel`)
   }
 
   cleanupTestFailover(planId: string) {

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -490,6 +490,10 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
     return this.get<any>(`/replication/plans/${id}`)
   }
 
+  getPlanRestorePoints(planId: string) {
+    return this.get<any>(`/replication/plans/${planId}/restore-points`)
+  }
+
   createRecoveryPlan(body: any) {
     return this.post<any>('/replication/plans', body)
   }
@@ -502,12 +506,12 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
     return this.delete<{ status: string }>(`/replication/plans/${id}`)
   }
 
-  testFailover(planId: string, body?: { network_isolated?: boolean }) {
+  testFailover(planId: string, body?: { network_isolated?: boolean; restore_points?: Record<number, string> }) {
     return this.post<any>(`/replication/plans/${planId}/test-failover`, body)
   }
 
-  executeFailover(planId: string) {
-    return this.post<any>(`/replication/plans/${planId}/failover`)
+  executeFailover(planId: string, body?: { restore_points?: Record<number, string> }) {
+    return this.post<any>(`/replication/plans/${planId}/failover`, body)
   }
 
   executeFailback(planId: string) {

--- a/frontend/src/lib/orchestrator/executionScope.test.ts
+++ b/frontend/src/lib/orchestrator/executionScope.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getExecutionMock = vi.fn()
+const getRecoveryPlanMock = vi.fn()
+const getTenantConnectionIdsMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getExecution: (...args: unknown[]) => getExecutionMock(...args),
+    getRecoveryPlan: (...args: unknown[]) => getRecoveryPlanMock(...args),
+  }),
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: () => getTenantConnectionIdsMock(),
+}))
+
+import { checkExecutionTenantScope } from './executionScope'
+
+beforeEach(() => {
+  getExecutionMock.mockReset()
+  getRecoveryPlanMock.mockReset()
+  getTenantConnectionIdsMock.mockReset().mockResolvedValue(new Set(['conn-src', 'conn-dst']))
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('checkExecutionTenantScope', () => {
+  it('traces back to the plan and allows access when the plan is in-tenant', async () => {
+    getExecutionMock.mockResolvedValue({ data: { id: 'exec-1', plan_id: 'plan-1' } })
+    getRecoveryPlanMock.mockResolvedValue({ data: { source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
+
+    const result = await checkExecutionTenantScope('exec-1')
+
+    expect(result.denied).toBeNull()
+    expect(result.execution).toEqual({ id: 'exec-1', plan_id: 'plan-1' })
+  })
+
+  it('denies access when the plan traced back via plan_id belongs to another tenant', async () => {
+    getExecutionMock.mockResolvedValue({ data: { id: 'exec-1', plan_id: 'plan-1' } })
+    getRecoveryPlanMock.mockResolvedValue({ data: { source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const result = await checkExecutionTenantScope('exec-1')
+
+    expect(result.denied).not.toBeNull()
+    expect(result.denied?.status).toBe(404)
+    expect(await result.denied?.json()).toEqual({ error: 'Not found' })
+  })
+
+  it('keeps the execution visible when the plan lookup throws (plan deleted)', async () => {
+    getExecutionMock.mockResolvedValue({ data: { id: 'exec-1', plan_id: 'plan-deleted' } })
+    getRecoveryPlanMock.mockRejectedValue(new Error('Orchestrator 404: plan not found'))
+
+    const result = await checkExecutionTenantScope('exec-1')
+
+    expect(result.denied).toBeNull()
+    expect(result.execution).toEqual({ id: 'exec-1', plan_id: 'plan-deleted' })
+  })
+
+  it('falls back to the execution own cluster fields when there is no plan_id', async () => {
+    getExecutionMock.mockResolvedValue({ data: { id: 'exec-1', source_cluster: 'conn-src', target_cluster: 'conn-dst' } })
+
+    const result = await checkExecutionTenantScope('exec-1')
+
+    expect(result.denied).toBeNull()
+    expect(getRecoveryPlanMock).not.toHaveBeenCalled()
+  })
+
+  it('denies access via the execution own cluster fields when out of tenant scope and there is no plan_id', async () => {
+    getExecutionMock.mockResolvedValue({ data: { id: 'exec-1', source_cluster: 'foreign', target_cluster: 'conn-dst' } })
+
+    const result = await checkExecutionTenantScope('exec-1')
+
+    expect(result.denied).not.toBeNull()
+    expect(result.denied?.status).toBe(404)
+    expect(getRecoveryPlanMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/orchestrator/executionScope.ts
+++ b/frontend/src/lib/orchestrator/executionScope.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server"
+
+import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { getTenantConnectionIds } from "@/lib/tenant"
+
+/**
+ * Tenant-scope guard for execution-scoped routes: resolves the execution,
+ * traces back to its plan and verifies the plan's clusters belong to the
+ * current tenant (same rules as the execution detail route). Returns the
+ * denial response to send, or null when access is allowed.
+ */
+export async function denyExecutionOutsideTenant(executionId: string): Promise<NextResponse | null> {
+  const client = getOrchestratorClient()
+  const response = await client.getExecution(executionId)
+  const execution = response.data
+  const tenantConnectionIds = await getTenantConnectionIds()
+
+  if (execution?.plan_id) {
+    try {
+      const planResponse = await client.getRecoveryPlan(execution.plan_id)
+      const plan = planResponse.data
+
+      if (
+        plan &&
+        ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
+        (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
+      ) {
+        return NextResponse.json({ error: "Not found" }, { status: 404 })
+      }
+    } catch {
+      // Plan may have been deleted; keep the execution visible, consistent
+      // with the execution detail route.
+    }
+  } else if (
+    execution &&
+    ((execution.source_cluster && !tenantConnectionIds.has(execution.source_cluster)) ||
+    (execution.target_cluster && !tenantConnectionIds.has(execution.target_cluster)))
+  ) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return null
+}

--- a/frontend/src/lib/orchestrator/executionScope.ts
+++ b/frontend/src/lib/orchestrator/executionScope.ts
@@ -4,12 +4,14 @@ import { getOrchestratorClient } from "@/lib/orchestrator/client"
 import { getTenantConnectionIds } from "@/lib/tenant"
 
 /**
- * Tenant-scope guard for execution-scoped routes: resolves the execution,
+ * Tenant-scope guard for execution-scoped routes: fetches the execution,
  * traces back to its plan and verifies the plan's clusters belong to the
- * current tenant (same rules as the execution detail route). Returns the
- * denial response to send, or null when access is allowed.
+ * current tenant (same rules as the execution detail route). Returns both
+ * the fetched execution and the denial response to send (or null when
+ * access is allowed), so callers that also need the execution body — the
+ * detail route — don't have to fetch it a second time.
  */
-export async function denyExecutionOutsideTenant(executionId: string): Promise<NextResponse | null> {
+export async function checkExecutionTenantScope(executionId: string): Promise<{ denied: NextResponse | null; execution: any }> {
   const client = getOrchestratorClient()
   const response = await client.getExecution(executionId)
   const execution = response.data
@@ -25,7 +27,7 @@ export async function denyExecutionOutsideTenant(executionId: string): Promise<N
         ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
         (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
       ) {
-        return NextResponse.json({ error: "Not found" }, { status: 404 })
+        return { denied: NextResponse.json({ error: "Not found" }, { status: 404 }), execution }
       }
     } catch {
       // Plan may have been deleted; keep the execution visible, consistent
@@ -36,8 +38,8 @@ export async function denyExecutionOutsideTenant(executionId: string): Promise<N
     ((execution.source_cluster && !tenantConnectionIds.has(execution.source_cluster)) ||
     (execution.target_cluster && !tenantConnectionIds.has(execution.target_cluster)))
   ) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 })
+    return { denied: NextResponse.json({ error: "Not found" }, { status: 404 }), execution }
   }
 
-  return null
+  return { denied: null, execution }
 }

--- a/frontend/src/lib/orchestrator/planFailbackProxy.ts
+++ b/frontend/src/lib/orchestrator/planFailbackProxy.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server"
+
+import { getOrchestratorClient, parseOrchestratorError } from "@/lib/orchestrator/client"
+import { checkPlanTenantScope } from "@/lib/orchestrator/planTenantScope"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+
+type OrchestratorClient = ReturnType<typeof getOrchestratorClient>
+
+export interface ProxyPlanFailbackActionOptions {
+  /** Invokes the plan-scoped orchestrator action, e.g. (client, id) => client.executeFailback(id). */
+  action: (client: OrchestratorClient, id: string) => Promise<{ data: any }>
+  /** Label passed to console.error when a non-ORCHESTRATOR_UNAVAILABLE error is caught. */
+  logLabel: string
+  /** Fallback error message used when the caught error has none of its own. */
+  fallbackMessage: string
+}
+
+/**
+ * Shared body for the three failback-family POST routes (failback,
+ * failback-cutover, failback-cancel): permission check, tenant-scoped plan
+ * lookup, the orchestrator action call, and upstream-error passthrough.
+ * Each route only differs by which client method it calls and the
+ * log/fallback strings, both supplied via `options`.
+ */
+export async function proxyPlanFailbackAction(
+  params: Promise<{ id: string }>,
+  options: ProxyPlanFailbackActionOptions,
+): Promise<NextResponse> {
+  const { action, logLabel, fallbackMessage } = options
+
+  try {
+    const denied = await checkPermission(PERMISSIONS.AUTOMATION_MANAGE, "global", "*")
+
+    if (denied) return denied
+
+    const { id } = await params
+    const { denied: scopeDenied } = await checkPlanTenantScope(id)
+
+    if (scopeDenied) return scopeDenied
+
+    const response = await action(getOrchestratorClient(), id)
+
+    return NextResponse.json(response.data)
+  } catch (e: any) {
+    if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
+      console.error(logLabel, e)
+    }
+
+    const upstream = parseOrchestratorError(e)
+
+    if (upstream) {
+      return NextResponse.json({ error: upstream.message }, { status: upstream.status })
+    }
+
+    return NextResponse.json(
+      { error: e?.message || fallbackMessage },
+      { status: 500 }
+    )
+  }
+}

--- a/frontend/src/lib/orchestrator/planTenantScope.ts
+++ b/frontend/src/lib/orchestrator/planTenantScope.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server"
+
+import { getOrchestratorClient } from "@/lib/orchestrator/client"
+import { getTenantConnectionIds } from "@/lib/tenant"
+
+/**
+ * Tenant-scope guard shared by every recovery-plan route: fetches the plan
+ * and verifies its source/target clusters belong to the current tenant.
+ * Returns both the fetched plan and the denial response to send (or null
+ * when access is allowed), so callers that also need the plan body don't
+ * have to fetch it a second time.
+ *
+ * Mirrors checkExecutionTenantScope's shape/contract for execution routes.
+ */
+export async function checkPlanTenantScope(planId: string): Promise<{ denied: NextResponse | null; plan: any }> {
+  const client = getOrchestratorClient()
+  const tenantConnectionIds = await getTenantConnectionIds()
+  const planResponse = await client.getRecoveryPlan(planId)
+  const plan = planResponse.data
+
+  if (
+    plan &&
+    ((plan.source_cluster && !tenantConnectionIds.has(plan.source_cluster)) ||
+    (plan.target_cluster && !tenantConnectionIds.has(plan.target_cluster)))
+  ) {
+    return { denied: NextResponse.json({ error: "Not found" }, { status: 404 }), plan }
+  }
+
+  return { denied: null, plan }
+}

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -171,6 +171,11 @@ export interface RecoveryVMResult {
   error?: string
   target_node?: string
   target_vmid?: number
+  // Fine-grained machine code for where a REAL failover currently stands for
+  // this VM: 'fencing', 'restoring', 'starting'. Cleared ("") once the VM
+  // reaches 'completed'; left in place on failure. Never set for a test
+  // failover. The UI maps the code to translated prose (siteRecovery.failover.step.*).
+  step?: string
 }
 
 export interface RecoveryExecution {

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -6,7 +6,7 @@ import type { ScheduleSpec } from '@/components/automation/site-recovery/schedul
 // Replication Jobs
 // ============================================
 
-export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending'
+export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending' | 'failed_over'
 
 export interface BandwidthWindow {
   days: number[]          // 0=Sun, 1=Mon, …, 6=Sat

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -42,6 +42,8 @@ export interface ReplicationJob {
   error_message?: string
   created_at: string
   updated_at: string
+  snapshot_keep_source?: number
+  snapshot_keep_target?: number
 }
 
 export interface CreateReplicationJobRequest {
@@ -60,6 +62,8 @@ export interface CreateReplicationJobRequest {
   vmid_prefix?: number
   install_pv?: boolean
   network_mapping: Record<string, string>
+  snapshot_keep_source?: number
+  snapshot_keep_target?: number
 }
 
 export interface UpdateReplicationJobRequest {
@@ -71,6 +75,8 @@ export interface UpdateReplicationJobRequest {
   rate_limit_mbps?: number
   bandwidth_windows?: BandwidthWindow[]
   network_mapping?: Record<string, string>
+  snapshot_keep_source?: number
+  snapshot_keep_target?: number
 }
 
 export interface ReplicationJobLog {
@@ -122,6 +128,32 @@ export interface UpdateRecoveryPlanRequest {
   name?: string
   description?: string
   vms?: Array<{ vm_id: number; tier: 1 | 2 | 3; boot_order: number }>
+}
+
+// ============================================
+// Restore Points
+// ============================================
+
+export interface RestorePoint {
+  snapshot: string
+  created_ts: number
+  created_iso: string
+}
+
+export interface VMRestorePoints {
+  vm_id: number
+  vm_name: string
+  target_vmid: number
+  job_id?: string
+  disk_count: number
+  restore_points: RestorePoint[]
+  error?: string
+}
+
+export interface PlanRestorePoints {
+  plan_id: string
+  target_cluster: string
+  vms: VMRestorePoints[]
 }
 
 // ============================================

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -187,6 +187,10 @@ export interface RecoveryExecution {
   // 'stabilizing', 'capturing', then cleared once it's done. Only ever set
   // for type === 'test'.
   phase?: string
+  // Deadline for the current 'stabilizing' phase (ISO timestamp), so the
+  // frontend can show a live countdown instead of an indefinite spinner.
+  // Cleared alongside phase for every other phase/transition.
+  phase_ends_at?: string
 }
 
 // ============================================

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -182,6 +182,11 @@ export interface RecoveryExecution {
   started_at: string
   completed_at?: string
   vm_results: RecoveryVMResult[]
+  // Fine-grained progress marker for a running test failover, set past VM
+  // boot as the post-boot screenshot pipeline advances: 'booting',
+  // 'stabilizing', 'capturing', then cleared once it's done. Only ever set
+  // for type === 'test'.
+  phase?: string
 }
 
 // ============================================

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -91,7 +91,7 @@ export interface ReplicationJobLog {
 // Recovery Plans
 // ============================================
 
-export type RecoveryPlanStatus = 'ready' | 'degraded' | 'executing' | 'failed' | 'not_ready' | 'failed_over'
+export type RecoveryPlanStatus = 'ready' | 'degraded' | 'executing' | 'failed' | 'not_ready' | 'failed_over' | 'failing_back'
 
 export interface RecoveryPlanVM {
   vm_id: number
@@ -112,6 +112,7 @@ export interface RecoveryPlan {
   last_test: string | null
   last_failover: string | null
   active_test_execution_id?: string | null
+  active_failback_execution_id?: string | null
   created_at: string
   updated_at: string
 }
@@ -171,11 +172,19 @@ export interface RecoveryVMResult {
   error?: string
   target_node?: string
   target_vmid?: number
-  // Fine-grained machine code for where a REAL failover currently stands for
-  // this VM: 'fencing', 'restoring', 'starting'. Cleared ("") once the VM
-  // reaches 'completed'; left in place on failure. Never set for a test
-  // failover. The UI maps the code to translated prose (siteRecovery.failover.step.*).
+  // Fine-grained machine code for where a REAL failover or an in-progress
+  // failback currently stands for this VM: 'fencing', 'restoring', 'starting'
+  // (failover), or a reverse-sync/cutover step code (failback). Cleared ("")
+  // once the VM reaches 'completed'; left in place on failure. Never set for
+  // a test failover. The UI maps the code to translated prose
+  // (siteRecovery.failover.step.*).
   step?: string
+  // Reverse-sync progress for a failback in phase 'reverse_sync': when this
+  // VM's per-disk delta was last transferred back to the source, and how
+  // many bytes it carried. Absent until the first reverse-sync pass for the
+  // VM completes.
+  last_reverse_sync_at?: string
+  last_reverse_sync_bytes?: number
 }
 
 export interface RecoveryExecution {
@@ -187,10 +196,12 @@ export interface RecoveryExecution {
   started_at: string
   completed_at?: string
   vm_results: RecoveryVMResult[]
-  // Fine-grained progress marker for a running test failover, set past VM
-  // boot as the post-boot screenshot pipeline advances: 'booting',
-  // 'stabilizing', 'capturing', then cleared once it's done. Only ever set
-  // for type === 'test'.
+  // Fine-grained progress marker for a running execution. For type === 'test',
+  // set past VM boot as the post-boot screenshot pipeline advances: 'booting',
+  // 'stabilizing', 'capturing', then cleared once it's done. For
+  // type === 'failback', tracks the two-phase flow: 'reverse_sync' (ongoing
+  // convergence loop back to source) then 'cutover' (operator-triggered
+  // switchback), cleared once the failback completes.
   phase?: string
   // Deadline for the current 'stabilizing' phase (ISO timestamp), so the
   // frontend can show a live countdown instead of an indefinite spinner.

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -105,6 +105,7 @@ export interface RecoveryPlan {
   vms: RecoveryPlanVM[]
   last_test: string | null
   last_failover: string | null
+  active_test_execution_id?: string | null
   created_at: string
   updated_at: string
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4277,6 +4277,10 @@
       "restorePointsLoadFailed": "Wiederherstellungspunkte konnten nicht geladen werden, der neueste replizierte Zustand wird verwendet.",
       "restorePointRebaseWarning": "Ein Failover auf einen älteren Wiederherstellungspunkt löscht dauerhaft die neueren DR-Snapshots dieser VM."
     },
+    "screenshots": {
+      "view": "Boot-Screenshot ansehen",
+      "capturedAt": "Aufgenommen um"
+    },
     "emergencyDR": {
       "title": "Notfall-DR",
       "noVMs": "Keine DR-bereiten VMs",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4282,7 +4282,15 @@
       "restorePointsHelp": "Jede VM startet vom ausgewählten replizierten Snapshot.",
       "restorePointsNone": "Keine Wiederherstellungspunkte",
       "restorePointsLoadFailed": "Wiederherstellungspunkte konnten nicht geladen werden, der neueste replizierte Zustand wird verwendet.",
-      "restorePointRebaseWarning": "Ein Failover auf einen älteren Wiederherstellungspunkt löscht dauerhaft die neueren DR-Snapshots dieser VM."
+      "restorePointRebaseWarning": "Ein Failover auf einen älteren Wiederherstellungspunkt löscht dauerhaft die neueren DR-Snapshots dieser VM.",
+      "step": {
+        "fencing": "Quell-VM wird gestoppt",
+        "restoring": "Zurücksetzen auf den gewählten Wiederherstellungspunkt",
+        "starting": "Start auf dem DR-Standort"
+      },
+      "completeTitle": "Failover abgeschlossen",
+      "completeVMs": "VM(s) laufen jetzt am DR-Standort",
+      "completeLocked": "Die Replikation ist gesperrt und der Plan ist umgeschaltet — Failback bringt ihn zurück."
     },
     "screenshots": {
       "view": "Boot-Screenshot ansehen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4180,6 +4180,11 @@
       "sshFailed": "Direct SSH connection fehlgeschlagen",
       "sshRequirement": "Passwortloses SSH muss zwischen Quell- und Ziel-Cluster konfiguriert sein. Stellen Sie sicher, dass Root sich ohne Passwortabfrage per SSH vom Quell- zum Ziel-Cluster verbinden kann.",
       "sshRetry": "Wiederholen",
+      "snapshotRetention": "Snapshot-Aufbewahrung",
+      "snapshotRetentionHelp": "Anzahl der pro Datenträger nach jeder Synchronisierung aufbewahrten Spiegel-Snapshots (mindestens 2).",
+      "retentionSource": "Aufbewahren auf der Quelle",
+      "retentionTarget": "Aufbewahren auf dem Ziel (DR)",
+      "retentionTargetHelp": "Mehr Snapshots auf der DR-Seite bedeuten mehr Wiederherstellungspunkte, kosten aber mehr Ceph-Kapazität.",
       "vmidPrefix": "VMID-Präfix",
       "vmidPrefixHelp": "Präfix für VM-IDs auf dem Ziel-Cluster (z.B. Präfix 9 + VM 100 = 9100). Leer oder 0 lassen, um die gleiche VMID beizubehalten.",
       "engine": "Replikation Engine",
@@ -4262,7 +4267,13 @@
       "disksRolledBack": "RBD-Festplatte(n) zurückgesetzt",
       "jobsResumed": "Replikation job(s) resumed",
       "testActiveBanner": "Ein am {date} gestarteter Test-Failover wartet auf die Bereinigung. Test-VMs könnten noch auf dem DR-Standort laufen.",
-      "testConflict": "Für diesen Plan ist bereits ein Test-Failover aktiv. Bereinigen Sie ihn zuerst."
+      "testConflict": "Für diesen Plan ist bereits ein Test-Failover aktiv. Bereinigen Sie ihn zuerst.",
+      "restorePoint": "Wiederherstellungspunkt",
+      "restorePointLatest": "Neuester (Standard)",
+      "restorePointsHelp": "Jede VM startet vom ausgewählten replizierten Snapshot.",
+      "restorePointsNone": "Keine Wiederherstellungspunkte",
+      "restorePointsLoadFailed": "Wiederherstellungspunkte konnten nicht geladen werden, der neueste replizierte Zustand wird verwendet.",
+      "restorePointRebaseWarning": "Ein Failover auf einen älteren Wiederherstellungspunkt löscht dauerhaft die neueren DR-Snapshots dieser VM."
     },
     "emergencyDR": {
       "title": "Notfall-DR",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4135,6 +4135,8 @@
       "tierImportant": "Wichtig",
       "tierStandard": "Standard",
       "executionHistory": "Execution Verlauf",
+      "clearHistory": "Verlauf leeren",
+      "clearHistoryConfirm": "Alle bisherigen Ausführungen dieses Plans löschen? Boot-Screenshots werden mit gelöscht. Die aktive Testausführung bleibt erhalten.",
       "actions": "Aktionen",
       "testFailover": "Failover testen",
       "failover": "Failover",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4142,6 +4142,7 @@
       "deletePlan": "Wiederherstellungsplan löschen",
       "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
       "cleanupPending": "Bereinigung ausstehend",
+      "testRunning": "Test-Failover läuft",
       "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten."
     },
     "rpoTargetLabel": "RPO-Ziel",
@@ -4270,6 +4271,7 @@
       "testConflict": "Für diesen Plan ist bereits ein Test-Failover aktiv. Bereinigen Sie ihn zuerst.",
       "restorePoint": "Wiederherstellungspunkt",
       "restorePointLatest": "Neuester (Standard)",
+      "restorePointChoose": "Wiederherstellungspunkt wählen",
       "restorePointsHelp": "Jede VM startet vom ausgewählten replizierten Snapshot.",
       "restorePointsNone": "Keine Wiederherstellungspunkte",
       "restorePointsLoadFailed": "Wiederherstellungspunkte konnten nicht geladen werden, der neueste replizierte Zustand wird verwendet.",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4279,7 +4279,10 @@
     },
     "screenshots": {
       "view": "Boot-Screenshot ansehen",
-      "capturedAt": "Aufgenommen um"
+      "capturedAt": "Aufgenommen um",
+      "stepBoot": "VMs werden gestartet",
+      "stepStabilize": "Warten auf Stabilisierung",
+      "stepCapture": "Boot-Screenshots werden aufgenommen"
     },
     "emergencyDR": {
       "title": "Notfall-DR",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4140,7 +4140,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Wiederherstellungsplan löschen",
-      "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+      "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+      "cleanupPending": "Bereinigung ausstehend",
+      "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten."
     },
     "rpoTargetLabel": "RPO-Ziel",
     "createJob": {
@@ -4258,7 +4260,9 @@
       "cleanupDone": "Cleanup abgeschlossen",
       "stopped": "Gestoppt",
       "disksRolledBack": "RBD-Festplatte(n) zurückgesetzt",
-      "jobsResumed": "Replikation job(s) resumed"
+      "jobsResumed": "Replikation job(s) resumed",
+      "testActiveBanner": "Ein am {date} gestarteter Test-Failover wartet auf die Bereinigung. Test-VMs könnten noch auf dem DR-Standort laufen.",
+      "testConflict": "Für diesen Plan ist bereits ein Test-Failover aktiv. Bereinigen Sie ihn zuerst."
     },
     "emergencyDR": {
       "title": "Notfall-DR",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4300,6 +4300,9 @@
       "completeLocked": "Die Replikation ist gesperrt und der Plan ist umgeschaltet — Failback bringt ihn zurück."
     },
     "failback": {
+      "phase1Title": "Umgekehrte Replikation läuft",
+      "colLastSync": "Letzter Reverse-Sync",
+      "colTransferred": "Übertragen",
       "phase1Help": "Die umgekehrte Replikation läuft, während die DR-VMs online bleiben. Starten Sie das Cutover, wenn der letzte Sync aktuell genug ist.",
       "neverSynced": "Noch kein Reverse-Sync",
       "cutoverNotReady": "Warten auf den ersten Reverse-Sync jeder VM",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4302,6 +4302,7 @@
     "failback": {
       "phase1Help": "Die umgekehrte Replikation läuft, während die DR-VMs online bleiben. Starten Sie das Cutover, wenn der letzte Sync aktuell genug ist.",
       "neverSynced": "Noch kein Reverse-Sync",
+      "cutoverNotReady": "Warten auf den ersten Reverse-Sync jeder VM",
       "cutover": "Cutover",
       "cutoverConfirm": "DR-VMs stoppen, letztes Delta anwenden und Quell-VMs starten?",
       "cancelFailback": "Failback abbrechen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4150,7 +4150,10 @@
       "cleanupPending": "Bereinigung ausstehend",
       "testRunning": "Test-Failover läuft",
       "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten.",
-      "failedOverTooltip": "Plan ist umgeschaltet — nur Failback ist möglich."
+      "failedOverTooltip": "Plan ist umgeschaltet — nur Failback ist möglich.",
+      "statusFailingBack": "Failback läuft",
+      "openFailback": "Failback öffnen",
+      "failingBackTooltip": "Failback abbrechen, bevor dieser Plan gelöscht wird."
     },
     "rpoTargetLabel": "RPO-Ziel",
     "createJob": {
@@ -4286,11 +4289,25 @@
       "step": {
         "fencing": "Quell-VM wird gestoppt",
         "restoring": "Zurücksetzen auf den gewählten Wiederherstellungspunkt",
-        "starting": "Start auf dem DR-Standort"
+        "starting": "Start auf dem DR-Standort",
+        "fencing_dr": "DR-VM wird gestoppt",
+        "final_sync": "Letztes Delta wird angewendet",
+        "starting_source": "Start am Quellstandort",
+        "reprotect": "Schutz wird wiederhergestellt"
       },
       "completeTitle": "Failover abgeschlossen",
       "completeVMs": "VM(s) laufen jetzt am DR-Standort",
       "completeLocked": "Die Replikation ist gesperrt und der Plan ist umgeschaltet — Failback bringt ihn zurück."
+    },
+    "failback": {
+      "phase1Help": "Die umgekehrte Replikation läuft, während die DR-VMs online bleiben. Starten Sie das Cutover, wenn der letzte Sync aktuell genug ist.",
+      "neverSynced": "Noch kein Reverse-Sync",
+      "cutover": "Cutover",
+      "cutoverConfirm": "DR-VMs stoppen, letztes Delta anwenden und Quell-VMs starten?",
+      "cancelFailback": "Failback abbrechen",
+      "cancelConfirm": "Umgekehrte Replikation stoppen und den Plan auf failed over zurücksetzen? An den VMs ändert sich nichts.",
+      "completeTitle": "Failback abgeschlossen",
+      "completeReprotected": "Die Quell-VMs laufen und die Replikation schützt sie wieder in der ursprünglichen Richtung."
     },
     "screenshots": {
       "view": "Boot-Screenshot ansehen",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4122,6 +4122,10 @@
       "noJobFoundDesc": "Ändern Sie Ihre Filter oder erstellen Sie einen neuen Replikationsjob.",
       "selectJob": "Wählen Sie einen Job, um Details anzuzeigen."
     },
+    "jobs": {
+      "failedOver": "Umgeschaltet",
+      "failedOverTooltip": "Die DR-Kopie dieses Jobs ist jetzt produktiv. Eine Fortsetzung der Replikation würde sie überschreiben — zuerst Failback."
+    },
     "plans": {
       "planName": "Plan",
       "sourceDestination": "Quelle / Ziel",
@@ -4145,7 +4149,8 @@
       "deletePlanConfirm": "Sind Sie sicher, dass Sie diesen Wiederherstellungsplan löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
       "cleanupPending": "Bereinigung ausstehend",
       "testRunning": "Test-Failover läuft",
-      "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten."
+      "testActiveTooltip": "Ein Test-Failover ist am DR-Standort aktiv. Führen Sie die Bereinigung aus, bevor Sie einen neuen Test starten.",
+      "failedOverTooltip": "Plan ist umgeschaltet — nur Failback ist möglich."
     },
     "rpoTargetLabel": "RPO-Ziel",
     "createJob": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Delete Recovery Plan",
-      "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone."
+      "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone.",
+      "cleanupPending": "Cleanup pending",
+      "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test."
     },
     "rpoTargetLabel": "RPO target",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Cleanup completed",
       "stopped": "stopped",
       "disksRolledBack": "RBD disk(s) rolled back",
-      "jobsResumed": "replication job(s) resumed"
+      "jobsResumed": "replication job(s) resumed",
+      "testActiveBanner": "A test failover started {date} is awaiting cleanup. Test VMs may still be running on the DR site.",
+      "testConflict": "A test failover is already active for this plan. Clean it up first."
     },
     "emergencyDR": {
       "title": "Emergency DR",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4218,6 +4218,11 @@
       "sshFailed": "Direct SSH connection failed",
       "sshRequirement": "Passwordless SSH must be configured between source and target clusters. Ensure root can SSH from source to target without a password prompt.",
       "sshRetry": "Retry",
+      "snapshotRetention": "Snapshot retention",
+      "snapshotRetentionHelp": "Mirror snapshots kept per disk after each sync (minimum 2).",
+      "retentionSource": "Keep on source",
+      "retentionTarget": "Keep on target (DR)",
+      "retentionTargetHelp": "More snapshots on the DR side means more restore points, at the cost of Ceph capacity.",
       "vmidPrefix": "VMID Prefix",
       "vmidPrefixHelp": "Prefix added to VM IDs on the target cluster (e.g. prefix 9 + VM 100 = 9100). Leave empty or 0 to keep the same VMID.",
       "engine": "Replication Engine",
@@ -4300,7 +4305,13 @@
       "disksRolledBack": "RBD disk(s) rolled back",
       "jobsResumed": "replication job(s) resumed",
       "testActiveBanner": "A test failover started {date} is awaiting cleanup. Test VMs may still be running on the DR site.",
-      "testConflict": "A test failover is already active for this plan. Clean it up first."
+      "testConflict": "A test failover is already active for this plan. Clean it up first.",
+      "restorePoint": "Restore point",
+      "restorePointLatest": "Latest (default)",
+      "restorePointsHelp": "Each VM will boot from the selected replicated snapshot.",
+      "restorePointsNone": "No restore points",
+      "restorePointsLoadFailed": "Restore points could not be loaded, the latest replicated state will be used.",
+      "restorePointRebaseWarning": "Failing over to an older restore point permanently deletes the newer DR snapshots of that VM."
     },
     "emergencyDR": {
       "title": "Emergency DR",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4173,6 +4173,8 @@
       "tierImportant": "Important",
       "tierStandard": "Standard",
       "executionHistory": "Execution History",
+      "clearHistory": "Clear history",
+      "clearHistoryConfirm": "Delete all past executions of this plan? Boot screenshots are deleted with them. The active test execution is kept.",
       "actions": "Actions",
       "testFailover": "Test Failover",
       "failover": "Failover",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4320,7 +4320,15 @@
       "restorePointsHelp": "Each VM will boot from the selected replicated snapshot.",
       "restorePointsNone": "No restore points",
       "restorePointsLoadFailed": "Restore points could not be loaded, the latest replicated state will be used.",
-      "restorePointRebaseWarning": "Failing over to an older restore point permanently deletes the newer DR snapshots of that VM."
+      "restorePointRebaseWarning": "Failing over to an older restore point permanently deletes the newer DR snapshots of that VM.",
+      "step": {
+        "fencing": "Stopping the source VM",
+        "restoring": "Rolling back to the selected restore point",
+        "starting": "Starting on the DR site"
+      },
+      "completeTitle": "Failover complete",
+      "completeVMs": "VM(s) now running on the DR site",
+      "completeLocked": "Replication is locked and the plan is failed over — failback will bring it home."
     },
     "screenshots": {
       "view": "View boot screenshot",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4317,7 +4317,10 @@
     },
     "screenshots": {
       "view": "View boot screenshot",
-      "capturedAt": "Captured at"
+      "capturedAt": "Captured at",
+      "stepBoot": "Starting VMs",
+      "stepStabilize": "Letting guests settle",
+      "stepCapture": "Capturing boot screenshots"
     },
     "emergencyDR": {
       "title": "Emergency DR",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4160,6 +4160,10 @@
       "noJobFoundDesc": "Modify your filters or create a new replication job.",
       "selectJob": "Select a job to view details."
     },
+    "jobs": {
+      "failedOver": "Failed over",
+      "failedOverTooltip": "This job's DR copy is now production. Resuming replication would overwrite it — failback first."
+    },
     "plans": {
       "planName": "Plan",
       "sourceDestination": "Source / Destination",
@@ -4183,7 +4187,8 @@
       "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone.",
       "cleanupPending": "Cleanup pending",
       "testRunning": "Test failover in progress",
-      "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test."
+      "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test.",
+      "failedOverTooltip": "Plan is failed over — only failback is possible."
     },
     "rpoTargetLabel": "RPO target",
     "createJob": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4338,6 +4338,9 @@
       "completeLocked": "Replication is locked and the plan is failed over — failback will bring it home."
     },
     "failback": {
+      "phase1Title": "Reverse replication in progress",
+      "colLastSync": "Last reverse sync",
+      "colTransferred": "Transferred",
       "phase1Help": "Reverse replication is running while the DR VMs stay online. Trigger the cutover when the last sync is fresh enough.",
       "neverSynced": "No reverse sync yet",
       "cutoverNotReady": "Waiting for the first reverse sync of every VM",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4340,6 +4340,7 @@
     "failback": {
       "phase1Help": "Reverse replication is running while the DR VMs stay online. Trigger the cutover when the last sync is fresh enough.",
       "neverSynced": "No reverse sync yet",
+      "cutoverNotReady": "Waiting for the first reverse sync of every VM",
       "cutover": "Cutover",
       "cutoverConfirm": "Stop the DR VMs, apply the final delta and start the source VMs?",
       "cancelFailback": "Cancel failback",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4315,6 +4315,10 @@
       "restorePointsLoadFailed": "Restore points could not be loaded, the latest replicated state will be used.",
       "restorePointRebaseWarning": "Failing over to an older restore point permanently deletes the newer DR snapshots of that VM."
     },
+    "screenshots": {
+      "view": "View boot screenshot",
+      "capturedAt": "Captured at"
+    },
     "emergencyDR": {
       "title": "Emergency DR",
       "noVMs": "No DR-ready VMs",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4188,7 +4188,10 @@
       "cleanupPending": "Cleanup pending",
       "testRunning": "Test failover in progress",
       "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test.",
-      "failedOverTooltip": "Plan is failed over — only failback is possible."
+      "failedOverTooltip": "Plan is failed over — only failback is possible.",
+      "statusFailingBack": "Failing back",
+      "openFailback": "Open failback",
+      "failingBackTooltip": "Cancel the failback before deleting this plan."
     },
     "rpoTargetLabel": "RPO target",
     "createJob": {
@@ -4324,11 +4327,25 @@
       "step": {
         "fencing": "Stopping the source VM",
         "restoring": "Rolling back to the selected restore point",
-        "starting": "Starting on the DR site"
+        "starting": "Starting on the DR site",
+        "fencing_dr": "Stopping the DR VM",
+        "final_sync": "Applying the final delta",
+        "starting_source": "Starting on the source site",
+        "reprotect": "Re-protecting"
       },
       "completeTitle": "Failover complete",
       "completeVMs": "VM(s) now running on the DR site",
       "completeLocked": "Replication is locked and the plan is failed over — failback will bring it home."
+    },
+    "failback": {
+      "phase1Help": "Reverse replication is running while the DR VMs stay online. Trigger the cutover when the last sync is fresh enough.",
+      "neverSynced": "No reverse sync yet",
+      "cutover": "Cutover",
+      "cutoverConfirm": "Stop the DR VMs, apply the final delta and start the source VMs?",
+      "cancelFailback": "Cancel failback",
+      "cancelConfirm": "Stop reverse replication and return the plan to failed over? Nothing is changed on the VMs.",
+      "completeTitle": "Failback complete",
+      "completeReprotected": "Source VMs are running and replication protects them again in the original direction."
     },
     "screenshots": {
       "view": "View boot screenshot",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4180,6 +4180,7 @@
       "deletePlan": "Delete Recovery Plan",
       "deletePlanConfirm": "Are you sure you want to delete this recovery plan? This action cannot be undone.",
       "cleanupPending": "Cleanup pending",
+      "testRunning": "Test failover in progress",
       "testActiveTooltip": "A test failover is active on the DR site. Run cleanup before starting a new test."
     },
     "rpoTargetLabel": "RPO target",
@@ -4308,6 +4309,7 @@
       "testConflict": "A test failover is already active for this plan. Clean it up first.",
       "restorePoint": "Restore point",
       "restorePointLatest": "Latest (default)",
+      "restorePointChoose": "Choose the restore point",
       "restorePointsHelp": "Each VM will boot from the selected replicated snapshot.",
       "restorePointsNone": "No restore points",
       "restorePointsLoadFailed": "Restore points could not be loaded, the latest replicated state will be used.",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4317,7 +4317,10 @@
     },
     "screenshots": {
       "view": "Ver la captura de arranque",
-      "capturedAt": "Capturada a las"
+      "capturedAt": "Capturada a las",
+      "stepBoot": "Iniciando las VM",
+      "stepStabilize": "Estabilizando los invitados",
+      "stepCapture": "Capturando pantallas de arranque"
     },
     "emergencyDR": {
       "title": "DR de emergencia",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4180,6 +4180,7 @@
       "deletePlan": "Eliminar plan de recuperación",
       "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer.",
       "cleanupPending": "Limpieza pendiente",
+      "testRunning": "Failover de prueba en curso",
       "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba."
     },
     "rpoTargetLabel": "RPO objetivo",
@@ -4308,6 +4309,7 @@
       "testConflict": "Ya hay un failover de prueba activo para este plan. Límpialo primero.",
       "restorePoint": "Punto de restauración",
       "restorePointLatest": "Más reciente (predeterminado)",
+      "restorePointChoose": "Elegir el punto de restauración",
       "restorePointsHelp": "Cada VM arrancará desde el snapshot replicado seleccionado.",
       "restorePointsNone": "Sin puntos de restauración",
       "restorePointsLoadFailed": "No se pudieron cargar los puntos de restauración, se usará el último estado replicado.",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4340,6 +4340,7 @@
     "failback": {
       "phase1Help": "La replicación inversa se ejecuta mientras las VM DR siguen en línea. Inicie el cutover cuando la última sincronización sea lo bastante reciente.",
       "neverSynced": "Aún sin sincronización inversa",
+      "cutoverNotReady": "Esperando la primera sincronización inversa de cada VM",
       "cutover": "Cutover",
       "cutoverConfirm": "¿Detener las VM DR, aplicar el delta final e iniciar las VM de origen?",
       "cancelFailback": "Cancelar el failback",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4320,7 +4320,15 @@
       "restorePointsHelp": "Cada VM arrancará desde el snapshot replicado seleccionado.",
       "restorePointsNone": "Sin puntos de restauración",
       "restorePointsLoadFailed": "No se pudieron cargar los puntos de restauración, se usará el último estado replicado.",
-      "restorePointRebaseWarning": "Hacer failover a un punto de restauración más antiguo elimina permanentemente los snapshots DR más recientes de esa VM."
+      "restorePointRebaseWarning": "Hacer failover a un punto de restauración más antiguo elimina permanentemente los snapshots DR más recientes de esa VM.",
+      "step": {
+        "fencing": "Deteniendo la VM de origen",
+        "restoring": "Restaurando al punto de restauración elegido",
+        "starting": "Iniciando en el sitio DR"
+      },
+      "completeTitle": "Failover completado",
+      "completeVMs": "VM ahora activas en el sitio DR",
+      "completeLocked": "La replicación está bloqueada y el plan está conmutado — el failback lo devolverá."
     },
     "screenshots": {
       "view": "Ver la captura de arranque",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4338,6 +4338,9 @@
       "completeLocked": "La replicación está bloqueada y el plan está conmutado — el failback lo devolverá."
     },
     "failback": {
+      "phase1Title": "Replicación inversa en curso",
+      "colLastSync": "Última sincronización inversa",
+      "colTransferred": "Transferido",
       "phase1Help": "La replicación inversa se ejecuta mientras las VM DR siguen en línea. Inicie el cutover cuando la última sincronización sea lo bastante reciente.",
       "neverSynced": "Aún sin sincronización inversa",
       "cutoverNotReady": "Esperando la primera sincronización inversa de cada VM",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4188,7 +4188,10 @@
       "cleanupPending": "Limpieza pendiente",
       "testRunning": "Failover de prueba en curso",
       "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba.",
-      "failedOverTooltip": "Plan conmutado — solo es posible el failback."
+      "failedOverTooltip": "Plan conmutado — solo es posible el failback.",
+      "statusFailingBack": "Failback en curso",
+      "openFailback": "Abrir failback",
+      "failingBackTooltip": "Cancele el failback antes de eliminar este plan."
     },
     "rpoTargetLabel": "RPO objetivo",
     "createJob": {
@@ -4324,11 +4327,25 @@
       "step": {
         "fencing": "Deteniendo la VM de origen",
         "restoring": "Restaurando al punto de restauración elegido",
-        "starting": "Iniciando en el sitio DR"
+        "starting": "Iniciando en el sitio DR",
+        "fencing_dr": "Deteniendo la VM DR",
+        "final_sync": "Aplicando el delta final",
+        "starting_source": "Iniciando en el sitio de origen",
+        "reprotect": "Reprotegiendo"
       },
       "completeTitle": "Failover completado",
       "completeVMs": "VM ahora activas en el sitio DR",
       "completeLocked": "La replicación está bloqueada y el plan está conmutado — el failback lo devolverá."
+    },
+    "failback": {
+      "phase1Help": "La replicación inversa se ejecuta mientras las VM DR siguen en línea. Inicie el cutover cuando la última sincronización sea lo bastante reciente.",
+      "neverSynced": "Aún sin sincronización inversa",
+      "cutover": "Cutover",
+      "cutoverConfirm": "¿Detener las VM DR, aplicar el delta final e iniciar las VM de origen?",
+      "cancelFailback": "Cancelar el failback",
+      "cancelConfirm": "¿Detener la replicación inversa y devolver el plan a failed over? No se modifica nada en las VM.",
+      "completeTitle": "Failback completado",
+      "completeReprotected": "Las VM de origen están en ejecución y la replicación vuelve a protegerlas en la dirección original."
     },
     "screenshots": {
       "view": "Ver la captura de arranque",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4315,6 +4315,10 @@
       "restorePointsLoadFailed": "No se pudieron cargar los puntos de restauración, se usará el último estado replicado.",
       "restorePointRebaseWarning": "Hacer failover a un punto de restauración más antiguo elimina permanentemente los snapshots DR más recientes de esa VM."
     },
+    "screenshots": {
+      "view": "Ver la captura de arranque",
+      "capturedAt": "Capturada a las"
+    },
     "emergencyDR": {
       "title": "DR de emergencia",
       "noVMs": "No hay VMs listas para DR",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4160,6 +4160,10 @@
       "noJobFoundDesc": "Modifica los filtros o crea un nuevo trabajo de replicación.",
       "selectJob": "Selecciona un trabajo para ver los detalles."
     },
+    "jobs": {
+      "failedOver": "Conmutado",
+      "failedOverTooltip": "La copia DR de este job ahora es producción. Reanudar la replicación la sobrescribiría — primero failback."
+    },
     "plans": {
       "planName": "Plan",
       "sourceDestination": "Origen / Destino",
@@ -4183,7 +4187,8 @@
       "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer.",
       "cleanupPending": "Limpieza pendiente",
       "testRunning": "Failover de prueba en curso",
-      "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba."
+      "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba.",
+      "failedOverTooltip": "Plan conmutado — solo es posible el failback."
     },
     "rpoTargetLabel": "RPO objetivo",
     "createJob": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Eliminar plan de recuperación",
-      "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer."
+      "deletePlanConfirm": "¿Seguro que quieres eliminar este plan de recuperación? Esta acción no se puede deshacer.",
+      "cleanupPending": "Limpieza pendiente",
+      "testActiveTooltip": "Hay un failover de prueba activo en el sitio DR. Ejecuta la limpieza antes de iniciar una nueva prueba."
     },
     "rpoTargetLabel": "RPO objetivo",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Limpieza completada",
       "stopped": "detenida",
       "disksRolledBack": "disco(s) RBD revertido(s)",
-      "jobsResumed": "trabajo(s) de replicación reanudado(s)"
+      "jobsResumed": "trabajo(s) de replicación reanudado(s)",
+      "testActiveBanner": "Un failover de prueba iniciado el {date} está esperando limpieza. Las VMs de prueba pueden seguir ejecutándose en el sitio DR.",
+      "testConflict": "Ya hay un failover de prueba activo para este plan. Límpialo primero."
     },
     "emergencyDR": {
       "title": "DR de emergencia",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4218,6 +4218,11 @@
       "sshFailed": "La conexión SSH directa ha fallado",
       "sshRequirement": "SSH sin contraseña debe estar configurado entre los clústeres origen y destino. Asegúrate de que root pueda hacer SSH desde el origen al destino sin solicitud de contraseña.",
       "sshRetry": "Reintentar",
+      "snapshotRetention": "Retención de snapshots",
+      "snapshotRetentionHelp": "Snapshots espejo conservados por disco tras cada sincronización (mínimo 2).",
+      "retentionSource": "Conservar en origen",
+      "retentionTarget": "Conservar en destino (DR)",
+      "retentionTargetHelp": "Más snapshots en el lado DR significa más puntos de restauración, a costa de la capacidad de Ceph.",
       "vmidPrefix": "Prefijo VMID",
       "vmidPrefixHelp": "Prefijo añadido a los IDs de VM en el clúster destino (p. ej., prefijo 9 + VM 100 = 9100). Déjalo vacío o en 0 para conservar el mismo VMID.",
       "engine": "Motor de replicación",
@@ -4300,7 +4305,13 @@
       "disksRolledBack": "disco(s) RBD revertido(s)",
       "jobsResumed": "trabajo(s) de replicación reanudado(s)",
       "testActiveBanner": "Un failover de prueba iniciado el {date} está esperando limpieza. Las VMs de prueba pueden seguir ejecutándose en el sitio DR.",
-      "testConflict": "Ya hay un failover de prueba activo para este plan. Límpialo primero."
+      "testConflict": "Ya hay un failover de prueba activo para este plan. Límpialo primero.",
+      "restorePoint": "Punto de restauración",
+      "restorePointLatest": "Más reciente (predeterminado)",
+      "restorePointsHelp": "Cada VM arrancará desde el snapshot replicado seleccionado.",
+      "restorePointsNone": "Sin puntos de restauración",
+      "restorePointsLoadFailed": "No se pudieron cargar los puntos de restauración, se usará el último estado replicado.",
+      "restorePointRebaseWarning": "Hacer failover a un punto de restauración más antiguo elimina permanentemente los snapshots DR más recientes de esa VM."
     },
     "emergencyDR": {
       "title": "DR de emergencia",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4173,6 +4173,8 @@
       "tierImportant": "Importante",
       "tierStandard": "Estándar",
       "executionHistory": "Historial de ejecución",
+      "clearHistory": "Vaciar el historial",
+      "clearHistoryConfirm": "¿Eliminar todas las ejecuciones pasadas de este plan? Las capturas de arranque se eliminarán con ellas. La ejecución de prueba activa se conserva.",
       "actions": "Acciones",
       "testFailover": "Probar failover",
       "failover": "Failover",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4180,6 +4180,7 @@
       "deletePlan": "Supprimer le plan de reprise",
       "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible.",
       "cleanupPending": "Nettoyage en attente",
+      "testRunning": "Test failover en cours",
       "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test."
     },
     "rpoTargetLabel": "RPO cible",
@@ -4308,6 +4309,7 @@
       "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord.",
       "restorePoint": "Point de restauration",
       "restorePointLatest": "Le plus récent (défaut)",
+      "restorePointChoose": "Choisir le point de rétention",
       "restorePointsHelp": "Chaque VM démarrera depuis le snapshot répliqué sélectionné.",
       "restorePointsNone": "Aucun point de restauration",
       "restorePointsLoadFailed": "Les points de restauration n'ont pas pu être chargés, le dernier état répliqué sera utilisé.",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4160,6 +4160,10 @@
       "noJobFoundDesc": "Modifiez vos filtres ou créez un nouveau job de réplication.",
       "selectJob": "Sélectionnez un job pour voir les détails."
     },
+    "jobs": {
+      "failedOver": "Basculé",
+      "failedOverTooltip": "La copie DR de ce job est désormais la production. Reprendre la réplication l'écraserait — failback d'abord."
+    },
     "plans": {
       "planName": "Plan",
       "sourceDestination": "Source / Destination",
@@ -4183,7 +4187,8 @@
       "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible.",
       "cleanupPending": "Nettoyage en attente",
       "testRunning": "Test failover en cours",
-      "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test."
+      "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test.",
+      "failedOverTooltip": "Plan basculé — seul le failback est possible."
     },
     "rpoTargetLabel": "RPO cible",
     "createJob": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4320,7 +4320,15 @@
       "restorePointsHelp": "Chaque VM démarrera depuis le snapshot répliqué sélectionné.",
       "restorePointsNone": "Aucun point de restauration",
       "restorePointsLoadFailed": "Les points de restauration n'ont pas pu être chargés, le dernier état répliqué sera utilisé.",
-      "restorePointRebaseWarning": "Basculer vers un point de restauration plus ancien supprime définitivement les snapshots DR plus récents de cette VM."
+      "restorePointRebaseWarning": "Basculer vers un point de restauration plus ancien supprime définitivement les snapshots DR plus récents de cette VM.",
+      "step": {
+        "fencing": "Arrêt de la VM source",
+        "restoring": "Retour au point de restauration choisi",
+        "starting": "Démarrage sur le site DR"
+      },
+      "completeTitle": "Failover terminé",
+      "completeVMs": "VM désormais actives sur le site DR",
+      "completeLocked": "La réplication est verrouillée et le plan est basculé — le failback fera le retour."
     },
     "screenshots": {
       "view": "Voir la capture au boot",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4315,6 +4315,10 @@
       "restorePointsLoadFailed": "Les points de restauration n'ont pas pu être chargés, le dernier état répliqué sera utilisé.",
       "restorePointRebaseWarning": "Basculer vers un point de restauration plus ancien supprime définitivement les snapshots DR plus récents de cette VM."
     },
+    "screenshots": {
+      "view": "Voir la capture au boot",
+      "capturedAt": "Capturée à"
+    },
     "emergencyDR": {
       "title": "DR d'urgence",
       "noVMs": "Aucune VM prête pour le DR",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4178,7 +4178,9 @@
       "failover": "Failover",
       "failback": "Failback",
       "deletePlan": "Supprimer le plan de reprise",
-      "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible."
+      "deletePlanConfirm": "Êtes-vous sûr de vouloir supprimer ce plan de reprise ? Cette action est irréversible.",
+      "cleanupPending": "Nettoyage en attente",
+      "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test."
     },
     "rpoTargetLabel": "RPO cible",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "Nettoyage terminé",
       "stopped": "arrêtée(s)",
       "disksRolledBack": "disque(s) RBD restauré(s)",
-      "jobsResumed": "job(s) de réplication repris"
+      "jobsResumed": "job(s) de réplication repris",
+      "testActiveBanner": "Un test de bascule démarré le {date} attend son nettoyage. Des VM de test peuvent encore tourner sur le site de secours.",
+      "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord."
     },
     "emergencyDR": {
       "title": "DR d'urgence",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4309,7 +4309,7 @@
       "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord.",
       "restorePoint": "Point de restauration",
       "restorePointLatest": "Le plus récent (défaut)",
-      "restorePointChoose": "Choisir le point de rétention",
+      "restorePointChoose": "Choisir le point de restauration",
       "restorePointsHelp": "Chaque VM démarrera depuis le snapshot répliqué sélectionné.",
       "restorePointsNone": "Aucun point de restauration",
       "restorePointsLoadFailed": "Les points de restauration n'ont pas pu être chargés, le dernier état répliqué sera utilisé.",
@@ -4317,7 +4317,10 @@
     },
     "screenshots": {
       "view": "Voir la capture au boot",
-      "capturedAt": "Capturée à"
+      "capturedAt": "Capturée à",
+      "stepBoot": "Démarrage des VM",
+      "stepStabilize": "Stabilisation des invités",
+      "stepCapture": "Capture des écrans de boot"
     },
     "emergencyDR": {
       "title": "DR d'urgence",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4340,6 +4340,7 @@
     "failback": {
       "phase1Help": "La réplication inverse tourne pendant que les VM DR restent en ligne. Lancez le cutover quand le dernier sync est assez frais.",
       "neverSynced": "Aucun sync inverse encore",
+      "cutoverNotReady": "En attente du premier sync inverse de chaque VM",
       "cutover": "Cutover",
       "cutoverConfirm": "Arrêter les VM DR, appliquer le delta final et démarrer les VM source ?",
       "cancelFailback": "Annuler le failback",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4188,7 +4188,10 @@
       "cleanupPending": "Nettoyage en attente",
       "testRunning": "Test failover en cours",
       "testActiveTooltip": "Un test de bascule est actif sur le site de secours. Lancez le nettoyage avant de démarrer un nouveau test.",
-      "failedOverTooltip": "Plan basculé — seul le failback est possible."
+      "failedOverTooltip": "Plan basculé — seul le failback est possible.",
+      "statusFailingBack": "Retour en cours",
+      "openFailback": "Ouvrir le failback",
+      "failingBackTooltip": "Annulez le failback avant de supprimer ce plan."
     },
     "rpoTargetLabel": "RPO cible",
     "createJob": {
@@ -4324,11 +4327,25 @@
       "step": {
         "fencing": "Arrêt de la VM source",
         "restoring": "Retour au point de restauration choisi",
-        "starting": "Démarrage sur le site DR"
+        "starting": "Démarrage sur le site DR",
+        "fencing_dr": "Arrêt de la VM DR",
+        "final_sync": "Application du delta final",
+        "starting_source": "Démarrage sur le site source",
+        "reprotect": "Re-protection"
       },
       "completeTitle": "Failover terminé",
       "completeVMs": "VM désormais actives sur le site DR",
       "completeLocked": "La réplication est verrouillée et le plan est basculé — le failback fera le retour."
+    },
+    "failback": {
+      "phase1Help": "La réplication inverse tourne pendant que les VM DR restent en ligne. Lancez le cutover quand le dernier sync est assez frais.",
+      "neverSynced": "Aucun sync inverse encore",
+      "cutover": "Cutover",
+      "cutoverConfirm": "Arrêter les VM DR, appliquer le delta final et démarrer les VM source ?",
+      "cancelFailback": "Annuler le failback",
+      "cancelConfirm": "Arrêter la réplication inverse et remettre le plan en failed over ? Rien n'est modifié sur les VM.",
+      "completeTitle": "Failback terminé",
+      "completeReprotected": "Les VM source tournent et la réplication les protège de nouveau dans le sens d'origine."
     },
     "screenshots": {
       "view": "Voir la capture au boot",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4173,6 +4173,8 @@
       "tierImportant": "Important",
       "tierStandard": "Standard",
       "executionHistory": "Historique d'exécution",
+      "clearHistory": "Vider l'historique",
+      "clearHistoryConfirm": "Supprimer toutes les exécutions passées de ce plan ? Les captures de boot seront supprimées avec. L'exécution de test active est conservée.",
       "actions": "Actions",
       "testFailover": "Test de failover",
       "failover": "Failover",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4218,6 +4218,11 @@
       "sshFailed": "Échec de la connexion SSH directe",
       "sshRequirement": "Le SSH sans mot de passe doit être configuré entre les clusters source et cible. Assurez-vous que root peut se connecter en SSH de la source vers la cible sans invite de mot de passe.",
       "sshRetry": "Réessayer",
+      "snapshotRetention": "Rétention des snapshots",
+      "snapshotRetentionHelp": "Nombre de snapshots miroir conservés par disque après chaque synchronisation (minimum 2).",
+      "retentionSource": "Conserver sur la source",
+      "retentionTarget": "Conserver sur la cible (DR)",
+      "retentionTargetHelp": "Plus de snapshots côté DR offre plus de points de restauration, au prix de la capacité Ceph.",
       "vmidPrefix": "Préfixe VMID",
       "vmidPrefixHelp": "Préfixe ajouté aux IDs de VM sur le cluster cible (ex : préfixe 9 + VM 100 = 9100). Laisser vide ou 0 pour garder le même VMID.",
       "engine": "Moteur de réplication",
@@ -4300,7 +4305,13 @@
       "disksRolledBack": "disque(s) RBD restauré(s)",
       "jobsResumed": "job(s) de réplication repris",
       "testActiveBanner": "Un test de bascule démarré le {date} attend son nettoyage. Des VM de test peuvent encore tourner sur le site de secours.",
-      "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord."
+      "testConflict": "Un test de bascule est déjà actif pour ce plan. Nettoyez-le d'abord.",
+      "restorePoint": "Point de restauration",
+      "restorePointLatest": "Le plus récent (défaut)",
+      "restorePointsHelp": "Chaque VM démarrera depuis le snapshot répliqué sélectionné.",
+      "restorePointsNone": "Aucun point de restauration",
+      "restorePointsLoadFailed": "Les points de restauration n'ont pas pu être chargés, le dernier état répliqué sera utilisé.",
+      "restorePointRebaseWarning": "Basculer vers un point de restauration plus ancien supprime définitivement les snapshots DR plus récents de cette VM."
     },
     "emergencyDR": {
       "title": "DR d'urgence",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4338,6 +4338,9 @@
       "completeLocked": "La réplication est verrouillée et le plan est basculé — le failback fera le retour."
     },
     "failback": {
+      "phase1Title": "Réplication inverse en cours",
+      "colLastSync": "Dernier sync inversé",
+      "colTransferred": "Volume",
       "phase1Help": "La réplication inverse tourne pendant que les VM DR restent en ligne. Lancez le cutover quand le dernier sync est assez frais.",
       "neverSynced": "Aucun sync inverse encore",
       "cutoverNotReady": "En attente du premier sync inverse de chaque VM",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4218,6 +4218,11 @@
       "sshFailed": "직접 SSH 연결 실패",
       "sshRequirement": "소스와 대상 클러스터 간에 비밀번호 없는 SSH가 구성되어 있어야 합니다. root가 비밀번호 입력 없이 소스에서 대상으로 SSH 접속할 수 있는지 확인하세요.",
       "sshRetry": "재시도",
+      "snapshotRetention": "스냅샷 보관",
+      "snapshotRetentionHelp": "각 동기화 후 디스크별로 보관되는 미러 스냅샷 수입니다 (최소 2개).",
+      "retentionSource": "소스에 보관",
+      "retentionTarget": "대상(DR)에 보관",
+      "retentionTargetHelp": "DR 측에 스냅샷이 많을수록 복원 지점이 늘어나지만 Ceph 용량을 더 사용합니다.",
       "vmidPrefix": "VMID 접두사",
       "vmidPrefixHelp": "대상 클러스터의 VM ID에 추가되는 접두사입니다 (예: 접두사 9 + VM 100 = 9100). 동일한 VMID를 유지하려면 비워 두거나 0을 입력하세요.",
       "engine": "복제 엔진",
@@ -4300,7 +4305,13 @@
       "disksRolledBack": "RBD 디스크 롤백됨",
       "jobsResumed": "복제 작업 재개됨",
       "testActiveBanner": "{date}에 시작된 테스트 페일오버가 정리를 기다리고 있습니다. 테스트 VM이 DR 사이트에서 계속 실행 중일 수 있습니다.",
-      "testConflict": "이 계획에 대해 테스트 페일오버가 이미 진행 중입니다. 먼저 정리하세요."
+      "testConflict": "이 계획에 대해 테스트 페일오버가 이미 진행 중입니다. 먼저 정리하세요.",
+      "restorePoint": "복원 지점",
+      "restorePointLatest": "최신 (기본값)",
+      "restorePointsHelp": "각 VM은 선택한 복제 스냅샷에서 부팅됩니다.",
+      "restorePointsNone": "복원 지점 없음",
+      "restorePointsLoadFailed": "복원 지점을 불러올 수 없어 최신 복제 상태가 사용됩니다.",
+      "restorePointRebaseWarning": "이전 복원 지점으로 페일오버하면 해당 VM의 최신 DR 스냅샷이 영구적으로 삭제됩니다."
     },
     "emergencyDR": {
       "title": "긴급 DR",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4160,6 +4160,10 @@
       "noJobFoundDesc": "필터를 수정하거나 새 복제 작업을 생성하세요.",
       "selectJob": "상세 정보를 보려면 작업을 선택하세요."
     },
+    "jobs": {
+      "failedOver": "페일오버됨",
+      "failedOverTooltip": "이 작업의 DR 복제본이 이제 프로덕션입니다. 복제를 재개하면 덮어씁니다 — 먼저 페일백하세요."
+    },
     "plans": {
       "planName": "계획",
       "sourceDestination": "소스 / 대상",
@@ -4183,7 +4187,8 @@
       "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
       "cleanupPending": "정리 대기 중",
       "testRunning": "테스트 페일오버 진행 중",
-      "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요."
+      "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요.",
+      "failedOverTooltip": "플랜이 페일오버되었습니다 — 페일백만 가능합니다."
     },
     "rpoTargetLabel": "RPO 목표",
     "createJob": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4178,7 +4178,9 @@
       "failover": "페일오버",
       "failback": "페일백",
       "deletePlan": "복구 계획 삭제",
-      "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+      "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+      "cleanupPending": "정리 대기 중",
+      "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요."
     },
     "rpoTargetLabel": "RPO 목표",
     "createJob": {
@@ -4296,7 +4298,9 @@
       "cleanupDone": "정리 완료",
       "stopped": "중지됨",
       "disksRolledBack": "RBD 디스크 롤백됨",
-      "jobsResumed": "복제 작업 재개됨"
+      "jobsResumed": "복제 작업 재개됨",
+      "testActiveBanner": "{date}에 시작된 테스트 페일오버가 정리를 기다리고 있습니다. 테스트 VM이 DR 사이트에서 계속 실행 중일 수 있습니다.",
+      "testConflict": "이 계획에 대해 테스트 페일오버가 이미 진행 중입니다. 먼저 정리하세요."
     },
     "emergencyDR": {
       "title": "긴급 DR",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4180,6 +4180,7 @@
       "deletePlan": "복구 계획 삭제",
       "deletePlanConfirm": "이 복구 계획을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
       "cleanupPending": "정리 대기 중",
+      "testRunning": "테스트 페일오버 진행 중",
       "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요."
     },
     "rpoTargetLabel": "RPO 목표",
@@ -4308,6 +4309,7 @@
       "testConflict": "이 계획에 대해 테스트 페일오버가 이미 진행 중입니다. 먼저 정리하세요.",
       "restorePoint": "복원 지점",
       "restorePointLatest": "최신 (기본값)",
+      "restorePointChoose": "복원 지점 선택",
       "restorePointsHelp": "각 VM은 선택한 복제 스냅샷에서 부팅됩니다.",
       "restorePointsNone": "복원 지점 없음",
       "restorePointsLoadFailed": "복원 지점을 불러올 수 없어 최신 복제 상태가 사용됩니다.",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4320,7 +4320,15 @@
       "restorePointsHelp": "각 VM은 선택한 복제 스냅샷에서 부팅됩니다.",
       "restorePointsNone": "복원 지점 없음",
       "restorePointsLoadFailed": "복원 지점을 불러올 수 없어 최신 복제 상태가 사용됩니다.",
-      "restorePointRebaseWarning": "이전 복원 지점으로 페일오버하면 해당 VM의 최신 DR 스냅샷이 영구적으로 삭제됩니다."
+      "restorePointRebaseWarning": "이전 복원 지점으로 페일오버하면 해당 VM의 최신 DR 스냅샷이 영구적으로 삭제됩니다.",
+      "step": {
+        "fencing": "소스 VM 중지 중",
+        "restoring": "선택한 복원 지점으로 롤백 중",
+        "starting": "DR 사이트에서 시작 중"
+      },
+      "completeTitle": "페일오버 완료",
+      "completeVMs": "VM이 DR 사이트에서 실행 중",
+      "completeLocked": "복제가 잠기고 플랜이 페일오버되었습니다 — 페일백으로 복구합니다."
     },
     "screenshots": {
       "view": "부팅 스크린샷 보기",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4315,6 +4315,10 @@
       "restorePointsLoadFailed": "복원 지점을 불러올 수 없어 최신 복제 상태가 사용됩니다.",
       "restorePointRebaseWarning": "이전 복원 지점으로 페일오버하면 해당 VM의 최신 DR 스냅샷이 영구적으로 삭제됩니다."
     },
+    "screenshots": {
+      "view": "부팅 스크린샷 보기",
+      "capturedAt": "캡처 시각"
+    },
     "emergencyDR": {
       "title": "긴급 DR",
       "noVMs": "DR 준비 VM 없음",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4338,6 +4338,9 @@
       "completeLocked": "복제가 잠기고 플랜이 페일오버되었습니다 — 페일백으로 복구합니다."
     },
     "failback": {
+      "phase1Title": "역방향 복제 진행 중",
+      "colLastSync": "마지막 역방향 동기화",
+      "colTransferred": "전송량",
       "phase1Help": "DR VM이 온라인 상태를 유지하는 동안 역방향 복제가 실행됩니다. 마지막 동기화가 충분히 최신일 때 컷오버를 시작하세요.",
       "neverSynced": "아직 역방향 동기화 없음",
       "cutoverNotReady": "모든 VM의 첫 역방향 동기화를 기다리는 중",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4173,6 +4173,8 @@
       "tierImportant": "중요",
       "tierStandard": "표준",
       "executionHistory": "실행 기록",
+      "clearHistory": "기록 지우기",
+      "clearHistoryConfirm": "이 플랜의 지난 실행 기록을 모두 삭제하시겠습니까? 부팅 스크린샷도 함께 삭제됩니다. 활성 테스트 실행은 유지됩니다.",
       "actions": "작업",
       "testFailover": "테스트 페일오버",
       "failover": "페일오버",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4188,7 +4188,10 @@
       "cleanupPending": "정리 대기 중",
       "testRunning": "테스트 페일오버 진행 중",
       "testActiveTooltip": "DR 사이트에서 테스트 페일오버가 진행 중입니다. 새 테스트를 시작하기 전에 정리를 실행하세요.",
-      "failedOverTooltip": "플랜이 페일오버되었습니다 — 페일백만 가능합니다."
+      "failedOverTooltip": "플랜이 페일오버되었습니다 — 페일백만 가능합니다.",
+      "statusFailingBack": "페일백 진행 중",
+      "openFailback": "페일백 열기",
+      "failingBackTooltip": "플랜을 삭제하기 전에 페일백을 취소하세요."
     },
     "rpoTargetLabel": "RPO 목표",
     "createJob": {
@@ -4324,11 +4327,25 @@
       "step": {
         "fencing": "소스 VM 중지 중",
         "restoring": "선택한 복원 지점으로 롤백 중",
-        "starting": "DR 사이트에서 시작 중"
+        "starting": "DR 사이트에서 시작 중",
+        "fencing_dr": "DR VM 중지 중",
+        "final_sync": "최종 델타 적용 중",
+        "starting_source": "소스 사이트에서 시작 중",
+        "reprotect": "재보호 중"
       },
       "completeTitle": "페일오버 완료",
       "completeVMs": "VM이 DR 사이트에서 실행 중",
       "completeLocked": "복제가 잠기고 플랜이 페일오버되었습니다 — 페일백으로 복구합니다."
+    },
+    "failback": {
+      "phase1Help": "DR VM이 온라인 상태를 유지하는 동안 역방향 복제가 실행됩니다. 마지막 동기화가 충분히 최신일 때 컷오버를 시작하세요.",
+      "neverSynced": "아직 역방향 동기화 없음",
+      "cutover": "컷오버",
+      "cutoverConfirm": "DR VM을 중지하고 최종 델타를 적용한 후 소스 VM을 시작하시겠습니까?",
+      "cancelFailback": "페일백 취소",
+      "cancelConfirm": "역방향 복제를 중지하고 플랜을 페일오버 상태로 되돌리시겠습니까? VM은 변경되지 않습니다.",
+      "completeTitle": "페일백 완료",
+      "completeReprotected": "소스 VM이 실행 중이며 복제가 원래 방향으로 다시 보호합니다."
     },
     "screenshots": {
       "view": "부팅 스크린샷 보기",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4317,7 +4317,10 @@
     },
     "screenshots": {
       "view": "부팅 스크린샷 보기",
-      "capturedAt": "캡처 시각"
+      "capturedAt": "캡처 시각",
+      "stepBoot": "VM 시작 중",
+      "stepStabilize": "게스트 안정화 대기 중",
+      "stepCapture": "부팅 스크린샷 캡처 중"
     },
     "emergencyDR": {
       "title": "긴급 DR",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4340,6 +4340,7 @@
     "failback": {
       "phase1Help": "DR VM이 온라인 상태를 유지하는 동안 역방향 복제가 실행됩니다. 마지막 동기화가 충분히 최신일 때 컷오버를 시작하세요.",
       "neverSynced": "아직 역방향 동기화 없음",
+      "cutoverNotReady": "모든 VM의 첫 역방향 동기화를 기다리는 중",
       "cutover": "컷오버",
       "cutoverConfirm": "DR VM을 중지하고 최종 델타를 적용한 후 소스 VM을 시작하시겠습니까?",
       "cancelFailback": "페일백 취소",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4139,7 +4139,9 @@
       "failover": "故障转移",
       "failback": "故障回切",
       "deletePlan": "删除恢复计划",
-      "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。"
+      "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。",
+      "cleanupPending": "待清理",
+      "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。"
     },
     "rpoTargetLabel": "RPO 目标",
     "createJob": {
@@ -4257,7 +4259,9 @@
       "cleanupDone": "清理完成",
       "stopped": "已停止",
       "disksRolledBack": "RBD 磁盘已回滚",
-      "jobsResumed": "复制任务已恢复"
+      "jobsResumed": "复制任务已恢复",
+      "testActiveBanner": "于 {date} 启动的测试故障转移正在等待清理。测试 VM 可能仍在灾备站点上运行。",
+      "testConflict": "此计划已有一个测试故障转移正在进行。请先清理它。"
     },
     "emergencyDR": {
       "title": "紧急灾难恢复",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4278,7 +4278,10 @@
     },
     "screenshots": {
       "view": "查看启动截图",
-      "capturedAt": "截图时间"
+      "capturedAt": "截图时间",
+      "stepBoot": "正在启动虚拟机",
+      "stepStabilize": "等待系统稳定",
+      "stepCapture": "正在捕获启动截图"
     },
     "emergencyDR": {
       "title": "紧急灾难恢复",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4149,7 +4149,10 @@
       "cleanupPending": "待清理",
       "testRunning": "测试故障转移进行中",
       "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。",
-      "failedOverTooltip": "计划已故障转移——只能执行故障回复。"
+      "failedOverTooltip": "计划已故障转移——只能执行故障回复。",
+      "statusFailingBack": "故障回复进行中",
+      "openFailback": "打开故障回复",
+      "failingBackTooltip": "删除此计划前请先取消故障回复。"
     },
     "rpoTargetLabel": "RPO 目标",
     "createJob": {
@@ -4285,11 +4288,25 @@
       "step": {
         "fencing": "正在停止源虚拟机",
         "restoring": "正在回滚到所选恢复点",
-        "starting": "正在 DR 站点上启动"
+        "starting": "正在 DR 站点上启动",
+        "fencing_dr": "正在停止 DR 虚拟机",
+        "final_sync": "正在应用最终增量",
+        "starting_source": "正在源站点上启动",
+        "reprotect": "正在重新保护"
       },
       "completeTitle": "故障转移完成",
       "completeVMs": "虚拟机现已在 DR 站点运行",
       "completeLocked": "复制已锁定，计划已故障转移——故障回复将恢复原状。"
+    },
+    "failback": {
+      "phase1Help": "反向复制正在运行，DR 虚拟机保持在线。当最后一次同步足够新时，即可执行切换。",
+      "neverSynced": "尚无反向同步",
+      "cutover": "切换",
+      "cutoverConfirm": "停止 DR 虚拟机，应用最终增量并启动源虚拟机？",
+      "cancelFailback": "取消故障回复",
+      "cancelConfirm": "停止反向复制并将计划恢复为已故障转移状态？虚拟机不会有任何更改。",
+      "completeTitle": "故障回复完成",
+      "completeReprotected": "源虚拟机正在运行，复制已恢复原方向的保护。"
     },
     "screenshots": {
       "view": "查看启动截图",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4179,6 +4179,11 @@
       "sshFailed": "直连 SSH 连接失败",
       "sshRequirement": "必须在源集群和目标集群之间配置免密 SSH。确保 root 用户可以从源免密 SSH 连接到目标。",
       "sshRetry": "重试",
+      "snapshotRetention": "快照保留",
+      "snapshotRetentionHelp": "每次同步后每个磁盘保留的镜像快照数量（最少 2 个）。",
+      "retentionSource": "源端保留数量",
+      "retentionTarget": "目标端（灾备）保留数量",
+      "retentionTargetHelp": "灾备端保留更多快照意味着更多恢复点，但会占用更多 Ceph 容量。",
       "vmidPrefix": "VMID 前缀",
       "vmidPrefixHelp": "添加到目标集群 VM ID 的前缀（例如前缀 9 + VM 100 = 9100）。留空或填 0 以保持相同 VMID。",
       "engine": "复制引擎",
@@ -4261,7 +4266,13 @@
       "disksRolledBack": "RBD 磁盘已回滚",
       "jobsResumed": "复制任务已恢复",
       "testActiveBanner": "于 {date} 启动的测试故障转移正在等待清理。测试 VM 可能仍在灾备站点上运行。",
-      "testConflict": "此计划已有一个测试故障转移正在进行。请先清理它。"
+      "testConflict": "此计划已有一个测试故障转移正在进行。请先清理它。",
+      "restorePoint": "恢复点",
+      "restorePointLatest": "最新（默认）",
+      "restorePointsHelp": "每个 VM 将从所选的复制快照启动。",
+      "restorePointsNone": "无恢复点",
+      "restorePointsLoadFailed": "无法加载恢复点，将使用最新的复制状态。",
+      "restorePointRebaseWarning": "故障转移到更早的恢复点将永久删除该 VM 更新的灾备快照。"
     },
     "emergencyDR": {
       "title": "紧急灾难恢复",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4276,6 +4276,10 @@
       "restorePointsLoadFailed": "无法加载恢复点，将使用最新的复制状态。",
       "restorePointRebaseWarning": "故障转移到更早的恢复点将永久删除该 VM 更新的灾备快照。"
     },
+    "screenshots": {
+      "view": "查看启动截图",
+      "capturedAt": "截图时间"
+    },
     "emergencyDR": {
       "title": "紧急灾难恢复",
       "noVMs": "无灾备就绪的 VM",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4299,6 +4299,9 @@
       "completeLocked": "复制已锁定，计划已故障转移——故障回复将恢复原状。"
     },
     "failback": {
+      "phase1Title": "反向复制进行中",
+      "colLastSync": "上次反向同步",
+      "colTransferred": "已传输",
       "phase1Help": "反向复制正在运行，DR 虚拟机保持在线。当最后一次同步足够新时，即可执行切换。",
       "neverSynced": "尚无反向同步",
       "cutoverNotReady": "正在等待每台虚拟机完成首次反向同步",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4134,6 +4134,8 @@
       "tierImportant": "重要",
       "tierStandard": "标准",
       "executionHistory": "执行历史",
+      "clearHistory": "清空历史记录",
+      "clearHistoryConfirm": "删除此计划的所有历史执行记录？启动截图将一并删除。当前活动的测试执行将被保留。",
       "actions": "操作",
       "testFailover": "测试故障转移",
       "failover": "故障转移",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4281,7 +4281,15 @@
       "restorePointsHelp": "每个 VM 将从所选的复制快照启动。",
       "restorePointsNone": "无恢复点",
       "restorePointsLoadFailed": "无法加载恢复点，将使用最新的复制状态。",
-      "restorePointRebaseWarning": "故障转移到更早的恢复点将永久删除该 VM 更新的灾备快照。"
+      "restorePointRebaseWarning": "故障转移到更早的恢复点将永久删除该 VM 更新的灾备快照。",
+      "step": {
+        "fencing": "正在停止源虚拟机",
+        "restoring": "正在回滚到所选恢复点",
+        "starting": "正在 DR 站点上启动"
+      },
+      "completeTitle": "故障转移完成",
+      "completeVMs": "虚拟机现已在 DR 站点运行",
+      "completeLocked": "复制已锁定，计划已故障转移——故障回复将恢复原状。"
     },
     "screenshots": {
       "view": "查看启动截图",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4141,6 +4141,7 @@
       "deletePlan": "删除恢复计划",
       "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。",
       "cleanupPending": "待清理",
+      "testRunning": "测试故障转移进行中",
       "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。"
     },
     "rpoTargetLabel": "RPO 目标",
@@ -4269,6 +4270,7 @@
       "testConflict": "此计划已有一个测试故障转移正在进行。请先清理它。",
       "restorePoint": "恢复点",
       "restorePointLatest": "最新（默认）",
+      "restorePointChoose": "选择恢复点",
       "restorePointsHelp": "每个 VM 将从所选的复制快照启动。",
       "restorePointsNone": "无恢复点",
       "restorePointsLoadFailed": "无法加载恢复点，将使用最新的复制状态。",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4301,6 +4301,7 @@
     "failback": {
       "phase1Help": "反向复制正在运行，DR 虚拟机保持在线。当最后一次同步足够新时，即可执行切换。",
       "neverSynced": "尚无反向同步",
+      "cutoverNotReady": "正在等待每台虚拟机完成首次反向同步",
       "cutover": "切换",
       "cutoverConfirm": "停止 DR 虚拟机，应用最终增量并启动源虚拟机？",
       "cancelFailback": "取消故障回复",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4121,6 +4121,10 @@
       "noJobFoundDesc": "修改您的过滤条件或创建新的复制任务。",
       "selectJob": "选择一个任务以查看详情。"
     },
+    "jobs": {
+      "failedOver": "已故障转移",
+      "failedOverTooltip": "此任务的 DR 副本现已成为生产环境。恢复复制将覆盖它——请先执行故障回复。"
+    },
     "plans": {
       "planName": "计划",
       "sourceDestination": "源 / 目标",
@@ -4144,7 +4148,8 @@
       "deletePlanConfirm": "确定要删除此恢复计划吗？此操作不可撤销。",
       "cleanupPending": "待清理",
       "testRunning": "测试故障转移进行中",
-      "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。"
+      "testActiveTooltip": "灾备站点上有一个测试故障转移正在进行。请先运行清理，然后再开始新的测试。",
+      "failedOverTooltip": "计划已故障转移——只能执行故障回复。"
     },
     "rpoTargetLabel": "RPO 目标",
     "createJob": {


### PR DESCRIPTION
## Summary

Implements the full Site Recovery improvement set requested in #664, plus the failback half of #580:

- **Configurable snapshot retention** per replication job: separate keep counts for the source and DR sides (slider UI), batched pruning convergence when lowering, snapshot table kept in phase.
- **Point-in-time recovery**: per-VM restore point selector in Test Failover and Failover, built live from the DR-side mirror snapshots, with all-or-nothing rollback and incremental chain re-base.
- **Per-cluster VM name resolution**: fixes the Create Recovery Plan picker (and every other Site Recovery view) alternating names when the same VMID exists on both sites.
- **Persistent test failover state**: survives page reloads and orchestrator restarts, refuses concurrent tests (409), cleanup resumes only the jobs the test itself paused, distinct running vs cleanup-pending indicators.
- **Boot evidence**: each test failover automatically captures a console screenshot of every booted DR VM, archived with the execution history (thumbnails + full-size preview) and shown in the failover dialog.
- **Real failover hardening**: source VMs are fenced (graceful shutdown, forced stop, onboot disabled) before their DR replicas start; after failover the plan and its replication jobs are locked (server-side 409 guards) until failback.
- **Failback**: two-phase workflow. Reverse incremental replication runs while the DR VMs stay online (live table with animated flow banner, cancellable); the operator triggers the cutover (stop DR VM, final delta, start source VM), gated until every VM has a completed reverse sync; replication then re-protects automatically in the original direction with no re-seed. Crash-safe: interrupted phases resume at orchestrator startup, stranded states are repaired, resume probes fail closed.
- **Quality of life**: clearable plan execution history, per-VM failover steps and completion summary, stabilization countdown, restore point list refreshed on every dialog open, i18n for all new strings in the 6 locales.

Requires the matching orchestrator changes (same branch name).

## Test plan

- Full frontend suite green locally (4245 tests), including new coverage for every feature above; lint and production build green.
- End-to-end validation on a dual-cluster Ceph lab: test failover with restore point selection and boot screenshots, real failover with fencing and lockdown, and the complete failback cycle ending in automatic incremental re-protection.

Closes #664
