### PR TITLE
feat(backups): list PVE vzdump archives in a guest's Backups tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ backend/
 # this repo or in a private one. The Superpowers skill writes its plans
 # and specs under docs/superpowers/; that path is now ignored entirely.
 **/docs/superpowers/
+.superpowers/
 **/docs/internal/
 **/docs/audits/
 **/docs/plans/

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -1135,6 +1135,7 @@ export default function InventoryDetails({
     backupsVzdumpScanned, setBackupsVzdumpScanned,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
+    backupsScannedForIdRef,
     selectedBackup, setSelectedBackup,
 
     // Node tabs
@@ -1489,7 +1490,17 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
     setBackupsError(null)
     setBackupsWarnings([])
     setBackupsPreloaded(false)
+    // Verdicts portés par la réponse précédente : sans ce nettoyage, l'état
+    // vide à trois branches de l'onglet pourrait décrire un balayage effectué
+    // pour un AUTRE guest — « aucune archive sur les stockages du cluster »
+    // alors qu'ils n'ont jamais été interrogés pour celui-ci.
+    setBackupsPbsConfigured(null)
+    setBackupsVzdumpScanned(false)
     // Note: backupsLoadedForIdRef est géré dans l'effet de chargement des backups
+    // Le balayage vzdump, lui, est réarmé ici : son effet ne se redéclenche que
+    // sur changement d'onglet, il ne verrait donc jamais passer une sélection
+    // intermédiaire (nœud, cluster) et resterait muet au retour sur ce guest.
+    backupsScannedForIdRef.current = null
     setGuestInfo(null)
     setHeaderCollapsed(false)
 
@@ -1622,9 +1633,6 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
 
   const canShowRrd = selection && (selection.type === 'node' || selection.type === 'vm') && !data?.isTemplate
 
-  // Sélection dont l'onglet Sauvegardes a déjà déclenché son balayage vzdump.
-  const backupsScannedForIdRef = useRef<string | null>(null)
-
   // Précharger les backups quand on sélectionne une VM. Snapshots PBS
   // uniquement : le balayage des stockages PVE (archives vzdump) coûte
   // 1 + 1 + N nœuds x M stockages appels à pveproxy, inacceptable à chaque clic
@@ -1652,8 +1660,10 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
   }, [selection?.type, selection?.id, detailTab, loadBackups])
 
   // Recharger avec le balayage vzdump à l'ouverture de l'onglet Sauvegardes.
-  // Une fois par couple (guest, ouverture) : le ref porte l'id de sélection,
-  // donc changer de VM réarme le balayage et rien d'autre ne le redéclenche.
+  // Une fois par guest : le ref porte l'id de sélection et l'effet de
+  // réinitialisation le remet à null à chaque changement de sélection, y compris
+  // vers un nœud ou le cluster. Revenir sur l'onglet ne rebalaye donc pas, mais
+  // revenir sur le guest, si.
   useEffect(() => {
     if (selection?.type !== 'vm' || detailTab !== VM_BACKUPS_TAB_INDEX) return
     if (backupsScannedForIdRef.current === selection.id) return

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -133,11 +133,18 @@ import { UploadDialog } from '@/components/storage/StorageContentBrowser'
 import TemplateDownloadDialog from '@/components/storage/TemplateDownloadDialog'
 import { loadNodeAptUpdates } from '@/lib/proxmox/loadNodeAptUpdates'
 
+/**
+ * Rang de l'onglet Sauvegardes d'une VM dans `VmDetailTabs` (Résumé, Matériel,
+ * Options, Historique, Sauvegardes...). À garder aligné sur l'ordre des `Tab`
+ * qui y sont déclarés, comme l'index 7 de la réplication plus bas.
+ */
+const VM_BACKUPS_TAB_INDEX = 4
+
 /* ------------------------------------------------------------------ */
 /* Main component                                                     */
 /* ------------------------------------------------------------------ */
 
-export default function InventoryDetails({ 
+export default function InventoryDetails({
   selection,
   onSelect,
   onBack,
@@ -1615,7 +1622,14 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
 
   const canShowRrd = selection && (selection.type === 'node' || selection.type === 'vm') && !data?.isTemplate
 
-  // Charger les backups quand on sélectionne une VM
+  // Sélection dont l'onglet Sauvegardes a déjà déclenché son balayage vzdump.
+  const backupsScannedForIdRef = useRef<string | null>(null)
+
+  // Précharger les backups quand on sélectionne une VM. Snapshots PBS
+  // uniquement : le balayage des stockages PVE (archives vzdump) coûte
+  // 1 + 1 + N nœuds x M stockages appels à pveproxy, inacceptable à chaque clic
+  // dans l'arbre. Il n'a lieu qu'à l'ouverture de l'onglet Sauvegardes, juste
+  // en dessous.
   useEffect(() => {
     if (selection?.type !== 'vm') {
       backupsLoadedForIdRef.current = null
@@ -1624,12 +1638,33 @@ return textExts.includes(ext) || imageExts.includes(ext) || fileName.startsWith(
 
     const currentSelectionId = selection.id
     if (backupsLoadedForIdRef.current === currentSelectionId) return
+
+    // Onglet Sauvegardes déjà ouvert : son propre effet charge la même VM avec
+    // le balayage. Précharger en plus lancerait deux requêtes concurrentes dont
+    // la plus lente écraserait l'autre.
+    if (detailTab === VM_BACKUPS_TAB_INDEX) return
+
     backupsLoadedForIdRef.current = currentSelectionId
 
-    const { connId, type, vmid } = parseVmId(selection.id)
-    loadBackups(vmid, type, connId)
+    const { connId, node, type, vmid } = parseVmId(selection.id)
+    loadBackups(vmid, type, connId, { node })
     setBackupsPreloaded(true)
-  }, [selection?.type, selection?.id, loadBackups])
+  }, [selection?.type, selection?.id, detailTab, loadBackups])
+
+  // Recharger avec le balayage vzdump à l'ouverture de l'onglet Sauvegardes.
+  // Une fois par couple (guest, ouverture) : le ref porte l'id de sélection,
+  // donc changer de VM réarme le balayage et rien d'autre ne le redéclenche.
+  useEffect(() => {
+    if (selection?.type !== 'vm' || detailTab !== VM_BACKUPS_TAB_INDEX) return
+    if (backupsScannedForIdRef.current === selection.id) return
+
+    backupsScannedForIdRef.current = selection.id
+    backupsLoadedForIdRef.current = selection.id
+
+    const { connId, node, type, vmid } = parseVmId(selection.id)
+    loadBackups(vmid, type, connId, { node, scanVzdump: true })
+    setBackupsPreloaded(true)
+  }, [selection?.type, selection?.id, detailTab, loadBackups])
 
   // Note: snapshot preloading is handled inside useSnapshots hook
 

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -1125,6 +1125,7 @@ export default function InventoryDetails({
     backupsStats, setBackupsStats,
     backupsWarnings, setBackupsWarnings,
     backupsPbsConfigured, setBackupsPbsConfigured,
+    backupsVzdumpScanned, setBackupsVzdumpScanned,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
     selectedBackup, setSelectedBackup,
@@ -3430,7 +3431,7 @@ return vm?.isCluster ?? false
           {selection?.type === 'vm' && (
             <VmDetailTabs
               {...{addCephReplicationDialogOpen, addReplicationDialogOpen, availableTargetNodes, backToArchives, backToBackupsList,
-                backups, backupsError, backupsLoading, backupsPreloaded, backupsStats, backupsWarnings, backupsPbsConfigured, balloon,
+                backups, backupsError, backupsLoading, backupsPreloaded, backupsStats, backupsWarnings, backupsPbsConfigured, backupsVzdumpScanned, balloon,
                 balloonEnabled, browseArchive, canPreview, canShowRrd, cephClusters, cephClustersLoading,
                 cephReplicationJobs, cephReplicationSchedule, compatibleStorages, cpuCores, cpuLimit,
                 cpuFlags, cpuLimitEnabled, cpuModified, cpuSockets, cpuType, createSnapshot,

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -202,7 +202,12 @@ export interface InventoryDialogsProps {
   creatingBackup: boolean
   setCreatingBackup: (v: boolean) => void
   backupStorages: any[]
-  loadBackups: (vmid: string, vmType: string, connId?: string) => void
+  loadBackups: (
+    vmid: string,
+    vmType: string,
+    connId?: string,
+    opts?: { node?: string; scanVzdump?: boolean },
+  ) => void
 
   // Delete VM dialog
   deleteVmDialogOpen: boolean
@@ -1780,11 +1785,13 @@ return
                 showSnackbar(t('backups.backupStarted'), 'success')
                 
                 // Recharger les backups après un délai
+                // La sauvegarde qui vient d'être lancée peut être un vzdump sur
+                // un stockage PVE : on rebalaye, sinon elle n'apparaîtrait pas.
                 setTimeout(() => {
                   if (selection?.type === 'vm') {
-                    const { connId, type: vmType, vmid } = parseVmId(selection.id)
+                    const { connId, node, type: vmType, vmid } = parseVmId(selection.id)
 
-                    loadBackups(vmid, vmType, connId)
+                    loadBackups(vmid, vmType, connId, { node, scanVzdump: true })
                   }
                 }, 5000)
               } catch (e: any) {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
@@ -570,8 +570,23 @@ export function useHardwareHandlers({
   useSyslogLive(nodeSyslogLive, selection?.type, selection?.id, nodeTab, nodeSystemSubTab, setNodeSyslogData)
   useCephLogLive(nodeCephLogLive, selection?.type, selection?.id, data?.clusterName, setNodeCephData)
 
-  // Charger les sauvegardes d'une VM
-  const loadBackups = useCallback(async (vmid: string, type: string, connId?: string) => {
+  /**
+   * Charger les sauvegardes d'une VM.
+   *
+   * `opts.node` = nœud courant du guest : la route le fait remonter en tête du
+   * balayage vzdump, pour que la troncature au plafond dur n'écarte jamais le
+   * nœud qui porte le plus probablement ses archives.
+   *
+   * `opts.scanVzdump` = balayer les stockages PVE. Coûteux (1 + 1 + N nœuds x
+   * M stockages appels pveproxy) : réservé à l'ouverture réelle de l'onglet
+   * Sauvegardes, jamais au préchargement déclenché par la sélection.
+   */
+  const loadBackups = useCallback(async (
+    vmid: string,
+    type: string,
+    connId?: string,
+    opts?: { node?: string; scanVzdump?: boolean },
+  ) => {
     if (!vmid) return
 
     setBackupsLoading(true)
@@ -590,6 +605,8 @@ export function useHardwareHandlers({
       // Pass the guest's PVE connection so the route can tell whether a
       // connected PBS actually backs up this cluster (drives the empty state).
       if (connId) params.set('connectionId', connId)
+      if (opts?.node) params.set('node', opts.node)
+      if (opts?.scanVzdump) params.set('scanVzdump', '1')
 
       const res = await fetch(`/api/v1/guests/${encodeURIComponent(vmid)}/backups?${params}`, { cache: 'no-store' })
       const json = await res.json()

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
@@ -368,6 +368,9 @@ export function useHardwareHandlers({
   const [backupsVzdumpScanned, setBackupsVzdumpScanned] = useState<boolean>(false)
   const [backupsPreloaded, setBackupsPreloaded] = useState(false)
   const backupsLoadedForIdRef = useRef<string | null>(null) // Track which selection ID backups were loaded for
+  // Idem pour le balayage vzdump, déclenché par la seule ouverture de l'onglet
+  // Sauvegardes. Les deux refs sont réarmées ensemble au changement de sélection.
+  const backupsScannedForIdRef = useRef<string | null>(null)
   const [selectedBackup, setSelectedBackup] = useState<any>(null)
 
   // État pour les onglets node (host standalone)
@@ -1413,6 +1416,7 @@ return explorerFiles.filter((file: any) =>
     backupsVzdumpScanned, setBackupsVzdumpScanned,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
+    backupsScannedForIdRef,
     selectedBackup, setSelectedBackup,
 
     // Node tabs

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useHardwareHandlers.ts
@@ -365,6 +365,7 @@ export function useHardwareHandlers({
   const [backupsStats, setBackupsStats] = useState<any>(null)
   const [backupsWarnings, setBackupsWarnings] = useState<string[]>([])
   const [backupsPbsConfigured, setBackupsPbsConfigured] = useState<boolean | null>(null)
+  const [backupsVzdumpScanned, setBackupsVzdumpScanned] = useState<boolean>(false)
   const [backupsPreloaded, setBackupsPreloaded] = useState(false)
   const backupsLoadedForIdRef = useRef<string | null>(null) // Track which selection ID backups were loaded for
   const [selectedBackup, setSelectedBackup] = useState<any>(null)
@@ -579,6 +580,7 @@ export function useHardwareHandlers({
     setBackupsStats(null)
     setBackupsWarnings([])
     setBackupsPbsConfigured(null)
+    setBackupsVzdumpScanned(false)
 
     try {
       const params = new URLSearchParams()
@@ -599,6 +601,7 @@ export function useHardwareHandlers({
         setBackupsStats(json.data?.stats || null)
         setBackupsWarnings(json.data?.warnings || [])
         setBackupsPbsConfigured(json.data?.pbsConfigured ?? null)
+        setBackupsVzdumpScanned(json.data?.vzdumpScanned === true)
       }
     } catch (e: any) {
       setBackupsError(e.message || t('errors.loadingError'))
@@ -1390,6 +1393,7 @@ return explorerFiles.filter((file: any) =>
     backupsStats, setBackupsStats,
     backupsWarnings, setBackupsWarnings,
     backupsPbsConfigured, setBackupsPbsConfigured,
+    backupsVzdumpScanned, setBackupsVzdumpScanned,
     backupsPreloaded, setBackupsPreloaded,
     backupsLoadedForIdRef,
     selectedBackup, setSelectedBackup,

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -2822,9 +2822,12 @@ return (
                               <Typography variant="caption" sx={{ opacity: 0.6 }}>{t('backups.verified')}</Typography>
                             </Box>
                           )}
+                          {/* Sans PBS, la tuile « Vérifiées » disparaît et
+                              celle-ci jouxte le compteur : deux « Total »
+                              côte à côte ne disent plus lequel est lequel. */}
                           <Box sx={{ textAlign: 'center', p: 1, bgcolor: 'action.hover', borderRadius: 2 }}>
                             <Typography variant="h6" sx={{ fontWeight: 700 }}>{backupsStats.totalSizeFormatted}</Typography>
-                            <Typography variant="caption" sx={{ opacity: 0.6 }}>Total</Typography>
+                            <Typography variant="caption" sx={{ opacity: 0.6 }}>{t('common.size')}</Typography>
                           </Box>
                         </Box>
                       </CardContent>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -4854,12 +4854,20 @@ return (
       </Dialog>
       {restoreDialog && selection?.type === 'vm' && (() => {
         const { connId, node, type, vmid } = parseVmId(selection.id)
+
+        // Une archive vzdump sur un stockage non partagé n'est lisible que
+        // depuis le nœud qui la détient : après migration du guest, son nœud
+        // courant n'est pas celui de l'archive.
+        const restoreNode = restoreDialog.backup?.source === 'vzdump' && restoreDialog.backup?.node
+          ? restoreDialog.backup.node
+          : node
+
         return (
           <RestoreVmDialog
             open
             onClose={() => setRestoreDialog(null)}
             connectionId={connId}
-            node={node}
+            node={restoreNode}
             type={(type === 'lxc' ? 'lxc' : 'qemu')}
             backup={restoreDialog.backup}
             sourceVmid={Number(vmid)}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -1141,7 +1141,9 @@ export default function VmDetailTabs(props: any) {
                                 onClick={() => setCpuFlagsOpen(!cpuFlagsOpen)}
                                 sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 1, cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' } }}
                               >
-                                <Typography variant="body2" fontWeight={600} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                {/* component="div": body2 would render a <p>, and the Chip
+                                    below renders a <div> — invalid nesting, hydration error. */}
+                                <Typography variant="body2" component="div" fontWeight={600} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                                   <i className="ri-flag-line" style={{ fontSize: 16 }} />
                                   {t('inventory.cpuFlags')}
                                   {activeCount > 0 && (

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -379,10 +379,14 @@ export default function VmDetailTabs(props: any) {
   const changeTrackingAvailable = hasFeature(Features.CHANGE_TRACKING)
 
   // Namespaces seen in the loaded backup snapshots, sorted alphabetically with
-  // root first. Drives the dropdown above the BACKUP list.
+  // root first. Drives the dropdown above the BACKUP list. vzdump archives live
+  // on a PVE storage and have no namespace, so they never feed the dropdown.
   const availableBackupNamespaces = useMemo<string[]>(() => {
     const set = new Set<string>()
-    for (const b of backups || []) set.add(b.namespace || '')
+    for (const b of backups || []) {
+      if (b.source === 'vzdump') continue
+      set.add(b.namespace || '')
+    }
     return Array.from(set).sort((a, b) => (a === '' ? -1 : b === '' ? 1 : a.localeCompare(b)))
   }, [backups])
 
@@ -2803,15 +2807,20 @@ return (
                   {!backupsLoading && backupsStats && backupsStats.total > 0 && !selectedBackup && (
                     <Card variant="outlined" sx={{ mb: 2 }}>
                       <CardContent sx={{ pb: '16px !important' }}>
-                        <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 2 }}>
+                        <Box sx={{ display: 'grid', gridTemplateColumns: backupsStats.pbsTotal > 0 ? '1fr 1fr 1fr' : '1fr 1fr', gap: 2 }}>
                           <Box sx={{ textAlign: 'center', p: 1, bgcolor: 'action.hover', borderRadius: 2 }}>
                             <Typography variant="h6" sx={{ fontWeight: 700, color: primaryColor }}>{backupsStats.total}</Typography>
                             <Typography variant="caption" sx={{ opacity: 0.6 }}>Total</Typography>
                           </Box>
-                          <Box sx={{ textAlign: 'center', p: 1, bgcolor: 'action.hover', borderRadius: 2 }}>
-                            <Typography variant="h6" sx={{ fontWeight: 700, color: 'success.main' }}>{backupsStats.verifiedCount || 0}</Typography>
-                            <Typography variant="caption" sx={{ opacity: 0.6 }}>{t('backups.verified')}</Typography>
-                          </Box>
+                          {/* "Verified" only means something for PBS snapshots: a vzdump
+                              archive is never verified, so counting it in would read as
+                              a failed verification. */}
+                          {backupsStats.pbsTotal > 0 && (
+                            <Box sx={{ textAlign: 'center', p: 1, bgcolor: 'action.hover', borderRadius: 2 }}>
+                              <Typography variant="h6" sx={{ fontWeight: 700, color: 'success.main' }}>{backupsStats.verifiedCount || 0}</Typography>
+                              <Typography variant="caption" sx={{ opacity: 0.6 }}>{t('backups.verified')}</Typography>
+                            </Box>
+                          )}
                           <Box sx={{ textAlign: 'center', p: 1, bgcolor: 'action.hover', borderRadius: 2 }}>
                             <Typography variant="h6" sx={{ fontWeight: 700 }}>{backupsStats.totalSizeFormatted}</Typography>
                             <Typography variant="caption" sx={{ opacity: 0.6 }}>Total</Typography>
@@ -2846,9 +2855,12 @@ return (
 
                     // Apply the namespace filter before grouping so the rest of
                     // the UI (counts, totals) stays consistent with what is shown.
+                    // vzdump archives have no namespace at all, so they stay
+                    // visible whichever namespace is selected.
                     const visibleBackups = vmBackupNamespaceFilter === 'all'
                       ? backups
-                      : backups.filter((b: any) => (b.namespace || '') === vmBackupNamespaceFilter)
+                      : backups.filter((b: any) =>
+                          b.source === 'vzdump' || (b.namespace || '') === vmBackupNamespaceFilter)
 
                     if (visibleBackups.length === 0) {
                       return (
@@ -2858,10 +2870,15 @@ return (
                       )
                     }
 
-                    // Group by pbsName/datastore
+                    // Group by PBS/datastore for PBS snapshots, by node/storage for
+                    // vzdump archives. The source is part of the key so the two
+                    // families never land in the same group.
                     const groupMap = new Map<string, any[]>()
                     for (const backup of visibleBackups) {
-                      const groupKey = `${backup.pbsName || 'PBS'}/${backup.datastore || 'default'}`
+                      const groupKey = backup.source === 'vzdump'
+                        ? `vzdump|${backup.node}|${backup.storage}`
+                        : `pbs|${backup.pbsName || 'PBS'}|${backup.datastore || 'default'}`
+
                       if (!groupMap.has(groupKey)) groupMap.set(groupKey, [])
                       groupMap.get(groupKey)!.push(backup)
                     }
@@ -2881,7 +2898,8 @@ return (
                             const isExpanded = expandedVmBackupGroups.has(groupId)
                             const totalSize = groupBackups.reduce((sum: number, b: any) => sum + (b.size || 0), 0)
                             const verifiedCount = groupBackups.filter((b: any) => b.verified).length
-                            const [pbsName, dsName] = groupId.split('/')
+                            const [groupSource, groupPrimary, groupSecondary] = groupId.split('|')
+                            const isVzdumpGroup = groupSource === 'vzdump'
 
                             return (
                               <Box key={groupId}>
@@ -2907,27 +2925,40 @@ return (
                                   <i className={isExpanded ? 'ri-subtract-line' : 'ri-add-line'} style={{ fontSize: 18, opacity: 0.5 }} />
                                   <i className="ri-shield-check-line" style={{ fontSize: 16, color: primaryColor }} />
                                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                                    <Typography variant="body2" fontWeight={600} noWrap sx={{ fontSize: 12 }}>
-                                      {pbsName}
-                                    </Typography>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0 }}>
+                                      <Typography variant="body2" fontWeight={600} noWrap sx={{ fontSize: 12 }}>
+                                        {groupPrimary}
+                                      </Typography>
+                                      <Chip
+                                        size="small"
+                                        label={isVzdumpGroup ? t('backups.sourceVzdump') : 'PBS'}
+                                        sx={{ height: 18, fontSize: 10 }}
+                                      />
+                                    </Box>
                                     <Typography variant="caption" sx={{ opacity: 0.5, fontSize: 10 }}>
-                                      {dsName}
+                                      {groupSecondary}
                                     </Typography>
                                   </Box>
                                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                                     <Typography variant="body2" sx={{ opacity: 0.7, fontSize: 12 }}>
-                                      {groupBackups.length} snapshot{groupBackups.length > 1 ? 's' : ''}
+                                      {isVzdumpGroup
+                                        ? t('backups.archivesCount', { count: groupBackups.length })
+                                        : `${groupBackups.length} snapshot${groupBackups.length > 1 ? 's' : ''}`}
                                     </Typography>
-                                    {verifiedCount === groupBackups.length ? (
-                                      <MuiTooltip title={t('inventory.pbsAllVerified')}>
-                                        <i className="ri-checkbox-circle-fill" style={{ fontSize: 16, color: '#4caf50' }} />
-                                      </MuiTooltip>
-                                    ) : verifiedCount > 0 ? (
-                                      <MuiTooltip title={`${verifiedCount}/${groupBackups.length}`}>
-                                        <i className="ri-checkbox-circle-line" style={{ fontSize: 16, color: '#ff9800' }} />
-                                      </MuiTooltip>
-                                    ) : (
-                                      <i className="ri-checkbox-blank-circle-line" style={{ fontSize: 16, opacity: 0.3 }} />
+                                    {/* A vzdump archive is never verified: showing the group
+                                        verification state would read as "nothing verified". */}
+                                    {!isVzdumpGroup && (
+                                      verifiedCount === groupBackups.length ? (
+                                        <MuiTooltip title={t('inventory.pbsAllVerified')}>
+                                          <i className="ri-checkbox-circle-fill" style={{ fontSize: 16, color: '#4caf50' }} />
+                                        </MuiTooltip>
+                                      ) : verifiedCount > 0 ? (
+                                        <MuiTooltip title={`${verifiedCount}/${groupBackups.length}`}>
+                                          <i className="ri-checkbox-circle-line" style={{ fontSize: 16, color: '#ff9800' }} />
+                                        </MuiTooltip>
+                                      ) : (
+                                        <i className="ri-checkbox-blank-circle-line" style={{ fontSize: 16, opacity: 0.3 }} />
+                                      )
                                     )}
                                     <Typography variant="body2" sx={{ opacity: 0.6, minWidth: 70, textAlign: 'right', fontFamily: 'monospace', fontSize: 12 }}>
                                       {formatBytes(totalSize)}
@@ -2951,7 +2982,12 @@ return (
                                       <Typography variant="caption" fontWeight={600} sx={{ opacity: 0.6, fontSize: 10, textAlign: 'center' }}>{t('common.status')}</Typography>
                                       <Typography variant="caption" fontWeight={600} sx={{ opacity: 0.6, fontSize: 10, textAlign: 'center' }}></Typography>
                                     </Box>
-                                    {groupBackups.map((backup: any, idx: number) => (
+                                    {groupBackups.map((backup: any, idx: number) => {
+                                      // A vzdump archive cannot be browsed: the row is inert,
+                                      // only its Restore button stays active.
+                                      const isVzdump = backup.source === 'vzdump'
+
+                                      return (
                                       <Box
                                         key={backup.id || idx}
                                         sx={{
@@ -2961,11 +2997,11 @@ return (
                                           borderBottom: idx < groupBackups.length - 1 ? '1px solid' : 'none',
                                           borderColor: 'divider',
                                           alignItems: 'center',
-                                          cursor: 'pointer',
-                                          '&:hover': { bgcolor: 'action.focus' },
+                                          cursor: isVzdump ? 'default' : 'pointer',
+                                          '&:hover': isVzdump ? undefined : { bgcolor: 'action.focus' },
                                           minHeight: 28,
                                         }}
-                                        onClick={() => {
+                                        onClick={isVzdump ? undefined : () => {
                                           setSelectedBackup(backup)
                                           loadBackupContent(backup)
                                         }}
@@ -2984,7 +3020,7 @@ return (
                                             <MuiTooltip title={t('backups.verified')}>
                                               <i className="ri-checkbox-circle-fill" style={{ fontSize: 15, color: '#4caf50' }} />
                                             </MuiTooltip>
-                                          ) : (
+                                          ) : isVzdump ? null : (
                                             <i className="ri-checkbox-blank-circle-line" style={{ fontSize: 15, opacity: 0.3 }} />
                                           )}
                                           {backup.protected && (
@@ -2994,7 +3030,13 @@ return (
                                           )}
                                         </Box>
                                         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
-                                          <i className="ri-arrow-right-s-line" style={{ fontSize: 16, opacity: 0.4 }} />
+                                          {isVzdump ? (
+                                            <MuiTooltip title={t('backups.vzdumpNoBrowsing')}>
+                                              <i className="ri-information-line" style={{ fontSize: 15, opacity: 0.4 }} />
+                                            </MuiTooltip>
+                                          ) : (
+                                            <i className="ri-arrow-right-s-line" style={{ fontSize: 16, opacity: 0.4 }} />
+                                          )}
                                         </Box>
                                         <Box sx={{ display: 'flex', justifyContent: 'center' }}>
                                           <MuiTooltip title={t('inventory.pbsRestoreVm') ?? 'Restore'}>
@@ -3008,7 +3050,8 @@ return (
                                           </MuiTooltip>
                                         </Box>
                                       </Box>
-                                    ))}
+                                      )
+                                    })}
                                   </Box>
                                 )}
                               </Box>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/VmDetailTabs.tsx
@@ -196,6 +196,7 @@ export default function VmDetailTabs(props: any) {
     backupsStats,
     backupsWarnings,
     backupsPbsConfigured,
+    backupsVzdumpScanned,
     balloon,
     balloonEnabled,
     browseArchive,
@@ -2833,6 +2834,24 @@ return (
                   {/* Liste des backups groupés par PBS/datastore */}
                   {!backupsLoading && !selectedBackup && (() => {
                     if (backups.length === 0) {
+                      // On a aussi balayé les stockages du cluster sans rien
+                      // trouver : dire « pas de PBS » serait trompeur.
+                      if (backupsPbsConfigured === false && backupsVzdumpScanned) {
+                        return (
+                          <Alert severity="info" sx={{ mt: 2 }}>
+                            <Typography variant="body2" fontWeight={600}>
+                              {t('backups.noBackupsAnywhereTitle')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ mt: 0.5 }}>
+                              {t('backups.noBackupsAnywhereHint')}
+                            </Typography>
+                            <Typography variant="body2" sx={{ mt: 0.5, opacity: 0.7 }}>
+                              {t('backups.noPbsConfiguredHint')}
+                            </Typography>
+                          </Alert>
+                        )
+                      }
+
                       if (backupsPbsConfigured === false) {
                         return (
                           <Alert severity="info" sx={{ mt: 2 }}>

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/restore/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/restore/route.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+// Hoisted mocks -- referenced from vi.mock factories below, which vitest
+// hoists above these imports/consts, so they must themselves be created
+// via vi.hoisted().
+const {
+  getConnectionByIdMock,
+  getInfraMock,
+  checkPermissionMock,
+  pveFetchMock,
+  resolveVdcForTenantMock,
+  getCurrentTenantIdMock,
+} = vi.hoisted(() => ({
+  getConnectionByIdMock: vi.fn(),
+  getInfraMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+  resolveVdcForTenantMock: vi.fn(),
+  getCurrentTenantIdMock: vi.fn(),
+}))
+
+// The route schedules post-restore work (waitForTask, pool placement, IPAM
+// sync) via next/server's after(). We only care about the synchronous
+// response + the immediate PVE POST, so after() is stubbed to a no-op that
+// never runs its callback -- keeping NextResponse itself real.
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>()
+  return { ...actual, after: vi.fn() }
+})
+
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: pveFetchMock }))
+vi.mock("@/lib/connections/getConnection", () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: () => checkPermissionMock(),
+  buildNodeResourceId: (...a: any[]) => a.join(":"),
+  PERMISSIONS: { VM_BACKUP: "vm.backup" },
+}))
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: () => getCurrentTenantIdMock(),
+  DEFAULT_TENANT_ID: "default",
+}))
+vi.mock("@/lib/tenant/infraScope", () => ({
+  getTenantInfrastructureScope: (...a: any[]) => getInfraMock(...a),
+}))
+vi.mock("@/lib/vdc/quota", () => ({
+  resolveVdcForTenant: (...a: any[]) => resolveVdcForTenantMock(...a),
+}))
+// Only exercised by the pbsBackup path, which none of these tests take.
+vi.mock("@/lib/vdc/scope", () => ({ assertVdcPbsAccess: vi.fn() }))
+// Guards prisma.vdc.findFirst (pool-placement lookup, isTenant only) and
+// prisma.connection.findUnique (pbsBackup path, unused here) from hitting a
+// real database.
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    vdc: { findFirst: vi.fn().mockResolvedValue(null) },
+    connection: { findUnique: vi.fn() },
+  },
+}))
+// Dynamically imported by the route (`await import("@/lib/audit")`); vi.mock
+// intercepts dynamic imports too.
+vi.mock("@/lib/audit", () => ({ audit: vi.fn().mockResolvedValue("audit-1") }))
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  getConnectionByIdMock.mockReset().mockResolvedValue({
+    id: "pve-1",
+    name: "pve-1",
+    baseUrl: "https://pve.local:8006",
+    apiToken: "t",
+    insecureDev: false,
+    behindProxy: false,
+  })
+  getCurrentTenantIdMock.mockReset().mockResolvedValue("default")
+  getInfraMock.mockReset().mockResolvedValue({ kind: "provider" })
+  resolveVdcForTenantMock.mockReset().mockResolvedValue(null)
+  pveFetchMock.mockReset().mockResolvedValue("UPID:pve-1:00000000:00000000:00000000:qmrestore:111:root@pam:")
+})
+
+/** Decode the URL-encoded form body of a pveFetch(conn, path, opts) call. */
+function postedParams(call: unknown[]): URLSearchParams {
+  const opts = call[2] as { body?: string }
+  return new URLSearchParams(opts?.body ?? "")
+}
+
+const VZDUMP_QEMU_VOLID = "local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst"
+const VZDUMP_LXC_VOLID = "local:backup/vzdump-lxc-111-2026_08_11-15_51_33.tar.zst"
+
+describe("POST /api/v1/connections/[id]/nodes/[node]/restore -- raw archive volid contract", () => {
+  it("qemu: archive volid is posted as `archive` to /nodes/{node}/qemu", async () => {
+    const { POST } = await import("./route")
+
+    const res = await callRoute(POST, {
+      method: "POST",
+      params: { id: "pve-1", node: "node1" },
+      body: { vmid: 111, archive: VZDUMP_QEMU_VOLID, type: "qemu" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+
+    const call = pveFetchMock.mock.calls[0]
+    expect(call[1]).toBe("/nodes/node1/qemu")
+    const params = postedParams(call)
+    expect(params.get("archive")).toBe(VZDUMP_QEMU_VOLID)
+    expect(params.get("vmid")).toBe("111")
+    expect(params.has("ostemplate")).toBe(false)
+    expect(params.has("restore")).toBe(false)
+  })
+
+  it("lxc: archive volid is posted as `ostemplate` with restore=1 to /nodes/{node}/lxc", async () => {
+    const { POST } = await import("./route")
+
+    const res = await callRoute(POST, {
+      method: "POST",
+      params: { id: "pve-1", node: "node1" },
+      body: { vmid: 111, archive: VZDUMP_LXC_VOLID, type: "lxc" },
+    })
+
+    expect(res.status).toBe(200)
+    expect(pveFetchMock).toHaveBeenCalledTimes(1)
+
+    const call = pveFetchMock.mock.calls[0]
+    expect(call[1]).toBe("/nodes/node1/lxc")
+    const params = postedParams(call)
+    expect(params.get("ostemplate")).toBe(VZDUMP_LXC_VOLID)
+    expect(params.get("restore")).toBe("1")
+    expect(params.has("archive")).toBe(false)
+  })
+
+  it("iaas tenant: archive storage outside the vDC allow-list is refused, no PVE call emitted", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("tenant-x")
+    getInfraMock.mockResolvedValue({
+      kind: "iaas",
+      vdcScope: {
+        connectionIds: new Set(["pve-1"]),
+        pbsConnectionIds: new Set<string>(),
+        nodesByConnection: new Map<string, Set<string>>(),
+        // Allow-listed storage is "ceph-vdc" -- deliberately does NOT
+        // include "local", which is the prefix of the archive below.
+        storagesByConnection: new Map([["pve-1", new Set(["ceph-vdc"])]]),
+        poolsByConnection: new Map<string, Set<string>>(),
+        vnetsByConnection: new Map<string, Set<string>>(),
+        sharedBridgesByConnection: new Map<string, Set<string>>(),
+        pbsNamespacesByConnection: new Map<string, Array<{ datastore: string; namespace: string }>>(),
+        pbsNamespacesByPveConnection: new Map<string, Set<string>>(),
+      },
+    })
+    // Tenant does have a vDC on this connection/node -- the allow-list
+    // check, not the "no vDC" branch, is what must reject this request.
+    resolveVdcForTenantMock.mockResolvedValue({ vdcId: "vdc-1", poolName: "pool-1", quota: null })
+
+    const { POST } = await import("./route")
+    const res = await callRoute(POST, {
+      method: "POST",
+      params: { id: "pve-1", node: "node1" },
+      body: { vmid: 111, archive: VZDUMP_QEMU_VOLID, type: "qemu" },
+    })
+
+    expect(res.status).toBe(403)
+    const json = await readJson<{ error: string }>(res)
+    expect(json?.error).toMatch(/not authorised/i)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
@@ -144,11 +144,14 @@ describe("GET /api/v1/guests/[vmid]/backups vzdump tenant isolation", () => {
     })
 
     const { GET } = await import("./route")
-    await callRoute(GET as any, {
+    const res = await callRoute(GET as any, {
       params: { vmid: "1105" },
       searchParams: { connectionId: "pve-1" },
     })
 
+    // Sans ce contrôle, une exception levée avant la porte de masquage ferait
+    // passer le test pour la mauvaise raison : le mock ne serait pas appelé.
+    expect(res.status).toBe(200)
     expect(listVzdumpMock).not.toHaveBeenCalled()
   })
 
@@ -156,11 +159,12 @@ describe("GET /api/v1/guests/[vmid]/backups vzdump tenant isolation", () => {
     getInfraMock.mockResolvedValue({ kind: "provider" })
 
     const { GET } = await import("./route")
-    await callRoute(GET as any, {
+    const res = await callRoute(GET as any, {
       params: { vmid: "1105" },
       searchParams: { connectionId: "pve-1" },
     })
 
+    expect(res.status).toBe(200)
     expect(listVzdumpMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
@@ -3,11 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { callRoute } from "../../../../../../__tests__/setup/route-test"
 
 // Hoist mocks
-const { findManyGlobalMock, findManySessionMock, getInfraMock, checkPermissionMock } = vi.hoisted(() => ({
+const {
+  findManyGlobalMock,
+  findManySessionMock,
+  getInfraMock,
+  checkPermissionMock,
+  pveFetchMock,
+  getConnectionByIdMock,
+  listVzdumpMock,
+} = vi.hoisted(() => ({
   findManyGlobalMock: vi.fn(),
   findManySessionMock: vi.fn(),
   getInfraMock: vi.fn(),
   checkPermissionMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+  getConnectionByIdMock: vi.fn(),
+  listVzdumpMock: vi.fn(),
 }))
 
 // Keep REAL inventoryConnectionPlan; only mock getTenantInfrastructureScope
@@ -50,11 +61,18 @@ vi.mock("next/headers", () => ({
   cookies: async () => ({ get: () => undefined }),
 }))
 
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: pveFetchMock }))
+vi.mock("@/lib/connections/getConnection", () => ({ getConnectionById: getConnectionByIdMock }))
+vi.mock("@/lib/backups/pveVzdump", () => ({ listGuestVzdumpBackups: listVzdumpMock }))
+
 beforeEach(() => {
   checkPermissionMock.mockReset().mockResolvedValue(null)
   findManyGlobalMock.mockReset().mockResolvedValue([])
   findManySessionMock.mockReset().mockResolvedValue([])
   getInfraMock.mockReset()
+  pveFetchMock.mockReset().mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'pve-1', apiToken: 't' })
+  listVzdumpMock.mockReset().mockResolvedValue({ data: [], warnings: [] })
 })
 
 describe("GET /api/v1/guests/[vmid]/backups PBS connection scope", () => {
@@ -115,5 +133,34 @@ describe("GET /api/v1/guests/[vmid]/backups PBS connection scope", () => {
 
     expect(res.status).toBe(200)
     expect(getInfraMock).toHaveBeenCalledWith("tenant-x", { ignoreVdcContext: true })
+  })
+})
+
+describe("GET /api/v1/guests/[vmid]/backups vzdump tenant isolation", () => {
+  it("never scans PVE storages for a vDC tenant", async () => {
+    getInfraMock.mockResolvedValue({
+      kind: "iaas",
+      vdcScope: { pbsConnectionIds: new Set(["pbs-1"]), storagesByConnection: new Map() },
+    })
+
+    const { GET } = await import("./route")
+    await callRoute(GET as any, {
+      params: { vmid: "1105" },
+      searchParams: { connectionId: "pve-1" },
+    })
+
+    expect(listVzdumpMock).not.toHaveBeenCalled()
+  })
+
+  it("scans PVE storages for a provider", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+
+    const { GET } = await import("./route")
+    await callRoute(GET as any, {
+      params: { vmid: "1105" },
+      searchParams: { connectionId: "pve-1" },
+    })
+
+    expect(listVzdumpMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/guestBackupsScope.test.ts
@@ -144,9 +144,11 @@ describe("GET /api/v1/guests/[vmid]/backups vzdump tenant isolation", () => {
     })
 
     const { GET } = await import("./route")
+    // Le balayage est explicitement demandé : c'est bien le masquage tenant qui
+    // doit le refuser, pas l'absence du paramètre.
     const res = await callRoute(GET as any, {
       params: { vmid: "1105" },
-      searchParams: { connectionId: "pve-1" },
+      searchParams: { connectionId: "pve-1", scanVzdump: "1" },
     })
 
     // Sans ce contrôle, une exception levée avant la porte de masquage ferait
@@ -161,7 +163,7 @@ describe("GET /api/v1/guests/[vmid]/backups vzdump tenant isolation", () => {
     const { GET } = await import("./route")
     const res = await callRoute(GET as any, {
       params: { vmid: "1105" },
-      searchParams: { connectionId: "pve-1" },
+      searchParams: { connectionId: "pve-1", scanVzdump: "1" },
     })
 
     expect(res.status).toBe(200)

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
@@ -8,6 +8,7 @@ const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
 const getVdcScopeMock = vi.fn<(tenantId?: string) => Promise<any>>()
 const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
 const findManyMock = vi.fn<(args: any) => Promise<any[]>>()
+const listVzdumpMock = vi.fn<(...args: any[]) => Promise<any>>()
 
 vi.mock('@/lib/tenant', () => ({
   getSessionPrisma: async () => ({ connection: { findMany: findManyMock } }),
@@ -24,6 +25,7 @@ vi.mock('@/lib/rbac', () => ({
   PERMISSIONS: { BACKUP_VIEW: 'backup.view' },
 }))
 vi.mock('next/headers', () => ({ cookies: async () => ({ get: () => ({ value: 'en' }) }) }))
+vi.mock('@/lib/backups/pveVzdump', () => ({ listGuestVzdumpBackups: listVzdumpMock }))
 
 beforeEach(() => {
   checkPermissionMock.mockReset().mockResolvedValue(null)
@@ -32,6 +34,7 @@ beforeEach(() => {
   getVdcScopeMock.mockReset().mockResolvedValue(null)
   getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'pve-1', apiToken: 't' })
   findManyMock.mockReset().mockResolvedValue([])
+  listVzdumpMock.mockReset().mockResolvedValue({ data: [], warnings: [] })
 })
 
 async function call(connectionId?: string) {
@@ -90,5 +93,130 @@ describe('GET /api/v1/guests/[vmid]/backups — pbsConfigured (PBS connection ma
     pveFetchMock.mockRejectedValue(new Error('storage unreachable'))
     const body = await call('pve-1')
     expect(body.data.pbsConfigured).toBe(true)
+  })
+})
+
+const VZDUMP_ENTRY = {
+  id: 'node2/local:backup/vzdump-qemu-1105-2026_08_11-15_51_33.vma.zst',
+  source: 'vzdump',
+  volid: 'local:backup/vzdump-qemu-1105-2026_08_11-15_51_33.vma.zst',
+  node: 'node2',
+  storage: 'local',
+  backupType: 'vm',
+  backupTime: 1786000293,
+  backupTimeKnown: true,
+  size: 100,
+  sizeFormatted: '100 B',
+  verified: false,
+  verification: null,
+  protected: false,
+}
+
+describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages', () => {
+  it('returns vzdump archives even when no PBS connection exists at all', async () => {
+    // The exact reported case: a cluster with zero PBS, backing up to local.
+    findManyMock.mockResolvedValue([])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+    listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
+
+    const body = await call('pve-1')
+
+    expect(body.data.backups).toHaveLength(1)
+    expect(body.data.backups[0].source).toBe('vzdump')
+    expect(body.data.stats.total).toBe(1)
+    expect(body.data.pbsConfigured).toBe(false)
+    expect(body.data.vzdumpScanned).toBe(true)
+  })
+
+  it('merges both sources and sorts them by date, most recent first', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([
+      { storage: 'PBS_DS', type: 'pbs', server: '10.0.0.1' },
+      { storage: 'local', type: 'dir', content: 'backup' },
+    ])
+    pbsFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/admin/datastore') return [{ store: 'store1' }]
+      if (path.includes('/snapshots')) {
+        return [{ 'backup-id': '1105', 'backup-type': 'vm', 'backup-time': 1786100000, size: 10 }]
+      }
+      return []
+    })
+    listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
+
+    const body = await call('pve-1')
+
+    expect(body.data.backups.map((b: any) => b.source)).toEqual(['pbs', 'vzdump'])
+    expect(body.data.stats.total).toBe(2)
+  })
+
+  it('counts only PBS snapshots as verified', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+    pbsFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/admin/datastore') return [{ store: 'store1' }]
+      if (path.includes('/snapshots')) {
+        return [{
+          'backup-id': '1105', 'backup-type': 'vm', 'backup-time': 1786100000,
+          size: 10, verification: { state: 'ok' },
+        }]
+      }
+      return []
+    })
+    listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
+
+    const body = await call('pve-1')
+
+    expect(body.data.stats.total).toBe(2)
+    expect(body.data.stats.verifiedCount).toBe(1)
+    expect(body.data.stats.pbsTotal).toBe(1)
+  })
+
+  it('does not scan PVE storages when no connectionId is provided', async () => {
+    findManyMock.mockResolvedValue([])
+    const body = await call()
+
+    expect(listVzdumpMock).not.toHaveBeenCalled()
+    expect(body.data.vzdumpScanned).toBe(false)
+    expect(body.data.backups).toEqual([])
+  })
+
+  it('still returns vzdump archives when the PBS fan-out fails', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+    pbsFetchMock.mockRejectedValue(new Error('pbs unreachable'))
+    listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
+
+    const body = await call('pve-1')
+
+    expect(body.data.backups).toHaveLength(1)
+    expect(body.data.warnings.join(' ')).toContain('pbs unreachable')
+  })
+
+  it('still returns PBS snapshots when the PVE storage config cannot be read', async () => {
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockRejectedValue(new Error('storage unreachable'))
+    pbsFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/admin/datastore') return [{ store: 'store1' }]
+      if (path.includes('/snapshots')) {
+        return [{ 'backup-id': '1105', 'backup-type': 'vm', 'backup-time': 1786100000, size: 10 }]
+      }
+      return []
+    })
+
+    const body = await call('pve-1')
+
+    expect(body.data.backups).toHaveLength(1)
+    expect(body.data.backups[0].source).toBe('pbs')
+    expect(body.data.pbsConfigured).toBe(true)
+    expect(body.data.vzdumpScanned).toBe(false)
+    expect(listVzdumpMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.test.ts
@@ -37,14 +37,19 @@ beforeEach(() => {
   listVzdumpMock.mockReset().mockResolvedValue({ data: [], warnings: [] })
 })
 
-async function call(connectionId?: string) {
+async function call(connectionId?: string, extra?: Record<string, string>) {
   const { GET } = await import('./route')
+  const searchParams = { ...(connectionId ? { connectionId } : {}), ...(extra || {}) }
   const res = await callRoute(GET as any, {
     params: { vmid: '1105' },
-    searchParams: connectionId ? { connectionId } : undefined,
+    searchParams: Object.keys(searchParams).length > 0 ? searchParams : undefined,
   })
   return readJson<any>(res)
 }
+
+/** Le balayage vzdump est opt-in : l'UI ne le demande qu'à l'ouverture de
+ *  l'onglet Sauvegardes. */
+const callScan = (connectionId?: string) => call(connectionId, { scanVzdump: '1' })
 
 describe('GET /api/v1/guests/[vmid]/backups — pbsConfigured (PBS connection mapped to the cluster)', () => {
   it('is false when no PBS connection exists at all', async () => {
@@ -119,7 +124,7 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
     pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
     listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
 
-    const body = await call('pve-1')
+    const body = await callScan('pve-1')
 
     expect(body.data.backups).toHaveLength(1)
     expect(body.data.backups[0].source).toBe('vzdump')
@@ -145,7 +150,7 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
     })
     listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
 
-    const body = await call('pve-1')
+    const body = await callScan('pve-1')
 
     expect(body.data.backups.map((b: any) => b.source)).toEqual(['pbs', 'vzdump'])
     expect(body.data.stats.total).toBe(2)
@@ -168,7 +173,7 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
     })
     listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
 
-    const body = await call('pve-1')
+    const body = await callScan('pve-1')
 
     expect(body.data.stats.total).toBe(2)
     expect(body.data.stats.verifiedCount).toBe(1)
@@ -177,7 +182,7 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
 
   it('does not scan PVE storages when no connectionId is provided', async () => {
     findManyMock.mockResolvedValue([])
-    const body = await call()
+    const body = await callScan()
 
     expect(listVzdumpMock).not.toHaveBeenCalled()
     expect(body.data.vzdumpScanned).toBe(false)
@@ -192,7 +197,7 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
     pbsFetchMock.mockRejectedValue(new Error('pbs unreachable'))
     listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
 
-    const body = await call('pve-1')
+    const body = await callScan('pve-1')
 
     expect(body.data.backups).toHaveLength(1)
     expect(body.data.warnings.join(' ')).toContain('pbs unreachable')
@@ -211,12 +216,95 @@ describe('GET /api/v1/guests/[vmid]/backups — vzdump archives on PVE storages'
       return []
     })
 
-    const body = await call('pve-1')
+    const body = await callScan('pve-1')
 
     expect(body.data.backups).toHaveLength(1)
     expect(body.data.backups[0].source).toBe('pbs')
     expect(body.data.pbsConfigured).toBe(true)
     expect(body.data.vzdumpScanned).toBe(false)
     expect(listVzdumpMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/v1/guests/[vmid]/backups — vzdump scan is opt-in', () => {
+  it('does not scan PVE storages without scanVzdump, but still returns PBS snapshots', async () => {
+    // Le préchargement déclenché à chaque clic dans l'arbre passe par ce
+    // chemin : il ne doit coûter aucun appel de contenu à pveproxy.
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+    pbsFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/admin/datastore') return [{ store: 'store1' }]
+      if (path.includes('/snapshots')) {
+        return [{ 'backup-id': '1105', 'backup-type': 'vm', 'backup-time': 1786100000, size: 10 }]
+      }
+      return []
+    })
+    listVzdumpMock.mockResolvedValue({ data: [VZDUMP_ENTRY], warnings: [] })
+
+    const body = await call('pve-1')
+
+    expect(listVzdumpMock).not.toHaveBeenCalled()
+    expect(body.data.vzdumpScanned).toBe(false)
+    expect(body.data.backups).toHaveLength(1)
+    expect(body.data.backups[0].source).toBe('pbs')
+  })
+
+  it('treats scanVzdump=0 as no scan', async () => {
+    findManyMock.mockResolvedValue([])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+
+    const body = await call('pve-1', { scanVzdump: '0' })
+
+    expect(listVzdumpMock).not.toHaveBeenCalled()
+    expect(body.data.vzdumpScanned).toBe(false)
+  })
+
+  it('forwards the guest current node to the vzdump collector', async () => {
+    // Sans ce paramètre, la priorisation du nœud du guest est du code mort et
+    // la troncature au plafond dur peut écarter le nœud qui porte l'archive.
+    findManyMock.mockResolvedValue([])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+    listVzdumpMock.mockResolvedValue({ data: [], warnings: [] })
+
+    await call('pve-1', { scanVzdump: '1', node: 'node2' })
+
+    expect(listVzdumpMock).toHaveBeenCalledTimes(1)
+    expect(listVzdumpMock.mock.calls[0][2]).toMatchObject({ currentNode: 'node2' })
+  })
+})
+
+describe('GET /api/v1/guests/[vmid]/backups — both collections run concurrently', () => {
+  it('starts the PBS fan-out without waiting for the vzdump scan', async () => {
+    // Le scan vzdump ne se débloque que lorsque le fan-out PBS a commencé :
+    // si la route sérialisait les deux, ce test resterait bloqué jusqu'au
+    // timeout au lieu de passer.
+    findManyMock.mockResolvedValue([
+      { id: 'pbs-1', name: 'PBS', baseUrl: 'https://10.0.0.1:8007', insecureTLS: false, apiTokenEnc: 'enc' },
+    ])
+    pveFetchMock.mockResolvedValue([{ storage: 'local', type: 'dir', content: 'backup' }])
+
+    let releaseVzdump: () => void = () => {}
+    const pbsStarted = new Promise<void>(resolve => { releaseVzdump = resolve })
+
+    listVzdumpMock.mockImplementation(async () => {
+      await pbsStarted
+
+      return { data: [VZDUMP_ENTRY], warnings: [] }
+    })
+    pbsFetchMock.mockImplementation(async (_c: any, path: string) => {
+      releaseVzdump()
+      if (path === '/admin/datastore') return [{ store: 'store1' }]
+      if (path.includes('/snapshots')) {
+        return [{ 'backup-id': '1105', 'backup-type': 'vm', 'backup-time': 1786100000, size: 10 }]
+      }
+
+      return []
+    })
+
+    const body = await callScan('pve-1')
+
+    expect(body.data.backups.map((b: any) => b.source)).toEqual(['pbs', 'vzdump'])
   })
 })

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers"
 
 import { getSessionPrisma, getCurrentTenantId } from "@/lib/tenant"
 import { prisma as globalPrisma } from "@/lib/db/prisma"
-import { getTenantInfrastructureScope } from "@/lib/tenant/infraScope"
+import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
+import { listGuestVzdumpBackups } from "@/lib/backups/pveVzdump"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
@@ -82,14 +83,22 @@ export async function GET(
       }
     })
 
-    if (pbsConnections.length === 0) {
-      return NextResponse.json({
-        data: {
-          backups: [],
-          stats: { total: 0, totalSize: 0, totalSizeFormatted: '0 B' },
-          pbsConfigured: false,
-        }
-      })
+    const allBackups: any[] = []
+    const warnings: string[] = []
+
+    // Config de stockage cluster-wide : sert au test pbsConfigured ET à la
+    // collecte vzdump. Un échec ici reste une panne locale — il ne doit
+    // effacer ni les snapshots PBS ni le repli de pbsConfigured.
+    let pveConn: any = null
+    let pveStorages: any[] | null = null
+
+    if (connectionId) {
+      try {
+        pveConn = await getConnectionById(connectionId)
+        pveStorages = await pveFetch<any[]>(pveConn, '/storage')
+      } catch (e: any) {
+        warnings.push(`cluster storage config: ${e?.message || String(e)}`)
+      }
     }
 
     // Is one of these PBS connections actually the backup target of THIS guest's
@@ -98,26 +107,34 @@ export async function GET(
     // (different host) counts as "no PBS configured" — we cannot read its
     // snapshots — which is what drives the empty-state message.
     let pbsConfigured = pbsConnections.length > 0
-    if (connectionId) {
-      try {
-        const connHosts = new Set(
-          pbsConnections.map(c => normalizeHost(c.baseUrl)).filter(Boolean)
-        )
-        const pveConn = await getConnectionById(connectionId)
-        const pveStorages = await pveFetch<any[]>(pveConn, '/storage')
 
-        pbsConfigured = (pveStorages || []).some(
-          (s: any) => s?.type === 'pbs' && connHosts.has(normalizeHost(s.server))
-        )
-      } catch {
-        // Cannot read the cluster storage config: fall back to "a PBS connection
-        // exists" so we never wrongly claim none is configured.
-        pbsConfigured = pbsConnections.length > 0
-      }
+    if (pveStorages) {
+      const connHosts = new Set(
+        pbsConnections.map(c => normalizeHost(c.baseUrl)).filter(Boolean)
+      )
+
+      pbsConfigured = pveStorages.some(
+        (s: any) => s?.type === 'pbs' && connHosts.has(normalizeHost(s.server))
+      )
     }
 
-    const allBackups: any[] = []
-    const warnings: string[] = []
+    // Archives vzdump sur les stockages PVE. Les tenants vDC en sont exclus :
+    // même règle que /nodes/{node}/storages, où content=backup ne montre que du
+    // PBS à un tenant (isolation par namespace PBS = seule voie supportée).
+    let vzdumpScanned = false
+
+    if (pveConn && pveStorages && maskingScope(infra) === null) {
+      const vz = await listGuestVzdumpBackups(pveConn, String(vmid), {
+        typeFilter,
+        dateLocale,
+        storages: pveStorages,
+        currentNode: url.searchParams.get('node'),
+      })
+
+      vzdumpScanned = true
+      allBackups.push(...vz.data)
+      warnings.push(...vz.warnings)
+    }
 
     // Interroger chaque PBS en parallèle
     const pbsPromises = pbsConnections.map(async (pbs) => {
@@ -185,6 +202,7 @@ export async function GET(
 
                   return {
                     id: `${storeName}/${ns ? ns + '/' : ''}${snap['backup-type']}/${snap['backup-id']}/${snap['backup-time']}`,
+                    source: 'pbs' as const,
 
                     // Infos PBS
                     pbsId: pbs.id,
@@ -259,16 +277,27 @@ return []
     results.forEach(backups => allBackups.push(...backups))
 
     // Trier par date (plus récent en premier)
-    allBackups.sort((a, b) => b.backupTime - a.backupTime)
+    allBackups.sort((a, b) => {
+      const aKnown = a.backupTimeKnown !== false
+      const bKnown = b.backupTimeKnown !== false
+
+      if (aKnown !== bKnown) return aKnown ? -1 : 1
+
+      return (b.backupTime || 0) - (a.backupTime || 0)
+    })
 
     // Stats
     const totalSize = allBackups.reduce((sum, b) => sum + (b.size || 0), 0)
+    const pbsBackups = allBackups.filter(b => b.source === 'pbs')
 
     const stats = {
       total: allBackups.length,
       totalSize,
       totalSizeFormatted: formatBytes(totalSize),
-      verifiedCount: allBackups.filter(b => b.verified).length,
+      // La vérification n'existe que côté PBS : compter les vzdump comme non
+      // vérifiés ferait lire « 1 vérifié sur 3 » comme deux échecs.
+      pbsTotal: pbsBackups.length,
+      verifiedCount: pbsBackups.filter(b => b.verified).length,
       protectedCount: allBackups.filter(b => b.protected).length,
       oldestBackup: allBackups.length > 0 ? allBackups[allBackups.length - 1].backupTimeFormatted : null,
       newestBackup: allBackups.length > 0 ? allBackups[0].backupTimeFormatted : null,
@@ -281,6 +310,7 @@ return []
         stats,
         warnings,
         pbsConfigured,
+        vzdumpScanned,
       }
     })
   } catch (e: any) {

--- a/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/backups/route.ts
@@ -33,6 +33,9 @@ function normalizeHost(s?: string | null): string {
  * 
  * Query params:
  * - type: 'vm' | 'ct' (optionnel, pour filtrer par type)
+ * - connectionId: connexion PVE du guest (optionnel)
+ * - node: nœud courant du guest (optionnel, priorise son balayage)
+ * - scanVzdump: '1' pour balayer les stockages PVE (opt-in, voir plus bas)
  */
 export async function GET(
   req: Request,
@@ -57,6 +60,14 @@ export async function GET(
     const url = new URL(req.url)
     const typeFilter = url.searchParams.get('type') // 'vm' | 'ct'
     const connectionId = url.searchParams.get('connectionId') // the guest's PVE connection
+    const currentNode = url.searchParams.get('node') // the node the guest runs on
+
+    // Le balayage vzdump coûte 1 (/storage) + 1 (/cluster/resources) + N nœuds
+    // x M stockages appels de contenu. Le préchargement déclenché à chaque
+    // sélection de VM dans l'arbre d'inventaire ne le demande pas : seule
+    // l'ouverture effective de l'onglet Sauvegardes l'active.
+    const scanParam = url.searchParams.get('scanVzdump')
+    const scanVzdumpRequested = scanParam !== null && scanParam !== '0' && scanParam !== 'false'
 
     // Récupérer toutes les connexions PBS visibles. Provider sees its own
     // PBS via tenant prisma; vDC tenants reach PBS connections referenced
@@ -121,20 +132,21 @@ export async function GET(
     // Archives vzdump sur les stockages PVE. Les tenants vDC en sont exclus :
     // même règle que /nodes/{node}/storages, où content=backup ne montre que du
     // PBS à un tenant (isolation par namespace PBS = seule voie supportée).
-    let vzdumpScanned = false
+    //
+    // La promesse est lancée ici mais attendue plus bas, avec le fan-out PBS :
+    // les deux collectes sont indépendantes, les sérialiser additionnerait
+    // leurs latences pour rien.
+    const vzdumpPromise =
+      scanVzdumpRequested && pveConn && pveStorages && maskingScope(infra) === null
+        ? listGuestVzdumpBackups(pveConn, String(vmid), {
+            typeFilter,
+            dateLocale,
+            storages: pveStorages,
+            currentNode,
+          })
+        : null
 
-    if (pveConn && pveStorages && maskingScope(infra) === null) {
-      const vz = await listGuestVzdumpBackups(pveConn, String(vmid), {
-        typeFilter,
-        dateLocale,
-        storages: pveStorages,
-        currentNode: url.searchParams.get('node'),
-      })
-
-      vzdumpScanned = true
-      allBackups.push(...vz.data)
-      warnings.push(...vz.warnings)
-    }
+    const vzdumpScanned = vzdumpPromise !== null
 
     // Interroger chaque PBS en parallèle
     const pbsPromises = pbsConnections.map(async (pbs) => {
@@ -272,7 +284,14 @@ return []
       }
     })
 
-    const results = await Promise.all(pbsPromises)
+    const [vz, results] = await Promise.all([vzdumpPromise, Promise.all(pbsPromises)])
+
+    // Ordre de fusion inchangé : vzdump d'abord, PBS ensuite. Le tri final est
+    // stable, deux entrées de même date gardent donc cet ordre.
+    if (vz) {
+      allBackups.push(...vz.data)
+      warnings.push(...vz.warnings)
+    }
 
     results.forEach(backups => allBackups.push(...backups))
 

--- a/frontend/src/lib/backups/pveVzdump.test.ts
+++ b/frontend/src/lib/backups/pveVzdump.test.ts
@@ -81,6 +81,47 @@ describe('resolveVzdumpScanTargets', () => {
     expect(targets).toEqual([{ node: 'node1', storage: 'nfs-bkp' }])
   })
 
+  it('queries a storage shared only per /cluster/resources exactly once', () => {
+    // PVE n'écrit `shared` dans storage.cfg que s'il a été posé à la main :
+    // un export NFS revient sans le champ, mais /cluster/resources porte la
+    // valeur calculée. Se fier à la config seule = 1 requête par nœud.
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'nfs-bkp', type: 'nfs', content: 'backup' }],
+      [
+        ...nodes('node1', 'node2', 'node3'),
+        { type: 'storage', storage: 'nfs-bkp', node: 'node1', status: 'available', shared: 1 },
+        { type: 'storage', storage: 'nfs-bkp', node: 'node2', status: 'available', shared: 1 },
+        { type: 'storage', storage: 'nfs-bkp', node: 'node3', status: 'available', shared: 1 },
+      ],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'nfs-bkp' }])
+  })
+
+  it('trusts /cluster/resources over a stale shared flag in the config', () => {
+    // La ligne de ressource dit « pas partagé » : on interroge chaque nœud,
+    // sinon une archive posée sur le nœud non interrogé disparaîtrait.
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'bkp', type: 'dir', content: 'backup', shared: 1 }],
+      [
+        ...nodes('node1', 'node2'),
+        { type: 'storage', storage: 'bkp', node: 'node1', status: 'available', shared: 0 },
+        { type: 'storage', storage: 'bkp', node: 'node2', status: 'available', shared: 0 },
+      ],
+    )
+    expect(targets).toEqual([
+      { node: 'node1', storage: 'bkp' },
+      { node: 'node2', storage: 'bkp' },
+    ])
+  })
+
+  it('falls back to the backend type when neither source carries a shared flag', () => {
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'cephfs-bkp', type: 'cephfs', content: 'backup' }],
+      [...nodes('node1', 'node2'), storageRes('cephfs-bkp', 'node1'), storageRes('cephfs-bkp', 'node2')],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'cephfs-bkp' }])
+  })
+
   it('skips offline nodes', () => {
     const { targets } = resolveVzdumpScanTargets(
       [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }],
@@ -333,6 +374,39 @@ describe('listGuestVzdumpBackups', () => {
     expect(data).toEqual([])
     expect(warnings).toEqual([])
     expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('lists a resources-only shared storage once instead of once per node', async () => {
+    // Le dédoublonnage masquait le surcoût : ici on compte les appels, pas les
+    // résultats. Un NFS partagé = 1 listing, pas un par nœud en ligne.
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') {
+        return [
+          { type: 'node', node: 'node1', status: 'online' },
+          { type: 'node', node: 'node2', status: 'online' },
+          { type: 'storage', storage: 'nfs-bkp', node: 'node1', status: 'available', shared: 1 },
+          { type: 'storage', storage: 'nfs-bkp', node: 'node2', status: 'available', shared: 1 },
+        ]
+      }
+      if (path.includes('/content')) {
+        return [{ volid: 'nfs-bkp:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst', ctime: 5, size: 2 }]
+      }
+      return []
+    })
+
+    const { data } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm',
+      dateLocale: 'en',
+      // Aucun `shared` dans la config : c'est le cas réel d'un export NFS.
+      storages: [{ storage: 'nfs-bkp', type: 'nfs', content: 'backup' }],
+    })
+
+    const contentCalls = pveFetchMock.mock.calls
+      .map(c => String(c[1]))
+      .filter(p => p.includes('/content'))
+
+    expect(contentCalls).toHaveLength(1)
+    expect(data).toHaveLength(1)
   })
 
   it('deduplicates the same archive reported by two nodes', async () => {

--- a/frontend/src/lib/backups/pveVzdump.test.ts
+++ b/frontend/src/lib/backups/pveVzdump.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+
+import { parseVzdumpVolidTime, vzdumpBackupTypeFromVolid } from './pveVzdump'
+
+describe('parseVzdumpVolidTime', () => {
+  it('extracts the timestamp encoded in a vzdump filename', () => {
+    const t = parseVzdumpVolidTime('local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst')
+    expect(t).not.toBeNull()
+    expect(new Date(t! * 1000).toISOString()).toBe('2026-08-11T15:51:33.000Z')
+  })
+
+  it('returns null when the volid carries no date', () => {
+    expect(parseVzdumpVolidTime('local:backup/whatever.vma.zst')).toBeNull()
+  })
+})
+
+describe('vzdumpBackupTypeFromVolid', () => {
+  it('maps qemu archives to vm', () => {
+    expect(vzdumpBackupTypeFromVolid('local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst')).toBe('vm')
+  })
+
+  it('maps lxc archives to ct', () => {
+    expect(vzdumpBackupTypeFromVolid('local:backup/vzdump-lxc-200-2026_08_11-15_51_33.tar.zst')).toBe('ct')
+  })
+
+  it('maps legacy openvz archives to ct', () => {
+    expect(vzdumpBackupTypeFromVolid('local:backup/vzdump-openvz-200-2026_08_11-15_51_33.tar.lzo')).toBe('ct')
+  })
+
+  it('returns null for a non-vzdump volid', () => {
+    expect(vzdumpBackupTypeFromVolid('local:iso/debian.iso')).toBeNull()
+  })
+})

--- a/frontend/src/lib/backups/pveVzdump.test.ts
+++ b/frontend/src/lib/backups/pveVzdump.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { parseVzdumpVolidTime, vzdumpBackupTypeFromVolid, resolveVzdumpScanTargets, VZDUMP_MAX_PAIRS } from './pveVzdump'
+const { pveFetchMock } = vi.hoisted(() => ({ pveFetchMock: vi.fn<(...args: any[]) => Promise<any>>() }))
+
+vi.mock('@/lib/proxmox/client', () => ({ pveFetch: pveFetchMock }))
+vi.mock('@/utils/format', () => ({ formatBytes: (n: number) => `${n}B` }))
+
+import {
+  parseVzdumpVolidTime,
+  vzdumpBackupTypeFromVolid,
+  resolveVzdumpScanTargets,
+  VZDUMP_MAX_PAIRS,
+  listGuestVzdumpBackups,
+} from './pveVzdump'
 
 describe('parseVzdumpVolidTime', () => {
   it('extracts the timestamp encoded in a vzdump filename', () => {
@@ -145,5 +156,207 @@ describe('resolveVzdumpScanTargets', () => {
     const { targets, truncated } = resolveVzdumpScanTargets(storages, resources)
     expect(targets).toHaveLength(VZDUMP_MAX_PAIRS)
     expect(truncated).toBe(false)
+  })
+})
+
+const CONN = { id: 'pve-1', baseUrl: 'https://pve.local', apiToken: 't' }
+
+const RESOURCES = [
+  { type: 'node', node: 'node1', status: 'online' },
+  { type: 'node', node: 'node2', status: 'online' },
+  { type: 'storage', storage: 'local', node: 'node1', status: 'available' },
+  { type: 'storage', storage: 'local', node: 'node2', status: 'available' },
+]
+
+const STORAGES = [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }]
+
+beforeEach(() => {
+  pveFetchMock.mockReset()
+})
+
+describe('listGuestVzdumpBackups', () => {
+  it('returns archives found on the node that holds them', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.startsWith('/nodes/node2/storage/local/content')) {
+        return [{
+          volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst',
+          ctime: 1786000293,
+          size: 4600000000,
+          format: 'vma.zst',
+          vmid: 111,
+        }]
+      }
+      return []
+    })
+
+    const { data, warnings } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm',
+      dateLocale: 'en',
+      storages: STORAGES,
+    })
+
+    expect(warnings).toEqual([])
+    expect(data).toHaveLength(1)
+    expect(data[0]).toMatchObject({
+      source: 'vzdump',
+      node: 'node2',
+      storage: 'local',
+      backupType: 'vm',
+      backupId: '111',
+      backupTime: 1786000293,
+      backupTimeKnown: true,
+      size: 4600000000,
+      sizeFormatted: '4600000000B',
+      verified: false,
+      verification: null,
+      volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst',
+    })
+    expect(data[0].id).toBe('node2/local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst')
+  })
+
+  it('passes the vmid filter to PVE and asks for backup content only', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) =>
+      path === '/cluster/resources' ? RESOURCES : [])
+
+    await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm', dateLocale: 'en', storages: STORAGES,
+    })
+
+    const contentCalls = pveFetchMock.mock.calls
+      .map(c => String(c[1]))
+      .filter(p => p.includes('/content'))
+
+    expect(contentCalls).toHaveLength(2)
+    for (const p of contentCalls) {
+      expect(p).toContain('content=backup')
+      expect(p).toContain('vmid=111')
+    }
+  })
+
+  it('drops archives whose type does not match the requested guest type', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.startsWith('/nodes/node1/storage/local/content')) {
+        return [
+          { volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst', ctime: 1, size: 1 },
+          { volid: 'local:backup/vzdump-lxc-111-2026_08_11-15_51_33.tar.zst', ctime: 2, size: 1 },
+        ]
+      }
+      return []
+    })
+
+    const { data } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'ct', dateLocale: 'en', storages: STORAGES,
+    })
+
+    expect(data).toHaveLength(1)
+    expect(data[0].backupType).toBe('ct')
+  })
+
+  it('falls back to the volid timestamp when ctime is missing', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.startsWith('/nodes/node1/storage/local/content')) {
+        return [{ volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst' }]
+      }
+      return []
+    })
+
+    const { data } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm', dateLocale: 'en', storages: STORAGES,
+    })
+
+    expect(data[0].backupTime).toBe(Math.floor(Date.UTC(2026, 7, 11, 15, 51, 33) / 1000))
+    expect(data[0].backupTimeKnown).toBe(true)
+    expect(data[0].size).toBe(0)
+  })
+
+  it('marks the time unknown and sorts the entry last when nothing is parsable', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.startsWith('/nodes/node1/storage/local/content')) {
+        return [
+          { volid: 'local:backup/vzdump-qemu-111-undated.vma.zst' },
+          { volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst', ctime: 900 },
+        ]
+      }
+      return []
+    })
+
+    const { data } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm', dateLocale: 'en', storages: STORAGES,
+    })
+
+    expect(data).toHaveLength(2)
+    expect(data[data.length - 1].backupTimeKnown).toBe(false)
+    expect(data[data.length - 1].backupTime).toBe(0)
+  })
+
+  it('reports a warning when one node fails but keeps the others', async () => {
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.startsWith('/nodes/node1/storage/local/content')) throw new Error('node1 down')
+      if (path.startsWith('/nodes/node2/storage/local/content')) {
+        return [{ volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst', ctime: 5, size: 2 }]
+      }
+      return []
+    })
+
+    const { data, warnings } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm', dateLocale: 'en', storages: STORAGES,
+    })
+
+    expect(data).toHaveLength(1)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('node1/local')
+  })
+
+  it('warns and returns nothing when the cluster topology cannot be read', async () => {
+    pveFetchMock.mockRejectedValue(new Error('cluster unreachable'))
+
+    const { data, warnings } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm', dateLocale: 'en', storages: STORAGES,
+    })
+
+    expect(data).toEqual([])
+    expect(warnings).toHaveLength(1)
+  })
+
+  it('does nothing when no storage supports backup content', async () => {
+    const { data, warnings } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm',
+      dateLocale: 'en',
+      storages: [{ storage: 'data', type: 'lvmthin', content: 'images', shared: 0 }],
+    })
+
+    expect(data).toEqual([])
+    expect(warnings).toEqual([])
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates the same archive reported by two nodes', async () => {
+    // Non-shared storage, so BOTH nodes are queried and both answer with the
+    // same volid — this is what actually exercises the dedup path.
+    pveFetchMock.mockImplementation(async (_c: any, path: string) => {
+      if (path === '/cluster/resources') return RESOURCES
+      if (path.includes('/content')) {
+        return [{ volid: 'local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst', ctime: 5, size: 2 }]
+      }
+      return []
+    })
+
+    const { data } = await listGuestVzdumpBackups(CONN, '111', {
+      typeFilter: 'vm',
+      dateLocale: 'en',
+      storages: STORAGES,
+    })
+
+    const contentCalls = pveFetchMock.mock.calls
+      .map(c => String(c[1]))
+      .filter(p => p.includes('/content'))
+
+    expect(contentCalls).toHaveLength(2)
+    expect(data).toHaveLength(1)
   })
 })

--- a/frontend/src/lib/backups/pveVzdump.test.ts
+++ b/frontend/src/lib/backups/pveVzdump.test.ts
@@ -104,4 +104,46 @@ describe('resolveVzdumpScanTargets', () => {
     expect(targets).toHaveLength(VZDUMP_MAX_PAIRS)
     expect(targets[0]).toEqual({ node: 'node40', storage: 'local' })
   })
+
+  it('preserves current node pairs across multiple storages when truncating', () => {
+    const many = Array.from({ length: 20 }, (_, i) => `node${i + 1}`)
+    const storages = [
+      { storage: 'local', type: 'dir', content: 'backup', shared: 0 },
+      { storage: 'backup2', type: 'dir', content: 'backup', shared: 0 },
+    ]
+    const resources = [
+      ...nodes(...many),
+      ...many.map(n => storageRes('local', n)),
+      ...many.map(n => storageRes('backup2', n)),
+    ]
+    const { targets, truncated } = resolveVzdumpScanTargets(storages, resources, 'node5')
+    expect(truncated).toBe(true)
+    expect(targets).toHaveLength(VZDUMP_MAX_PAIRS)
+    const firstTwo = new Set([
+      JSON.stringify(targets[0]),
+      JSON.stringify(targets[1]),
+    ])
+    expect(firstTwo).toEqual(
+      new Set([
+        JSON.stringify({ node: 'node5', storage: 'local' }),
+        JSON.stringify({ node: 'node5', storage: 'backup2' }),
+      ]),
+    )
+  })
+
+  it('does not truncate when targets length equals the hard cap', () => {
+    const many = Array.from({ length: 16 }, (_, i) => `node${i + 1}`)
+    const storages = [
+      { storage: 'local', type: 'dir', content: 'backup', shared: 0 },
+      { storage: 'backup2', type: 'dir', content: 'backup', shared: 0 },
+    ]
+    const resources = [
+      ...nodes(...many),
+      ...many.map(n => storageRes('local', n)),
+      ...many.map(n => storageRes('backup2', n)),
+    ]
+    const { targets, truncated } = resolveVzdumpScanTargets(storages, resources)
+    expect(targets).toHaveLength(VZDUMP_MAX_PAIRS)
+    expect(truncated).toBe(false)
+  })
 })

--- a/frontend/src/lib/backups/pveVzdump.test.ts
+++ b/frontend/src/lib/backups/pveVzdump.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { parseVzdumpVolidTime, vzdumpBackupTypeFromVolid } from './pveVzdump'
+import { parseVzdumpVolidTime, vzdumpBackupTypeFromVolid, resolveVzdumpScanTargets, VZDUMP_MAX_PAIRS } from './pveVzdump'
 
 describe('parseVzdumpVolidTime', () => {
   it('extracts the timestamp encoded in a vzdump filename', () => {
@@ -29,5 +29,79 @@ describe('vzdumpBackupTypeFromVolid', () => {
 
   it('returns null for a non-vzdump volid', () => {
     expect(vzdumpBackupTypeFromVolid('local:iso/debian.iso')).toBeNull()
+  })
+})
+
+const nodes = (...names: string[]) =>
+  names.map(n => ({ type: 'node', node: n, status: 'online' }))
+
+const storageRes = (storage: string, node: string, status = 'available') =>
+  ({ type: 'storage', storage, node, status })
+
+describe('resolveVzdumpScanTargets', () => {
+  it('keeps only backup-capable storages that are not PBS', () => {
+    const { targets } = resolveVzdumpScanTargets(
+      [
+        { storage: 'local', type: 'dir', content: 'backup,iso', shared: 0 },
+        { storage: 'pbs-01', type: 'pbs', content: 'backup', shared: 1 },
+        { storage: 'data', type: 'lvmthin', content: 'images', shared: 0 },
+      ],
+      [...nodes('node1'), storageRes('local', 'node1'), storageRes('pbs-01', 'node1'), storageRes('data', 'node1')],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'local' }])
+  })
+
+  it('queries a non-shared storage on every online node', () => {
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }],
+      [...nodes('node1', 'node2'), storageRes('local', 'node1'), storageRes('local', 'node2')],
+    )
+    expect(targets).toEqual([
+      { node: 'node1', storage: 'local' },
+      { node: 'node2', storage: 'local' },
+    ])
+  })
+
+  it('queries a shared storage only once', () => {
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'nfs-bkp', type: 'nfs', content: 'backup', shared: 1 }],
+      [...nodes('node1', 'node2'), storageRes('nfs-bkp', 'node1'), storageRes('nfs-bkp', 'node2')],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'nfs-bkp' }])
+  })
+
+  it('skips offline nodes', () => {
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }],
+      [
+        { type: 'node', node: 'node1', status: 'online' },
+        { type: 'node', node: 'node2', status: 'offline' },
+        storageRes('local', 'node1'),
+        storageRes('local', 'node2'),
+      ],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'local' }])
+  })
+
+  it('still scans a storage whose status is indeterminate', () => {
+    // `status` derives from RRD stats and can stay unknown without meaning the
+    // storage is absent — treat `available` as a positive signal, never a filter.
+    const { targets } = resolveVzdumpScanTargets(
+      [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }],
+      [...nodes('node1'), storageRes('local', 'node1', 'unknown')],
+    )
+    expect(targets).toEqual([{ node: 'node1', storage: 'local' }])
+  })
+
+  it('puts the guest current node first and truncates past the hard cap', () => {
+    const many = Array.from({ length: 40 }, (_, i) => `node${i + 1}`)
+    const { targets, truncated } = resolveVzdumpScanTargets(
+      [{ storage: 'local', type: 'dir', content: 'backup', shared: 0 }],
+      [...nodes(...many), ...many.map(n => storageRes('local', n))],
+      'node40',
+    )
+    expect(truncated).toBe(true)
+    expect(targets).toHaveLength(VZDUMP_MAX_PAIRS)
+    expect(targets[0]).toEqual({ node: 'node40', storage: 'local' })
   })
 })

--- a/frontend/src/lib/backups/pveVzdump.ts
+++ b/frontend/src/lib/backups/pveVzdump.ts
@@ -34,3 +34,87 @@ export function vzdumpBackupTypeFromVolid(volid: string): 'vm' | 'ct' | null {
 
   return null
 }
+
+export interface VzdumpStorageConfig {
+  storage: string
+  type?: string
+  content?: string
+  shared?: number
+}
+
+export interface VzdumpScanTarget {
+  node: string
+  storage: string
+}
+
+/**
+ * Plafond dur du nombre de paires nœud/stockage interrogées par requête. Le
+ * produit nœuds en ligne x stockages de sauvegarde non partagés croît avec la
+ * taille du cluster et l'onglet le réévalue à chaque ouverture.
+ */
+export const VZDUMP_MAX_PAIRS = 32
+
+function supportsBackupContent(s: VzdumpStorageConfig): boolean {
+  return (s.content || '')
+    .split(',')
+    .map(c => c.trim())
+    .includes('backup')
+}
+
+/**
+ * Paires nœud/stockage à interroger pour trouver les archives vzdump d'un guest.
+ *
+ * Les stockages PBS sont écartés : leurs snapshots remontent déjà par le fan-out
+ * PBS, les inclure ici les compterait deux fois. Un stockage partagé n'est
+ * interrogé qu'une fois ; un stockage local l'est sur chaque nœud en ligne,
+ * parce qu'une archive reste sur le nœud qui l'a produite même après migration
+ * du guest.
+ */
+export function resolveVzdumpScanTargets(
+  storages: VzdumpStorageConfig[],
+  resources: any[],
+  currentNode?: string | null,
+): { targets: VzdumpScanTarget[]; truncated: boolean } {
+  const onlineNodes = new Set(
+    (resources || [])
+      .filter(r => r?.type === 'node' && r?.status === 'online')
+      .map(r => String(r.node)),
+  )
+
+  const orderedNodes = (nodesForStorage: string[]) => {
+    const online = nodesForStorage.filter(n => onlineNodes.has(n))
+
+    if (currentNode && online.includes(currentNode)) {
+      return [currentNode, ...online.filter(n => n !== currentNode)]
+    }
+
+    return online
+  }
+
+  const targets: VzdumpScanTarget[] = []
+
+  for (const s of storages || []) {
+    if (!s?.storage) continue
+    if ((s.type || '').toLowerCase() === 'pbs') continue
+    if (!supportsBackupContent(s)) continue
+
+    const nodesForStorage = (resources || [])
+      .filter(r => r?.type === 'storage' && r?.storage === s.storage)
+      .map(r => String(r.node))
+
+    const candidates = orderedNodes(Array.from(new Set(nodesForStorage)))
+
+    if (candidates.length === 0) continue
+
+    if (s.shared === 1) targets.push({ node: candidates[0], storage: s.storage })
+    else for (const node of candidates) targets.push({ node, storage: s.storage })
+  }
+
+  if (currentNode) {
+    targets.sort((a, b) => Number(b.node === currentNode) - Number(a.node === currentNode))
+  }
+
+  const truncated = targets.length > VZDUMP_MAX_PAIRS
+
+  return { targets: truncated ? targets.slice(0, VZDUMP_MAX_PAIRS) : targets, truncated }
+}

--- a/frontend/src/lib/backups/pveVzdump.ts
+++ b/frontend/src/lib/backups/pveVzdump.ts
@@ -4,6 +4,7 @@
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { mapWithConcurrency } from "@/lib/inventory/concurrency"
+import { isSharedStorage } from "@/lib/proxmox/storage"
 import { formatBytes } from "@/utils/format"
 
 /**
@@ -66,6 +67,25 @@ function supportsBackupContent(s: VzdumpStorageConfig): boolean {
 }
 
 /**
+ * Partage réel d'un stockage, vu par le cluster.
+ *
+ * `/storage` ne porte `shared` que s'il a été posé explicitement dans
+ * storage.cfg : nfs, cifs et cephfs sont partagés par leur plugin et reviennent
+ * le plus souvent sans le champ. Les lignes `type: 'storage'` de
+ * `/cluster/resources`, elles, portent la valeur calculée par PVE — c'est la
+ * source qui fait foi. Repli sur la config (drapeau explicite, puis type de
+ * backend) quand aucune ligne ne la porte, sinon on interrogerait un stockage
+ * partagé une fois par nœud du cluster.
+ */
+function isStorageShared(s: VzdumpStorageConfig, storageRows: any[]): boolean {
+  const rowsWithFlag = storageRows.filter(r => r?.shared !== undefined && r?.shared !== null)
+
+  if (rowsWithFlag.length > 0) return rowsWithFlag.some(r => Number(r.shared) === 1)
+
+  return isSharedStorage(s)
+}
+
+/**
  * Paires nœud/stockage à interroger pour trouver les archives vzdump d'un guest.
  *
  * Les stockages PBS sont écartés : leurs snapshots remontent déjà par le fan-out
@@ -102,15 +122,16 @@ export function resolveVzdumpScanTargets(
     if ((s.type || '').toLowerCase() === 'pbs') continue
     if (!supportsBackupContent(s)) continue
 
-    const nodesForStorage = (resources || [])
-      .filter(r => r?.type === 'storage' && r?.storage === s.storage)
-      .map(r => String(r.node))
+    const storageRows = (resources || []).filter(
+      r => r?.type === 'storage' && r?.storage === s.storage,
+    )
 
+    const nodesForStorage = storageRows.map(r => String(r.node))
     const candidates = orderedNodes(Array.from(new Set(nodesForStorage)))
 
     if (candidates.length === 0) continue
 
-    if (s.shared === 1) targets.push({ node: candidates[0], storage: s.storage })
+    if (isStorageShared(s, storageRows)) targets.push({ node: candidates[0], storage: s.storage })
     else for (const node of candidates) targets.push({ node, storage: s.storage })
   }
 

--- a/frontend/src/lib/backups/pveVzdump.ts
+++ b/frontend/src/lib/backups/pveVzdump.ts
@@ -1,0 +1,36 @@
+// Collecte des archives vzdump d'un guest sur les stockages PVE. Symétrique de
+// pbsSnapshots.ts, qui fait le même travail pour les snapshots PBS. L'onglet
+// Backups d'une VM fusionne les deux sources.
+
+/**
+ * Date encodée dans le nom de fichier d'une archive vzdump, par exemple
+ * `local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst`.
+ *
+ * Repli utilisé uniquement quand `ctime` est absent de la réponse PVE, ce champ
+ * étant optionnel au schéma. Proxmox écrit ce nom en heure locale du nœud ; on
+ * l'interprète en UTC, donc le résultat peut dériver du décalage horaire. C'est
+ * acceptable pour un repli dont le seul rôle est d'ordonner la liste.
+ */
+export function parseVzdumpVolidTime(volid: string): number | null {
+  const m = /(\d{4})_(\d{2})_(\d{2})-(\d{2})_(\d{2})_(\d{2})/.exec(volid)
+
+  if (!m) return null
+
+  const ms = Date.UTC(
+    Number(m[1]), Number(m[2]) - 1, Number(m[3]),
+    Number(m[4]), Number(m[5]), Number(m[6]),
+  )
+
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000)
+}
+
+/**
+ * Type de guest porté par le volid, normalisé sur le vocabulaire PBS
+ * (`vm` / `ct`) pour que les deux sources partagent le même champ.
+ */
+export function vzdumpBackupTypeFromVolid(volid: string): 'vm' | 'ct' | null {
+  if (volid.includes('vzdump-qemu-')) return 'vm'
+  if (volid.includes('vzdump-lxc-') || volid.includes('vzdump-openvz-')) return 'ct'
+
+  return null
+}

--- a/frontend/src/lib/backups/pveVzdump.ts
+++ b/frontend/src/lib/backups/pveVzdump.ts
@@ -2,6 +2,10 @@
 // pbsSnapshots.ts, qui fait le même travail pour les snapshots PBS. L'onglet
 // Backups d'une VM fusionne les deux sources.
 
+import { pveFetch } from "@/lib/proxmox/client"
+import { mapWithConcurrency } from "@/lib/inventory/concurrency"
+import { formatBytes } from "@/utils/format"
+
 /**
  * Date encodée dans le nom de fichier d'une archive vzdump, par exemple
  * `local:backup/vzdump-qemu-111-2026_08_11-15_51_33.vma.zst`.
@@ -117,4 +121,160 @@ export function resolveVzdumpScanTargets(
   const truncated = targets.length > VZDUMP_MAX_PAIRS
 
   return { targets: truncated ? targets.slice(0, VZDUMP_MAX_PAIRS) : targets, truncated }
+}
+
+/** pveproxy a un pool de workers limité ; on reste bien sous le plafond
+ *  d'inventaire pour ne pas affamer l'UI Proxmox du client. */
+export const VZDUMP_SCAN_CONCURRENCY = 6
+
+export interface VzdumpBackup {
+  id: string
+  source: 'vzdump'
+  volid: string
+  node: string
+  storage: string
+  backupType: 'vm' | 'ct'
+  backupId: string
+  backupTime: number
+  backupTimeKnown: boolean
+  backupTimeFormatted: string
+  size: number
+  sizeFormatted: string
+  format: string
+  protected: boolean
+  comment: string
+  verified: false
+  verification: null
+}
+
+function normalizeVzdumpItem(
+  item: any,
+  node: string,
+  storage: string,
+  dateLocale: string,
+): VzdumpBackup | null {
+  const volid = String(item?.volid || '')
+
+  if (!volid) return null
+
+  const backupType = vzdumpBackupTypeFromVolid(volid)
+
+  if (!backupType) return null
+
+  // `ctime` est optionnel au schéma PVE : repli sur la date du nom de fichier,
+  // puis date inconnue. Jamais de 0 silencieux qui fausserait le tri.
+  const ctime = typeof item?.ctime === 'number' ? item.ctime : null
+  const parsed = ctime ?? parseVzdumpVolidTime(volid)
+  const backupTimeKnown = parsed !== null
+  const backupTime = parsed ?? 0
+  const size = typeof item?.size === 'number' ? item.size : 0
+
+  return {
+    id: `${node}/${volid}`,
+    source: 'vzdump',
+    volid,
+    node,
+    storage,
+    backupType,
+    backupId: String(item?.vmid ?? ''),
+    backupTime,
+    backupTimeKnown,
+    backupTimeFormatted: backupTimeKnown
+      ? new Date(backupTime * 1000).toLocaleString(dateLocale)
+      : '-',
+    size,
+    sizeFormatted: formatBytes(size),
+    format: String(item?.format || ''),
+    protected: !!item?.protected,
+    comment: String(item?.notes || ''),
+    verified: false,
+    verification: null,
+  }
+}
+
+/**
+ * Archives vzdump d'un guest, tous stockages PVE non-PBS du cluster confondus.
+ *
+ * `storages` est la configuration cluster-wide `/storage`, déjà récupérée par
+ * l'appelant : la route en a besoin par ailleurs pour calculer `pbsConfigured`,
+ * on ne la refetch pas ici.
+ *
+ * Ne lève jamais. Toute panne devient un warning, pour qu'un stockage
+ * injoignable n'efface pas les archives trouvées ailleurs.
+ */
+export async function listGuestVzdumpBackups(
+  conn: any,
+  vmid: string,
+  opts: {
+    typeFilter?: string | null
+    dateLocale: string
+    storages: VzdumpStorageConfig[]
+    currentNode?: string | null
+  },
+): Promise<{ data: VzdumpBackup[]; warnings: string[] }> {
+  const warnings: string[] = []
+
+  const backupStorages = (opts.storages || []).filter(
+    s => s?.storage && (s.type || '').toLowerCase() !== 'pbs' && supportsBackupContent(s),
+  )
+
+  if (backupStorages.length === 0) return { data: [], warnings }
+
+  let resources: any[] = []
+
+  try {
+    resources = await pveFetch<any[]>(conn, '/cluster/resources')
+  } catch (e: any) {
+    warnings.push(`cluster topology: ${e?.message || String(e)}`)
+
+    return { data: [], warnings }
+  }
+
+  const { targets, truncated } = resolveVzdumpScanTargets(backupStorages, resources, opts.currentNode)
+
+  if (truncated) {
+    warnings.push(`vzdump scan truncated to ${VZDUMP_MAX_PAIRS} node/storage pairs`)
+  }
+
+  const perTarget = await mapWithConcurrency(
+    targets,
+    VZDUMP_SCAN_CONCURRENCY,
+    async ({ node, storage }) => {
+      const path =
+        `/nodes/${encodeURIComponent(node)}/storage/${encodeURIComponent(storage)}` +
+        `/content?content=backup&vmid=${encodeURIComponent(vmid)}`
+
+      try {
+        const items = await pveFetch<any[]>(conn, path)
+
+        return (items || [])
+          .map(item => normalizeVzdumpItem(item, node, storage, opts.dateLocale))
+          .filter((b): b is VzdumpBackup => b !== null)
+      } catch (e: any) {
+        warnings.push(`${node}/${storage}: ${e?.message || String(e)}`)
+
+        return []
+      }
+    },
+  )
+
+  const wanted = opts.typeFilter === 'vm' || opts.typeFilter === 'ct' ? opts.typeFilter : null
+  const seen = new Set<string>()
+  const data: VzdumpBackup[] = []
+
+  for (const backup of perTarget.flat()) {
+    if (wanted && backup.backupType !== wanted) continue
+    if (seen.has(backup.volid)) continue
+    seen.add(backup.volid)
+    data.push(backup)
+  }
+
+  // Récent d'abord ; les entrées sans date connue ferment la marche.
+  data.sort((a, b) => {
+    if (a.backupTimeKnown !== b.backupTimeKnown) return a.backupTimeKnown ? -1 : 1
+
+    return b.backupTime - a.backupTime
+  })
+
+  return { data, warnings }
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2402,7 +2402,7 @@
     "noGuestBackups": "Keine Sicherungen für diese Maschine gefunden.",
     "sourceVzdump": "Lokales Archiv",
     "vzdumpNoBrowsing": "Das Durchsuchen von Dateien in einem vzdump-Archiv erfordert einen Proxmox Backup Server",
-    "archivesCount": "{count} Archive",
+    "archivesCount": "{count, plural, =1 {# Archiv} other {# Archive}}",
     "noBackupsAnywhereTitle": "Keine Sicherungen gefunden",
     "noBackupsAnywhereHint": "Dieser Gast hat weder einen Snapshot auf einem verbundenen Proxmox Backup Server noch ein vzdump-Archiv auf den Speichern des Clusters."
   },

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2399,7 +2399,12 @@
     "trendsDistribution": "Typverteilung",
     "noPbsConfiguredTitle": "Kein Proxmox Backup Server konfiguriert",
     "noPbsConfiguredHint": "Kein verbundener Proxmox Backup Server sichert den Cluster dieses Gasts. Fügen Sie den PBS des Clusters als Verbindung hinzu, um seine Sicherungen hier zu sehen.",
-    "noGuestBackups": "Keine Sicherungen für diese Maschine gefunden."
+    "noGuestBackups": "Keine Sicherungen für diese Maschine gefunden.",
+    "sourceVzdump": "Lokales Archiv",
+    "vzdumpNoBrowsing": "Das Durchsuchen von Dateien in einem vzdump-Archiv erfordert einen Proxmox Backup Server",
+    "archivesCount": "{count} Archive",
+    "noBackupsAnywhereTitle": "Keine Sicherungen gefunden",
+    "noBackupsAnywhereHint": "Dieser Gast hat weder einen Snapshot auf einem verbundenen Proxmox Backup Server noch ein vzdump-Archiv auf den Speichern des Clusters."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2429,7 +2429,12 @@
     "trendsDistribution": "Type distribution",
     "noPbsConfiguredTitle": "No Proxmox Backup Server configured",
     "noPbsConfiguredHint": "No connected Proxmox Backup Server backs up this guest's cluster. Add the cluster's PBS as a connection to see its backups here.",
-    "noGuestBackups": "No backups found for this guest."
+    "noGuestBackups": "No backups found for this guest.",
+    "sourceVzdump": "Local archive",
+    "vzdumpNoBrowsing": "Browsing files inside a vzdump archive requires a Proxmox Backup Server",
+    "archivesCount": "{count} archives",
+    "noBackupsAnywhereTitle": "No backups found",
+    "noBackupsAnywhereHint": "This guest has no snapshot on a connected Proxmox Backup Server, and no vzdump archive on the cluster's storages."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2432,7 +2432,7 @@
     "noGuestBackups": "No backups found for this guest.",
     "sourceVzdump": "Local archive",
     "vzdumpNoBrowsing": "Browsing files inside a vzdump archive requires a Proxmox Backup Server",
-    "archivesCount": "{count} archives",
+    "archivesCount": "{count, plural, =1 {# archive} other {# archives}}",
     "noBackupsAnywhereTitle": "No backups found",
     "noBackupsAnywhereHint": "This guest has no snapshot on a connected Proxmox Backup Server, and no vzdump archive on the cluster's storages."
   },

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2432,7 +2432,7 @@
     "noGuestBackups": "No se encontraron backups para este guest.",
     "sourceVzdump": "Archivo local",
     "vzdumpNoBrowsing": "Explorar los archivos de un archivo vzdump requiere un Proxmox Backup Server",
-    "archivesCount": "{count} archivos",
+    "archivesCount": "{count, plural, =1 {# archivo} other {# archivos}}",
     "noBackupsAnywhereTitle": "No se han encontrado copias de seguridad",
     "noBackupsAnywhereHint": "Este huésped no tiene ninguna instantánea en un Proxmox Backup Server conectado, ni ningún archivo vzdump en los almacenamientos del clúster."
   },

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2429,7 +2429,12 @@
     "trendsDistribution": "Distribución por tipo",
     "noPbsConfiguredTitle": "No hay ningún Proxmox Backup Server configurado",
     "noPbsConfiguredHint": "Ningún Proxmox Backup Server conectado realiza backups del cluster de este guest. Añade el PBS del cluster como conexión para ver aquí sus backups.",
-    "noGuestBackups": "No se encontraron backups para este guest."
+    "noGuestBackups": "No se encontraron backups para este guest.",
+    "sourceVzdump": "Archivo local",
+    "vzdumpNoBrowsing": "Explorar los archivos de un archivo vzdump requiere un Proxmox Backup Server",
+    "archivesCount": "{count} archivos",
+    "noBackupsAnywhereTitle": "No se han encontrado copias de seguridad",
+    "noBackupsAnywhereHint": "Este huésped no tiene ninguna instantánea en un Proxmox Backup Server conectado, ni ningún archivo vzdump en los almacenamientos del clúster."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2432,7 +2432,7 @@
     "noGuestBackups": "Aucune sauvegarde trouvée pour cette machine.",
     "sourceVzdump": "Archive locale",
     "vzdumpNoBrowsing": "Parcourir les fichiers d'une archive vzdump nécessite un Proxmox Backup Server",
-    "archivesCount": "{count} archives",
+    "archivesCount": "{count, plural, =1 {# archive} other {# archives}}",
     "noBackupsAnywhereTitle": "Aucune sauvegarde trouvée",
     "noBackupsAnywhereHint": "Cette instance n'a aucun snapshot sur un Proxmox Backup Server connecté, ni aucune archive vzdump sur les stockages du cluster."
   },

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2429,7 +2429,12 @@
     "trendsDistribution": "Répartition par type",
     "noPbsConfiguredTitle": "Aucun serveur Proxmox Backup Server configuré",
     "noPbsConfiguredHint": "Aucun Proxmox Backup Server connecté ne sauvegarde le cluster de cette machine. Ajoutez le PBS du cluster comme connexion pour voir ses sauvegardes ici.",
-    "noGuestBackups": "Aucune sauvegarde trouvée pour cette machine."
+    "noGuestBackups": "Aucune sauvegarde trouvée pour cette machine.",
+    "sourceVzdump": "Archive locale",
+    "vzdumpNoBrowsing": "Parcourir les fichiers d'une archive vzdump nécessite un Proxmox Backup Server",
+    "archivesCount": "{count} archives",
+    "noBackupsAnywhereTitle": "Aucune sauvegarde trouvée",
+    "noBackupsAnywhereHint": "Cette instance n'a aucun snapshot sur un Proxmox Backup Server connecté, ni aucune archive vzdump sur les stockages du cluster."
   },
   "backup": {
     "notifAuto": "Auto",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2429,7 +2429,12 @@
     "trendsDistribution": "유형 분포",
     "noPbsConfiguredTitle": "구성된 Proxmox Backup Server가 없습니다",
     "noPbsConfiguredHint": "이 게스트의 클러스터를 백업하는 연결된 Proxmox Backup Server가 없습니다. 클러스터의 PBS를 연결로 추가하면 여기에서 백업을 확인할 수 있습니다.",
-    "noGuestBackups": "이 게스트의 백업을 찾을 수 없습니다."
+    "noGuestBackups": "이 게스트의 백업을 찾을 수 없습니다.",
+    "sourceVzdump": "로컬 아카이브",
+    "vzdumpNoBrowsing": "vzdump 아카이브 내부의 파일을 탐색하려면 Proxmox Backup Server가 필요합니다",
+    "archivesCount": "아카이브 {count}개",
+    "noBackupsAnywhereTitle": "백업을 찾을 수 없습니다",
+    "noBackupsAnywhereHint": "이 게스트는 연결된 Proxmox Backup Server에 스냅샷이 없으며, 클러스터 스토리지에도 vzdump 아카이브가 없습니다."
   },
   "backup": {
     "notifAuto": "자동",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2432,7 +2432,7 @@
     "noGuestBackups": "이 게스트의 백업을 찾을 수 없습니다.",
     "sourceVzdump": "로컬 아카이브",
     "vzdumpNoBrowsing": "vzdump 아카이브 내부의 파일을 탐색하려면 Proxmox Backup Server가 필요합니다",
-    "archivesCount": "아카이브 {count}개",
+    "archivesCount": "{count, plural, other {아카이브 #개}}",
     "noBackupsAnywhereTitle": "백업을 찾을 수 없습니다",
     "noBackupsAnywhereHint": "이 게스트는 연결된 Proxmox Backup Server에 스냅샷이 없으며, 클러스터 스토리지에도 vzdump 아카이브가 없습니다."
   },

--- a/frontend/src/messages/vzdumpBackupsMessages.test.ts
+++ b/frontend/src/messages/vzdumpBackupsMessages.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+
+import en from './en.json'
+import fr from './fr.json'
+import de from './de.json'
+import zhCN from './zh-CN.json'
+import ko from './ko.json'
+import es from './es.json'
+
+type Messages = Record<string, any>
+
+const REQUIRED = [
+  'sourceVzdump',
+  'vzdumpNoBrowsing',
+  'archivesCount',
+  'noBackupsAnywhereTitle',
+  'noBackupsAnywhereHint',
+]
+
+const locales: Array<[string, Messages]> = [
+  ['en', en as Messages],
+  ['fr', fr as Messages],
+  ['de', de as Messages],
+  ['zh-CN', zhCN as Messages],
+  ['ko', ko as Messages],
+  ['es', es as Messages],
+]
+
+describe('vzdump backup message keys', () => {
+  for (const [name, messages] of locales) {
+    it(`${name} defines every vzdump backup key`, () => {
+      for (const key of REQUIRED) {
+        expect(messages.backups?.[key], `${name}.backups.${key}`).toBeTruthy()
+      }
+    })
+  }
+
+  it('archivesCount carries the count placeholder in every locale', () => {
+    for (const [name, messages] of locales) {
+      expect(messages.backups.archivesCount, name).toContain('{count}')
+    }
+  })
+})

--- a/frontend/src/messages/vzdumpBackupsMessages.test.ts
+++ b/frontend/src/messages/vzdumpBackupsMessages.test.ts
@@ -37,7 +37,68 @@ describe('vzdump backup message keys', () => {
 
   it('archivesCount carries the count placeholder in every locale', () => {
     for (const [name, messages] of locales) {
-      expect(messages.backups.archivesCount, name).toContain('{count}')
+      // Forme ICU : `{count, plural, ...}`. Le placeholder nu `{count}` a
+      // disparu avec la mise au pluriel, la virgule le prouve.
+      expect(messages.backups.archivesCount, name).toContain('{count,')
+    }
+  })
+
+  it('archivesCount is an ICU plural with an other branch in every locale', () => {
+    for (const [name, messages] of locales) {
+      expect(messages.backups.archivesCount, name).toMatch(/^\{count, plural,.*other \{/)
+    }
+  })
+
+  it('archivesCount renders a singular form where the language has one', () => {
+    // Le cas le plus probable chez un client sans PBS : un seul archive dans le
+    // groupe. « 1 archives » était la régression visible.
+    const singular: Record<string, string> = {
+      en: '1 archive',
+      fr: '1 archive',
+      de: '1 Archiv',
+      es: '1 archivo',
+    }
+
+    for (const [name, messages] of locales) {
+      const expected = singular[name]
+
+      if (!expected) continue
+
+      expect(formatMessage(messages.backups.archivesCount, 1), name).toBe(expected)
+    }
+  })
+
+  it('archivesCount keeps a plural form for counts above one', () => {
+    const plural: Record<string, string> = {
+      en: '3 archives',
+      fr: '3 archives',
+      de: '3 Archive',
+      es: '3 archivos',
+      ko: '아카이브 3개',
+      'zh-CN': '3 个归档',
+    }
+
+    for (const [name, messages] of locales) {
+      expect(formatMessage(messages.backups.archivesCount, 3), name).toBe(plural[name])
     }
   })
 })
+
+/** Rendu minimal d'un pluriel ICU à une seule variable, suffisant pour vérifier
+ *  la forme des messages sans embarquer un formateur complet. */
+function formatMessage(message: string, count: number): string {
+  const m = /^\{count, plural,\s*(.*)\}$/s.exec(message)
+
+  if (!m) return message
+
+  const branches = new Map<string, string>()
+  const re = /(=\d+|zero|one|two|few|many|other)\s*\{([^{}]*)\}/g
+  let hit: RegExpExecArray | null
+
+  while ((hit = re.exec(m[1])) !== null) branches.set(hit[1], hit[2])
+
+  const category = new Intl.PluralRules('en').select(count)
+  const chosen = branches.get(`=${count}`) ?? branches.get(category) ?? branches.get('other') ?? ''
+
+  return chosen.replaceAll('#', String(count))
+}

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2401,7 +2401,7 @@
     "noGuestBackups": "未找到此机器的备份。",
     "sourceVzdump": "本地归档",
     "vzdumpNoBrowsing": "浏览 vzdump 归档中的文件需要 Proxmox Backup Server",
-    "archivesCount": "{count} 个归档",
+    "archivesCount": "{count, plural, other {# 个归档}}",
     "noBackupsAnywhereTitle": "未找到备份",
     "noBackupsAnywhereHint": "该实例在已连接的 Proxmox Backup Server 上没有快照，集群存储上也没有 vzdump 归档。"
   },

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2398,7 +2398,12 @@
     "trendsDistribution": "类型分布",
     "noPbsConfiguredTitle": "未配置 Proxmox Backup Server",
     "noPbsConfiguredHint": "没有已连接的 Proxmox Backup Server 备份此机器的集群。请将该集群的 PBS 添加为连接以在此处查看备份。",
-    "noGuestBackups": "未找到此机器的备份。"
+    "noGuestBackups": "未找到此机器的备份。",
+    "sourceVzdump": "本地归档",
+    "vzdumpNoBrowsing": "浏览 vzdump 归档中的文件需要 Proxmox Backup Server",
+    "archivesCount": "{count} 个归档",
+    "noBackupsAnywhereTitle": "未找到备份",
+    "noBackupsAnywhereHint": "该实例在已连接的 Proxmox Backup Server 上没有快照，集群存储上也没有 vzdump 归档。"
   },
   "backup": {
     "notifAuto": "自动",


### PR DESCRIPTION
## Problem

A guest's **Backups** tab only ever listed Proxmox Backup Server snapshots. It never listed vzdump archives written to a PVE storage, so a cluster that backs up straight to each node's `local` showed "No Proxmox Backup Server configured" while its backups plainly existed.

This was not a regression. PR #399, which introduced the tab's two empty states, states that the tab "lists PBS snapshots only". The gap went unnoticed because our users connect a PBS.

The inconsistency worth fixing: ProxCenter already **writes** vzdump archives to arbitrary PVE storages, from both the VM tab and the inventory tree, and offers `local` to provider and MSP admins. It could not read back what it had just written.

## Change

The guest backups route now returns vzdump archives alongside PBS snapshots, and they are restorable.

A new `lib/backups/pveVzdump.ts`, modelled on the existing `lib/backups/pbsSnapshots.ts`, resolves which node/storage pairs can hold a guest's archives and collects them. `GET /api/v1/guests/[vmid]/backups` loses its "no PBS connection" short-circuit and runs both collections concurrently.

### How the scan is bounded

- Storage topology comes from `/storage` (fetched once, shared with the existing `pbsConfigured` check) and `/cluster/resources`. A shared storage is queried once; a non-shared one is queried on every online node, because a vzdump archive stays on the node that produced it even after the guest migrates.
- PBS-type storages are excluded here, since their snapshots arrive through the PBS fan-out and would otherwise be counted twice.
- Bounded concurrency, a hard cap of 32 node/storage pairs, and the guest's current node scanned first.
- The scan runs **only when the Backups tab is opened**, not on every VM selection in the tree. On an 8-node cluster with two backup-capable storages, preloading it on every selection would have cost about 18 PVE calls per click.
- No failure is fatal. An unreachable storage or an offline node becomes a warning, so it cannot erase archives found elsewhere.

### Data handling

- `ctime` is optional in the PVE storage-content schema, so the timestamp falls back to the date encoded in the volid filename, then to "unknown", sorted last. No silent `0` that would corrupt the ordering.
- `shared` is read from `/cluster/resources` rather than the storage config, because PVE omits it for implicitly shared plugins such as nfs, cifs and cephfs.

### Interface

- vzdump archives render as their own groups in the existing list, labelled by node and storage, with a source chip.
- The "verified" stat tile only appears when PBS snapshots are present. A vzdump archive has no notion of verification, so counting it as unverified would read as a failed verification.
- The namespace filter applies to PBS entries only; vzdump groups have no namespace and stay visible.
- A vzdump row is not clickable. Browsing files inside a `.vma` requires a PBS, since the Proxmox file restore tooling only supports PBS snapshots. A tooltip says so, and the Restore button stays active.
- Restore targets the node that holds the archive, not the guest's current node. On a non-shared storage the archive is only readable from its own node, so a migrated guest would previously have restored to a node that cannot read the volid.
- Three empty states instead of two, so "no PBS configured" is no longer claimed when the cluster's storages were scanned and found empty.

### Tenancy

vDC tenants are unchanged and never trigger the scan, mirroring the rule in `nodes/[node]/storages` where a `content=backup` query shows a tenant only PBS targets. PBS namespace isolation remains the only supported tenant backup path. The restore route's existing vDC allow-list is a second barrier.

## Also included

A pre-existing hydration error in the Hardware tab is fixed in its own commit: the CPU flags header rendered a `Chip` (a `div`) inside a `Typography variant="body2"` (a `p`).

## Out of scope

- `lib/backups/freshness.ts` is still PBS-only, so guests backed up with vzdump still read as unprotected in reports, the public API and compliance collection. This is tracked separately and is the more serious remaining gap.
- Restore and file-restore actions in the storage detail panel are still gated on PBS storages.
- The backup job dialog still filters its storage picker to PBS targets.
- Deleting an archive from the tab.

## Testing

74 test files, 1001 tests, exit 0.

New coverage: the collection module (topology resolution, shared versus per-node scanning, cap truncation, the `ctime` fallback chain, dedup, per-node failure warnings), the merged route (including the zero-PBS case that motivated this work, both failure directions, and PBS-only verified counting), tenant isolation, locale parity, and the restore route's raw volid contract, which had no tests at all.

The UI is not covered: nothing in the suite mounts the inventory detail component. Those changes were verified by review and by manual testing on a real cluster: a guest with a single vzdump archive on `local`, with no PBS connected, now lists and restores it.

Worth exercising manually before release: a guest migrated away from the node holding its archive, a guest with both PBS snapshots and vzdump archives, and reselecting the same guest after selecting a node with the Backups tab open.
