### PR TITLE
Wait out vSphere snapshot tasks instead of giving up at 120s

### DIFF
--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -21,7 +21,7 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
 import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
-import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, buildVmdkDownloadUrl, buildVmdkDescriptorUrl, extractProp, soapCreateSnapshot, soapRemoveAllSnapshots, soapPowerOffVm, soapExportVm, soapWaitForNfcLease, soapNfcLeaseProgress, soapNfcLeaseComplete, soapNfcLeaseAbort } from "@/lib/vmware/soap"
+import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, buildVmdkDownloadUrl, buildVmdkDescriptorUrl, extractProp, soapCreateSnapshot, soapRemoveAllSnapshots, soapPowerOffVm, soapExportVm, soapWaitForNfcLease, soapNfcLeaseProgress, soapNfcLeaseComplete, soapNfcLeaseAbort, SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS } from "@/lib/vmware/soap"
 import { mapEsxiToPveConfig, isWindowsVm } from "./configMapper"
 import type { SoapSession, EsxiVmConfig, EsxiDiskInfo, NfcLeaseDeviceUrl } from "@/lib/vmware/soap"
 import {
@@ -2657,7 +2657,10 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       } finally {
         // Always remove snapshot after cloning (even on failure)
         await appendLog(jobId, "Removing ESXi snapshot...", "info")
-        await soapRemoveAllSnapshots(soapSession!, config.sourceVmId).catch((e: any) => {
+        // Bounded on purpose: the very next phase powers the source off and
+        // starts counting downtime, so this must not inherit the multi-hour
+        // budget a warm delta pass needs (nothing here waits on the merge).
+        await soapRemoveAllSnapshots(soapSession!, config.sourceVmId, { timeoutMs: SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS }).catch((e: any) => {
           appendLog(jobId, `Warning: failed to remove snapshot: ${e.message}`, "warn")
         })
       }

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -44,6 +44,7 @@ import {
   soapNfcLeaseAbort,
   soapCreateSnapshot,
   soapRemoveSnapshot,
+  SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS,
   soapGetSnapshotQuiesced,
   soapPowerOffVm,
 } from "@/lib/vmware/soap"
@@ -1843,7 +1844,9 @@ export async function runV2vMigrationPipeline(
           )
         }
         try {
-          await soapRemoveSnapshot(vmwareSession, liveSnapshotMor)
+          // The source is already powered off here: this wait IS guest downtime,
+          // so it stays bounded instead of inheriting the multi-hour merge budget.
+          await soapRemoveSnapshot(vmwareSession, liveSnapshotMor, true, { timeoutMs: SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS })
           await appendLog(jobId, "Source snapshot removed", "success")
           liveSnapshotMor = null
         } catch (snapErr: any) {
@@ -2685,7 +2688,9 @@ export async function runV2vMigrationPipeline(
     // snapshot was either removed at that point or is a harmless leftover).
     if (liveSnapshotMor && vmwareSession && !livePoweredOff) {
       try {
-        await soapRemoveSnapshot(vmwareSession, liveSnapshotMor)
+        // Failure cleanup: the job is already dead, so bound the wait rather
+        // than hold the pipeline open for hours reporting an error.
+        await soapRemoveSnapshot(vmwareSession, liveSnapshotMor, true, { timeoutMs: SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS })
         await appendLog(jobId, "Removed leftover live-migration snapshot on source VM", "info")
       } catch (snapCleanupErr: any) {
         await appendLog(

--- a/frontend/src/lib/migration/warm/warm-pipeline.snapshot.test.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.snapshot.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Mock only the SOAP surface; the helpers under test are the pure orchestration
+// around it (tracking MORs for cleanup, sweeping leftovers).
+vi.mock("@/lib/vmware/soap", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/vmware/soap")>()
+  return {
+    ...actual,
+    soapCreateSnapshot: vi.fn(),
+    soapRemoveSnapshot: vi.fn(),
+    soapFindSnapshotsByNamePrefix: vi.fn(),
+  }
+})
+
+import { soapCreateSnapshot, soapRemoveSnapshot, soapFindSnapshotsByNamePrefix } from "@/lib/vmware/soap"
+import { createWarmSnapshot, sweepWarmSnapshots } from "./warm-pipeline"
+
+const create = vi.mocked(soapCreateSnapshot)
+const remove = vi.mocked(soapRemoveSnapshot)
+const findByPrefix = vi.mocked(soapFindSnapshotsByNamePrefix)
+const session = { baseUrl: "https://vcenter", cookie: "c", insecureTLS: true, propertyCollector: "pc", sessionManager: "sm", rootFolder: "rf", isVcenter: true } as any
+
+beforeEach(() => { create.mockReset(); remove.mockReset(); findByPrefix.mockReset() })
+
+describe("createWarmSnapshot", () => {
+  it("records the MOR for cleanup on the happy path", async () => {
+    create.mockResolvedValue("snapshot-12")
+    const ourSnapshots: string[] = []
+    await expect(createWarmSnapshot(session, "vm-9", "proxcenter-warm-full", ourSnapshots)).resolves.toBe("snapshot-12")
+    expect(ourSnapshots).toEqual(["snapshot-12"])
+  })
+
+  it("recovers the orphan by name when the create times out, then rethrows the real error", async () => {
+    // The production incident: CreateSnapshot times out, vCenter creates the
+    // snapshot anyway, and the MOR was never recorded -> orphan left on the VM.
+    const boom = new Error('Snapshot creation "proxcenter-warm-delta-1" on VM vm-9 did not complete within 30min')
+    create.mockRejectedValue(boom)
+    findByPrefix.mockResolvedValue([{ name: "proxcenter-warm-delta-1", mor: "snapshot-77" }])
+    const ourSnapshots: string[] = []
+    const onRecovered = vi.fn()
+
+    await expect(createWarmSnapshot(session, "vm-9", "proxcenter-warm-delta-1", ourSnapshots, onRecovered))
+      .rejects.toBe(boom)
+
+    expect(findByPrefix).toHaveBeenCalledWith(session, "vm-9", "proxcenter-warm-delta-1")
+    expect(ourSnapshots).toEqual(["snapshot-77"])
+    expect(onRecovered).toHaveBeenCalledWith("snapshot-77")
+  })
+
+  it("never lets a failed recovery mask the original error", async () => {
+    const boom = new Error("create timed out")
+    create.mockRejectedValue(boom)
+    findByPrefix.mockRejectedValue(new Error("session expired"))
+    const ourSnapshots: string[] = []
+    await expect(createWarmSnapshot(session, "vm-9", "proxcenter-warm-full", ourSnapshots)).rejects.toBe(boom)
+    expect(ourSnapshots).toEqual([])
+  })
+
+  it("recovers and throws when the create succeeds without returning a reference", async () => {
+    create.mockResolvedValue("")
+    findByPrefix.mockResolvedValue([{ name: "proxcenter-warm-full", mor: "snapshot-5" }])
+    const ourSnapshots: string[] = []
+    await expect(createWarmSnapshot(session, "vm-9", "proxcenter-warm-full", ourSnapshots))
+      .rejects.toThrow(/returned no snapshot reference/)
+    expect(ourSnapshots).toEqual(["snapshot-5"])
+  })
+
+  it("does not record a MOR twice when it is already tracked", async () => {
+    create.mockRejectedValue(new Error("boom"))
+    findByPrefix.mockResolvedValue([{ name: "proxcenter-warm-full", mor: "snapshot-5" }])
+    const ourSnapshots = ["snapshot-5"]
+    const onRecovered = vi.fn()
+    await expect(createWarmSnapshot(session, "vm-9", "proxcenter-warm-full", ourSnapshots, onRecovered)).rejects.toThrow()
+    expect(ourSnapshots).toEqual(["snapshot-5"])
+    expect(onRecovered).not.toHaveBeenCalled()
+  })
+})
+
+describe("sweepWarmSnapshots", () => {
+  it("removes every leftover proxcenter-warm-* snapshot and logs one line each", async () => {
+    findByPrefix.mockResolvedValue([
+      { name: "proxcenter-warm-full", mor: "snapshot-2" },
+      { name: "proxcenter-warm-delta-1", mor: "snapshot-3" },
+    ])
+    remove.mockResolvedValue(undefined)
+    const lines: string[] = []
+    await expect(sweepWarmSnapshots(session, "vm-9", async m => { lines.push(m) })).resolves.toBe(2)
+    expect(findByPrefix).toHaveBeenCalledWith(session, "vm-9", "proxcenter-warm-")
+    // never removeChildren: a user snapshot taken under ours must survive
+    expect(remove.mock.calls.map(c => [c[1], c[2]])).toEqual([["snapshot-2", false], ["snapshot-3", false]])
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatch(/Removed leftover warm snapshot "proxcenter-warm-full" \(snapshot-2\)/)
+  })
+
+  it("keeps going and never throws when one removal fails", async () => {
+    findByPrefix.mockResolvedValue([
+      { name: "proxcenter-warm-full", mor: "snapshot-2" },
+      { name: "proxcenter-warm-delta-1", mor: "snapshot-3" },
+    ])
+    remove.mockRejectedValueOnce(new Error("still consolidating")).mockResolvedValueOnce(undefined)
+    const lines: string[] = []
+    await expect(sweepWarmSnapshots(session, "vm-9", async m => { lines.push(m) })).resolves.toBe(1)
+    expect(lines[0]).toMatch(/could not be confirmed removed \(still consolidating\)/)
+    expect(lines[1]).toMatch(/Removed leftover warm snapshot "proxcenter-warm-delta-1"/)
+  })
+
+  it("returns 0 without throwing when the lookup itself fails", async () => {
+    findByPrefix.mockRejectedValue(new Error("session expired"))
+    await expect(sweepWarmSnapshots(session, "vm-9", async () => {})).resolves.toBe(0)
+    expect(remove).not.toHaveBeenCalled()
+  })
+
+  it("survives a logger that rejects", async () => {
+    findByPrefix.mockResolvedValue([{ name: "proxcenter-warm-full", mor: "snapshot-2" }])
+    remove.mockResolvedValue(undefined)
+    await expect(sweepWarmSnapshots(session, "vm-9", async () => { throw new Error("db down") })).resolves.toBe(1)
+  })
+})

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -6,6 +6,8 @@ import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import {
   soapLogin, soapLogout, soapGetVmConfig, parseVmConfig, soapCreateSnapshot, soapRemoveSnapshot,
+  soapWaitForConsolidation, soapFindSnapshotsByNamePrefix, CONSOLIDATION_TIMEOUT_MS,
+  SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS,
 } from "@/lib/vmware/soap"
 import type { SoapSession, EsxiVmConfig, EsxiDiskInfo } from "@/lib/vmware/soap"
 import {
@@ -232,6 +234,122 @@ export function checksumDiskWindows(diskIndex: number, diskCount: number): { sca
   const span = 70 / diskCount
   const scanStart = 10 + span * diskIndex
   return { scanStart, scanEnd: scanStart + 0.3 * span, applyEnd: 10 + span * (diskIndex + 1) }
+}
+
+/**
+ * Snapshot-removal budget for the LAST pass and for failure cleanup.
+ *
+ * The per-pass removal must be waited out in full (SNAPSHOT_REMOVE_TIMEOUT_MS,
+ * 4 h): the next pass creates a snapshot and vCenter cannot do that while it
+ * consolidates. After the cutover pass no snapshot follows, and the target VM
+ * is waiting to be attached and booted — blocking that for hours on a source
+ * that is already powered off would be its own regression. Same on the failure
+ * path: the job has already failed, so cleanup notes what it could not confirm
+ * and moves on. In both cases the removal task keeps running on vCenter; we
+ * simply stop waiting for it.
+ */
+const TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS = SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS
+
+/**
+ * Snapshot budgets for the CUTOVER pass, where the source is already powered
+ * off and every second is guest downtime.
+ *
+ * The generous defaults (30 min to create, 4 h to wait out a consolidation)
+ * are right while the guest is still serving users: spending them buys a
+ * migration that would otherwise die. They are wrong here. The declared
+ * downtime budget for a warm migration defaults to 300 s, so inheriting hours
+ * of patience in this window would silently turn a "few seconds" cutover into
+ * an outage — exactly the promise warm migration exists to keep. Both waits
+ * stay bounded; the consolidation one is fail-open and proceeds regardless.
+ */
+const CUTOVER_SNAPSHOT_CREATE_TIMEOUT_MS = 5 * 60 * 1000
+const CUTOVER_CONSOLIDATION_TIMEOUT_MS = 2 * 60 * 1000
+
+/**
+ * Slice of the consolidation wait between two cancellation checks. The whole
+ * budget is CONSOLIDATION_TIMEOUT_MS (hours); polling it in slices keeps the
+ * job cancellable while it waits.
+ */
+const CONSOLIDATION_SLICE_MS = 60_000
+
+/**
+ * Create a warm snapshot and record its MOR for cleanup — including when the
+ * create fails.
+ *
+ * `ourSnapshots.push(mor)` used to run only after soapCreateSnapshot returned,
+ * so a create that timed out (or succeeded without a parseable MOR) left the
+ * pipeline with no handle on a snapshot vCenter went on to create anyway. That
+ * is how a customer ended up with a growing orphan `proxcenter-warm-delta-1` on
+ * a production VM. On failure we now resolve the snapshot by its exact name and
+ * push whatever we find, so failure cleanup can remove it. The recovery has its
+ * own try/catch: it must never mask the real error, which is always rethrown.
+ */
+export async function createWarmSnapshot(
+  session: SoapSession,
+  vmid: string,
+  snapName: string,
+  ourSnapshots: string[],
+  onRecovered?: (mor: string) => Promise<void> | void,
+  createTimeoutMs?: number,
+): Promise<string> {
+  const recover = async () => {
+    try {
+      for (const s of await soapFindSnapshotsByNamePrefix(session, vmid, snapName)) {
+        if (ourSnapshots.includes(s.mor)) continue
+        ourSnapshots.push(s.mor)
+        await onRecovered?.(s.mor)
+      }
+    } catch { /* a failed recovery must never replace the real error */ }
+  }
+
+  let snapMor: string
+  try {
+    snapMor = await soapCreateSnapshot(session, vmid, snapName, "warm migration", false, { timeoutMs: createTimeoutMs })
+  } catch (err) {
+    await recover()
+    throw err
+  }
+  if (!snapMor) {
+    await recover()
+    throw new Error(`CreateSnapshot (${snapName}) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually`)
+  }
+  ourSnapshots.push(snapMor)
+  return snapMor
+}
+
+/**
+ * Remove every leftover `proxcenter-warm-*` snapshot from the source VM.
+ *
+ * Backstop for the MORs we never learned: a create that timed out can still
+ * land on the source after cleanup ran through `ourSnapshots`. Safe to sweep by
+ * name because the pipeline enforces one warm job per source VM (activeWarmVms),
+ * so no other run owns a snapshot with this prefix. Never throws — cleanup runs
+ * on the failure path and must not add a second failure. Returns how many
+ * snapshots it confirmed removed.
+ */
+export async function sweepWarmSnapshots(
+  session: SoapSession,
+  vmid: string,
+  log: (msg: string) => Promise<void>,
+): Promise<number> {
+  const safeLog = (msg: string) => Promise.resolve().then(() => log(msg)).catch(() => {})
+  let removed = 0
+  let leftovers: Array<{ name: string; mor: string }>
+  try {
+    leftovers = await soapFindSnapshotsByNamePrefix(session, vmid, `${SNAPSHOT_PREFIX}-`)
+  } catch {
+    return 0
+  }
+  for (const s of leftovers) {
+    try {
+      await soapRemoveSnapshot(session, s.mor, false, { timeoutMs: TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS })
+      removed++
+      await safeLog(`Removed leftover warm snapshot "${s.name}" (${s.mor}) from the source VM`)
+    } catch (e: any) {
+      await safeLog(`Leftover warm snapshot "${s.name}" (${s.mor}) could not be confirmed removed (${e?.message || e}); remove it manually if it is still there`)
+    }
+  }
+  return removed
 }
 
 /** One copy pass's slot on the locked progress scale (see scaleWarmProgress). */
@@ -557,11 +675,48 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       }
     }
 
+    /**
+     * Wait out any consolidation still running on the source before asking for
+     * a new snapshot. Root cause of the field incident: RemoveSnapshot_Task
+     * reports success while vCenter keeps merging the delta, and a
+     * CreateSnapshot issued during that window never completes — two 120 s
+     * stalls in a row and a dead 14-hour migration.
+     *
+     * Fail-open: a VM flagged for an unrelated reason must stay migratable, so
+     * an elapsed budget only produces a warning and the pass starts anyway. The
+     * budget is consumed in short slices rather than one long call so a cancel
+     * request is honoured within the slice instead of hours later.
+     */
+    async function waitOutSourceConsolidation(label: string, budgetMs = CONSOLIDATION_TIMEOUT_MS): Promise<void> {
+      const t0 = Date.now()
+      let announced = false
+      const announce = () => {
+        if (announced) return
+        announced = true
+        void appendLog(jobId, `Source is still consolidating a previous snapshot; waiting before the ${label} pass (merging a multi-terabyte delta can take hours). Cancel the job if you would rather stop here.`, "warn").catch(() => {})
+      }
+      let cleared = false
+      while (!cleared && Date.now() - t0 < budgetMs) {
+        if (isCancelled(jobId)) throw new Error("Migration cancelled")
+        cleared = await soapWaitForConsolidation(soapSession!, config.sourceVmId, Math.min(CONSOLIDATION_SLICE_MS, budgetMs), undefined, announce)
+      }
+      const waitedSec = Math.round((Date.now() - t0) / 1000)
+      if (!cleared) {
+        await appendLog(jobId, `Source is STILL consolidating after ${waitedSec}s; starting the ${label} pass anyway — vCenter may reject the snapshot`, "warn")
+      } else if (announced) {
+        await appendLog(jobId, `Source finished consolidating after ${waitedSec}s; starting the ${label} pass`, "info")
+      }
+    }
+
     // Run one CBT pass: snapshot, per-disk query+read+apply, record changeIds, remove the snapshot.
-    async function runCbtPass(label: string, baseline: (deviceKey: number) => string, window: PassWindow): Promise<number> {
-      const snapMor = await soapCreateSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-${label}`, "warm migration", false)
-      if (!snapMor) throw new Error(`CreateSnapshot (${label}) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually`)
-      ourSnapshots.push(snapMor)
+    async function runCbtPass(
+      label: string, baseline: (deviceKey: number) => string, window: PassWindow,
+      passOpts: { removeTimeoutMs?: number; createTimeoutMs?: number; consolidationTimeoutMs?: number } = {},
+    ): Promise<number> {
+      await waitOutSourceConsolidation(label, passOpts.consolidationTimeoutMs)
+      const snapMor = await createWarmSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-${label}`, ourSnapshots,
+        mor => appendLog(jobId, `CreateSnapshot (${label}) failed, but the snapshot ${mor} exists on the source — it is now tracked and will be cleaned up`, "warn"),
+        passOpts.createTimeoutMs)
       let bytes = 0
       try {
         // Query every disk's changed areas up front so the pass has its byte
@@ -601,9 +756,11 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         }
       } finally {
         // Always remove OUR snapshot, by its specific MOR, never the children (a
-        // user snapshot taken under ours must survive — section 11).
-        await soapRemoveSnapshot(soapSession!, snapMor, false).catch(async () => {
-          await appendLog(jobId, `Warning: could not remove warm snapshot ${snapMor}; remove it manually`, "warn")
+        // user snapshot taken under ours must survive — section 11). Waited out
+        // in full by default: the next pass cannot snapshot a VM that is still
+        // consolidating this one.
+        await soapRemoveSnapshot(soapSession!, snapMor, false, { timeoutMs: passOpts.removeTimeoutMs }).catch(async (e: any) => {
+          await appendLog(jobId, `Warning: warm snapshot ${snapMor} was not confirmed removed (${e?.message || e}); vCenter may still be consolidating it — check the source VM`, "warn")
         })
         const k = ourSnapshots.indexOf(snapMor)
         if (k >= 0) ourSnapshots.splice(k, 1)
@@ -659,7 +816,16 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId,
         "Cutover: requesting clean guest shutdown (VMware Tools)…")
       await appendLog(jobId, "Source powered off (confirmed) — applying final delta", "success")
-      await runCbtPass("cutover", dk => diskState.get(dk)!.currentChangeId || "*", { status: "cutover", currentStep: "cutover", rangeStart: 95, rangeEnd: 98 })
+      // Last pass, and the only one that runs on a powered-off source: every
+      // wait here is guest downtime, so all three budgets are the short ones
+      // (see CUTOVER_SNAPSHOT_CREATE_TIMEOUT_MS and TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS).
+      await runCbtPass("cutover", dk => diskState.get(dk)!.currentChangeId || "*",
+        { status: "cutover", currentStep: "cutover", rangeStart: 95, rangeEnd: 98 },
+        {
+          removeTimeoutMs: TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS,
+          createTimeoutMs: CUTOVER_SNAPSHOT_CREATE_TIMEOUT_MS,
+          consolidationTimeoutMs: CUTOVER_CONSOLIDATION_TIMEOUT_MS,
+        })
     } else {
       // ── checksum fallback: stop source, full block-diff vs the (zeroed) target ──
       // The early shutdown belongs to the full copy on this path, NOT the cutover:
@@ -670,9 +836,8 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
       await cleanShutdownAndConfirm(jobId, soapSession!, config.sourceVmId,
         "Checksum fallback: requesting clean guest shutdown of the source BEFORE the copy — the VM stays powered off until the migration completes (CBT unavailable)…")
       await updateJob(jobId, "full_copy", { progress: 10 })
-      const snapMor = await soapCreateSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-checksum`, "warm migration", false)
-      if (!snapMor) throw new Error("CreateSnapshot (checksum) returned no snapshot reference; a snapshot may have been created on the source — verify and remove it manually")
-      ourSnapshots.push(snapMor)
+      const snapMor = await createWarmSnapshot(soapSession!, config.sourceVmId, `${SNAPSHOT_PREFIX}-checksum`, ourSnapshots,
+        mor => appendLog(jobId, `CreateSnapshot (checksum) failed, but the snapshot ${mor} exists on the source — it is now tracked and will be cleaned up`, "warn"))
       try {
         for (let i = 0; i < vmConfig.disks.length; i++) {
           const disk = vmConfig.disks[i]
@@ -728,7 +893,11 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
         // completed; a failure mid loop leaves the volumes unmarked and freeable.
         markVolumesCopied(allocatedVolumes)
       } finally {
-        await soapRemoveSnapshot(soapSession!, snapMor, false).catch(() => {})
+        // Terminal on this path too: the checksum fallback takes exactly one
+        // snapshot, so nothing downstream waits on the consolidation.
+        await soapRemoveSnapshot(soapSession!, snapMor, false, { timeoutMs: TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS }).catch(async (e: any) => {
+          await appendLog(jobId, `Warning: warm snapshot ${snapMor} was not confirmed removed (${e?.message || e}); vCenter may still be consolidating it — check the source VM`, "warn").catch(() => {})
+        })
         const k = ourSnapshots.indexOf(snapMor)
         if (k >= 0) ourSnapshots.splice(k, 1)
       }
@@ -880,7 +1049,14 @@ async function cleanupOnFailure(
     if (nodeIp) await stopVddkReader(config.targetConnectionId, nodeIp, r).catch(() => {})
   }
   if (session) {
-    for (const mor of [...ourSnapshots]) await soapRemoveSnapshot(session, mor, false).catch(() => {})
+    for (const mor of [...ourSnapshots]) {
+      await soapRemoveSnapshot(session, mor, false, { timeoutMs: TERMINAL_SNAPSHOT_REMOVE_TIMEOUT_MS }).catch(() => {})
+    }
+    // Backstop for the MORs we never learned (a create that timed out can still
+    // land afterwards): sweep anything named proxcenter-warm-* off the source.
+    // One warm job per source VM, so nothing else owns these.
+    await sweepWarmSnapshots(session, config.sourceVmId,
+      msg => appendLog(jobId, msg, "warn")).catch(() => {})
   }
   // Unmap RBD + free volumes the VM never referenced (orphans). volumesToFree also
   // covers a volume created by an allocation that reported a failure, and skips the

--- a/frontend/src/lib/vmware/soap.snapshot.test.ts
+++ b/frontend/src/lib/vmware/soap.snapshot.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// The snapshot helpers call soapRequest, which lives in the module under test,
+// so the transport is mocked one level lower: undici's request(). Same spirit as
+// cbt.soap.test.ts (mock the SOAP transport, keep the real parsing/looping).
+const undiciRequest = vi.fn()
+vi.mock("undici", () => ({
+  request: (...args: any[]) => undiciRequest(...args),
+  Agent: class { constructor(_opts?: any) { /* no-op */ } },
+}))
+
+import {
+  soapCreateSnapshot, soapRemoveSnapshot, soapRemoveAllSnapshots,
+  soapWaitForConsolidation, soapFindSnapshotsByNamePrefix, parseSnapshotList,
+  formatSoapBudget,
+} from "./soap"
+
+const session = {
+  baseUrl: "https://vcenter", cookie: "vmware_soap_session=abc", insecureTLS: true,
+  propertyCollector: "propertyCollector", sessionManager: "SessionManager",
+  rootFolder: "group-d1", isVcenter: true,
+} as any
+
+/** One undici response carrying `text` as the SOAP body. */
+function reply(text: string) {
+  return { statusCode: 200, headers: {}, body: { text: async () => text } }
+}
+const TASK = '<returnval type="Task">task-42</returnval>'
+const RUNNING = '<propSet><name>info.state</name><val xsi:type="TaskInfoState">running</val></propSet>'
+const DONE = '<propSet><name>info.state</name><val xsi:type="TaskInfoState">success</val></propSet>'
+const TASK_ERROR = '<propSet><name>info.state</name><val xsi:type="TaskInfoState">error</val></propSet>' +
+  "<localizedMessage>Another task is already in progress</localizedMessage>"
+const CREATE_DONE = DONE +
+  '<propSet><name>info.result</name><val xsi:type="ManagedObjectReference" type="VirtualMachineSnapshot">snapshot-12</val></propSet>'
+
+// Tiny intervals so no test ever sleeps. backoffAfterMs sits between the two so
+// a short poll loop exercises BOTH the fast and the backed-off interval.
+const fast = { pollMs: 1, slowPollMs: 1, backoffAfterMs: 10 }
+// Single-poll cases override only the interval, so the backoff defaults apply.
+const onePoll = { pollMs: 1 }
+
+/** Body of the nth SOAP request the code under test issued. */
+const bodyOf = (n: number) => String(undiciRequest.mock.calls[n][1].body)
+
+beforeEach(() => { undiciRequest.mockReset() })
+
+describe("soapCreateSnapshot", () => {
+  it("submits CreateSnapshot_Task and returns the snapshot MOR once the task succeeds", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(CREATE_DONE))
+    await expect(soapCreateSnapshot(session, "vm-9", "proxcenter-warm-full", "warm migration", false, onePoll))
+      .resolves.toBe("snapshot-12")
+    expect(bodyOf(0)).toContain("<urn:CreateSnapshot_Task>")
+    expect(bodyOf(0)).toContain("<urn:quiesce>false</urn:quiesce>")
+    // the poll asks for the three task properties the old inline loop asked for
+    expect(bodyOf(1)).toContain("<urn:pathSet>info.result</urn:pathSet>")
+  })
+
+  it("throws when vCenter faults the create call", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<faultstring>InvalidState</faultstring>"))
+    await expect(soapCreateSnapshot(session, "vm-9", "snap", "", false, fast))
+      .rejects.toThrow(/Failed to create snapshot: InvalidState/)
+  })
+
+  it("throws when no task reference comes back", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<returnval/>"))
+    await expect(soapCreateSnapshot(session, "vm-9", "snap", "", false, fast))
+      .rejects.toThrow(/No task returned from CreateSnapshot_Task/)
+  })
+
+  it("throws with the localized message when the task reports error", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(TASK_ERROR))
+    await expect(soapCreateSnapshot(session, "vm-9", "snap", "", false, fast))
+      .rejects.toThrow(/Snapshot creation failed: Another task is already in progress/)
+  })
+
+  it("falls back to a generic message when the failed task carries no localized message", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK))
+      .mockResolvedValueOnce(reply('<val xsi:type="TaskInfoState">error</val>'))
+    await expect(soapCreateSnapshot(session, "vm-9", "snap", "", false, onePoll))
+      .rejects.toThrow(/Snapshot creation failed: Unknown error/)
+  })
+
+  it("returns an empty MOR when the successful task exposes no snapshot reference", async () => {
+    // Caller-visible contract the warm pipeline depends on: "" means "no handle
+    // on the snapshot", and it resolves it by name instead.
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(DONE))
+    await expect(soapCreateSnapshot(session, "vm-9", "snap", "", false, onePoll)).resolves.toBe("")
+  })
+
+  it("honours the injected budget and names it, the VM and the task (no more hardcoded 120s)", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValue(reply(RUNNING))
+    const err = await soapCreateSnapshot(session, "vm-9", "proxcenter-warm-delta-1", "", false, { ...fast, timeoutMs: 30 })
+      .catch((e: Error) => e)
+    expect(String(err)).toMatch(/proxcenter-warm-delta-1/)
+    expect(String(err)).toMatch(/vm-9/)
+    expect(String(err)).toMatch(/task-42/)
+    expect(String(err)).toMatch(/within 30ms/)
+    expect(String(err)).not.toMatch(/120s/)
+  })
+})
+
+describe("soapRemoveSnapshot", () => {
+  it("submits RemoveSnapshot_Task and resolves once the task succeeds", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(DONE))
+    await expect(soapRemoveSnapshot(session, "snapshot-7", false, onePoll)).resolves.toBeUndefined()
+    expect(bodyOf(0)).toContain("<urn:RemoveSnapshot_Task>")
+    expect(bodyOf(0)).toContain("<urn:removeChildren>false</urn:removeChildren>")
+    expect(bodyOf(0)).toContain("<urn:consolidate>true</urn:consolidate>")
+  })
+
+  it("returns (unchanged loose semantics) when the task itself reports error", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(TASK_ERROR))
+    await expect(soapRemoveSnapshot(session, "snapshot-7", false, fast)).resolves.toBeUndefined()
+  })
+
+  it("throws when vCenter faults the remove call", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<faultstring>not found</faultstring>"))
+    await expect(soapRemoveSnapshot(session, "snapshot-7", false, fast))
+      .rejects.toThrow(/Failed to remove snapshot snapshot-7: not found/)
+  })
+
+  it("returns without polling when no task reference comes back", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<returnval/>"))
+    await expect(soapRemoveSnapshot(session, "snapshot-7", false, fast)).resolves.toBeUndefined()
+    expect(undiciRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it("THROWS on timeout instead of returning silently while vCenter still consolidates", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValue(reply(RUNNING))
+    const err = await soapRemoveSnapshot(session, "snapshot-7", false, { ...fast, timeoutMs: 30 })
+      .catch((e: Error) => e)
+    expect(err).toBeInstanceOf(Error)
+    expect(String(err)).toMatch(/Removal of snapshot snapshot-7 did not complete within 30ms/)
+  })
+})
+
+describe("soapRemoveAllSnapshots", () => {
+  it("submits RemoveAllSnapshots_Task and resolves once the task succeeds", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValueOnce(reply(DONE))
+    await expect(soapRemoveAllSnapshots(session, "vm-9", onePoll)).resolves.toBeUndefined()
+    expect(bodyOf(0)).toContain("<urn:RemoveAllSnapshots_Task>")
+  })
+
+  it("throws when vCenter faults the call", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<faultstring>busy</faultstring>"))
+    await expect(soapRemoveAllSnapshots(session, "vm-9", fast)).rejects.toThrow(/Failed to remove snapshots: busy/)
+  })
+
+  it("returns without polling when no task reference comes back", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<returnval/>"))
+    await expect(soapRemoveAllSnapshots(session, "vm-9", fast)).resolves.toBeUndefined()
+    expect(undiciRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it("THROWS on timeout instead of returning silently", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(TASK)).mockResolvedValue(reply(RUNNING))
+    await expect(soapRemoveAllSnapshots(session, "vm-9", { ...fast, timeoutMs: 30 }))
+      .rejects.toThrow(/Removal of all snapshots on VM vm-9 did not complete within 30ms/)
+  })
+})
+
+describe("formatSoapBudget", () => {
+  it("renders sub-second, second, minute and hour budgets", () => {
+    expect(formatSoapBudget(30)).toBe("30ms")
+    expect(formatSoapBudget(45_000)).toBe("45s")
+    expect(formatSoapBudget(30 * 60 * 1000)).toBe("30min")
+    expect(formatSoapBudget(4 * 60 * 60 * 1000)).toBe("4h")
+    expect(formatSoapBudget(90 * 60 * 1000)).toBe("1.5h")
+  })
+})
+
+const consolidation = (v: string) =>
+  `<propSet><name>runtime.consolidationNeeded</name><val xsi:type="xsd:boolean">${v}</val></propSet>`
+
+describe("soapWaitForConsolidation", () => {
+  it("returns true immediately when the VM has no pending consolidation", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(consolidation("false")))
+    await expect(soapWaitForConsolidation(session, "vm-9", 5000, 1)).resolves.toBe(true)
+    expect(undiciRequest).toHaveBeenCalledTimes(1)
+    expect(bodyOf(0)).toContain("<urn:pathSet>runtime.consolidationNeeded</urn:pathSet>")
+  })
+
+  it("returns true when the flag clears, announcing the wait exactly once", async () => {
+    undiciRequest
+      .mockResolvedValueOnce(reply(consolidation("true")))
+      .mockResolvedValueOnce(reply(consolidation("true")))
+      .mockResolvedValueOnce(reply(consolidation("false")))
+    const onWaitStart = vi.fn()
+    await expect(soapWaitForConsolidation(session, "vm-9", 5000, 1, onWaitStart)).resolves.toBe(true)
+    expect(onWaitStart).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns false (never throws) when the budget elapses with consolidation still pending", async () => {
+    undiciRequest.mockResolvedValue(reply(consolidation("true")))
+    await expect(soapWaitForConsolidation(session, "vm-9", 20, 1)).resolves.toBe(false)
+  })
+
+  it("fails open (true) when the property is absent, so an older host never blocks a migration", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<objects><obj>vm-9</obj></objects>"))
+    await expect(soapWaitForConsolidation(session, "vm-9", 20, 1)).resolves.toBe(true)
+  })
+
+  it("fails open (true) when the query itself fails", async () => {
+    undiciRequest.mockRejectedValue(new Error("socket hang up"))
+    await expect(soapWaitForConsolidation(session, "vm-9", 20, 1)).resolves.toBe(true)
+  })
+})
+
+// Realistic VirtualMachineSnapshotInfo payload: a root snapshot with two nested
+// children (the second nested inside the first), plus the currentSnapshot ref
+// that must NOT be mistaken for a tree node.
+const SNAPSHOT_TREE = `<currentSnapshot type="VirtualMachineSnapshot">snapshot-3</currentSnapshot>
+<rootSnapshotList>
+  <snapshot type="VirtualMachineSnapshot">snapshot-1</snapshot>
+  <vm type="VirtualMachine">vm-9</vm>
+  <name>daily-backup</name>
+  <description>user snapshot</description>
+  <id>1</id>
+  <createTime>2026-08-11T01:00:00Z</createTime>
+  <state>poweredOn</state>
+  <quiesced>false</quiesced>
+  <replaySupported>false</replaySupported>
+  <childSnapshotList>
+    <snapshot type="VirtualMachineSnapshot">snapshot-2</snapshot>
+    <vm type="VirtualMachine">vm-9</vm>
+    <name>proxcenter-warm-full</name>
+    <description>warm migration</description>
+    <id>2</id>
+    <state>poweredOn</state>
+    <childSnapshotList>
+      <snapshot type="VirtualMachineSnapshot">snapshot-3</snapshot>
+      <vm type="VirtualMachine">vm-9</vm>
+      <name>proxcenter-warm-delta-1</name>
+      <description>warm migration</description>
+      <id>3</id>
+      <state>poweredOn</state>
+    </childSnapshotList>
+  </childSnapshotList>
+</rootSnapshotList>`
+
+describe("parseSnapshotList", () => {
+  it("walks the nested rootSnapshotList and pairs every snapshot with its name", () => {
+    expect(parseSnapshotList(SNAPSHOT_TREE)).toEqual([
+      { name: "daily-backup", mor: "snapshot-1" },
+      { name: "proxcenter-warm-full", mor: "snapshot-2" },
+      { name: "proxcenter-warm-delta-1", mor: "snapshot-3" },
+    ])
+  })
+
+  it("tolerates an extra xsi:type attribute on the snapshot reference", () => {
+    expect(parseSnapshotList(
+      '<rootSnapshotList><snapshot xsi:type="ManagedObjectReference" type="VirtualMachineSnapshot">snapshot-8</snapshot>' +
+      "<name>proxcenter-warm-cutover</name></rootSnapshotList>",
+    )).toEqual([{ name: "proxcenter-warm-cutover", mor: "snapshot-8" }])
+  })
+
+  it("returns an empty list for a VM with no snapshots", () => {
+    expect(parseSnapshotList("")).toEqual([])
+    expect(parseSnapshotList("<rootSnapshotList></rootSnapshotList>")).toEqual([])
+    // a <name> with no snapshot reference before it belongs to something else
+    expect(parseSnapshotList("<name>not a snapshot</name>")).toEqual([])
+  })
+})
+
+describe("soapFindSnapshotsByNamePrefix", () => {
+  it("reads the VM's snapshot property and keeps only the matching names", async () => {
+    undiciRequest.mockResolvedValueOnce(reply(
+      `<objects><propSet><name>snapshot</name><val xsi:type="VirtualMachineSnapshotInfo">${SNAPSHOT_TREE}</val></propSet></objects>`,
+    ))
+    await expect(soapFindSnapshotsByNamePrefix(session, "vm-9", "proxcenter-warm-")).resolves.toEqual([
+      { name: "proxcenter-warm-full", mor: "snapshot-2" },
+      { name: "proxcenter-warm-delta-1", mor: "snapshot-3" },
+    ])
+    expect(bodyOf(0)).toContain("<urn:pathSet>snapshot</urn:pathSet>")
+    expect(bodyOf(0)).toContain('<urn:obj type="VirtualMachine">vm-9</urn:obj>')
+  })
+
+  it("returns an empty list when the VM carries no snapshot property", async () => {
+    undiciRequest.mockResolvedValueOnce(reply("<objects><obj>vm-9</obj></objects>"))
+    await expect(soapFindSnapshotsByNamePrefix(session, "vm-9", "proxcenter-warm-")).resolves.toEqual([])
+  })
+})

--- a/frontend/src/lib/vmware/soap.ts
+++ b/frontend/src/lib/vmware/soap.ts
@@ -241,8 +241,129 @@ export async function soapPowerOffVm(session: SoapSession, vmid: string): Promis
   throw new Error("VM did not power off within 60s")
 }
 
+// ── vSphere task polling ────────────────────────────────────────────────────
+//
+// Every long-running vSphere call hands back a Task MOR that we poll through
+// the PropertyCollector. The three snapshot helpers below each carried their
+// own copy of that loop, all hardcoded to 60 iterations × 2 s = 120 s. That
+// budget is meaningless on real workloads: merging a multi-terabyte delta on
+// vSAN genuinely takes hours. Worse, two of the three copies simply *returned*
+// when the 120 s elapsed — reporting "removed" while vCenter was still
+// consolidating — and the next CreateSnapshot then hit a VM that could not
+// take a snapshot and timed out in turn. Field incident: a 3 TB RHEL warm
+// migration died on two consecutive 120 s stalls (remove gave up silently,
+// then create timed out), leaving an orphan snapshot growing on a production
+// VM. One helper, real budgets, and a give-up that is always visible.
+
+/** Poll interval while a vSphere task is running. */
+export const SOAP_TASK_POLL_MS = 2000
+/** Poll interval used once a task has been running for SOAP_TASK_POLL_BACKOFF_AFTER_MS. */
+export const SOAP_TASK_SLOW_POLL_MS = 10_000
+/** A task still running after this long is a slow one — stop hammering the API. */
+export const SOAP_TASK_POLL_BACKOFF_AFTER_MS = 2 * 60 * 1000
+/** Budget for CreateSnapshot_Task (a busy VM can take minutes to quiesce/stun). */
+export const SNAPSHOT_CREATE_TIMEOUT_MS = 30 * 60 * 1000
+/** Budget for RemoveSnapshot_Task / RemoveAllSnapshots_Task: the delta merge is the slow part. */
+export const SNAPSHOT_REMOVE_TIMEOUT_MS = 4 * 60 * 60 * 1000
+/**
+ * Budget for a removal whose consolidation nothing downstream waits on: the last
+ * snapshot of a run, or failure cleanup. The full 4 h above is only justified
+ * when a FOLLOWING CreateSnapshot would collide with the merge. Everywhere else
+ * the caller is either holding a powered-off source (downtime is ticking) or
+ * reporting a job that already failed, and hanging for hours trades one
+ * regression for another. The task keeps running on vCenter; we stop waiting.
+ */
+export const SNAPSHOT_REMOVE_TERMINAL_TIMEOUT_MS = 15 * 60 * 1000
+/** Budget for waiting out a consolidation already in flight on a VM. */
+export const CONSOLIDATION_TIMEOUT_MS = 4 * 60 * 60 * 1000
+/** Poll interval for runtime.consolidationNeeded. */
+export const CONSOLIDATION_POLL_MS = 5000
+
+/**
+ * Per-call overrides for the task poll loop. Every field is optional and every
+ * public helper takes this as a trailing parameter, so existing call sites are
+ * unaffected; tests inject tiny values so nothing actually sleeps.
+ */
+export interface SoapTaskWaitOptions {
+  /** Total budget before the helper gives up. */
+  timeoutMs?: number
+  /** Interval between polls during the first `backoffAfterMs`. */
+  pollMs?: number
+  /** Interval between polls after `backoffAfterMs` (never shorter than pollMs). */
+  slowPollMs?: number
+  /** Elapsed time after which the poll interval widens to `slowPollMs`. */
+  backoffAfterMs?: number
+}
+
+/** Render a budget for an error message: "45s", "30min", "4h", "250ms". Pure. */
+export function formatSoapBudget(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}min`
+  const h = ms / 3_600_000
+  return `${Number.isInteger(h) ? h : h.toFixed(1)}h`
+}
+
+/**
+ * Poll a vSphere Task until it reports completion, or the budget elapses.
+ *
+ * Completion detection is deliberately the same loose `includes("success")` /
+ * `includes("error")` test the three inlined loops used before: this helper is
+ * shared by the warm, v2v and cold pipelines and a parsing change must not ride
+ * along with the timeout fix. Callers get the raw response text back and decide
+ * what "error" means for them (create throws, the removals just return).
+ *
+ * Returns the completed task's response text. An elapsed budget always throws,
+ * naming the operation, the object and the real budget: giving up quietly is
+ * the behaviour that caused the incident above, so this helper cannot do it.
+ */
+async function waitForSoapTask(
+  session: SoapSession,
+  taskMor: string,
+  opts: SoapTaskWaitOptions & {
+    timeoutMs: number
+    /** Operation + object, used verbatim in the timeout message. */
+    label: string
+    /** Task properties to retrieve (defaults to info.state only). */
+    paths?: string[]
+  },
+): Promise<{ text: string }> {
+  const pollMs = opts.pollMs ?? SOAP_TASK_POLL_MS
+  const slowPollMs = Math.max(pollMs, opts.slowPollMs ?? SOAP_TASK_SLOW_POLL_MS)
+  const backoffAfterMs = opts.backoffAfterMs ?? SOAP_TASK_POLL_BACKOFF_AFTER_MS
+  const pathTags = (opts.paths ?? ["info.state"]).map(p => `<urn:pathSet>${p}</urn:pathSet>`).join("")
+  const statusBody = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RetrievePropertiesEx>
+      <urn:_this type="PropertyCollector">${session.propertyCollector}</urn:_this>
+      <urn:specSet>
+        <urn:propSet><urn:type>Task</urn:type>${pathTags}</urn:propSet>
+        <urn:objectSet><urn:obj type="Task">${taskMor}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
+      </urn:specSet>
+      <urn:options/>
+    </urn:RetrievePropertiesEx>
+  </soapenv:Body>
+</soapenv:Envelope>`
+
+  const started = Date.now()
+  let elapsed = 0
+  while (elapsed < opts.timeoutMs) {
+    // Sleep first, exactly like the loops this replaces: a task is never ready
+    // the instant it is created, and the first poll costs a round trip.
+    await new Promise(r => setTimeout(r, elapsed >= backoffAfterMs ? slowPollMs : pollMs))
+    const status = await soapRequest(session.baseUrl, statusBody, session.cookie, session.insecureTLS)
+    if (status.text.includes("success") || status.text.includes("error")) return { text: status.text }
+    elapsed = Date.now() - started
+  }
+  throw new Error(
+    `${opts.label} did not complete within ${formatSoapBudget(opts.timeoutMs)} (vSphere task ${taskMor} is still running). ` +
+    `vCenter may still be working on it — check the source VM before retrying.`,
+  )
+}
+
 /** Create a snapshot on a VM (makes base disks read-only and downloadable while VM runs) */
-export async function soapCreateSnapshot(session: SoapSession, vmid: string, name: string, description = "", quiesce = false): Promise<string> {
+export async function soapCreateSnapshot(session: SoapSession, vmid: string, name: string, description = "", quiesce = false, opts: SoapTaskWaitOptions = {}): Promise<string> {
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
   <soapenv:Body>
@@ -266,37 +387,29 @@ export async function soapCreateSnapshot(session: SoapSession, vmid: string, nam
   const taskMor = result.text.match(/<returnval type="Task">([^<]+)<\/returnval>/)?.[1]
   if (!taskMor) throw new Error("No task returned from CreateSnapshot_Task")
 
-  for (let i = 0; i < 60; i++) {
-    await new Promise(r => setTimeout(r, 2000))
-    const statusBody = `<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
-  <soapenv:Body>
-    <urn:RetrievePropertiesEx>
-      <urn:_this type="PropertyCollector">${session.propertyCollector}</urn:_this>
-      <urn:specSet>
-        <urn:propSet><urn:type>Task</urn:type><urn:pathSet>info.state</urn:pathSet><urn:pathSet>info.error</urn:pathSet><urn:pathSet>info.result</urn:pathSet></urn:propSet>
-        <urn:objectSet><urn:obj type="Task">${taskMor}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
-      </urn:specSet>
-      <urn:options/>
-    </urn:RetrievePropertiesEx>
-  </soapenv:Body>
-</soapenv:Envelope>`
-    const status = await soapRequest(session.baseUrl, statusBody, session.cookie, session.insecureTLS)
-    if (status.text.includes("success")) {
-      // Extract snapshot MOR from result
-      const snapMor = status.text.match(/<val[^>]*type="VirtualMachineSnapshot"[^>]*>([^<]+)<\/val>/)?.[1] || ""
-      return snapMor
-    }
-    if (status.text.includes("error")) {
-      const fault = status.text.match(/<localizedMessage>([^<]*)<\/localizedMessage>/)?.[1] || "Unknown error"
-      throw new Error(`Snapshot creation failed: ${fault}`)
-    }
+  const status = await waitForSoapTask(session, taskMor, {
+    ...opts,
+    timeoutMs: opts.timeoutMs ?? SNAPSHOT_CREATE_TIMEOUT_MS,
+    label: `Snapshot creation "${name}" on VM ${vmid}`,
+    paths: ["info.state", "info.error", "info.result"],
+  })
+  if (status.text.includes("success")) {
+    // Extract snapshot MOR from result
+    return status.text.match(/<val[^>]*type="VirtualMachineSnapshot"[^>]*>([^<]+)<\/val>/)?.[1] || ""
   }
-  throw new Error("Snapshot creation timed out after 120s")
+  const fault = status.text.match(/<localizedMessage>([^<]*)<\/localizedMessage>/)?.[1] || "Unknown error"
+  throw new Error(`Snapshot creation failed: ${fault}`)
 }
 
-/** Remove all snapshots from a VM */
-export async function soapRemoveAllSnapshots(session: SoapSession, vmid: string): Promise<void> {
+/**
+ * Remove all snapshots from a VM.
+ *
+ * Waits for the consolidation to actually finish (SNAPSHOT_REMOVE_TIMEOUT_MS by
+ * default) and THROWS when the budget elapses. It used to fall out of a 120 s
+ * loop and return as if the removal had succeeded — see the header comment on
+ * waitForSoapTask for what that silence cost in the field.
+ */
+export async function soapRemoveAllSnapshots(session: SoapSession, vmid: string, opts: SoapTaskWaitOptions = {}): Promise<void> {
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
   <soapenv:Body>
@@ -317,24 +430,11 @@ export async function soapRemoveAllSnapshots(session: SoapSession, vmid: string)
   const taskMor = result.text.match(/<returnval type="Task">([^<]+)<\/returnval>/)?.[1]
   if (!taskMor) return
 
-  for (let i = 0; i < 60; i++) {
-    await new Promise(r => setTimeout(r, 2000))
-    const statusBody = `<?xml version="1.0" encoding="UTF-8"?>
-<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
-  <soapenv:Body>
-    <urn:RetrievePropertiesEx>
-      <urn:_this type="PropertyCollector">${session.propertyCollector}</urn:_this>
-      <urn:specSet>
-        <urn:propSet><urn:type>Task</urn:type><urn:pathSet>info.state</urn:pathSet></urn:propSet>
-        <urn:objectSet><urn:obj type="Task">${taskMor}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
-      </urn:specSet>
-      <urn:options/>
-    </urn:RetrievePropertiesEx>
-  </soapenv:Body>
-</soapenv:Envelope>`
-    const status = await soapRequest(session.baseUrl, statusBody, session.cookie, session.insecureTLS)
-    if (status.text.includes("success") || status.text.includes("error")) return
-  }
+  await waitForSoapTask(session, taskMor, {
+    ...opts,
+    timeoutMs: opts.timeoutMs ?? SNAPSHOT_REMOVE_TIMEOUT_MS,
+    label: `Removal of all snapshots on VM ${vmid}`,
+  })
 }
 
 /**
@@ -373,8 +473,14 @@ export async function soapGetSnapshotQuiesced(session: SoapSession, snapshotMor:
  * live migration path so we don't destroy pre-existing snapshots the user had
  * on the source VM, only the one ProxCenter created for the NFC export.
  * removeChildren=true consolidates any child snapshots into the parent.
+ *
+ * Waits up to SNAPSHOT_REMOVE_TIMEOUT_MS (overridable) for the merge to finish
+ * and THROWS when the budget elapses, instead of the old 120 s loop that
+ * returned as if the snapshot were gone while vCenter was still consolidating.
+ * Callers that treat a removal failure as non-fatal already wrap this in a
+ * `.catch()`; they now get a warning line instead of silence.
  */
-export async function soapRemoveSnapshot(session: SoapSession, snapshotMor: string, removeChildren = true): Promise<void> {
+export async function soapRemoveSnapshot(session: SoapSession, snapshotMor: string, removeChildren = true, opts: SoapTaskWaitOptions = {}): Promise<void> {
   const body = `<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
   <soapenv:Body>
@@ -392,28 +498,136 @@ export async function soapRemoveSnapshot(session: SoapSession, snapshotMor: stri
     throw new Error(`Failed to remove snapshot ${snapshotMor}: ${fault}`)
   }
 
-  // Wait for task completion (up to 2 min: merging a large delta can be slow)
+  // Wait for task completion: merging a multi-terabyte delta takes hours, not
+  // the 2 min this used to allow before returning as if it had worked.
   const taskMor = result.text.match(/<returnval type="Task">([^<]+)<\/returnval>/)?.[1]
   if (!taskMor) return
 
-  for (let i = 0; i < 60; i++) {
-    await new Promise(r => setTimeout(r, 2000))
-    const statusBody = `<?xml version="1.0" encoding="UTF-8"?>
+  await waitForSoapTask(session, taskMor, {
+    ...opts,
+    timeoutMs: opts.timeoutMs ?? SNAPSHOT_REMOVE_TIMEOUT_MS,
+    label: `Removal of snapshot ${snapshotMor}`,
+  })
+}
+
+/**
+ * Wait until the VM has no pending snapshot consolidation.
+ *
+ * RemoveSnapshot_Task reaching "success" does NOT mean the datastore is done:
+ * vCenter can still be merging the delta, and it flags that on the VM as
+ * runtime.consolidationNeeded. Asking for a new snapshot during that window
+ * produces a CreateSnapshot task that never completes — the exact double stall
+ * that killed a 3 TB warm migration in the field.
+ *
+ * FAIL-OPEN by contract: it never throws and never blocks forever. A VM whose
+ * consolidation flag is set for an unrelated, pre-existing reason must stay
+ * migratable, so the budget elapsing returns false and the caller is expected
+ * to log a warning and carry on. A query error is also treated as "can't tell,
+ * proceed" (returns true) rather than stalling the migration on a blip.
+ *
+ * `onWaitStart` fires once, the first time consolidation is observed pending,
+ * so the caller can log BEFORE a potentially long wait rather than after it.
+ */
+export async function soapWaitForConsolidation(
+  session: SoapSession,
+  vmid: string,
+  timeoutMs: number = CONSOLIDATION_TIMEOUT_MS,
+  pollMs: number = CONSOLIDATION_POLL_MS,
+  onWaitStart?: () => void,
+): Promise<boolean> {
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
   <soapenv:Body>
     <urn:RetrievePropertiesEx>
       <urn:_this type="PropertyCollector">${session.propertyCollector}</urn:_this>
       <urn:specSet>
-        <urn:propSet><urn:type>Task</urn:type><urn:pathSet>info.state</urn:pathSet></urn:propSet>
-        <urn:objectSet><urn:obj type="Task">${taskMor}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
+        <urn:propSet><urn:type>VirtualMachine</urn:type><urn:pathSet>runtime.consolidationNeeded</urn:pathSet></urn:propSet>
+        <urn:objectSet><urn:obj type="VirtualMachine">${vmid}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
       </urn:specSet>
       <urn:options/>
     </urn:RetrievePropertiesEx>
   </soapenv:Body>
 </soapenv:Envelope>`
-    const status = await soapRequest(session.baseUrl, statusBody, session.cookie, session.insecureTLS)
-    if (status.text.includes("success") || status.text.includes("error")) return
+
+  const started = Date.now()
+  let announced = false
+  do {
+    let pending: boolean
+    try {
+      const result = await soapRequest(session.baseUrl, body, session.cookie, session.insecureTLS)
+      // Absent property (older/ESXi hosts, VM without snapshots) reads as "".
+      pending = extractProp(result.text, "runtime.consolidationNeeded").trim() === "true"
+    } catch {
+      // Can't tell — never turn a transient query failure into a stalled migration.
+      return true
+    }
+    if (!pending) return true
+    if (!announced) { announced = true; onWaitStart?.() }
+    await new Promise(r => setTimeout(r, pollMs))
+  } while (Date.now() - started < timeoutMs)
+  return false
+}
+
+/**
+ * Flatten a VirtualMachine `snapshot` property payload into {name, mor} pairs.
+ *
+ * The payload nests VirtualMachineSnapshotTree entries: each carries its own
+ * `<snapshot type="VirtualMachineSnapshot">snapshot-NNN</snapshot>` followed by
+ * `<name>`, and children hang off `<childSnapshotList>` inside their parent. The
+ * MOR always precedes the name within a node, so one linear scan that pairs each
+ * snapshot reference with the next name walks the whole tree, depth included,
+ * without parsing the nesting. `<currentSnapshot>` is a different element and is
+ * intentionally not matched. Pure — unit-tested.
+ */
+export function parseSnapshotList(snapshotXml: string): Array<{ name: string; mor: string }> {
+  const out: Array<{ name: string; mor: string }> = []
+  if (!snapshotXml) return out
+  // `<snapshot …>` only — `<currentSnapshot>` starts with a different tag name
+  // and is skipped. Attributes are matched loosely so an extra xsi:type or a
+  // different attribute order does not silently disable the orphan recovery.
+  const tokenRe = /<snapshot\b[^>]*type="VirtualMachineSnapshot"[^>]*>([^<]*)<\/snapshot>|<name>([\s\S]*?)<\/name>/g
+  let pendingMor: string | null = null
+  let m: RegExpExecArray | null
+  while ((m = tokenRe.exec(snapshotXml)) !== null) {
+    if (m[1] !== undefined) {
+      pendingMor = m[1].trim()
+    } else if (pendingMor) {
+      out.push({ name: m[2].trim(), mor: pendingMor })
+      pendingMor = null
+    }
   }
+  return out
+}
+
+/**
+ * List the VM's snapshots whose name starts with `prefix`.
+ *
+ * Used to recover from a CreateSnapshot that timed out: vCenter may still land
+ * the snapshot after we gave up waiting, and without its MOR failure cleanup
+ * cannot remove it (the customer is left with a growing orphan delta on a
+ * production VM). Resolving by name is the only handle we have at that point.
+ */
+export async function soapFindSnapshotsByNamePrefix(
+  session: SoapSession,
+  vmid: string,
+  prefix: string,
+): Promise<Array<{ name: string; mor: string }>> {
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:urn="urn:vim25">
+  <soapenv:Body>
+    <urn:RetrievePropertiesEx>
+      <urn:_this type="PropertyCollector">${session.propertyCollector}</urn:_this>
+      <urn:specSet>
+        <urn:propSet><urn:type>VirtualMachine</urn:type><urn:pathSet>snapshot</urn:pathSet></urn:propSet>
+        <urn:objectSet><urn:obj type="VirtualMachine">${vmid}</urn:obj><urn:skip>false</urn:skip></urn:objectSet>
+      </urn:specSet>
+      <urn:options/>
+    </urn:RetrievePropertiesEx>
+  </soapenv:Body>
+</soapenv:Envelope>`
+
+  const result = await soapRequest(session.baseUrl, body, session.cookie, session.insecureTLS)
+  return parseSnapshotList(extractProp(result.text, "snapshot")).filter(s => s.name.startsWith(prefix))
 }
 
 // ── HttpNfcLease (Export VM) — for downloading disks when snapshots are active ──


### PR DESCRIPTION
## Problem

A warm migration of a 3 TB VM (vCenter on vSAN, multi-disk) failed in production with:

```
[1:35:24 AM] ✓ Full copy done: 2956.43 GB at 59 MB/s
[1:37:24 AM] ✗ Warm migration failed: Snapshot creation timed out after 120s
```

Two consecutive ~120 s stalls, right after a 14-hour full copy had completed successfully.

The timeout value was only the visible symptom. Every snapshot helper in `soap.ts` polled its vSphere task with the same hardcoded `60 × 2 s` loop, and two of the three simply *returned* when that budget elapsed:

1. The full-copy pass held one VMware snapshot for ~14 h, so its delta was large.
2. `soapRemoveSnapshot` gave up silently after 120 s while vCenter was still consolidating it, and reported success. That is the unexplained 1:33:09 → 1:35:24 gap in the log.
3. The delta pass immediately asked for a new snapshot on a VM that could not take one while consolidating, and that request burned its own 120 s budget and failed the run.

A create that times out also leaked. `ourSnapshots.push(mor)` ran only after the call returned, so a snapshot vCenter went on to create afterwards was invisible to failure cleanup and was left growing on a production VM.

## Changes

**Real budgets, and a give-up that is always visible.** The three duplicated poll loops become one `waitForSoapTask` helper: 30 min to create, 4 h for a merge, poll backing off from 2 s to 10 s after two minutes. Completion detection is byte-for-byte the previous logic, deliberately — this helper is shared by three pipelines and a parsing change must not ride along with a timeout fix. Both removal helpers now throw instead of returning as if the work were done. All budgets are optional trailing parameters, so existing call sites are unaffected.

**The actual root cause.** Before every pass the pipeline waits out any consolidation still in flight on the source (`runtime.consolidationNeeded`). It is fail-open by contract: a VM carrying that flag for an unrelated reason must stay migratable, so an elapsed budget only logs a warning and the pass starts anyway. The wait is consumed in short slices so the job stays cancellable.

**Downtime stays bounded.** The cutover pass is the one pass that runs on a powered-off source, so it keeps short budgets rather than inheriting hours of patience. The two non-warm sites that remove a snapshot after power-off or during failure cleanup are bounded for the same reason.

**No more orphan snapshots.** A failed create resolves the snapshot by name and records it, and failure cleanup sweeps any remaining `proxcenter-warm-*` snapshot off the source. Safe by name because the pipeline already enforces one warm job per source VM.

No UI or API surface changes: sizing a vSAN delta merge is not something an operator can estimate, so this is fixed at the root rather than exposed as a setting.

## Verification

- Full suite: 459 files, 4507 tests green. 45 new tests across two files.
- New-code line coverage on `soap.ts`: 100% (59 instrumented lines changed, 0 uncovered). The other three files are already in `sonar.coverage.exclusions`.
- `next build` exit 0; `tsc` shows no error in any touched file; ESLint clean.
- Not lab-reproduced: triggering it needs a multi-terabyte source whose snapshot merge exceeds two minutes.
