### PR TITLE
Expose the PVE rule log level in firewall dialogs and rules tables

### DIFF
--- a/frontend/src/app/(dashboard)/automation/network/components/DeploymentWizard.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/DeploymentWizard.tsx
@@ -265,7 +265,7 @@ export default function DeploymentWizard({
                   </Box>
                 </TableCell>
                 <TableCell><Chip label={rule.proto.toUpperCase()} size="small" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
-                <TableCell sx={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{rule.dport}</TableCell>
+                <TableCell sx={{ fontSize: 12 }}>{rule.dport}</TableCell>
                 <TableCell><Chip label="IN" size="small" color="info" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
                 <TableCell><Chip label="ACCEPT" size="small" color="success" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
                 <TableCell />
@@ -280,7 +280,7 @@ export default function DeploymentWizard({
                   </Box>
                 </TableCell>
                 <TableCell><Chip label={rule.proto.toUpperCase()} size="small" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
-                <TableCell sx={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 12 }}>{rule.dport}</TableCell>
+                <TableCell sx={{ fontSize: 12 }}>{rule.dport}</TableCell>
                 <TableCell><Chip label="IN" size="small" color="info" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
                 <TableCell><Chip label="ACCEPT" size="small" color="success" sx={{ height: 22, fontSize: 11, fontWeight: 600 }} /></TableCell>
                 <TableCell>

--- a/frontend/src/app/(dashboard)/automation/network/components/ObjectsTab.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/ObjectsTab.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Component tests for ObjectsTab.tsx — the firewall Aliases and IP Sets tab.
+ *
+ * The tab is prop-driven (the objects come from the page above) and every
+ * write goes through the firewall API module, which is stubbed. What matters
+ * here is the round trip an operator does: read the objects, open a create
+ * or edit dialog, and have the values reach PVE under the right names.
+ *
+ * The edit dialogs are worth their own assertions because they are seeded
+ * from the row that was clicked and read back with `editingAlias?.cidr || ''`
+ * — a form that renders empty on a real object, or leaks a stale one after
+ * cancel, is the failure mode.
+ *
+ * `view` narrows the tab to one of the two sections; the network page uses it
+ * to show Aliases and IP Sets under separate menu entries, so both the
+ * narrowed and the combined rendering are covered.
+ *
+ * `window.confirm` gates the deletions and jsdom does not implement it, so it
+ * is stubbed per test rather than globally.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPIType from '@/lib/api/firewall'
+
+vi.mock('@/lib/api/firewall', () => ({
+  createAlias: vi.fn(),
+  updateAlias: vi.fn(),
+  deleteAlias: vi.fn(),
+  createIPSet: vi.fn(),
+  deleteIPSet: vi.fn(),
+  addIPSetEntry: vi.fn(),
+  deleteIPSetEntry: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import ObjectsTab from './ObjectsTab'
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+const CONN = 'conn-1'
+
+const ALIASES: firewallAPIType.Alias[] = [
+  { name: 'net-mgmt', cidr: '10.99.99.0/24', comment: 'management' },
+  { name: 'net-dmz', cidr: '10.98.0.0/16' },
+]
+
+const IPSETS: firewallAPIType.IPSet[] = [
+  { name: 'trusted', comment: 'jump hosts', members: [{ cidr: '1.2.3.4' }, { cidr: '5.6.7.8' }] },
+  { name: 'blocklist', members: [] },
+]
+
+function props(overrides: Partial<React.ComponentProps<typeof ObjectsTab>> = {}) {
+  return {
+    aliases: ALIASES,
+    ipsets: IPSETS,
+    selectedConnection: CONN,
+    loading: false,
+    reload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderTab(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<ObjectsTab {...p} />)
+
+  return p
+}
+
+const rowOf = (text: string) => screen.getAllByRole('row').find(r => within(r).queryByText(text))!
+
+const dialog = () => within(screen.getByRole('dialog'))
+
+describe('ObjectsTab', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const fn of Object.values(api)) fn.mockResolvedValue?.(undefined)
+  })
+
+  it('lists the aliases with their CIDR and comment', () => {
+    renderTab()
+
+    expect(screen.getByText('2 aliases')).toBeInTheDocument()
+    expect(screen.getByText('net-mgmt')).toBeInTheDocument()
+    expect(screen.getByText('10.99.99.0/24')).toBeInTheDocument()
+    expect(screen.getByText('management')).toBeInTheDocument()
+
+    // An alias without a comment reads as a dash, not as blank.
+    expect(within(rowOf('net-dmz')).getByText('-')).toBeInTheDocument()
+  })
+
+  it('lists the IP sets with their entries and entry count', () => {
+    renderTab()
+
+    expect(screen.getByText('2 sets • 2 entries')).toBeInTheDocument()
+    expect(screen.getByText('trusted')).toBeInTheDocument()
+    expect(screen.getByText('jump hosts')).toBeInTheDocument()
+    expect(screen.getByText('1.2.3.4')).toBeInTheDocument()
+    expect(screen.getByText('5.6.7.8')).toBeInTheDocument()
+
+    // A set with no comment falls back to a placeholder.
+    expect(screen.getByText('No description')).toBeInTheDocument()
+  })
+
+  it('narrows to one section when the page asks for a single view', () => {
+    renderTab({ view: 'aliases' })
+
+    expect(screen.getByText('Aliases')).toBeInTheDocument()
+    expect(screen.queryByText('IP Sets')).not.toBeInTheDocument()
+
+    cleanup()
+
+    renderTab({ view: 'ipsets' })
+    expect(screen.getByText('IP Sets')).toBeInTheDocument()
+    expect(screen.queryByText('Aliases')).not.toBeInTheDocument()
+  })
+
+  it('creates an alias from the New dialog', async () => {
+    const p = renderTab({ view: 'aliases' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    await waitFor(() => expect(screen.getByText('Create Alias')).toBeInTheDocument())
+
+    // Create stays disabled until both the name and the CIDR are given.
+    expect(dialog().getByRole('button', { name: 'Create' })).toBeDisabled()
+
+    fireEvent.change(dialog().getByLabelText('Name'), { target: { value: 'net-new' } })
+    expect(dialog().getByRole('button', { name: 'Create' })).toBeDisabled()
+
+    fireEvent.change(dialog().getByLabelText('CIDR'), { target: { value: '10.1.0.0/24' } })
+    fireEvent.change(dialog().getByLabelText('Description'), { target: { value: 'from test' } })
+
+    fireEvent.click(dialog().getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(api.createAlias).toHaveBeenCalledWith(CONN, {
+      name: 'net-new', cidr: '10.1.0.0/24', comment: 'from test',
+    }))
+    expect(p.reload).toHaveBeenCalled()
+  })
+
+  it('edits an alias CIDR, keeping its name read-only', async () => {
+    renderTab({ view: 'aliases' })
+
+    fireEvent.click(within(rowOf('net-mgmt')).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByText('Edit Alias')).toBeInTheDocument())
+
+    // PVE identifies an alias by its name, so the form seeds it and locks it.
+    expect(dialog().getByLabelText('Name')).toHaveValue('net-mgmt')
+    expect(dialog().getByLabelText('Name')).toBeDisabled()
+    expect(dialog().getByLabelText('CIDR')).toHaveValue('10.99.99.0/24')
+
+    fireEvent.change(dialog().getByLabelText('CIDR'), { target: { value: '10.99.0.0/16' } })
+    fireEvent.change(dialog().getByLabelText('Description'), { target: { value: 'widened' } })
+
+    fireEvent.click(dialog().getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.updateAlias).toHaveBeenCalledWith(CONN, 'net-mgmt', {
+      cidr: '10.99.0.0/16', comment: 'widened',
+    }))
+  })
+
+  it('seeds the edit form from an alias that carries no comment', async () => {
+    renderTab({ view: 'aliases' })
+
+    fireEvent.click(within(rowOf('net-dmz')).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByText('Edit Alias')).toBeInTheDocument())
+
+    expect(dialog().getByLabelText('CIDR')).toHaveValue('10.98.0.0/16')
+    expect(dialog().getByLabelText('Description')).toHaveValue('')
+  })
+
+  it('asks the browser to confirm before deleting an alias', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    renderTab({ view: 'aliases' })
+
+    fireEvent.click(within(rowOf('net-mgmt')).getByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete alias "net-mgmt"?')
+    expect(api.deleteAlias).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    fireEvent.click(within(rowOf('net-mgmt')).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteAlias).toHaveBeenCalledWith(CONN, 'net-mgmt'))
+    confirmSpy.mockRestore()
+  })
+
+  it('creates an IP set from the New dialog', async () => {
+    renderTab({ view: 'ipsets' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'New' }))
+    await waitFor(() => expect(screen.getByText('Create IP Set')).toBeInTheDocument())
+
+    expect(dialog().getByRole('button', { name: 'Create' })).toBeDisabled()
+
+    fireEvent.change(dialog().getByLabelText('Name'), { target: { value: 'jump-hosts' } })
+    fireEvent.change(dialog().getByLabelText('Description'), { target: { value: 'bastions' } })
+
+    fireEvent.click(dialog().getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(api.createIPSet).toHaveBeenCalledWith(CONN, { name: 'jump-hosts', comment: 'bastions' }))
+  })
+
+  it('edits an IP set description, keeping its name read-only', async () => {
+    renderTab({ view: 'ipsets' })
+
+    const card = screen.getByText('trusted').closest('div')!
+
+    fireEvent.click(within(card.parentElement!.parentElement!).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByText('Edit IP Set')).toBeInTheDocument())
+
+    expect(dialog().getByLabelText('Name')).toHaveValue('trusted')
+    expect(dialog().getByLabelText('Name')).toBeDisabled()
+    expect(dialog().getByLabelText('Description')).toHaveValue('jump hosts')
+
+    fireEvent.change(dialog().getByLabelText('Description'), { target: { value: 'renamed' } })
+    expect(dialog().getByLabelText('Description')).toHaveValue('renamed')
+  })
+
+  it('adds an entry to an IP set', async () => {
+    renderTab({ view: 'ipsets' })
+
+    // Each set card carries its own Add button.
+    fireEvent.click(screen.getAllByRole('button', { name: 'Add' })[0])
+    await waitFor(() => expect(screen.getByText('Add to trusted')).toBeInTheDocument())
+
+    expect(dialog().getByRole('button', { name: 'Add' })).toBeDisabled()
+
+    fireEvent.change(dialog().getByLabelText('CIDR'), { target: { value: '9.9.9.9' } })
+    fireEvent.change(dialog().getByLabelText('Comment'), { target: { value: 'new bastion' } })
+
+    fireEvent.click(dialog().getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addIPSetEntry).toHaveBeenCalledWith(CONN, 'trusted', {
+      cidr: '9.9.9.9', comment: 'new bastion',
+    }))
+  })
+
+  it('deletes an IP set entry from its chip', async () => {
+    renderTab({ view: 'ipsets' })
+
+    // The chip's delete affordance is a sibling of its label.
+    const chip = screen.getByText('1.2.3.4').closest('.MuiChip-root')!
+
+    fireEvent.click(chip.querySelector('.MuiChip-deleteIcon')!)
+
+    await waitFor(() => expect(api.deleteIPSetEntry).toHaveBeenCalledWith(CONN, 'trusted', '1.2.3.4'))
+  })
+
+  it('asks the browser to confirm before deleting an IP set', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    renderTab({ view: 'ipsets' })
+
+    const card = screen.getByText('blocklist').closest('div')!
+
+    fireEvent.click(within(card.parentElement!.parentElement!).getByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete IP Set "blocklist"?')
+    await waitFor(() => expect(api.deleteIPSet).toHaveBeenCalledWith(CONN, 'blocklist'))
+    confirmSpy.mockRestore()
+  })
+
+  it('says so when the connection has no alias and no IP set', () => {
+    renderTab({ aliases: [], ipsets: [] })
+
+    expect(screen.getByText('No alias configured')).toBeInTheDocument()
+    expect(screen.getByText('No IP Set configured')).toBeInTheDocument()
+  })
+
+  it('disables creation when no connection is selected', () => {
+    renderTab({ selectedConnection: '' })
+
+    for (const button of screen.getAllByRole('button', { name: 'New' })) expect(button).toBeDisabled()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/ObjectsTab.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/ObjectsTab.tsx
@@ -11,7 +11,6 @@ import {
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { useToast } from '@/contexts/ToastContext'
-import { monoStyle } from '../types'
 
 interface ObjectsTabProps {
   aliases: firewallAPI.Alias[]
@@ -165,8 +164,8 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
             <TableBody>
               {aliases.map((alias) => (
                 <TableRow key={alias.name} hover>
-                  <TableCell><code style={{ fontSize: 13, background: 'transparent', color: 'inherit' }}>{alias.name}</code></TableCell>
-                  <TableCell><code style={{ fontSize: 13, background: 'transparent', color: 'inherit' }}>{alias.cidr}</code></TableCell>
+                  <TableCell><span style={{ fontSize: 13 }}>{alias.name}</span></TableCell>
+                  <TableCell><span style={{ fontSize: 13 }}>{alias.cidr}</span></TableCell>
                   <TableCell sx={{ color: 'text.secondary', fontSize: 13 }}>{alias.comment || '-'}</TableCell>
                   <TableCell>
                     <Box sx={{ display: 'flex', gap: 0.5 }}>
@@ -214,7 +213,7 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
               <Paper key={ipset.name} sx={{ border: `1px solid ${alpha(theme.palette.divider, 0.15)}`, overflow: 'hidden' }}>
                 <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', bgcolor: alpha(theme.palette.background.default, 0.5) }}>
                   <Box>
-                    <code style={{ background: 'transparent', fontSize: 14, fontWeight: 600, color: 'inherit' }}>{ipset.name}</code>
+                    <span style={{ fontSize: 14, fontWeight: 600 }}>{ipset.name}</span>
                     <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 12, display: 'block' }}>{ipset.comment || t('networkPage.noDescription')}</Typography>
                   </Box>
                   <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
@@ -240,7 +239,7 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
                       {ipset.members.map((member, idx) => (
                         <Chip
                           key={idx}
-                          label={<code style={{ background: 'transparent', fontSize: 12, color: 'inherit' }}>{member.cidr}</code>}
+                          label={<span style={{ fontSize: 12 }}>{member.cidr}</span>}
                           size="small"
                           variant="outlined"
                           onDelete={() => handleDeleteIPSetEntry(ipset.name, member.cidr)}
@@ -268,8 +267,8 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
         <DialogTitle>{t('networkPage.createAliasTitle')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('common.name')} value={newAlias.name} onChange={(e) => setNewAlias({ ...newAlias, name: e.target.value })} placeholder="net-mgmt" fullWidth size="small" InputProps={{ sx: monoStyle }} />
-            <TextField label={t('firewall.cidr')} value={newAlias.cidr} onChange={(e) => setNewAlias({ ...newAlias, cidr: e.target.value })} placeholder="10.99.99.0/24" fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('common.name')} value={newAlias.name} onChange={(e) => setNewAlias({ ...newAlias, name: e.target.value })} placeholder="net-mgmt" fullWidth size="small" />
+            <TextField label={t('firewall.cidr')} value={newAlias.cidr} onChange={(e) => setNewAlias({ ...newAlias, cidr: e.target.value })} placeholder="10.99.99.0/24" fullWidth size="small" />
             <TextField label={t('common.description')} value={newAlias.comment} onChange={(e) => setNewAlias({ ...newAlias, comment: e.target.value })} fullWidth size="small" />
           </Stack>
         </DialogContent>
@@ -284,8 +283,8 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
         <DialogTitle>{t('networkPage.editAlias')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('common.name')} value={editingAlias?.name || ''} disabled fullWidth size="small" InputProps={{ sx: monoStyle }} />
-            <TextField label={t('firewall.cidr')} value={editingAlias?.cidr || ''} onChange={(e) => setEditingAlias(prev => prev ? { ...prev, cidr: e.target.value } : null)} fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('common.name')} value={editingAlias?.name || ''} disabled fullWidth size="small" />
+            <TextField label={t('firewall.cidr')} value={editingAlias?.cidr || ''} onChange={(e) => setEditingAlias(prev => prev ? { ...prev, cidr: e.target.value } : null)} fullWidth size="small" />
             <TextField label={t('common.description')} value={editingAlias?.comment || ''} onChange={(e) => setEditingAlias(prev => prev ? { ...prev, comment: e.target.value } : null)} fullWidth size="small" />
           </Stack>
         </DialogContent>
@@ -300,7 +299,7 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
         <DialogTitle>{t('networkPage.createIpSetTitle')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('common.name')} value={newIPSet.name} onChange={(e) => setNewIPSet({ ...newIPSet, name: e.target.value })} placeholder="trusted-hosts" fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('common.name')} value={newIPSet.name} onChange={(e) => setNewIPSet({ ...newIPSet, name: e.target.value })} placeholder="trusted-hosts" fullWidth size="small" />
             <TextField label={t('common.description')} value={newIPSet.comment} onChange={(e) => setNewIPSet({ ...newIPSet, comment: e.target.value })} fullWidth size="small" />
           </Stack>
         </DialogContent>
@@ -315,7 +314,7 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
         <DialogTitle>{t('networkPage.editIpSet')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('common.name')} value={editingIPSet?.name || ''} disabled fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('common.name')} value={editingIPSet?.name || ''} disabled fullWidth size="small" />
             <TextField label={t('common.description')} value={editingIPSet?.comment || ''} onChange={(e) => setEditingIPSet(prev => prev ? { ...prev, comment: e.target.value } : null)} fullWidth size="small" />
           </Stack>
         </DialogContent>
@@ -330,7 +329,7 @@ export default function ObjectsTab({ aliases, ipsets, selectedConnection, loadin
         <DialogTitle>{t('networkPage.addToTitle', { name: ipsetEntryDialog.ipsetName })}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('firewall.cidr')} value={newIPSetEntry.cidr} onChange={(e) => setNewIPSetEntry({ ...newIPSetEntry, cidr: e.target.value })} placeholder="10.0.0.0/24" fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('firewall.cidr')} value={newIPSetEntry.cidr} onChange={(e) => setNewIPSetEntry({ ...newIPSetEntry, cidr: e.target.value })} placeholder="10.0.0.0/24" fullWidth size="small" />
             <TextField label={t('networkPage.comment')} value={newIPSetEntry.comment} onChange={(e) => setNewIPSetEntry({ ...newIPSetEntry, comment: e.target.value })} fullWidth size="small" />
           </Stack>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/automation/network/components/RulesTab.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/RulesTab.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * Component tests for RulesTab.tsx — the sub-tab switcher above the three
+ * rules tables (cluster, hosts, VMs/CTs).
+ *
+ * Two behaviours live here rather than in the panels below. The rule counts on
+ * the three toggles are summed by this component, so a wrong sum misreports
+ * the cluster at a glance. And the legacy sub-tab remap is real logic: the
+ * stat cards and the dashboard tab still address the old five-tab layout, so
+ * an index above 2 (old 3 = Security Groups) has to be folded back onto the
+ * three that remain and reported upwards, or the tab would render nothing.
+ *
+ * The panels themselves are covered by their own suites; here they are kept
+ * inert with empty collections so the switcher is what is under test. The
+ * firewall API module is stubbed for the same reason — the cluster panel it
+ * mounts on the default tab would otherwise reach the network.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+
+import { renderWithProviders, screen, fireEvent } from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPIType from '@/lib/api/firewall'
+import type { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
+
+vi.mock('@/lib/api/firewall', () => ({
+  updateClusterOptions: vi.fn(),
+  getClusterRules: vi.fn(),
+  addClusterRule: vi.fn(),
+  deleteClusterRule: vi.fn(),
+  getNodeOptions: vi.fn(),
+  updateNodeOptions: vi.fn(),
+  addNodeRule: vi.fn(),
+  deleteNodeRule: vi.fn(),
+  toggleVMNICFirewall: vi.fn(),
+  updateVMOptions: vi.fn(),
+  addVMRule: vi.fn(),
+  updateVMRule: vi.fn(),
+  deleteVMRule: vi.fn(),
+  getVMFirewallLog: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import RulesTab from './RulesTab'
+
+const CLUSTER_RULES: firewallAPIType.FirewallRule[] = [
+  { pos: 0, type: 'in', action: 'ACCEPT' },
+  { pos: 1, type: 'in', action: 'DROP' },
+]
+
+const WEB_VM: VMFirewallInfo = {
+  vmid: 100, name: 'web-01', node: 'pve1', type: 'qemu', status: 'running',
+  firewallEnabled: true, options: null, vlans: [20],
+  rules: [{ pos: 0, type: 'in', action: 'ACCEPT' }],
+}
+
+function props(overrides: Partial<React.ComponentProps<typeof RulesTab>> = {}) {
+  return {
+    activeSubTab: 0,
+    onSubTabChange: vi.fn(),
+    clusterRules: CLUSTER_RULES,
+    setClusterRules: vi.fn(),
+    clusterOptions: { enable: 1 } as firewallAPIType.ClusterOptions,
+    setClusterOptions: vi.fn(),
+    hostRulesByNode: { pve1: [{ pos: 0, type: 'in', action: 'ACCEPT' }], pve2: [] },
+    nodesList: [] as string[],
+    loadingHostRules: false,
+    loadHostRules: vi.fn().mockResolvedValue(undefined),
+    reloadHostRulesForNode: vi.fn().mockResolvedValue(undefined),
+    vmFirewallData: [WEB_VM],
+    loadingVMRules: false,
+    loadVMFirewallData: vi.fn().mockResolvedValue(undefined),
+    reloadVMFirewallRules: vi.fn().mockResolvedValue(undefined),
+    securityGroups: [] as firewallAPIType.SecurityGroup[],
+    aliases: [] as firewallAPIType.Alias[],
+    ipsets: [] as firewallAPIType.IPSet[],
+    firewallMode: 'cluster' as firewallAPIType.FirewallMode,
+    totalRules: 3,
+    selectedConnection: 'conn-1',
+    reload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderTab(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<RulesTab {...p} />)
+
+  return p
+}
+
+const toggle = (name: RegExp) => screen.getByRole('button', { name })
+
+describe('RulesTab', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => vi.clearAllMocks())
+
+  it('counts the rules of each scope on its toggle', () => {
+    renderTab()
+
+    // Two cluster rules, one host rule across the two nodes, one VM rule.
+    expect(toggle(/Cluster/)).toHaveTextContent('2')
+    expect(toggle(/Host Rules/)).toHaveTextContent('1')
+    expect(toggle(/VM/)).toHaveTextContent('1')
+  })
+
+  it('shows the cluster table on the first sub-tab', () => {
+    renderTab()
+
+    expect(screen.getByText('Cluster Firewall')).toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('Search host...')).not.toBeInTheDocument()
+  })
+
+  it('shows the host panel on the second sub-tab', () => {
+    renderTab({ activeSubTab: 1 })
+
+    expect(screen.getByPlaceholderText('Search host...')).toBeInTheDocument()
+    expect(screen.queryByText('Cluster Firewall')).not.toBeInTheDocument()
+  })
+
+  it('shows the VM panel on the third sub-tab', () => {
+    renderTab({ activeSubTab: 2 })
+
+    expect(screen.getByPlaceholderText('Search VM...')).toBeInTheDocument()
+  })
+
+  it('reports a sub-tab change to the page', () => {
+    const p = renderTab()
+
+    fireEvent.click(toggle(/Host Rules/))
+
+    expect(p.onSubTabChange).toHaveBeenCalledWith(1)
+  })
+
+  it('folds a legacy sub-tab index back onto the three that remain', () => {
+    // Old index 3 was Security Groups, which no longer has its own sub-tab.
+    const p = renderTab({ activeSubTab: 3 })
+
+    expect(p.onSubTabChange).toHaveBeenCalledWith(0)
+
+    // It renders the cluster table meanwhile rather than nothing at all.
+    expect(screen.getByText('Cluster Firewall')).toBeInTheDocument()
+  })
+
+  it('swaps in the dark Proxmox logo on the Host Rules toggle when the theme is dark', () => {
+    renderTab()
+    expect(document.querySelector('img')).toHaveAttribute('src', '/images/proxmox-logo.svg')
+
+    cleanup()
+
+    const dark = createTheme({ palette: { mode: 'dark' } })
+
+    renderWithProviders(<ThemeProvider theme={dark}><RulesTab {...props()} /></ThemeProvider>)
+    expect(document.querySelector('img')).toHaveAttribute('src', '/images/proxmox-logo-dark.svg')
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/RulesTab.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/RulesTab.tsx
@@ -106,12 +106,18 @@ export default function RulesTab({
           }}
         >
           <ToggleButton value={0}>
-            <i className="ri-shield-flash-line" style={{ marginRight: 6, fontSize: 16 }} />
+            <i className="ri-server-line" style={{ marginRight: 6, fontSize: 16 }} />
             {t('networkPage.clusterFirewall')}
             <Chip label={policyRulesCount} size="small" sx={{ ml: 1, height: 18, minWidth: 18, fontSize: 10, fontWeight: 700 }} />
           </ToggleButton>
           <ToggleButton value={1}>
-            <i className="ri-server-line" style={{ marginRight: 6, fontSize: 16 }} />
+            <img
+              src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'}
+              alt=""
+              width={16}
+              height={16}
+              style={{ marginRight: 6, opacity: 0.8 }}
+            />
             {t('networkPage.hostRules')}
             <Chip label={hostRulesCount} size="small" sx={{ ml: 1, height: 18, minWidth: 18, fontSize: 10, fontWeight: 700 }} />
           </ToggleButton>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * Component tests for FirewallPolicyTable.tsx — the cluster firewall header
+ * (master switch + the two default policies) and the cluster rules table.
+ *
+ * Unlike the host and VM panels this table is flat: every cluster rule is
+ * always on screen, so a render alone exercises the rows. What it does not
+ * do itself is own the rules — the page above holds them and passes the
+ * setters down — so the reload after a write is asserted through
+ * `getClusterRules`, which is the panel's own refresh path.
+ *
+ * The rule writes go two ways on purpose: creation and deletion through the
+ * firewall API module, updates and reordering through a raw `fetch` PUT that
+ * MSW serves here. The jsdom setup errors on unhandled requests, so a route
+ * called without a fixture fails the test.
+ *
+ * The rule form is the shared RuleFormDialog, covered on its own; what is
+ * checked here is that the panel pre-fills it from the right rule — log
+ * level included, the field this PR stopped dropping.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import type * as firewallAPIType from '@/lib/api/firewall'
+
+vi.mock('@/lib/api/firewall', () => ({
+  updateClusterOptions: vi.fn(),
+  getClusterRules: vi.fn(),
+  addClusterRule: vi.fn(),
+  deleteClusterRule: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import FirewallPolicyTable from './FirewallPolicyTable'
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+const CONN = 'conn-1'
+
+const FULL_RULE: firewallAPIType.FirewallRule = {
+  pos: 0, type: 'in', action: 'ACCEPT', enable: 1,
+  proto: 'tcp', dport: '8006', sport: '', source: '10.0.0.0/8', dest: '',
+  macro: '', iface: 'vmbr0', log: 'warning', comment: 'pve ui',
+}
+
+/** A cluster rule may reference a security group; a host or SG rule may not. */
+const GROUP_RULE: firewallAPIType.FirewallRule = { pos: 1, type: 'group', action: 'sg-web', enable: 1 }
+
+function props(overrides: Partial<React.ComponentProps<typeof FirewallPolicyTable>> = {}) {
+  return {
+    clusterRules: [FULL_RULE, GROUP_RULE],
+    securityGroups: [{ group: 'sg-web' }] as firewallAPIType.SecurityGroup[],
+    selectedConnection: CONN,
+    setClusterRules: vi.fn(),
+    clusterOptions: { enable: 1, policy_in: 'DROP', policy_out: 'ACCEPT' } as firewallAPIType.ClusterOptions,
+    setClusterOptions: vi.fn(),
+    aliases: [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }] as firewallAPIType.Alias[],
+    ipsets: [] as firewallAPIType.IPSet[],
+    reload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderTable(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<FirewallPolicyTable {...p} />)
+
+  return p
+}
+
+const ruleRow = (text: string) => screen.getAllByRole('row').find(r => within(r).queryByText(text))!
+
+/**
+ * The cluster master switch. Every rule row carries an Active switch too, and
+ * the header renders before the table, so the first switch is the master one.
+ */
+const masterSwitch = () => screen.getAllByRole('switch')[0]
+
+/**
+ * The header's Add rule button. The footer carries a second one with the same
+ * accessible name; both open the same dialog, so the first is enough.
+ */
+const addRuleButton = () => screen.getAllByRole('button', { name: 'Add rule' })[0]
+
+/** A Select inside the open rule dialog, found from its rendered label. */
+function selectByLabel(label: string) {
+  const el = screen.queryAllByText(label).find(n => n.tagName === 'LABEL')
+
+  if (!el?.parentElement) throw new Error(`No Select labelled "${label}"`)
+
+  return within(el.parentElement).getByRole('combobox')
+}
+
+describe('FirewallPolicyTable', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.updateClusterOptions.mockResolvedValue(undefined)
+    api.getClusterRules.mockResolvedValue([FULL_RULE])
+    api.addClusterRule.mockResolvedValue(undefined)
+    api.deleteClusterRule.mockResolvedValue(undefined)
+  })
+
+  it('shows the cluster firewall as on, with its two default policies', () => {
+    renderTable()
+
+    expect(masterSwitch()).toBeChecked()
+    expect(screen.getByText('ON')).toBeInTheDocument()
+
+    const [policyIn, policyOut] = screen.getAllByRole('combobox')
+
+    expect(policyIn).toHaveTextContent('DROP')
+    expect(policyOut).toHaveTextContent('ACCEPT')
+  })
+
+  it('reads a cluster with no options at all as off, on PVE defaults', () => {
+    renderTable({ clusterOptions: null })
+
+    expect(masterSwitch()).not.toBeChecked()
+    expect(screen.getByText('OFF')).toBeInTheDocument()
+
+    const [policyIn, policyOut] = screen.getAllByRole('combobox')
+
+    expect(policyIn).toHaveTextContent('DROP')
+    expect(policyOut).toHaveTextContent('ACCEPT')
+  })
+
+  it('lists every cluster rule with its log level, group rules included', () => {
+    renderTable()
+
+    expect(screen.getByText('pve ui')).toBeInTheDocument()
+    expect(screen.getByText('warning')).toBeInTheDocument()
+    expect(screen.getByText('TCP/8006')).toBeInTheDocument()
+
+    // The group rule names the group it references and shows no traffic.
+    expect(screen.getByText('sg-web')).toBeInTheDocument()
+    expect(screen.getByText('GROUP')).toBeInTheDocument()
+  })
+
+  it('turns the cluster firewall off through the master switch', async () => {
+    const p = renderTable()
+
+    fireEvent.click(masterSwitch())
+
+    await waitFor(() => expect(api.updateClusterOptions).toHaveBeenCalledWith(CONN, { enable: 0 }))
+    expect(p.setClusterOptions).toHaveBeenCalled()
+    expect(p.reload).toHaveBeenCalled()
+  })
+
+  it('changes the inbound default policy', async () => {
+    const p = renderTable()
+
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'REJECT' }))
+
+    await waitFor(() => expect(api.updateClusterOptions).toHaveBeenCalledWith(CONN, { policy_in: 'REJECT' }))
+    expect(p.setClusterOptions).toHaveBeenCalled()
+  })
+
+  it('changes the outbound default policy', async () => {
+    renderTable()
+
+    fireEvent.mouseDown(screen.getAllByRole('combobox')[1])
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'DROP' }))
+
+    await waitFor(() => expect(api.updateClusterOptions).toHaveBeenCalledWith(CONN, { policy_out: 'DROP' }))
+  })
+
+  it('toggles a rule Active switch against the cluster rules endpoint', async () => {
+    renderTable()
+
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/cluster/${CONN}/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    fireEvent.click(within(ruleRow('pve ui')).getByRole('switch'))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toMatchObject({ pos: 0, enable: 0, log: 'warning' })
+
+    // The panel refreshes its own rules after the write.
+    await waitFor(() => expect(api.getClusterRules).toHaveBeenCalledWith(CONN))
+  })
+
+  it('pre-fills the edit dialog from the rule, log level included', async () => {
+    renderTable()
+
+    fireEvent.click(within(ruleRow('pve ui')).getByRole('button', { name: 'Edit' }))
+
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByLabelText('Source')).toHaveValue('10.0.0.0/8')
+    expect(dialog.getByLabelText('Dest port')).toHaveValue('8006')
+    expect(dialog.getByLabelText('Interface')).toHaveValue('vmbr0')
+    expect(dialog.getByLabelText('Comment')).toHaveValue('pve ui')
+    expect(selectByLabel('Log level')).toHaveTextContent('warning')
+    expect(screen.getByText('Cluster')).toBeInTheDocument()
+  })
+
+  it('saves an edited rule against its position', async () => {
+    renderTable()
+
+    fireEvent.click(within(ruleRow('pve ui')).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/cluster/${CONN}/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toMatchObject({ log: 'warning', comment: 'pve ui' })
+  })
+
+  it('adds a cluster rule with the picked log level', async () => {
+    renderTable()
+
+    fireEvent.click(addRuleButton())
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+
+    expect(selectByLabel('Log level')).toHaveTextContent('nolog')
+
+    fireEvent.mouseDown(selectByLabel('Log level'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'err' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addClusterRule).toHaveBeenCalledTimes(1))
+    expect(api.addClusterRule).toHaveBeenCalledWith(CONN, expect.objectContaining({ log: 'err', type: 'in' }))
+  })
+
+  it('confirms before deleting a rule, then deletes it', async () => {
+    renderTable()
+
+    fireEvent.click(within(ruleRow('pve ui')).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.getByText('Delete this rule?')).toBeInTheDocument())
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteClusterRule).toHaveBeenCalledWith(CONN, 0))
+  })
+
+  it('reorders a rule by dropping it on another row', async () => {
+    renderTable()
+
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/cluster/${CONN}/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    const from = ruleRow('pve ui')
+    const to = ruleRow('sg-web')
+    const dataTransfer = { effectAllowed: '', dropEffect: '', setData: vi.fn(), getData: () => '0' }
+
+    fireEvent.dragStart(from, { dataTransfer })
+
+    fireEvent.dragOver(to, { dataTransfer })
+    fireEvent.drop(to, { dataTransfer })
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toEqual({ moveto: 1 })
+  })
+
+  it('says so when the cluster has no rule, and still offers to add one', () => {
+    renderTable({ clusterRules: [] })
+
+    expect(screen.getByText('No rules')).toBeInTheDocument()
+    expect(addRuleButton()).toBeEnabled()
+  })
+
+  it('disables every write when no connection is selected', () => {
+    renderTable({ selectedConnection: '' })
+
+    expect(masterSwitch()).toBeDisabled()
+    for (const button of screen.getAllByRole('button', { name: 'Add rule' })) expect(button).toBeDisabled()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
@@ -4,17 +4,18 @@ import { useState, useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
+  Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   FormControl, IconButton, InputLabel, MenuItem, Paper, Select, Switch,
-  Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
+  Table, TableBody, TableCell, TableContainer, TableRow,
   Tooltip, Typography, useTheme, alpha
 } from '@mui/material'
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { useToast } from '@/contexts/ToastContext'
-import { formatLogLevel } from '@/components/firewall/logLevels'
 import { PolicySection } from '../../types'
 import RuleFormDialog, { RuleFormData } from './RuleFormDialog'
+import RulesTableHead from './shared/RulesTableHead'
+import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeadingCells, RuleTrafficCells } from './shared/RuleTableCells'
 
 // ── Props ──
 
@@ -29,29 +30,6 @@ interface FirewallPolicyTableProps {
   ipsets: firewallAPI.IPSet[]
   reload: () => void
 }
-
-// ── Helpers ──
-
-const ActionChip = ({ action }: { action: string }) => {
-  const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
-  const color = colors[action] || '#94a3b8'
-  return <Chip size="small" label={action} sx={{ height: 22, fontSize: 11, fontWeight: 700, bgcolor: alpha(color, 0.22), color, border: `1px solid ${alpha(color, 0.35)}`, minWidth: 70 }} />
-}
-
-function formatService(rule: firewallAPI.FirewallRule): string {
-  if (rule.type === 'group') return '-'
-  if (rule.macro) return rule.macro
-  const proto = rule.proto?.toUpperCase() || ''
-  const port = rule.dport || ''
-  if (!proto && !port) return 'any'
-  if (proto && port) return `${proto}/${port}`
-  return proto || port
-}
-
-// ── Column header style ──
-// Body cells are all `p: 0.5`; without the same padding here the header
-// labels sit ~12px right of their column's values (MUI's default 16px).
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -249,60 +227,16 @@ export default function FirewallPolicyTable({
           '&:active': { cursor: 'grabbing' }
         }}
       >
-        <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
-          <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
-        <TableCell sx={{ p: 0.5, width: 55 }}>
-          <Switch checked={rule.enable !== 0} onChange={() => handleToggleEnable(rule)} size="small" color="success" />
-        </TableCell>
-        <TableCell sx={{ p: 0.5, width: 65 }}>
-          <Chip
-            label={isGroupRule ? 'GROUP' : rule.type?.toUpperCase() || 'IN'}
-            size="small"
-            sx={{
-              height: 20, fontSize: 10, fontWeight: 600,
-              bgcolor: isGroupRule ? alpha('#8b5cf6', 0.22) : rule.type === 'in' ? alpha('#3b82f6', 0.22) : alpha('#ec4899', 0.22),
-              color: isGroupRule ? '#8b5cf6' : rule.type === 'in' ? '#3b82f6' : '#ec4899'
-            }}
-          />
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
-          {isGroupRule ? '-' : (rule.source || 'any')}
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
-          {isGroupRule ? '-' : (rule.dest || 'any')}
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
-          {formatService(rule)}
-        </TableCell>
-        <TableCell sx={{ p: 0.5, width: 90 }}>
-          {isGroupRule ? (
-            <Chip icon={<i className="ri-shield-line" style={{ fontSize: 10 }} />} label={rule.action} size="small" sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: alpha('#8b5cf6', 0.22), color: '#8b5cf6', '& .MuiChip-icon': { color: '#8b5cf6' } }} />
-          ) : (
-            <ActionChip action={rule.action || 'ACCEPT'} />
-          )}
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
-          {formatLogLevel(rule.log)}
-        </TableCell>
-        <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
-          <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
-        </TableCell>
-        <TableCell sx={{ p: 0.5, width: 70 }}>
-          <Box sx={{ display: 'flex', gap: 0 }}>
-            <Tooltip title={t('networkPage.edit')}>
-              <IconButton size="small" onClick={() => openEditRule(rule)}>
-                <i className="ri-pencil-line" style={{ fontSize: 14 }} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('networkPage.delete')}>
-              <IconButton size="small" color="error" onClick={() => setDeleteConfirm({ pos: rule.pos })}>
-                <i className="ri-delete-bin-line" style={{ fontSize: 14 }} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </TableCell>
+        <RuleRowLeadingCells
+          rule={rule}
+          isGroupRule={isGroupRule}
+          enabled={rule.enable !== 0}
+          onToggleEnable={() => handleToggleEnable(rule)}
+        />
+        <RuleTrafficCells rule={rule} isGroupRule={isGroupRule} />
+        <RuleActionCell rule={rule} isGroupRule={isGroupRule} />
+        <RuleLogCommentCells rule={rule} />
+        <RuleRowActionsCell onEdit={() => openEditRule(rule)} onDelete={() => setDeleteConfirm({ pos: rule.pos })} />
       </TableRow>
     )
   }
@@ -373,21 +307,7 @@ export default function FirewallPolicyTable({
         {/* Cluster Rules Table */}
         <TableContainer>
           <Table size="small">
-            <TableHead>
-              <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
-                <TableCell sx={{ ...headCellSx, width: 30, p: 0.5 }}></TableCell>
-                <TableCell sx={{ ...headCellSx, width: 35 }}>#</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 55 }}>{t('common.active')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 65 }}>{t('firewall.direction')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.source')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
-                <TableCell sx={{ width: 70 }}></TableCell>
-              </TableRow>
-            </TableHead>
+            <RulesTableHead />
             <TableBody>
               {clusterRules.length > 0 ? (
                 clusterRules.map((rule, idx) => renderRuleRow(rule, idx))

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
@@ -12,7 +12,8 @@ import {
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { useToast } from '@/contexts/ToastContext'
-import { PolicySection, monoStyle } from '../../types'
+import { formatLogLevel } from '@/components/firewall/logLevels'
+import { PolicySection } from '../../types'
 import RuleFormDialog, { RuleFormData } from './RuleFormDialog'
 
 // ── Props ──
@@ -48,7 +49,9 @@ function formatService(rule: firewallAPI.FirewallRule): string {
 }
 
 // ── Column header style ──
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap' } as const
+// Body cells are all `p: 0.5`; without the same padding here the header
+// labels sit ~12px right of their column's values (MUI's default 16px).
+const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -264,13 +267,13 @@ export default function FirewallPolicyTable({
             }}
           />
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
           {isGroupRule ? '-' : (rule.source || 'any')}
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
           {isGroupRule ? '-' : (rule.dest || 'any')}
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, width: 100 }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
           {formatService(rule)}
         </TableCell>
         <TableCell sx={{ p: 0.5, width: 90 }}>
@@ -279,6 +282,9 @@ export default function FirewallPolicyTable({
           ) : (
             <ActionChip action={rule.action || 'ACCEPT'} />
           )}
+        </TableCell>
+        <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
+          {formatLogLevel(rule.log)}
         </TableCell>
         <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
           <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
@@ -377,6 +383,7 @@ export default function FirewallPolicyTable({
                 <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
+                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
                 <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
                 <TableCell sx={{ width: 70 }}></TableCell>
               </TableRow>
@@ -386,7 +393,7 @@ export default function FirewallPolicyTable({
                 clusterRules.map((rule, idx) => renderRuleRow(rule, idx))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={10} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+                  <TableCell colSpan={11} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
                     <Typography variant="body2">{t('networkPage.noRules')}</Typography>
                   </TableCell>
                 </TableRow>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
@@ -176,7 +176,11 @@ export default function FirewallPolicyTable({
     setDragState({ draggedPos: pos, dragOverPos: null })
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', pos.toString())
-    setTimeout(() => { (e.currentTarget as HTMLElement).style.opacity = '0.5' }, 0)
+    // React nulls the event's currentTarget as soon as the handler returns,
+    // so the row must be captured before the opacity change is deferred.
+    const draggedRow = e.currentTarget as HTMLElement
+
+    setTimeout(() => { draggedRow.style.opacity = '0.5' }, 0)
   }
   const handleDragEnd = (e: React.DragEvent) => {
     (e.currentTarget as HTMLElement).style.opacity = '1'

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * Component tests for HostRulesPanel.tsx — the per-node (host) firewall
+ * rules table.
+ *
+ * The panel is fully prop-driven: the rules, the node list and the loading
+ * flag all come from the page above it, so a render here exercises the real
+ * table without a live cluster. Only the two things it fetches itself are
+ * stubbed — the firewall API module (per-node options on mount, and the
+ * add/delete rule calls) and the raw `fetch` PUTs it does for updates and
+ * reordering, which MSW serves. The jsdom setup errors on unhandled
+ * requests, so a route the panel calls without a fixture fails the test.
+ *
+ * The assertions follow what an operator reading the Host Rules tab relies
+ * on: a node is a collapsed section until clicked, its rules then show with
+ * the right log level, a node without rules offers to create one, the two
+ * switches (node firewall, per-rule Active) reach PVE, and the edit dialog
+ * is pre-filled from the rule — including its log level, the field this PR
+ * stopped dropping. Both the fully-populated and the bare rule are asserted
+ * because the dialog pre-fill falls back field by field (`rule.proto || ''`,
+ * `rule.log || 'nolog'`), and only a rule that carries nothing exercises
+ * those fallbacks.
+ *
+ * The MUI Selects in the rule dialog carry an InputLabel but no `labelId`,
+ * so their combobox has no accessible name and must be located from the
+ * rendered label element — same limitation as LogLevelSelect.test.tsx.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import type * as firewallAPIType from '@/lib/api/firewall'
+
+vi.mock('@/lib/api/firewall', () => ({
+  getNodeOptions: vi.fn(),
+  updateNodeOptions: vi.fn(),
+  addNodeRule: vi.fn(),
+  deleteNodeRule: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import HostRulesPanel from './HostRulesPanel'
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+const CONN = 'conn-1'
+const NODE = 'pve1'
+const OTHER_NODE = 'pve2'
+
+/** A rule where every optional PVE field is set. */
+const FULL_RULE: firewallAPIType.FirewallRule = {
+  pos: 0, type: 'in', action: 'ACCEPT', enable: 1,
+  proto: 'tcp', dport: '22', sport: '1024:65535',
+  source: '10.0.0.0/8', dest: '10.0.0.5', macro: '',
+  iface: 'vmbr0', log: 'warning', comment: 'ssh in',
+}
+
+/** A rule as PVE returns it when nothing optional was configured. */
+const BARE_RULE: firewallAPIType.FirewallRule = { pos: 1, type: '', action: '' }
+
+const ALIASES: firewallAPIType.Alias[] = [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }]
+const IPSETS: firewallAPIType.IPSet[] = [{ name: 'trusted', members: [{ cidr: '1.2.3.4' }] }]
+
+function props(overrides: Partial<React.ComponentProps<typeof HostRulesPanel>> = {}) {
+  return {
+    hostRulesByNode: { [NODE]: [FULL_RULE, BARE_RULE], [OTHER_NODE]: [] },
+    nodesList: [NODE, OTHER_NODE],
+    securityGroups: [{ group: 'sg-web' }] as firewallAPIType.SecurityGroup[],
+    loadingHostRules: false,
+    selectedConnection: CONN,
+    loadHostRules: vi.fn().mockResolvedValue(undefined),
+    reloadHostRulesForNode: vi.fn().mockResolvedValue(undefined),
+    aliases: ALIASES,
+    ipsets: IPSETS,
+    ...overrides,
+  }
+}
+
+/** Render and wait for the per-node options fetch to settle. */
+async function renderPanel(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<HostRulesPanel {...p} />)
+  await waitFor(() => expect(api.getNodeOptions).toHaveBeenCalled())
+
+  return p
+}
+
+/** The section header row of a node is clickable to expand it. */
+const expandNode = (node: string) => fireEvent.click(screen.getByText(node))
+
+/** A Select inside the open rule dialog, found from its rendered label. */
+function selectByLabel(label: string) {
+  const el = screen.queryAllByText(label).find(n => n.tagName === 'LABEL')
+
+  if (!el?.parentElement) throw new Error(`No Select labelled "${label}"`)
+
+  return within(el.parentElement).getByRole('combobox')
+}
+
+/** Open the edit dialog of the rule at `pos` and wait for the dialog title. */
+async function openEditDialog(pos: number) {
+  const rows = screen.getAllByRole('row')
+  const row = rows.find(r => within(r).queryByText(String(pos)) && within(r).queryByRole('button', { name: 'Edit' }))
+
+  if (!row) throw new Error(`No rule row at position ${pos}`)
+
+  fireEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+  await waitFor(() => expect(screen.getByText('Edit Host rule')).toBeInTheDocument())
+}
+
+describe('HostRulesPanel', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.getNodeOptions.mockResolvedValue({ enable: 1 })
+    api.updateNodeOptions.mockResolvedValue(undefined)
+    api.addNodeRule.mockResolvedValue(undefined)
+    api.deleteNodeRule.mockResolvedValue(undefined)
+    server.use(
+      http.put(`*/api/v1/firewall/nodes/${CONN}/:node/rules/:pos`, () => HttpResponse.json({})),
+    )
+  })
+
+  it('lists every node as a collapsed section with its rule count', async () => {
+    await renderPanel()
+
+    expect(screen.getByText(NODE)).toBeInTheDocument()
+    expect(screen.getByText(OTHER_NODE)).toBeInTheDocument()
+    expect(screen.getByText('2 rules')).toBeInTheDocument()
+    expect(screen.getByText('0 rules')).toBeInTheDocument()
+
+    // The toolbar counts hosts and rules across the whole tab.
+    expect(screen.getByText('2/2 hosts • 2 rules')).toBeInTheDocument()
+
+    // Collapsed: no rule is on screen yet.
+    expect(screen.queryByText('ssh in')).not.toBeInTheDocument()
+  })
+
+  it('reveals a node\'s rules, with their log level, when the section is expanded', async () => {
+    await renderPanel()
+
+    expandNode(NODE)
+
+    expect(screen.getByText('ssh in')).toBeInTheDocument()
+    expect(screen.getByText('warning')).toBeInTheDocument()
+    expect(screen.getByText('10.0.0.0/8')).toBeInTheDocument()
+    expect(screen.getByText('TCP/22')).toBeInTheDocument()
+
+    // Clicking again collapses it.
+    expandNode(NODE)
+    expect(screen.queryByText('ssh in')).not.toBeInTheDocument()
+  })
+
+  it('offers to create a rule on a node that has none', async () => {
+    await renderPanel()
+
+    expandNode(OTHER_NODE)
+
+    const emptyRow = screen.getAllByRole('row').find(r => within(r).queryByText('No rule configured'))!
+
+    expect(emptyRow).toBeDefined()
+
+    // The empty state's own Add button (every section header carries one too)
+    // opens the dialog for that node.
+    fireEvent.click(within(emptyRow).getByRole('button', { name: 'Add rule' }))
+    await waitFor(() => expect(screen.getByText('Add Host rule')).toBeInTheDocument())
+    expect(within(screen.getByRole('dialog')).getByText(OTHER_NODE)).toBeInTheDocument()
+  })
+
+  it('expands and collapses every node at once from the toolbar', async () => {
+    await renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+    expect(screen.getByText('ssh in')).toBeInTheDocument()
+    expect(screen.getByText('No rule configured')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+    expect(screen.queryByText('ssh in')).not.toBeInTheDocument()
+  })
+
+  it('filters the node list by the search box', async () => {
+    await renderPanel()
+
+    fireEvent.change(screen.getByPlaceholderText('Search host...'), { target: { value: OTHER_NODE } })
+
+    expect(screen.queryByText(NODE)).not.toBeInTheDocument()
+    expect(screen.getByText(OTHER_NODE)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Search host...'), { target: { value: 'nope' } })
+    expect(screen.getByText('No results for this search')).toBeInTheDocument()
+  })
+
+  it('turns a node firewall off through the section switch', async () => {
+    await renderPanel()
+
+    // One switch per node section header; the first belongs to pve1. Wait for
+    // the fetched options to reach it: clicking while they are still in flight
+    // would read the node as off and ask PVE to enable it instead.
+    const nodeSwitch = () => screen.getAllByRole('switch')[0]
+
+    await waitFor(() => expect(nodeSwitch()).toBeChecked())
+
+    fireEvent.click(nodeSwitch())
+
+    await waitFor(() => expect(api.updateNodeOptions).toHaveBeenCalledWith(CONN, NODE, { enable: 0 }))
+  })
+
+  it('toggles a rule\'s Active switch against the node rules endpoint', async () => {
+    await renderPanel()
+    expandNode(NODE)
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('ssh in'))!
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/nodes/${CONN}/${NODE}/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    fireEvent.click(within(row).getByRole('switch'))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toMatchObject({ pos: 0, enable: 0, log: 'warning' })
+  })
+
+  it('pre-fills the edit dialog from the rule, log level included', async () => {
+    await renderPanel()
+    expandNode(NODE)
+    await openEditDialog(0)
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByLabelText('Source')).toHaveValue('10.0.0.0/8')
+    expect(dialog.getByLabelText('Destination')).toHaveValue('10.0.0.5')
+    expect(dialog.getByLabelText('Destination port')).toHaveValue('22')
+    expect(dialog.getByLabelText('Source port')).toHaveValue('1024:65535')
+    expect(dialog.getByLabelText('Interface')).toHaveValue('vmbr0')
+    expect(dialog.getByLabelText('Comment')).toHaveValue('ssh in')
+    expect(selectByLabel('Log level')).toHaveTextContent('warning')
+    expect(selectByLabel('Type')).toHaveTextContent('IN (inbound)')
+  })
+
+  it('falls back to PVE defaults when editing a rule that carries nothing', async () => {
+    await renderPanel()
+    expandNode(NODE)
+    await openEditDialog(1)
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    // `rule.type || 'in'`, `rule.action || 'ACCEPT'`, `rule.log || 'nolog'`:
+    // an empty PVE field must not reach the form as an empty value.
+    expect(selectByLabel('Type')).toHaveTextContent('IN (inbound)')
+    expect(selectByLabel('Action')).toHaveTextContent('ACCEPT')
+    expect(selectByLabel('Log level')).toHaveTextContent('nolog')
+    expect(dialog.getByLabelText('Source')).toHaveValue('')
+    expect(dialog.getByLabelText('Comment')).toHaveValue('')
+  })
+
+  it('opens an empty add-rule dialog and sends the picked log level', async () => {
+    await renderPanel()
+    expandNode(NODE)
+
+    // The section header's own Add button (the first one on the pve1 row).
+    const section = screen.getAllByRole('row').find(r => within(r).queryByText(NODE))!
+
+    fireEvent.click(within(section).getByRole('button', { name: 'Add rule' }))
+    await waitFor(() => expect(screen.getByText('Add Host rule')).toBeInTheDocument())
+
+    expect(selectByLabel('Log level')).toHaveTextContent('nolog')
+
+    fireEvent.mouseDown(selectByLabel('Log level'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'crit' }))
+    expect(selectByLabel('Log level')).toHaveTextContent('crit')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addNodeRule).toHaveBeenCalledTimes(1))
+    expect(api.addNodeRule.mock.calls[0][2]).toMatchObject({ log: 'crit', type: 'in', action: 'ACCEPT' })
+  })
+
+  it('edits source and destination through the alias suggestions', async () => {
+    await renderPanel()
+    expandNode(NODE)
+    await openEditDialog(1)
+
+    const dialog = within(screen.getByRole('dialog'))
+    const source = dialog.getByLabelText('Source')
+
+    fireEvent.change(source, { target: { value: 'net' } })
+    fireEvent.click(await screen.findByRole('option', { name: /net-mgmt/ }))
+    expect(source).toHaveValue('net-mgmt')
+
+    const dest = dialog.getByLabelText('Destination')
+
+    fireEvent.change(dest, { target: { value: '192.168.1.0/24' } })
+    expect(dest).toHaveValue('192.168.1.0/24')
+  })
+
+  it('saves an edited rule against its position', async () => {
+    await renderPanel()
+    expandNode(NODE)
+    await openEditDialog(0)
+
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/nodes/${CONN}/${NODE}/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toMatchObject({ log: 'warning', comment: 'ssh in' })
+  })
+
+  it('confirms before deleting a rule, then deletes it', async () => {
+    const p = await renderPanel()
+
+    expandNode(NODE)
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('ssh in'))!
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.getByText('Delete this rule?')).toBeInTheDocument())
+    expect(screen.getByText(/Rule #0 on pve1 will be permanently deleted/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteNodeRule).toHaveBeenCalledWith(CONN, NODE, 0))
+    expect(p.reloadHostRulesForNode).toHaveBeenCalledWith(NODE)
+  })
+
+  it('shows a progress bar instead of the table while the rules load', async () => {
+    renderWithProviders(<HostRulesPanel {...props({ loadingHostRules: true })} />)
+
+    expect(screen.getByText('Loading host rules...')).toBeInTheDocument()
+    expect(screen.queryByText(NODE)).not.toBeInTheDocument()
+  })
+
+  it('swaps in the dark Proxmox logo when the theme is dark', async () => {
+    const dark = createTheme({ palette: { mode: 'dark' } })
+
+    renderWithProviders(
+      <ThemeProvider theme={dark}><HostRulesPanel {...props()} /></ThemeProvider>,
+    )
+    await waitFor(() => expect(api.getNodeOptions).toHaveBeenCalled())
+
+    const logos = document.querySelectorAll('img')
+
+    expect(logos).toHaveLength(2)
+    expect(logos[0]).toHaveAttribute('src', '/images/proxmox-logo-dark.svg')
+  })
+
+  it('renders nothing fetchable when no connection is selected', async () => {
+    renderWithProviders(<HostRulesPanel {...props({ selectedConnection: '', nodesList: [], hostRulesByNode: {} })} />)
+
+    expect(screen.getByText('Cannot retrieve node list.')).toBeInTheDocument()
+    expect(api.getNodeOptions).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
@@ -156,7 +156,11 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
     setHostDragState({ node, draggedPos: pos, dragOverPos: null })
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', pos.toString())
-    setTimeout(() => { (e.currentTarget as HTMLElement).style.opacity = '0.5' }, 0)
+    // React nulls the event's currentTarget as soon as the handler returns,
+    // so the row must be captured before the opacity change is deferred.
+    const draggedRow = e.currentTarget as HTMLElement
+
+    setTimeout(() => { draggedRow.style.opacity = '0.5' }, 0)
   }
   const handleDragEnd = (e: React.DragEvent) => {
     (e.currentTarget as HTMLElement).style.opacity = '1'

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
@@ -12,7 +12,9 @@ import {
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { useToast } from '@/contexts/ToastContext'
-import { DEFAULT_RULE, monoStyle } from '../../types'
+import LogLevelSelect from '@/components/firewall/LogLevelSelect'
+import { DEFAULT_LOG_LEVEL, formatLogLevel } from '@/components/firewall/logLevels'
+import { DEFAULT_RULE } from '../../types'
 
 interface HostRulesPanelProps {
   hostRulesByNode: Record<string, firewallAPI.FirewallRule[]>
@@ -44,7 +46,9 @@ function formatService(rule: firewallAPI.FirewallRule): string {
   return proto || port
 }
 
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap' } as const
+// Body cells are all `p: 0.5`; without the same padding here the header
+// labels sit ~12px right of their column's values (MUI's default 16px).
+const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -255,6 +259,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                 <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
+                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
                 <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
                 <TableCell sx={{ width: 70 }}></TableCell>
               </TableRow>
@@ -278,15 +283,21 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                       }}
                       onClick={() => setExpandedHosts(prev => { const n = new Set(prev); if (n.has(node)) n.delete(node); else n.add(node); return n })}
                     >
-                      <TableCell colSpan={10} sx={{ py: 1, px: 2 }}>
+                      <TableCell colSpan={11} sx={{ py: 1, px: 2 }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
                             <i
                               className={isExpanded ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'}
                               style={{ fontSize: 20, color: theme.palette.text.secondary, flexShrink: 0 }}
                             />
-                            <i className="ri-server-line" style={{ fontSize: 16, color: '#f59e0b', flexShrink: 0 }} />
-                            <code style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{node}</code>
+                            <img
+                              src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'}
+                              alt=""
+                              width={16}
+                              height={16}
+                              style={{ opacity: 0.8, flexShrink: 0 }}
+                            />
+                            <span style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{node}</span>
                             <Chip
                               label={t('firewall.rulesCount', { count: rules.length })}
                               size="small"
@@ -359,13 +370,13 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                               }}
                             />
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
                             {isGroupRule ? '-' : (rule.source || 'any')}
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
                             {isGroupRule ? '-' : (rule.dest || 'any')}
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, width: 100 }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
                             {formatService(rule)}
                           </TableCell>
                           <TableCell sx={{ p: 0.5, width: 90 }}>
@@ -374,6 +385,9 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                             ) : (
                               <ActionChip action={rule.action || 'ACCEPT'} />
                             )}
+                          </TableCell>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
+                            {formatLogLevel(rule.log)}
                           </TableCell>
                           <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
                             <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
@@ -387,7 +401,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                                     type: rule.type || 'in', action: rule.action || 'ACCEPT', enable: rule.enable ?? 1,
                                     proto: rule.proto || '', dport: rule.dport || '', sport: rule.sport || '',
                                     source: rule.source || '', dest: rule.dest || '', macro: rule.macro || '',
-                                    iface: rule.iface || '', log: rule.log || 'nolog', comment: rule.comment || ''
+                                    iface: rule.iface || '', log: rule.log || DEFAULT_LOG_LEVEL, comment: rule.comment || ''
                                   })
                                   setHostRuleDialogOpen(true)
                                 }}>
@@ -405,7 +419,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                       )
                     }) : (
                       <TableRow key={`empty-${node}`}>
-                        <TableCell colSpan={10} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+                        <TableCell colSpan={11} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
                           <Typography variant="body2">{t('networkPage.noRuleConfigured')}</Typography>
                           <Button size="small" sx={{ mt: 1 }} onClick={() => {
                             setEditingHostRule({ node, rule: null, isNew: true })
@@ -495,7 +509,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                     renderOption={(props, opt) => (
                       <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                          <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                          <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                           {typeof opt !== 'string' && opt.secondary && (
                             <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                           )}
@@ -517,7 +531,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                     renderOption={(props, opt) => (
                       <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                          <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                          <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                           {typeof opt !== 'string' && opt.secondary && (
                             <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                           )}
@@ -537,6 +551,9 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                 </Grid>
                 <Grid size={{ xs: 12, sm: 4 }}>
                   <TextField fullWidth size="small" label={t('firewall.interface')} value={newHostRule.iface} onChange={(e) => setNewHostRule({ ...newHostRule, iface: e.target.value })} placeholder="vmbr0, eth0..." />
+                </Grid>
+                <Grid size={{ xs: 12, sm: 4 }}>
+                  <LogLevelSelect value={newHostRule.log} onChange={(v) => setNewHostRule({ ...newHostRule, log: v })} />
                 </Grid>
               </>
             )}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/HostRulesPanel.tsx
@@ -1,20 +1,23 @@
 'use client'
 
-import { Fragment, useState, useEffect, useMemo } from 'react'
+import { Fragment, useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Autocomplete, Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
+  Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
   FormControl, Grid, IconButton, InputLabel, LinearProgress, MenuItem, Paper, Select, Stack,
-  Switch, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Tooltip,
+  Switch, Table, TableBody, TableCell, TableContainer, TableRow, TextField, Tooltip,
   Typography, useTheme, alpha
 } from '@mui/material'
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { useToast } from '@/contexts/ToastContext'
 import LogLevelSelect from '@/components/firewall/LogLevelSelect'
-import { DEFAULT_LOG_LEVEL, formatLogLevel } from '@/components/firewall/logLevels'
+import { DEFAULT_LOG_LEVEL } from '@/components/firewall/logLevels'
 import { DEFAULT_RULE } from '../../types'
+import RulesTableHead from './shared/RulesTableHead'
+import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeadingCells, RuleTrafficCells } from './shared/RuleTableCells'
+import AliasIpsetAutocomplete, { useAliasIpsetOptions } from './shared/AliasIpsetAutocomplete'
 
 interface HostRulesPanelProps {
   hostRulesByNode: Record<string, firewallAPI.FirewallRule[]>
@@ -27,28 +30,6 @@ interface HostRulesPanelProps {
   aliases: firewallAPI.Alias[]
   ipsets: firewallAPI.IPSet[]
 }
-
-// ── Helpers ──
-
-const ActionChip = ({ action }: { action: string }) => {
-  const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
-  const color = colors[action] || '#94a3b8'
-  return <Chip size="small" label={action} sx={{ height: 22, fontSize: 11, fontWeight: 700, bgcolor: alpha(color, 0.22), color, border: `1px solid ${alpha(color, 0.35)}`, minWidth: 70 }} />
-}
-
-function formatService(rule: firewallAPI.FirewallRule): string {
-  if (rule.type === 'group') return '-'
-  if (rule.macro) return rule.macro
-  const proto = rule.proto?.toUpperCase() || ''
-  const port = rule.dport || ''
-  if (!proto && !port) return 'any'
-  if (proto && port) return `${proto}/${port}`
-  return proto || port
-}
-
-// Body cells are all `p: 0.5`; without the same padding here the header
-// labels sit ~12px right of their column's values (MUI's default 16px).
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -94,12 +75,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
     !hostSearchQuery || node.toLowerCase().includes(hostSearchQuery.toLowerCase())
   )
 
-  const autocompleteOptions = useMemo(() => {
-    const opts: { label: string; secondary?: string }[] = []
-    for (const a of aliases) opts.push({ label: a.name, secondary: a.cidr })
-    for (const s of ipsets) opts.push({ label: `+${s.name}`, secondary: s.comment || `${s.members?.length || 0} entries` })
-    return opts
-  }, [aliases, ipsets])
+  const autocompleteOptions = useAliasIpsetOptions(aliases, ipsets)
 
   // ── Toggle node firewall ──
   const handleToggleNodeFirewall = async (node: string) => {
@@ -249,21 +225,7 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
       ) : filteredHosts.length > 0 ? (
         <TableContainer component={Paper} sx={{ border: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
           <Table size="small">
-            <TableHead>
-              <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
-                <TableCell sx={{ ...headCellSx, width: 30, p: 0.5 }}></TableCell>
-                <TableCell sx={{ ...headCellSx, width: 35 }}>#</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 55 }}>{t('common.active')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 65 }}>{t('firewall.direction')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.source')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
-                <TableCell sx={{ width: 70 }}></TableCell>
-              </TableRow>
-            </TableHead>
+            <RulesTableHead />
             <TableBody>
               {filteredHosts.map(node => {
                 const rules = hostRulesByNode[node] || []
@@ -352,69 +314,28 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                             '&:active': { cursor: 'grabbing' }
                           }}
                         >
-                          <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
-                            <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
-                          <TableCell sx={{ p: 0.5, width: 55 }}>
-                            <Switch checked={rule.enable !== 0} onChange={() => handleToggleHostRuleEnable(node, rule)} size="small" color="success" />
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 65 }}>
-                            <Chip
-                              label={isGroupRule ? 'GROUP' : rule.type?.toUpperCase() || 'IN'}
-                              size="small"
-                              sx={{
-                                height: 20, fontSize: 10, fontWeight: 600,
-                                bgcolor: isGroupRule ? alpha('#8b5cf6', 0.22) : rule.type === 'in' ? alpha('#3b82f6', 0.22) : alpha('#ec4899', 0.22),
-                                color: isGroupRule ? '#8b5cf6' : rule.type === 'in' ? '#3b82f6' : '#ec4899'
-                              }}
-                            />
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
-                            {isGroupRule ? '-' : (rule.source || 'any')}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
-                            {isGroupRule ? '-' : (rule.dest || 'any')}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
-                            {formatService(rule)}
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 90 }}>
-                            {isGroupRule ? (
-                              <Chip icon={<i className="ri-shield-line" style={{ fontSize: 10 }} />} label={rule.action} size="small" sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: alpha('#8b5cf6', 0.22), color: '#8b5cf6', '& .MuiChip-icon': { color: '#8b5cf6' } }} />
-                            ) : (
-                              <ActionChip action={rule.action || 'ACCEPT'} />
-                            )}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
-                            {formatLogLevel(rule.log)}
-                          </TableCell>
-                          <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
-                            <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 70 }}>
-                            <Box sx={{ display: 'flex', gap: 0 }}>
-                              <Tooltip title={t('networkPage.edit')}>
-                                <IconButton size="small" onClick={() => {
-                                  setEditingHostRule({ node, rule, isNew: false })
-                                  setNewHostRule({
-                                    type: rule.type || 'in', action: rule.action || 'ACCEPT', enable: rule.enable ?? 1,
-                                    proto: rule.proto || '', dport: rule.dport || '', sport: rule.sport || '',
-                                    source: rule.source || '', dest: rule.dest || '', macro: rule.macro || '',
-                                    iface: rule.iface || '', log: rule.log || DEFAULT_LOG_LEVEL, comment: rule.comment || ''
-                                  })
-                                  setHostRuleDialogOpen(true)
-                                }}>
-                                  <i className="ri-pencil-line" style={{ fontSize: 14 }} />
-                                </IconButton>
-                              </Tooltip>
-                              <Tooltip title={t('networkPage.delete')}>
-                                <IconButton size="small" color="error" onClick={() => setDeleteHostRuleConfirm({ node, pos: rule.pos })}>
-                                  <i className="ri-delete-bin-line" style={{ fontSize: 14 }} />
-                                </IconButton>
-                              </Tooltip>
-                            </Box>
-                          </TableCell>
+                          <RuleRowLeadingCells
+                            rule={rule}
+                            isGroupRule={isGroupRule}
+                            enabled={rule.enable !== 0}
+                            onToggleEnable={() => handleToggleHostRuleEnable(node, rule)}
+                          />
+                          <RuleTrafficCells rule={rule} isGroupRule={isGroupRule} />
+                          <RuleActionCell rule={rule} isGroupRule={isGroupRule} />
+                          <RuleLogCommentCells rule={rule} />
+                          <RuleRowActionsCell
+                            onEdit={() => {
+                              setEditingHostRule({ node, rule, isNew: false })
+                              setNewHostRule({
+                                type: rule.type || 'in', action: rule.action || 'ACCEPT', enable: rule.enable ?? 1,
+                                proto: rule.proto || '', dport: rule.dport || '', sport: rule.sport || '',
+                                source: rule.source || '', dest: rule.dest || '', macro: rule.macro || '',
+                                iface: rule.iface || '', log: rule.log || DEFAULT_LOG_LEVEL, comment: rule.comment || ''
+                              })
+                              setHostRuleDialogOpen(true)
+                            }}
+                            onDelete={() => setDeleteHostRuleConfirm({ node, pos: rule.pos })}
+                          />
                         </TableRow>
                       )
                     }) : (
@@ -500,47 +421,21 @@ export default function HostRulesPanel({ hostRulesByNode, nodesList, securityGro
                   <TextField fullWidth size="small" label={t('firewall.protocol')} value={newHostRule.proto} onChange={(e) => setNewHostRule({ ...newHostRule, proto: e.target.value })} placeholder="tcp, udp, icmp..." />
                 </Grid>
                 <Grid size={{ xs: 12, sm: 4 }}>
-                  <Autocomplete
-                    freeSolo
+                  <AliasIpsetAutocomplete
                     options={autocompleteOptions}
-                    getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                    inputValue={newHostRule.source || ''}
-                    onInputChange={(_, v) => setNewHostRule({ ...newHostRule, source: v })}
-                    renderOption={(props, opt) => (
-                      <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                          <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                          {typeof opt !== 'string' && opt.secondary && (
-                            <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                          )}
-                        </Box>
-                      </li>
-                    )}
-                    renderInput={(params) => (
-                      <TextField {...params} fullWidth size="small" label={t('firewall.source')} placeholder="IP, CIDR, alias..." />
-                    )}
+                    value={newHostRule.source || ''}
+                    onChange={(v) => setNewHostRule({ ...newHostRule, source: v })}
+                    label={t('firewall.source')}
+                    placeholder="IP, CIDR, alias..."
                   />
                 </Grid>
                 <Grid size={{ xs: 12, sm: 4 }}>
-                  <Autocomplete
-                    freeSolo
+                  <AliasIpsetAutocomplete
                     options={autocompleteOptions}
-                    getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                    inputValue={newHostRule.dest || ''}
-                    onInputChange={(_, v) => setNewHostRule({ ...newHostRule, dest: v })}
-                    renderOption={(props, opt) => (
-                      <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                        <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                          <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                          {typeof opt !== 'string' && opt.secondary && (
-                            <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                          )}
-                        </Box>
-                      </li>
-                    )}
-                    renderInput={(params) => (
-                      <TextField {...params} fullWidth size="small" label={t('firewall.destination')} placeholder="IP, CIDR, alias..." />
-                    )}
+                    value={newHostRule.dest || ''}
+                    onChange={(v) => setNewHostRule({ ...newHostRule, dest: v })}
+                    label={t('firewall.destination')}
+                    placeholder="IP, CIDR, alias..."
                   />
                 </Grid>
                 <Grid size={{ xs: 12, sm: 4 }}>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Component tests for RuleFormDialog.tsx — the rule form shared by the
+ * cluster policy table and the security groups panel.
+ *
+ * The dialog is fully controlled: it never holds the draft rule, it reports
+ * every edit through `onRuleChange` with the whole next rule. So the
+ * assertions here are on the object handed back, field by field — a field
+ * wired to the wrong key, or a handler that drops the rest of the rule,
+ * fails here. That is the class of bug this PR fixed for the log level.
+ *
+ * The two scopes it serves differ in more than a chip: only a cluster rule
+ * may reference a security group, so the GROUP type is offered there and
+ * withheld from a rule that lives inside a group (PVE forbids nesting).
+ *
+ * The Selects carry an InputLabel but no `labelId`, so their combobox has no
+ * accessible name and is located from the rendered label element — same
+ * limitation as LogLevelSelect.test.tsx.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPIType from '@/lib/api/firewall'
+
+import RuleFormDialog, { type RuleFormData } from './RuleFormDialog'
+
+const EMPTY_RULE: RuleFormData = {
+  type: 'in', action: 'ACCEPT', enable: 1, proto: '', dport: '', sport: '',
+  source: '', dest: '', macro: '', iface: '', log: 'nolog', comment: '',
+}
+
+const ALIASES: firewallAPIType.Alias[] = [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }]
+const IPSETS: firewallAPIType.IPSet[] = [{ name: 'trusted', comment: 'jump hosts', members: [{ cidr: '1.2.3.4' }] }]
+const GROUPS: firewallAPIType.SecurityGroup[] = [{ group: 'sg-web' }, { group: 'sg-db' }]
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof RuleFormDialog>> = {}) {
+  const onRuleChange = vi.fn()
+  const onSubmit = vi.fn()
+  const onClose = vi.fn()
+
+  renderWithProviders(
+    <RuleFormDialog
+      open
+      onClose={onClose}
+      onSubmit={onSubmit}
+      isNew
+      scope={{ type: 'cluster' }}
+      rule={EMPTY_RULE}
+      onRuleChange={onRuleChange}
+      securityGroups={GROUPS}
+      aliases={ALIASES}
+      ipsets={IPSETS}
+      {...overrides}
+    />,
+  )
+
+  return { onRuleChange, onSubmit, onClose }
+}
+
+/** A Select found from its rendered label (no labelId on these controls). */
+function selectByLabel(label: string) {
+  const el = screen.queryAllByText(label).find(n => n.tagName === 'LABEL')
+
+  if (!el?.parentElement) throw new Error(`No Select labelled "${label}"`)
+
+  return within(el.parentElement).getByRole('combobox')
+}
+
+/** Open a Select's menu and pick an option by its visible text. */
+function pick(label: string, option: string) {
+  fireEvent.mouseDown(selectByLabel(label))
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: option }))
+}
+
+describe('RuleFormDialog', () => {
+  afterEach(cleanup)
+
+  it('titles itself for a new cluster rule', () => {
+    renderDialog()
+
+    expect(within(screen.getByRole('dialog')).getByText('Add rule')).toBeInTheDocument()
+    expect(screen.getByText('Cluster')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+  })
+
+  it('titles itself for an edited rule inside a security group', () => {
+    renderDialog({ isNew: false, scope: { type: 'security-group', name: 'sg-web' } })
+
+    expect(within(screen.getByRole('dialog')).getByText('Edit rule')).toBeInTheDocument()
+    expect(screen.getByText('SG: sg-web')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('offers the GROUP type only for a cluster rule', () => {
+    renderDialog()
+    fireEvent.mouseDown(selectByLabel('Type'))
+    expect(within(screen.getByRole('listbox')).getByRole('option', { name: 'GROUP (Security Group)' })).toBeInTheDocument()
+
+    cleanup()
+
+    // PVE forbids nesting groups, so a rule inside one cannot be of type group.
+    renderDialog({ scope: { type: 'security-group', name: 'sg-web' } })
+    fireEvent.mouseDown(selectByLabel('Type'))
+    expect(within(screen.getByRole('listbox')).queryByRole('option', { name: 'GROUP (Security Group)' })).not.toBeInTheDocument()
+  })
+
+  it('lists the connection security groups as the action of a group rule', () => {
+    renderDialog({ rule: { ...EMPTY_RULE, type: 'group', action: 'sg-web' } })
+
+    expect(selectByLabel('Action')).toHaveTextContent('sg-web')
+
+    fireEvent.mouseDown(selectByLabel('Action'))
+    expect(within(screen.getByRole('listbox')).getAllByRole('option').map(o => o.textContent)).toEqual(['sg-web', 'sg-db'])
+  })
+
+  it('hides the traffic fields of a group rule, which carries none', () => {
+    renderDialog({ rule: { ...EMPTY_RULE, type: 'group', action: 'sg-web' } })
+
+    expect(screen.queryByLabelText('Source')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Destination')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Dest port')).not.toBeInTheDocument()
+    expect(screen.queryAllByText('Log level')).toHaveLength(0)
+
+    // The comment survives: it is what names the reference in the table.
+    expect(screen.getByLabelText('Comment')).toBeInTheDocument()
+  })
+
+  it('reports the whole rule when the log level changes', () => {
+    const { onRuleChange } = renderDialog()
+
+    expect(selectByLabel('Log level')).toHaveTextContent('nolog')
+
+    pick('Log level', 'crit')
+
+    // The rest of the rule must survive the edit, not be replaced by it.
+    expect(onRuleChange).toHaveBeenCalledWith({ ...EMPTY_RULE, log: 'crit' })
+  })
+
+  it.each([
+    ['Dest port', 'dport', '8006'],
+    ['Source port', 'sport', '1024:65535'],
+    ['Interface', 'iface', 'vmbr0'],
+    ['Comment', 'comment', 'from test'],
+  ])('reports %s edits under the %s key', (label, field, value) => {
+    const { onRuleChange } = renderDialog()
+
+    fireEvent.change(screen.getByLabelText(label), { target: { value } })
+
+    expect(onRuleChange).toHaveBeenCalledWith({ ...EMPTY_RULE, [field]: value })
+  })
+
+  it('reports the source and destination picked from the suggestions', async () => {
+    const { onRuleChange } = renderDialog()
+
+    // The aliases come first, then the IPSets in their `+name` PVE form.
+    fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'net' } })
+    fireEvent.click(await screen.findByRole('option', { name: /net-mgmt/ }))
+    expect(onRuleChange).toHaveBeenCalledWith({ ...EMPTY_RULE, source: 'net-mgmt' })
+
+    fireEvent.change(screen.getByLabelText('Destination'), { target: { value: '+tru' } })
+    fireEvent.click(await screen.findByRole('option', { name: /\+trusted/ }))
+    expect(onRuleChange).toHaveBeenLastCalledWith({ ...EMPTY_RULE, dest: '+trusted' })
+  })
+
+  it('reports the type, action, active flag and protocol', () => {
+    const { onRuleChange } = renderDialog()
+
+    pick('Type', 'OUT')
+    expect(onRuleChange).toHaveBeenLastCalledWith({ ...EMPTY_RULE, type: 'out' })
+
+    pick('Action', 'DROP')
+    expect(onRuleChange).toHaveBeenLastCalledWith({ ...EMPTY_RULE, action: 'DROP' })
+
+    // The active flag is a number for PVE, not a boolean.
+    pick('Active', 'Inactive')
+    expect(onRuleChange).toHaveBeenLastCalledWith({ ...EMPTY_RULE, enable: 0 })
+
+    pick('Protocol', 'UDP')
+    expect(onRuleChange).toHaveBeenLastCalledWith({ ...EMPTY_RULE, proto: 'udp' })
+  })
+
+  it('renders an incoming rule as its current values', () => {
+    renderDialog({
+      rule: {
+        ...EMPTY_RULE, type: 'out', action: 'REJECT', enable: 0, proto: 'tcp',
+        dport: '443', sport: '1024', source: '10.0.0.0/8', dest: '+trusted',
+        iface: 'vmbr1', log: 'warning', comment: 'https out',
+      },
+    })
+
+    expect(selectByLabel('Type')).toHaveTextContent('OUT')
+    expect(selectByLabel('Action')).toHaveTextContent('REJECT')
+    expect(selectByLabel('Active')).toHaveTextContent('Inactive')
+    expect(selectByLabel('Protocol')).toHaveTextContent('TCP')
+    expect(selectByLabel('Log level')).toHaveTextContent('warning')
+    expect(screen.getByLabelText('Source')).toHaveValue('10.0.0.0/8')
+    expect(screen.getByLabelText('Destination')).toHaveValue('+trusted')
+    expect(screen.getByLabelText('Dest port')).toHaveValue('443')
+    expect(screen.getByLabelText('Source port')).toHaveValue('1024')
+    expect(screen.getByLabelText('Interface')).toHaveValue('vmbr1')
+    expect(screen.getByLabelText('Comment')).toHaveValue('https out')
+  })
+
+  it('hands the submit and cancel back to the panel', () => {
+    const { onSubmit, onClose } = renderDialog()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing while closed', () => {
+    renderDialog({ open: false })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useMemo } from 'react'
 import { useTranslations } from 'next-intl'
 
 import {
-  Autocomplete, Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
+  Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
   FormControl, Grid, InputLabel, MenuItem, Select, TextField, alpha
 } from '@mui/material'
 
 import * as firewallAPI from '@/lib/api/firewall'
 import LogLevelSelect from '@/components/firewall/LogLevelSelect'
+import AliasIpsetAutocomplete, { useAliasIpsetOptions } from './shared/AliasIpsetAutocomplete'
 
 export interface RuleFormData {
   type: string
@@ -58,16 +58,7 @@ export default function RuleFormDialog({
     onRuleChange({ ...rule, [field]: value })
   }
 
-  const autocompleteOptions = useMemo(() => {
-    const opts: { label: string; secondary?: string }[] = []
-    for (const a of aliases) {
-      opts.push({ label: a.name, secondary: a.cidr })
-    }
-    for (const s of ipsets) {
-      opts.push({ label: `+${s.name}`, secondary: s.comment || `${s.members?.length || 0} entries` })
-    }
-    return opts
-  }, [aliases, ipsets])
+  const autocompleteOptions = useAliasIpsetOptions(aliases, ipsets)
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
@@ -129,47 +120,21 @@ export default function RuleFormDialog({
                 </FormControl>
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>
-                <Autocomplete
-                  freeSolo
+                <AliasIpsetAutocomplete
                   options={autocompleteOptions}
-                  getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                  inputValue={rule.source}
-                  onInputChange={(_, v) => set('source', v)}
-                  renderOption={(props, opt) => (
-                    <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                        <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                        {typeof opt !== 'string' && opt.secondary && (
-                          <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                        )}
-                      </Box>
-                    </li>
-                  )}
-                  renderInput={(params) => (
-                    <TextField {...params} fullWidth size="small" label={t('network.source')} placeholder="IP, CIDR, alias..." />
-                  )}
+                  value={rule.source}
+                  onChange={(v) => set('source', v)}
+                  label={t('network.source')}
+                  placeholder="IP, CIDR, alias..."
                 />
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>
-                <Autocomplete
-                  freeSolo
+                <AliasIpsetAutocomplete
                   options={autocompleteOptions}
-                  getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                  inputValue={rule.dest}
-                  onInputChange={(_, v) => set('dest', v)}
-                  renderOption={(props, opt) => (
-                    <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                      <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                        <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                        {typeof opt !== 'string' && opt.secondary && (
-                          <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                        )}
-                      </Box>
-                    </li>
-                  )}
-                  renderInput={(params) => (
-                    <TextField {...params} fullWidth size="small" label={t('network.destination')} placeholder="IP, CIDR, alias..." />
-                  )}
+                  value={rule.dest}
+                  onChange={(v) => set('dest', v)}
+                  label={t('network.destination')}
+                  placeholder="IP, CIDR, alias..."
                 />
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/RuleFormDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from '@mui/material'
 
 import * as firewallAPI from '@/lib/api/firewall'
-import { monoStyle } from '../../types'
+import LogLevelSelect from '@/components/firewall/LogLevelSelect'
 
 export interface RuleFormData {
   type: string
@@ -138,7 +138,7 @@ export default function RuleFormDialog({
                   renderOption={(props, opt) => (
                     <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                       <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                        <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                        <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                         {typeof opt !== 'string' && opt.secondary && (
                           <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                         )}
@@ -146,7 +146,7 @@ export default function RuleFormDialog({
                     </li>
                   )}
                   renderInput={(params) => (
-                    <TextField {...params} fullWidth size="small" label={t('network.source')} placeholder="IP, CIDR, alias..." InputProps={{ ...params.InputProps, sx: monoStyle }} />
+                    <TextField {...params} fullWidth size="small" label={t('network.source')} placeholder="IP, CIDR, alias..." />
                   )}
                 />
               </Grid>
@@ -160,7 +160,7 @@ export default function RuleFormDialog({
                   renderOption={(props, opt) => (
                     <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                       <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                        <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                        <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                         {typeof opt !== 'string' && opt.secondary && (
                           <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                         )}
@@ -168,18 +168,21 @@ export default function RuleFormDialog({
                     </li>
                   )}
                   renderInput={(params) => (
-                    <TextField {...params} fullWidth size="small" label={t('network.destination')} placeholder="IP, CIDR, alias..." InputProps={{ ...params.InputProps, sx: monoStyle }} />
+                    <TextField {...params} fullWidth size="small" label={t('network.destination')} placeholder="IP, CIDR, alias..." />
                   )}
                 />
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>
-                <TextField fullWidth size="small" label={t('network.destPort')} value={rule.dport} onChange={(e) => set('dport', e.target.value)} placeholder="22, 80, 443..." InputProps={{ sx: monoStyle }} />
+                <TextField fullWidth size="small" label={t('network.destPort')} value={rule.dport} onChange={(e) => set('dport', e.target.value)} placeholder="22, 80, 443..." />
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>
-                <TextField fullWidth size="small" label={t('firewall.sourcePort')} value={rule.sport} onChange={(e) => set('sport', e.target.value)} InputProps={{ sx: monoStyle }} />
+                <TextField fullWidth size="small" label={t('firewall.sourcePort')} value={rule.sport} onChange={(e) => set('sport', e.target.value)} />
               </Grid>
               <Grid size={{ xs: 12, sm: 4 }}>
-                <TextField fullWidth size="small" label={t('firewall.interface')} value={rule.iface} onChange={(e) => set('iface', e.target.value)} placeholder="vmbr0, eth0..." InputProps={{ sx: monoStyle }} />
+                <TextField fullWidth size="small" label={t('firewall.interface')} value={rule.iface} onChange={(e) => set('iface', e.target.value)} placeholder="vmbr0, eth0..." />
+              </Grid>
+              <Grid size={{ xs: 12, sm: 4 }}>
+                <LogLevelSelect value={rule.log} onChange={(v) => set('log', v)} />
               </Grid>
             </>
           )}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * Component tests for SecurityGroupsPanel.tsx — the security groups rules
+ * table.
+ *
+ * Two things are specific to this panel and asserted here. First, it owns an
+ * extra "Applied To" column: the count of guests whose rules reference the
+ * group, derived from the VM firewall data rather than given by the caller,
+ * so a wrong derivation shows an operator the wrong blast radius. Second, a
+ * security group cannot itself hold a group rule (PVE forbids nesting), so
+ * the shared row cells are rendered without `isGroupRule` and a rule that
+ * names a group keeps the plain rendering.
+ *
+ * The rule form is the shared RuleFormDialog, covered on its own; what is
+ * checked here is that the panel pre-fills it from the right rule and sends
+ * the result to the right group.
+ *
+ * `window.confirm` gates the group deletion and jsdom does not implement it,
+ * so it is stubbed per test rather than globally.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPIType from '@/lib/api/firewall'
+import type { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
+
+vi.mock('@/lib/api/firewall', () => ({
+  addSecurityGroupRule: vi.fn(),
+  updateSecurityGroupRule: vi.fn(),
+  deleteSecurityGroupRule: vi.fn(),
+  createSecurityGroup: vi.fn(),
+  deleteSecurityGroup: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import SecurityGroupsPanel from './SecurityGroupsPanel'
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+const CONN = 'conn-1'
+
+const WEB_RULE: firewallAPIType.FirewallRule = {
+  pos: 0, type: 'in', action: 'ACCEPT', enable: 1,
+  proto: 'tcp', dport: '443', source: '10.0.0.0/8', log: 'warning', comment: 'https in',
+}
+
+const DISABLED_RULE: firewallAPIType.FirewallRule = { pos: 1, type: 'in', action: 'DROP', enable: 0 }
+
+const GROUPS: firewallAPIType.SecurityGroup[] = [
+  { group: 'sg-web', comment: 'front tier', rules: [WEB_RULE, DISABLED_RULE] },
+  { group: 'sg-db', rules: [] },
+]
+
+/** A guest whose rules reference sg-web, so the group counts one applied VM. */
+const WEB_VM: VMFirewallInfo = {
+  vmid: 100, name: 'web-01', node: 'pve1', type: 'qemu', status: 'running',
+  firewallEnabled: true, options: null, vlans: [20],
+  rules: [{ pos: 0, type: 'group', action: 'sg-web', enable: 1 }],
+}
+
+function props(overrides: Partial<React.ComponentProps<typeof SecurityGroupsPanel>> = {}) {
+  return {
+    securityGroups: GROUPS,
+    vmFirewallData: [WEB_VM],
+    firewallMode: 'cluster' as firewallAPIType.FirewallMode,
+    selectedConnection: CONN,
+    totalRules: 2,
+    aliases: [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }] as firewallAPIType.Alias[],
+    ipsets: [] as firewallAPIType.IPSet[],
+    reload: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderPanel(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<SecurityGroupsPanel {...p} />)
+
+  return p
+}
+
+const expandGroup = (name: string) => fireEvent.click(screen.getByText(name))
+
+const ruleRow = (text: string) => screen.getAllByRole('row').find(r => within(r).queryByText(text))!
+
+/** A Select inside the open rule dialog, found from its rendered label. */
+function selectByLabel(label: string) {
+  const el = screen.queryAllByText(label).find(n => n.tagName === 'LABEL')
+
+  if (!el?.parentElement) throw new Error(`No Select labelled "${label}"`)
+
+  return within(el.parentElement).getByRole('combobox')
+}
+
+describe('SecurityGroupsPanel', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.addSecurityGroupRule.mockResolvedValue(undefined)
+    api.updateSecurityGroupRule.mockResolvedValue(undefined)
+    api.deleteSecurityGroupRule.mockResolvedValue(undefined)
+    api.createSecurityGroup.mockResolvedValue(undefined)
+    api.deleteSecurityGroup.mockResolvedValue(undefined)
+  })
+
+  it('lists each group collapsed, with its comment, rule count and applied guests', () => {
+    renderPanel()
+
+    expect(screen.getByText('sg-web')).toBeInTheDocument()
+    expect(screen.getByText('— front tier')).toBeInTheDocument()
+    expect(screen.getByText('2 rules')).toBeInTheDocument()
+    expect(screen.getByText('0 rules')).toBeInTheDocument()
+
+    // sg-web is referenced by web-01, sg-db by nobody.
+    expect(screen.getByText('1 VMs')).toBeInTheDocument()
+    expect(screen.getByText('0 VMs')).toBeInTheDocument()
+
+    expect(screen.queryByText('https in')).not.toBeInTheDocument()
+  })
+
+  it('carries an Applied To column the other rules tables do not have', () => {
+    renderPanel()
+
+    expect(screen.getByText('Applied To')).toBeInTheDocument()
+  })
+
+  it('reveals a group\'s rules, with their log level, when expanded', () => {
+    renderPanel()
+
+    expandGroup('sg-web')
+
+    expect(screen.getByText('https in')).toBeInTheDocument()
+    expect(screen.getByText('warning')).toBeInTheDocument()
+    expect(screen.getByText('TCP/443')).toBeInTheDocument()
+
+    expandGroup('sg-web')
+    expect(screen.queryByText('https in')).not.toBeInTheDocument()
+  })
+
+  it('offers to create a rule in a group that has none', () => {
+    renderPanel()
+
+    expandGroup('sg-db')
+
+    const emptyRow = screen.getAllByRole('row').find(r => within(r).queryByText('No rules'))!
+
+    fireEvent.click(within(emptyRow).getByRole('button', { name: 'Add rule' }))
+
+    expect(screen.getByText('SG: sg-db')).toBeInTheDocument()
+  })
+
+  it('expands and collapses every group at once, and filters by search', () => {
+    renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+    expect(screen.getByText('https in')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+    expect(screen.queryByText('https in')).not.toBeInTheDocument()
+
+    // Search matches the group name, its comment and its rules' fields.
+    fireEvent.change(screen.getByPlaceholderText('Search policies...'), { target: { value: 'front' } })
+    expect(screen.getByText('sg-web')).toBeInTheDocument()
+    expect(screen.queryByText('sg-db')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Search policies...'), { target: { value: 'nope' } })
+    expect(screen.getByText('No Security Group')).toBeInTheDocument()
+  })
+
+  it('toggles a rule Active switch against its group and position', async () => {
+    renderPanel()
+    expandGroup('sg-web')
+
+    fireEvent.click(within(ruleRow('https in')).getByRole('switch'))
+
+    await waitFor(() => expect(api.updateSecurityGroupRule).toHaveBeenCalledTimes(1))
+    expect(api.updateSecurityGroupRule.mock.calls[0].slice(0, 3)).toEqual([CONN, 'sg-web', 0])
+    expect(api.updateSecurityGroupRule.mock.calls[0][3]).toMatchObject({ enable: 0, log: 'warning' })
+  })
+
+  it('re-enables a rule PVE returned as disabled', async () => {
+    renderPanel()
+    expandGroup('sg-web')
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('DROP'))!
+    const toggle = within(row).getByRole('switch')
+
+    expect(toggle).not.toBeChecked()
+    fireEvent.click(toggle)
+
+    await waitFor(() => expect(api.updateSecurityGroupRule).toHaveBeenCalledTimes(1))
+    expect(api.updateSecurityGroupRule.mock.calls[0][3]).toMatchObject({ enable: 1 })
+  })
+
+  it('pre-fills the edit dialog from the rule and saves it to the group', async () => {
+    renderPanel()
+    expandGroup('sg-web')
+
+    fireEvent.click(within(ruleRow('https in')).getByRole('button', { name: 'Edit' }))
+
+    await waitFor(() => expect(screen.getByText('SG: sg-web')).toBeInTheDocument())
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByLabelText('Source')).toHaveValue('10.0.0.0/8')
+    expect(dialog.getByLabelText('Dest port')).toHaveValue('443')
+    expect(dialog.getByLabelText('Comment')).toHaveValue('https in')
+    expect(selectByLabel('Log level')).toHaveTextContent('warning')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.updateSecurityGroupRule).toHaveBeenCalledTimes(1))
+    expect(api.updateSecurityGroupRule.mock.calls[0].slice(0, 3)).toEqual([CONN, 'sg-web', 0])
+    expect(api.updateSecurityGroupRule.mock.calls[0][3]).toMatchObject({ log: 'warning' })
+  })
+
+  it('adds a rule to a group with the picked log level', async () => {
+    const p = renderPanel()
+
+    expandGroup('sg-web')
+
+    const section = screen.getAllByRole('row').find(r => within(r).queryByText('sg-web'))!
+
+    fireEvent.click(within(section).getByRole('button', { name: 'Add rule' }))
+    await waitFor(() => expect(screen.getByText('SG: sg-web')).toBeInTheDocument())
+
+    fireEvent.mouseDown(selectByLabel('Log level'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'info' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addSecurityGroupRule).toHaveBeenCalledTimes(1))
+    expect(api.addSecurityGroupRule).toHaveBeenCalledWith(CONN, 'sg-web', expect.objectContaining({ log: 'info' }))
+    expect(p.reload).toHaveBeenCalled()
+  })
+
+  it('confirms before deleting a rule, then deletes it', async () => {
+    renderPanel()
+    expandGroup('sg-web')
+
+    fireEvent.click(within(ruleRow('https in')).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.getByText('Delete this rule?')).toBeInTheDocument())
+
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteSecurityGroupRule).toHaveBeenCalledWith(CONN, 'sg-web', 0))
+  })
+
+  it('asks the browser to confirm before deleting a whole group', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    renderPanel()
+
+    const section = screen.getAllByRole('row').find(r => within(r).queryByText('sg-web'))!
+
+    fireEvent.click(within(section).getByRole('button', { name: 'Delete' }))
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete Security Group "sg-web"?')
+    expect(api.deleteSecurityGroup).not.toHaveBeenCalled()
+
+    confirmSpy.mockReturnValue(true)
+    fireEvent.click(within(section).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteSecurityGroup).toHaveBeenCalledWith(CONN, 'sg-web'))
+    confirmSpy.mockRestore()
+  })
+
+  it('creates a group from the New Policy dialog', async () => {
+    renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Policy' }))
+
+    await waitFor(() => expect(screen.getByText('Create Security Group')).toBeInTheDocument())
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    // The Create button stays disabled until the group has a name.
+    expect(dialog.getByRole('button', { name: 'Create' })).toBeDisabled()
+
+    fireEvent.change(dialog.getByLabelText('Name'), { target: { value: 'sg-new' } })
+    fireEvent.change(dialog.getByLabelText('Description'), { target: { value: 'from test' } })
+
+    fireEvent.click(dialog.getByRole('button', { name: 'Create' }))
+
+    await waitFor(() => expect(api.createSecurityGroup).toHaveBeenCalledWith(CONN, { group: 'sg-new', comment: 'from test' }))
+  })
+
+  it('explains that security groups need a cluster when the node is standalone', () => {
+    renderPanel({ firewallMode: 'standalone' })
+
+    expect(screen.getByText('Security Groups not available')).toBeInTheDocument()
+
+    // The rules table is replaced entirely, not merely disabled.
+    expect(screen.queryByText('sg-web')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New Policy' })).not.toBeInTheDocument()
+  })
+
+  it('offers to create the first group when the connection has none', () => {
+    renderPanel({ securityGroups: [] })
+
+    expect(screen.getByText('No Security Group')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create group' }))
+    expect(screen.getByText('Create Security Group')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
@@ -5,17 +5,18 @@ import { useTranslations } from 'next-intl'
 
 import {
   Avatar, Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
-  IconButton, Paper, Stack, Switch, Table, TableBody, TableCell,
-  TableContainer, TableHead, TableRow, TextField, Tooltip, Typography,
+  IconButton, Paper, Stack, Table, TableBody, TableCell,
+  TableContainer, TableRow, TextField, Tooltip, Typography,
   useTheme, alpha
 } from '@mui/material'
 
 import * as firewallAPI from '@/lib/api/firewall'
 import { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
 import { useToast } from '@/contexts/ToastContext'
-import { formatLogLevel } from '@/components/firewall/logLevels'
 import { PolicySection } from '../../types'
 import RuleFormDialog, { RuleFormData } from './RuleFormDialog'
+import RulesTableHead from './shared/RulesTableHead'
+import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeadingCells, RuleTrafficCells } from './shared/RuleTableCells'
 
 // ── Props ──
 
@@ -32,22 +33,6 @@ interface SecurityGroupsPanelProps {
 
 // ── Helpers ──
 
-const ActionChip = ({ action }: { action: string }) => {
-  const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
-  const color = colors[action] || '#94a3b8'
-  return <Chip size="small" label={action} sx={{ height: 22, fontSize: 11, fontWeight: 700, bgcolor: alpha(color, 0.22), color, border: `1px solid ${alpha(color, 0.35)}`, minWidth: 70 }} />
-}
-
-function formatService(rule: firewallAPI.FirewallRule): string {
-  if (rule.type === 'group') return '-'
-  if (rule.macro) return rule.macro
-  const proto = rule.proto?.toUpperCase() || ''
-  const port = rule.dport || ''
-  if (!proto && !port) return 'any'
-  if (proto && port) return `${proto}/${port}`
-  return proto || port
-}
-
 function computeAppliedTo(sgName: string, vmFirewallData: VMFirewallInfo[]): { vmid: number; name: string; node: string }[] {
   const vms: { vmid: number; name: string; node: string }[] = []
   for (const vm of vmFirewallData) {
@@ -56,11 +41,6 @@ function computeAppliedTo(sgName: string, vmFirewallData: VMFirewallInfo[]): { v
   }
   return vms
 }
-
-// ── Column header style ──
-// Body cells are all `p: 0.5`; without the same padding here the header
-// labels sit ~12px right of their column's values (MUI's default 16px).
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -281,33 +261,15 @@ export default function SecurityGroupsPanel({
           '&:active': { cursor: 'grabbing' }
         }}
       >
-        <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
-          <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
-        <TableCell sx={{ p: 0.5, width: 55 }}>
-          <Switch checked={rule.enable !== 0} onChange={() => handleToggleEnable(section, rule)} size="small" color="success" />
-        </TableCell>
-        <TableCell sx={{ p: 0.5, width: 65 }}>
-          <Chip
-            label={rule.type?.toUpperCase() || 'IN'}
-            size="small"
-            sx={{
-              height: 20, fontSize: 10, fontWeight: 600,
-              bgcolor: rule.type === 'in' ? alpha('#3b82f6', 0.22) : alpha('#ec4899', 0.22),
-              color: rule.type === 'in' ? '#3b82f6' : '#ec4899'
-            }}
-          />
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, color: rule.source ? 'text.primary' : 'text.disabled' }}>
-          {rule.source || 'any'}
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, color: rule.dest ? 'text.primary' : 'text.disabled' }}>
-          {rule.dest || 'any'}
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
-          {formatService(rule)}
-        </TableCell>
+        {/* A security group cannot itself hold a group rule (PVE forbids
+            nesting), so `isGroupRule` stays off here: no purple chips, no
+            dashed-out source/destination. */}
+        <RuleRowLeadingCells
+          rule={rule}
+          enabled={rule.enable !== 0}
+          onToggleEnable={() => handleToggleEnable(section, rule)}
+        />
+        <RuleTrafficCells rule={rule} />
         <TableCell sx={{ p: 0.5, width: 90 }}>
           <Tooltip
             title={section.appliedTo.length > 0
@@ -322,29 +284,12 @@ export default function SecurityGroupsPanel({
             />
           </Tooltip>
         </TableCell>
-        <TableCell sx={{ p: 0.5, width: 90 }}>
-          <ActionChip action={rule.action || 'ACCEPT'} />
-        </TableCell>
-        <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
-          {formatLogLevel(rule.log)}
-        </TableCell>
-        <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
-          <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
-        </TableCell>
-        <TableCell sx={{ p: 0.5, width: 70 }}>
-          <Box sx={{ display: 'flex', gap: 0 }}>
-            <Tooltip title={t('networkPage.edit')}>
-              <IconButton size="small" onClick={() => openEditRule(section.id, rule)}>
-                <i className="ri-pencil-line" style={{ fontSize: 14 }} />
-              </IconButton>
-            </Tooltip>
-            <Tooltip title={t('networkPage.delete')}>
-              <IconButton size="small" color="error" onClick={() => setDeleteConfirm({ groupName: section.id, pos: rule.pos })}>
-                <i className="ri-delete-bin-line" style={{ fontSize: 14 }} />
-              </IconButton>
-            </Tooltip>
-          </Box>
-        </TableCell>
+        <RuleActionCell rule={rule} />
+        <RuleLogCommentCells rule={rule} />
+        <RuleRowActionsCell
+          onEdit={() => openEditRule(section.id, rule)}
+          onDelete={() => setDeleteConfirm({ groupName: section.id, pos: rule.pos })}
+        />
       </TableRow>
     )
   }
@@ -514,22 +459,7 @@ export default function SecurityGroupsPanel({
       {filteredSections.length > 0 ? (
         <TableContainer component={Paper} sx={{ border: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
           <Table size="small">
-            <TableHead>
-              <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
-                <TableCell sx={{ ...headCellSx, width: 30, p: 0.5 }}></TableCell>
-                <TableCell sx={{ ...headCellSx, width: 35 }}>#</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 55 }}>{t('common.active')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 65 }}>{t('firewall.direction')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.source')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 90 }}>{t('networkPage.appliedTo')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
-                <TableCell sx={{ width: 70 }}></TableCell>
-              </TableRow>
-            </TableHead>
+            <RulesTableHead showAppliedTo />
             <TableBody>
               {filteredSections.map(section => (
                 <Fragment key={section.id}>{renderSectionRow(section)}{renderSGRuleRows(section)}</Fragment>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
@@ -13,7 +13,8 @@ import {
 import * as firewallAPI from '@/lib/api/firewall'
 import { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
 import { useToast } from '@/contexts/ToastContext'
-import { PolicySection, monoStyle } from '../../types'
+import { formatLogLevel } from '@/components/firewall/logLevels'
+import { PolicySection } from '../../types'
 import RuleFormDialog, { RuleFormData } from './RuleFormDialog'
 
 // ── Props ──
@@ -57,7 +58,9 @@ function computeAppliedTo(sgName: string, vmFirewallData: VMFirewallInfo[]): { v
 }
 
 // ── Column header style ──
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap' } as const
+// Body cells are all `p: 0.5`; without the same padding here the header
+// labels sit ~12px right of their column's values (MUI's default 16px).
+const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 // ── Main Component ──
 
@@ -296,13 +299,13 @@ export default function SecurityGroupsPanel({
             }}
           />
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: rule.source ? 'text.primary' : 'text.disabled' }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, color: rule.source ? 'text.primary' : 'text.disabled' }}>
           {rule.source || 'any'}
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: rule.dest ? 'text.primary' : 'text.disabled' }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, color: rule.dest ? 'text.primary' : 'text.disabled' }}>
           {rule.dest || 'any'}
         </TableCell>
-        <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, width: 100 }}>
+        <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
           {formatService(rule)}
         </TableCell>
         <TableCell sx={{ p: 0.5, width: 90 }}>
@@ -321,6 +324,9 @@ export default function SecurityGroupsPanel({
         </TableCell>
         <TableCell sx={{ p: 0.5, width: 90 }}>
           <ActionChip action={rule.action || 'ACCEPT'} />
+        </TableCell>
+        <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
+          {formatLogLevel(rule.log)}
         </TableCell>
         <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
           <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
@@ -358,14 +364,14 @@ export default function SecurityGroupsPanel({
         }}
         onClick={() => toggleSection(section.id)}
       >
-        <TableCell colSpan={11} sx={{ py: 1, px: 2 }}>
+        <TableCell colSpan={12} sx={{ py: 1, px: 2 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
               <i
                 className={isExpanded ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'}
                 style={{ fontSize: 20, color: theme.palette.text.secondary, flexShrink: 0 }}
               />
-              <code style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{section.name}</code>
+              <span style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{section.name}</span>
               {section.comment && (
                 <Typography variant="caption" sx={{ color: 'text.secondary', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
                   — {section.comment}
@@ -417,7 +423,7 @@ export default function SecurityGroupsPanel({
     if (section.rules.length === 0) {
       return (
         <TableRow key={`empty-${section.id}`}>
-          <TableCell colSpan={11} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+          <TableCell colSpan={12} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
             <Typography variant="body2">{t('networkPage.noRules')}</Typography>
             <Button size="small" sx={{ mt: 1 }} onClick={() => openAddRule(section.id)}>
               {t('networkPage.addRule')}
@@ -519,6 +525,7 @@ export default function SecurityGroupsPanel({
                 <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 90 }}>{t('networkPage.appliedTo')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
+                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
                 <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
                 <TableCell sx={{ width: 70 }}></TableCell>
               </TableRow>
@@ -559,7 +566,7 @@ export default function SecurityGroupsPanel({
         <DialogTitle>{t('networkPage.createSgTitle')}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <TextField label={t('common.name')} value={newGroup.group} onChange={e => setNewGroup({ ...newGroup, group: e.target.value })} placeholder="sg-web" fullWidth size="small" InputProps={{ sx: monoStyle }} />
+            <TextField label={t('common.name')} value={newGroup.group} onChange={e => setNewGroup({ ...newGroup, group: e.target.value })} placeholder="sg-web" fullWidth size="small" />
             <TextField label={t('common.description')} value={newGroup.comment} onChange={e => setNewGroup({ ...newGroup, comment: e.target.value })} fullWidth size="small" />
           </Stack>
         </DialogContent>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
@@ -209,7 +209,11 @@ export default function SecurityGroupsPanel({
     setDragState({ sectionId, draggedPos: pos, dragOverPos: null })
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', pos.toString())
-    setTimeout(() => { (e.currentTarget as HTMLElement).style.opacity = '0.5' }, 0)
+    // React nulls the event's currentTarget as soon as the handler returns,
+    // so the row must be captured before the opacity change is deferred.
+    const draggedRow = e.currentTarget as HTMLElement
+
+    setTimeout(() => { draggedRow.style.opacity = '0.5' }, 0)
   }
   const handleDragEnd = (e: React.DragEvent) => {
     (e.currentTarget as HTMLElement).style.opacity = '1'

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
@@ -1,0 +1,480 @@
+/**
+ * Component tests for VMRulesPanel.tsx — the VM/CT firewall rules table.
+ *
+ * The panel nests two levels of grouping the other rules tables do not have:
+ * guests are grouped by their primary VLAN, and each guest is itself a
+ * collapsible section. Both must be open before a rule row is on screen,
+ * which is what most of these tests walk through. The VLAN grouping order is
+ * asserted too (numbered VLANs ascending, untagged last), since it is
+ * computed rather than given by the caller.
+ *
+ * Everything else is prop-driven, so only the firewall API module is
+ * stubbed, plus the raw `fetch` PUT used for reordering, which MSW serves.
+ * The jsdom setup errors on unhandled requests, so a route called without a
+ * fixture fails the test.
+ *
+ * `scrollIntoView` is stubbed because the log dialog auto-scrolls to its
+ * last line on every log update and jsdom implements no layout — the same
+ * stub VmFirewallTab.test.tsx needs, kept local for the same reason.
+ *
+ * The VM rule dialog labels its fields directly (no next-intl), and its
+ * Selects carry an InputLabel but no `labelId`, so their combobox has no
+ * accessible name and is located from the rendered label element — same
+ * limitation as LogLevelSelect.test.tsx.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+import type * as firewallAPIType from '@/lib/api/firewall'
+import type { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
+
+vi.mock('@/lib/api/firewall', () => ({
+  toggleVMNICFirewall: vi.fn(),
+  updateVMOptions: vi.fn(),
+  addVMRule: vi.fn(),
+  updateVMRule: vi.fn(),
+  deleteVMRule: vi.fn(),
+  getVMFirewallLog: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import VMRulesPanel from './VMRulesPanel'
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+const CONN = 'conn-1'
+
+// The log dialog auto-scrolls to its last line; jsdom has no layout, so
+// scrollIntoView does not exist there.
+Element.prototype.scrollIntoView ??= vi.fn()
+
+/** A rule where every optional PVE field is set. */
+const FULL_RULE: firewallAPIType.FirewallRule = {
+  pos: 0, type: 'in', action: 'ACCEPT', enable: 1,
+  proto: 'tcp', dport: '443', sport: '1024:65535',
+  source: '10.0.0.0/8', dest: '10.0.0.5', macro: '',
+  iface: 'net0', log: 'warning', comment: 'https in',
+}
+
+/** A rule as PVE returns it when nothing optional was configured. */
+const BARE_RULE: firewallAPIType.FirewallRule = { pos: 1, type: '', action: '' }
+
+const WEB: VMFirewallInfo = {
+  vmid: 100, name: 'web-01', node: 'pve1', type: 'qemu', status: 'running',
+  firewallEnabled: true, rules: [FULL_RULE, BARE_RULE],
+  options: { enable: 1, policy_in: 'DROP', policy_out: 'ACCEPT', log_level_in: 'info', log_level_out: 'nolog' },
+  vlans: [20],
+}
+
+const DB: VMFirewallInfo = {
+  vmid: 101, name: 'db-01', node: 'pve2', type: 'lxc', status: 'running',
+  firewallEnabled: false, rules: [], options: null, vlans: [],
+}
+
+const ALIASES: firewallAPIType.Alias[] = [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }]
+const IPSETS: firewallAPIType.IPSet[] = [{ name: 'trusted', members: [{ cidr: '1.2.3.4' }] }]
+
+function props(overrides: Partial<React.ComponentProps<typeof VMRulesPanel>> = {}) {
+  return {
+    vmFirewallData: [WEB, DB],
+    loadingVMRules: false,
+    selectedConnection: CONN,
+    loadVMFirewallData: vi.fn().mockResolvedValue(undefined),
+    reloadVMFirewallRules: vi.fn().mockResolvedValue(undefined),
+    aliases: ALIASES,
+    ipsets: IPSETS,
+    ...overrides,
+  }
+}
+
+function renderPanel(overrides: Parameters<typeof props>[0] = {}) {
+  const p = props(overrides)
+
+  renderWithProviders(<VMRulesPanel {...p} />)
+
+  return p
+}
+
+/** A Select inside an open dialog, found from its rendered label. */
+function selectByLabel(label: string) {
+  const el = screen.queryAllByText(label).find(n => n.tagName === 'LABEL')
+
+  if (!el?.parentElement) throw new Error(`No Select labelled "${label}"`)
+
+  return within(el.parentElement).getByRole('combobox')
+}
+
+/** Open the VLAN group, then the guest section, so its rule rows render. */
+function expandTo(vmName: string, vlanLabel: string) {
+  fireEvent.click(screen.getByText(vlanLabel))
+  fireEvent.click(screen.getByText(vmName))
+}
+
+/** The table row of a guest's section header. */
+const rowOf = (text: string) => screen.getAllByRole('row').find(r => within(r).queryByText(text))!
+
+/**
+ * Wait for the rule dialog to mount. Its title text sits in a Box inside the
+ * DialogTitle rather than directly in the h2, so it is not addressable by
+ * selector; only one dialog of this panel is ever open at a time.
+ */
+const waitForRuleDialog = () =>
+  waitFor(() => expect(within(screen.getByRole('dialog')).getByLabelText('Source')).toBeInTheDocument())
+
+describe('VMRulesPanel', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.toggleVMNICFirewall.mockResolvedValue(undefined)
+    api.updateVMOptions.mockResolvedValue(undefined)
+    api.addVMRule.mockResolvedValue(undefined)
+    api.updateVMRule.mockResolvedValue(undefined)
+    api.deleteVMRule.mockResolvedValue(undefined)
+    api.getVMFirewallLog.mockResolvedValue([])
+  })
+
+  it('groups guests by their primary VLAN, untagged last', () => {
+    renderPanel()
+
+    const vlanLabels = screen.getAllByRole('row')
+      .map(r => r.textContent || '')
+      .filter(txt => txt.includes('VLAN 20') || txt.includes('Untagged'))
+
+    expect(vlanLabels[0]).toContain('VLAN 20')
+    expect(vlanLabels[1]).toContain('Untagged')
+
+    // Guests stay hidden until their VLAN group is opened.
+    expect(screen.queryByText('web-01')).not.toBeInTheDocument()
+    expect(screen.getAllByText('1 VM')).toHaveLength(2)
+    expect(screen.getByText('2 rules total')).toBeInTheDocument()
+    expect(screen.getByText('2/2 VMs • 1 protected')).toBeInTheDocument()
+  })
+
+  it('reveals a guest, then its rules with their log level', () => {
+    renderPanel()
+
+    fireEvent.click(screen.getByText('VLAN 20'))
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+
+    // The guest is still collapsed at this point.
+    expect(screen.queryByText('https in')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('web-01'))
+    expect(screen.getByText('https in')).toBeInTheDocument()
+    expect(screen.getByText('warning')).toBeInTheDocument()
+    expect(screen.getByText('TCP/443')).toBeInTheDocument()
+  })
+
+  it('offers to create a rule on a guest that has none', () => {
+    renderPanel()
+
+    expandTo('db-01', 'Untagged')
+
+    const emptyRow = screen.getAllByRole('row').find(r => within(r).queryByText('No rule configured'))!
+
+    fireEvent.click(within(emptyRow).getByRole('button', { name: 'Add rule' }))
+
+    expect(screen.getByText('db-01 (101)')).toBeInTheDocument()
+  })
+
+  it('expands and collapses every VLAN and guest at once', () => {
+    renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+    expect(screen.getByText('https in')).toBeInTheDocument()
+    expect(screen.getByText('No rule configured')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+    expect(screen.queryByText('web-01')).not.toBeInTheDocument()
+  })
+
+  it('searches guests by name, id, node and VLAN', () => {
+    renderPanel()
+
+    const search = screen.getByPlaceholderText('Search VM...')
+
+    fireEvent.change(search, { target: { value: 'db' } })
+    expect(screen.getByText('Untagged')).toBeInTheDocument()
+    expect(screen.queryByText('VLAN 20')).not.toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: '20' } })
+    expect(screen.getByText('VLAN 20')).toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'pve2' } })
+    expect(screen.getByText('Untagged')).toBeInTheDocument()
+
+    fireEvent.change(search, { target: { value: 'nothing' } })
+    expect(screen.getByText('No VM found')).toBeInTheDocument()
+  })
+
+  it('toggles a guest NIC firewall from its section switch', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    fireEvent.click(within(rowOf('web-01')).getByRole('switch'))
+
+    await waitFor(() => expect(api.toggleVMNICFirewall).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, false))
+  })
+
+  it('changes a guest inbound policy from its section select', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    const row = rowOf('web-01')
+    const inPolicy = within(row).getAllByRole('combobox')[0]
+
+    expect(inPolicy).toHaveTextContent('DROP')
+
+    fireEvent.mouseDown(inPolicy)
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'REJECT' }))
+
+    await waitFor(() => expect(api.updateVMOptions).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, { policy_in: 'REJECT' }))
+  })
+
+  it('toggles a rule Active switch through updateVMRule', async () => {
+    renderPanel()
+    expandTo('web-01', 'VLAN 20')
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('https in'))!
+
+    fireEvent.click(within(row).getByRole('switch'))
+
+    await waitFor(() => expect(api.updateVMRule).toHaveBeenCalledTimes(1))
+    expect(api.updateVMRule.mock.calls[0].slice(0, 5)).toEqual([CONN, 'pve1', 'qemu', 100, 0])
+    expect(api.updateVMRule.mock.calls[0][5]).toMatchObject({ enable: 0, log: 'warning' })
+  })
+
+  it('pre-fills the edit dialog from the rule, log level included', async () => {
+    renderPanel()
+    expandTo('web-01', 'VLAN 20')
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('https in'))!
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByText('Edit rule')).toBeInTheDocument())
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    expect(dialog.getByLabelText('Source')).toHaveValue('10.0.0.0/8')
+    expect(dialog.getByLabelText('Destination')).toHaveValue('10.0.0.5')
+    expect(dialog.getByLabelText('Port destination')).toHaveValue('443')
+    expect(dialog.getByLabelText('Port source')).toHaveValue('1024:65535')
+    expect(dialog.getByLabelText('Interface')).toHaveValue('net0')
+    expect(dialog.getByLabelText('Commentaire')).toHaveValue('https in')
+    expect(selectByLabel('Log level')).toHaveTextContent('warning')
+  })
+
+  it('opens an empty add-rule dialog and saves the picked log level', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Add rule' }))
+    await waitForRuleDialog()
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    // Every optional field starts empty on a new rule.
+    expect(dialog.getByLabelText('Source')).toHaveValue('')
+    expect(dialog.getByLabelText('Interface')).toHaveValue('')
+    expect(selectByLabel('Log level')).toHaveTextContent('nolog')
+
+    fireEvent.mouseDown(selectByLabel('Log level'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'crit' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+    expect(api.addVMRule.mock.calls[0][4]).toMatchObject({ log: 'crit', type: 'in', action: 'ACCEPT' })
+  })
+
+  it('edits the dialog fields, including source through the suggestions', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Add rule' }))
+    await waitForRuleDialog()
+
+    const dialog = within(screen.getByRole('dialog'))
+    const source = dialog.getByLabelText('Source')
+
+    fireEvent.change(source, { target: { value: 'net' } })
+    fireEvent.click(await screen.findByRole('option', { name: /net-mgmt/ }))
+    expect(source).toHaveValue('net-mgmt')
+
+    fireEvent.change(dialog.getByLabelText('Destination'), { target: { value: '10.0.0.9' } })
+    fireEvent.change(dialog.getByLabelText('Interface'), { target: { value: 'net1' } })
+    fireEvent.change(dialog.getByLabelText('Port destination'), { target: { value: '8006' } })
+    fireEvent.change(dialog.getByLabelText('Port source'), { target: { value: '1024' } })
+    fireEvent.change(dialog.getByLabelText('Commentaire'), { target: { value: 'from test' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+    expect(api.addVMRule.mock.calls[0][4]).toMatchObject({
+      source: 'net-mgmt', dest: '10.0.0.9', iface: 'net1', dport: '8006', sport: '1024', comment: 'from test',
+    })
+  })
+
+  it('clears the protocol when a macro is picked, and disables the port fields', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Add rule' }))
+    await waitForRuleDialog()
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    fireEvent.mouseDown(selectByLabel('Protocole'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'TCP' }))
+    expect(selectByLabel('Protocole')).toHaveTextContent('TCP')
+
+    fireEvent.mouseDown(selectByLabel('Macro'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'SSH' }))
+
+    // A macro carries its own ports, so the protocol is reset and the port
+    // fields go read-only rather than silently conflicting with it.
+    expect(selectByLabel('Macro')).toHaveTextContent('SSH')
+    expect(dialog.getByLabelText('Port destination')).toBeDisabled()
+    expect(dialog.getByLabelText('Port source')).toBeDisabled()
+  })
+
+  it('flips the Enabled switch of the rule dialog', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Add rule' }))
+    await waitForRuleDialog()
+
+    const toggle = within(screen.getByRole('dialog')).getByRole('switch')
+
+    expect(toggle).toBeChecked()
+    fireEvent.click(toggle)
+    expect(toggle).not.toBeChecked()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+    expect(api.addVMRule.mock.calls[0][4]).toMatchObject({ enable: 0 })
+  })
+
+  it('saves an edited rule against its position', async () => {
+    renderPanel()
+    expandTo('web-01', 'VLAN 20')
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('https in'))!
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Edit' }))
+    await waitFor(() => expect(screen.getByText('Edit rule')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(api.updateVMRule).toHaveBeenCalledTimes(1))
+    expect(api.updateVMRule.mock.calls[0][4]).toBe(0)
+    expect(api.updateVMRule.mock.calls[0][5]).toMatchObject({ log: 'warning', comment: 'https in' })
+  })
+
+  it('confirms before deleting a rule, then deletes it', async () => {
+    renderPanel()
+    expandTo('web-01', 'VLAN 20')
+
+    const row = screen.getAllByRole('row').find(r => within(r).queryByText('https in'))!
+
+    fireEvent.click(within(row).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(screen.getByText('Are you sure you want to delete this rule?')).toBeInTheDocument())
+    expect(within(screen.getByRole('dialog')).getByText(/web-01/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(api.deleteVMRule).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, 0))
+  })
+
+  it('shows the firewall log of a guest and its two log-level pickers', async () => {
+    api.getVMFirewallLog.mockResolvedValue([{ n: 1, t: 'DROP IN 10.0.0.1' }])
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Firewall Logs' }))
+
+    await waitFor(() => expect(screen.getByText('DROP IN 10.0.0.1')).toBeInTheDocument())
+    expect(api.getVMFirewallLog).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, 200)
+
+    // The guest's stored levels drive the two selects.
+    const logIn = within(screen.getByText('Log IN:').parentElement!).getByRole('combobox')
+
+    expect(logIn).toHaveTextContent('info')
+
+    fireEvent.mouseDown(logIn)
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'debug' }))
+
+    await waitFor(() => expect(api.updateVMOptions).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, { log_level_in: 'debug' }))
+  })
+
+  it('says so when a guest has no firewall log line', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('Untagged'))
+
+    fireEvent.click(within(rowOf('db-01')).getByRole('button', { name: 'Firewall Logs' }))
+
+    await waitFor(() => expect(screen.getByText('No firewall log entries')).toBeInTheDocument())
+
+    // A guest with no options falls back to PVE's own default level.
+    expect(within(screen.getByText('Log OUT:').parentElement!).getByRole('combobox')).toHaveTextContent('nolog')
+  })
+
+  it('reorders a rule by dropping it on another row', async () => {
+    renderPanel()
+    expandTo('web-01', 'VLAN 20')
+
+    const requests: Request[] = []
+
+    server.use(
+      http.put(`*/api/v1/firewall/vms/${CONN}/pve1/qemu/100/rules/0`, ({ request }) => {
+        requests.push(request.clone())
+
+        return HttpResponse.json({})
+      }),
+    )
+
+    const from = screen.getAllByRole('row').find(r => within(r).queryByText('https in'))!
+    const to = screen.getAllByRole('row').find(r => within(r).queryByText('1') && r !== from)!
+    const dataTransfer = { effectAllowed: '', dropEffect: '', setData: vi.fn(), getData: () => '0' }
+
+    fireEvent.dragStart(from, { dataTransfer })
+
+    fireEvent.dragOver(to, { dataTransfer })
+    fireEvent.drop(to, { dataTransfer })
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(await requests[0].json()).toEqual({ moveto: 1 })
+  })
+
+  it('shows a progress bar instead of the table while the rules load', () => {
+    renderPanel({ loadingVMRules: true })
+
+    expect(screen.getByText('Loading firewall rules...')).toBeInTheDocument()
+    expect(screen.queryByText('VLAN 20')).not.toBeInTheDocument()
+  })
+
+  it('offers to load the guests when there are none', () => {
+    const p = renderPanel({ vmFirewallData: [] })
+
+    expect(screen.getByText('No VM found')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load VMs' }))
+    expect(p.loadVMFirewallData).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
@@ -4,9 +4,9 @@ import { Fragment, useState, useMemo, useCallback, useRef, useEffect } from 'rea
 import { useTranslations } from 'next-intl'
 
 import {
-  Autocomplete, Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
+  Box, Button, Chip, Dialog, DialogTitle, DialogContent, DialogActions,
   FormControl, Grid, IconButton, InputLabel, LinearProgress, MenuItem, Paper, Select, Stack,
-  Switch, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, TextField, Tooltip,
+  Switch, Table, TableBody, TableCell, TableContainer, TableRow, TextField, Tooltip,
   Typography, useTheme, alpha
 } from '@mui/material'
 
@@ -14,8 +14,11 @@ import * as firewallAPI from '@/lib/api/firewall'
 import { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
 import { useToast } from '@/contexts/ToastContext'
 import LogLevelSelect from '@/components/firewall/LogLevelSelect'
-import { LOG_LEVELS, DEFAULT_LOG_LEVEL, formatLogLevel } from '@/components/firewall/logLevels'
+import { LOG_LEVELS, DEFAULT_LOG_LEVEL } from '@/components/firewall/logLevels'
 import { DEFAULT_RULE } from '../../types'
+import RulesTableHead from './shared/RulesTableHead'
+import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeadingCells, RuleTrafficCells } from './shared/RuleTableCells'
+import AliasIpsetAutocomplete, { useAliasIpsetOptions } from './shared/AliasIpsetAutocomplete'
 
 interface VMRulesPanelProps {
   vmFirewallData: VMFirewallInfo[]
@@ -28,26 +31,6 @@ interface VMRulesPanelProps {
 }
 
 // ── Helpers ──
-
-const ActionChip = ({ action }: { action: string }) => {
-  const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
-  const color = colors[action] || '#94a3b8'
-  return <Chip size="small" label={action} sx={{ height: 22, fontSize: 11, fontWeight: 700, bgcolor: alpha(color, 0.22), color, border: `1px solid ${alpha(color, 0.35)}`, minWidth: 70 }} />
-}
-
-function formatService(rule: firewallAPI.FirewallRule): string {
-  if (rule.type === 'group') return '-'
-  if (rule.macro) return rule.macro
-  const proto = rule.proto?.toUpperCase() || ''
-  const port = rule.dport || ''
-  if (!proto && !port) return 'any'
-  if (proto && port) return `${proto}/${port}`
-  return proto || port
-}
-
-// Body cells are all `p: 0.5`; without the same padding here the header
-// labels sit ~12px right of their column's values (MUI's default 16px).
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 const VLAN_COLORS = ['#f59e0b', '#3b82f6', '#8b5cf6', '#06b6d4', '#ec4899', '#10b981', '#f97316', '#6366f1', '#14b8a6', '#e11d48']
 function getVlanColor(vlanKey: string, index: number): string {
@@ -96,12 +79,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
     })
   }, [filteredVMData])
 
-  const autocompleteOptions = useMemo(() => {
-    const opts: { label: string; secondary?: string }[] = []
-    for (const a of aliases) opts.push({ label: a.name, secondary: a.cidr })
-    for (const s of ipsets) opts.push({ label: `+${s.name}`, secondary: s.comment || `${s.members?.length || 0} entries` })
-    return opts
-  }, [aliases, ipsets])
+  const autocompleteOptions = useAliasIpsetOptions(aliases, ipsets)
 
   // ── Toggle VM firewall (modifies NIC config firewall=0/1) ──
   const handleToggleVMFirewall = async (vm: VMFirewallInfo) => {
@@ -320,21 +298,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
       ) : filteredVMData.length > 0 ? (
         <TableContainer component={Paper} sx={{ border: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
           <Table size="small">
-            <TableHead>
-              <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
-                <TableCell sx={{ ...headCellSx, width: 30, p: 0.5 }}></TableCell>
-                <TableCell sx={{ ...headCellSx, width: 35 }}>#</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 55 }}>{t('common.active')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 65 }}>{t('firewall.direction')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.source')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
-                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
-                <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
-                <TableCell sx={{ width: 70 }}></TableCell>
-              </TableRow>
-            </TableHead>
+            <RulesTableHead />
             <TableBody>
               {vlanGroups.map(([vlanKey, vms], vlanIdx) => {
                 const isUntagged = vlanKey === '__untagged__'
@@ -481,60 +445,19 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                             '&:active': { cursor: 'grabbing' }
                           }}
                         >
-                          <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
-                            <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
-                          <TableCell sx={{ p: 0.5, width: 55 }}>
-                            <Switch checked={rule.enable === 1} onChange={() => handleToggleVMRuleEnable(vm, rule)} size="small" color="success" />
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 65 }}>
-                            <Chip
-                              label={isGroupRule ? 'GROUP' : rule.type?.toUpperCase() || 'IN'}
-                              size="small"
-                              sx={{
-                                height: 20, fontSize: 10, fontWeight: 600,
-                                bgcolor: isGroupRule ? alpha('#8b5cf6', 0.22) : rule.type === 'in' ? alpha('#3b82f6', 0.22) : alpha('#ec4899', 0.22),
-                                color: isGroupRule ? '#8b5cf6' : rule.type === 'in' ? '#3b82f6' : '#ec4899'
-                              }}
-                            />
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
-                            {isGroupRule ? '-' : (rule.source || 'any')}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
-                            {isGroupRule ? '-' : (rule.dest || 'any')}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
-                            {formatService(rule)}
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 90 }}>
-                            {isGroupRule ? (
-                              <Chip icon={<i className="ri-shield-line" style={{ fontSize: 10 }} />} label={rule.action} size="small" sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: alpha('#8b5cf6', 0.22), color: '#8b5cf6', '& .MuiChip-icon': { color: '#8b5cf6' } }} />
-                            ) : (
-                              <ActionChip action={rule.action || 'ACCEPT'} />
-                            )}
-                          </TableCell>
-                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
-                            {formatLogLevel(rule.log)}
-                          </TableCell>
-                          <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
-                            <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
-                          </TableCell>
-                          <TableCell sx={{ p: 0.5, width: 70 }}>
-                            <Box sx={{ display: 'flex', gap: 0 }}>
-                              <Tooltip title={t('networkPage.edit')}>
-                                <IconButton size="small" onClick={() => openVMRuleDialog(vm, rule)}>
-                                  <i className="ri-pencil-line" style={{ fontSize: 14 }} />
-                                </IconButton>
-                              </Tooltip>
-                              <Tooltip title={t('networkPage.delete')}>
-                                <IconButton size="small" color="error" onClick={() => setDeleteVMRuleConfirm({ vm, pos: rule.pos })}>
-                                  <i className="ri-delete-bin-line" style={{ fontSize: 14 }} />
-                                </IconButton>
-                              </Tooltip>
-                            </Box>
-                          </TableCell>
+                          <RuleRowLeadingCells
+                            rule={rule}
+                            isGroupRule={isGroupRule}
+                            enabled={rule.enable === 1}
+                            onToggleEnable={() => handleToggleVMRuleEnable(vm, rule)}
+                          />
+                          <RuleTrafficCells rule={rule} isGroupRule={isGroupRule} />
+                          <RuleActionCell rule={rule} isGroupRule={isGroupRule} />
+                          <RuleLogCommentCells rule={rule} />
+                          <RuleRowActionsCell
+                            onEdit={() => openVMRuleDialog(vm, rule)}
+                            onDelete={() => setDeleteVMRuleConfirm({ vm, pos: rule.pos })}
+                          />
                         </TableRow>
                       )
                     }) : (
@@ -641,50 +564,26 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
               <TextField label="Interface" value={newVMRule.iface || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, iface: e.target.value }))} fullWidth size="small" placeholder="net0" InputProps={{ sx: { fontSize: 13 } }} />
             </Grid>
             <Grid size={{ xs: 8, sm: 5 }}>
-              <Autocomplete
-                freeSolo
+              <AliasIpsetAutocomplete
                 options={autocompleteOptions}
-                getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                inputValue={newVMRule.source || ''}
-                onInputChange={(_, v) => setNewVMRule(prev => ({ ...prev, source: v }))}
-                renderOption={(props, opt) => (
-                  <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                      <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                      {typeof opt !== 'string' && opt.secondary && (
-                        <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                      )}
-                    </Box>
-                  </li>
-                )}
-                renderInput={(params) => (
-                  <TextField {...params} label="Source" fullWidth size="small" placeholder="192.168.1.0/24, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontSize: 13 } }} />
-                )}
+                value={newVMRule.source || ''}
+                onChange={(v) => setNewVMRule(prev => ({ ...prev, source: v }))}
+                label="Source"
+                placeholder="192.168.1.0/24, +ipset, alias"
+                inputSx={{ fontSize: 13 }}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 5 }}>
               <TextField label="Port source" value={newVMRule.sport || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, sport: e.target.value }))} fullWidth size="small" placeholder="80, 1024:65535" InputProps={{ sx: { fontSize: 13 } }} disabled={!!newVMRule.macro} />
             </Grid>
             <Grid size={{ xs: 12, sm: 7 }}>
-              <Autocomplete
-                freeSolo
+              <AliasIpsetAutocomplete
                 options={autocompleteOptions}
-                getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
-                inputValue={newVMRule.dest || ''}
-                onInputChange={(_, v) => setNewVMRule(prev => ({ ...prev, dest: v }))}
-                renderOption={(props, opt) => (
-                  <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                      <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
-                      {typeof opt !== 'string' && opt.secondary && (
-                        <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
-                      )}
-                    </Box>
-                  </li>
-                )}
-                renderInput={(params) => (
-                  <TextField {...params} label="Destination" fullWidth size="small" placeholder="10.0.0.0/8, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontSize: 13 } }} />
-                )}
+                value={newVMRule.dest || ''}
+                onChange={(v) => setNewVMRule(prev => ({ ...prev, dest: v }))}
+                label="Destination"
+                placeholder="10.0.0.0/8, +ipset, alias"
+                inputSx={{ fontSize: 13 }}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 5 }}>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
@@ -13,7 +13,9 @@ import {
 import * as firewallAPI from '@/lib/api/firewall'
 import { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
 import { useToast } from '@/contexts/ToastContext'
-import { DEFAULT_RULE, monoStyle } from '../../types'
+import LogLevelSelect from '@/components/firewall/LogLevelSelect'
+import { LOG_LEVELS, DEFAULT_LOG_LEVEL, formatLogLevel } from '@/components/firewall/logLevels'
+import { DEFAULT_RULE } from '../../types'
 
 interface VMRulesPanelProps {
   vmFirewallData: VMFirewallInfo[]
@@ -43,9 +45,9 @@ function formatService(rule: firewallAPI.FirewallRule): string {
   return proto || port
 }
 
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap' } as const
-
-const LOG_LEVELS = ['nolog', 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug'] as const
+// Body cells are all `p: 0.5`; without the same padding here the header
+// labels sit ~12px right of their column's values (MUI's default 16px).
+const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
 
 const VLAN_COLORS = ['#f59e0b', '#3b82f6', '#8b5cf6', '#06b6d4', '#ec4899', '#10b981', '#f97316', '#6366f1', '#14b8a6', '#e11d48']
 function getVlanColor(vlanKey: string, index: number): string {
@@ -194,7 +196,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
         type: rule.type || 'in', action: rule.action || 'ACCEPT', enable: rule.enable ?? 1,
         proto: rule.proto || '', dport: rule.dport || '', sport: rule.sport || '',
         source: rule.source || '', dest: rule.dest || '', macro: rule.macro || '',
-        iface: rule.iface || '', log: rule.log || 'nolog', comment: rule.comment || ''
+        iface: rule.iface || '', log: rule.log || DEFAULT_LOG_LEVEL, comment: rule.comment || ''
       })
     } else {
       setNewVMRule({ ...DEFAULT_RULE })
@@ -328,6 +330,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                 <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
                 <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
+                <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
                 <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
                 <TableCell sx={{ width: 70 }}></TableCell>
               </TableRow>
@@ -353,7 +356,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                       }}
                       onClick={() => setExpandedVlans(prev => { const n = new Set(prev); if (n.has(vlanKey)) n.delete(vlanKey); else n.add(vlanKey); return n })}
                     >
-                      <TableCell colSpan={10} sx={{ py: 1, px: 2 }}>
+                      <TableCell colSpan={11} sx={{ py: 1, px: 2 }}>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                           <i
                             className={isVlanExpanded ? 'ri-arrow-down-s-line' : 'ri-arrow-right-s-line'}
@@ -383,7 +386,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                             }}
                             onClick={() => setExpandedVMs(prev => { const n = new Set(prev); if (n.has(vm.vmid)) n.delete(vm.vmid); else n.add(vm.vmid); return n })}
                           >
-                            <TableCell colSpan={10} sx={{ py: 1, px: 2, pl: 5 }}>
+                            <TableCell colSpan={11} sx={{ py: 1, px: 2, pl: 5 }}>
                               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
                                   <i
@@ -394,7 +397,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                                     className={vm.type === 'qemu' ? 'ri-computer-line' : 'ri-instance-line'}
                                     style={{ fontSize: 16, color: vm.firewallEnabled ? '#22c55e' : theme.palette.text.secondary, flexShrink: 0 }}
                                   />
-                                  <code style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{vm.name}</code>
+                                  <span style={{ fontSize: 13, fontWeight: 700, whiteSpace: 'nowrap' }}>{vm.name}</span>
                                   <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 11 }}>({vm.vmid})</Typography>
                                   <Typography variant="caption" sx={{ color: 'text.secondary', fontSize: 11 }}>{vm.node}</Typography>
                                   <Chip
@@ -496,13 +499,13 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                               }}
                             />
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
                             {isGroupRule ? '-' : (rule.source || 'any')}
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
                             {isGroupRule ? '-' : (rule.dest || 'any')}
                           </TableCell>
-                          <TableCell sx={{ ...monoStyle, fontSize: 11, p: 0.5, width: 100 }}>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
                             {formatService(rule)}
                           </TableCell>
                           <TableCell sx={{ p: 0.5, width: 90 }}>
@@ -511,6 +514,9 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                             ) : (
                               <ActionChip action={rule.action || 'ACCEPT'} />
                             )}
+                          </TableCell>
+                          <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
+                            {formatLogLevel(rule.log)}
                           </TableCell>
                           <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
                             <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
@@ -533,7 +539,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                       )
                     }) : (
                       <TableRow key={`empty-${vm.vmid}`}>
-                        <TableCell colSpan={10} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+                        <TableCell colSpan={11} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
                           <Typography variant="body2">{t('networkPage.noRuleConfigured')}</Typography>
                           <Button size="small" sx={{ mt: 1 }} startIcon={<i className="ri-add-line" />} onClick={() => openVMRuleDialog(vm)}>
                             {t('networkPage.addRule')}
@@ -632,7 +638,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
               </Box>
             </Grid>
             <Grid size={{ xs: 4, sm: 2 }}>
-              <TextField label="Interface" value={newVMRule.iface || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, iface: e.target.value }))} fullWidth size="small" placeholder="net0" InputProps={{ sx: { fontFamily: 'monospace', fontSize: 13 } }} />
+              <TextField label="Interface" value={newVMRule.iface || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, iface: e.target.value }))} fullWidth size="small" placeholder="net0" InputProps={{ sx: { fontSize: 13 } }} />
             </Grid>
             <Grid size={{ xs: 8, sm: 5 }}>
               <Autocomplete
@@ -644,7 +650,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                 renderOption={(props, opt) => (
                   <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                      <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                      <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                       {typeof opt !== 'string' && opt.secondary && (
                         <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                       )}
@@ -652,12 +658,12 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                   </li>
                 )}
                 renderInput={(params) => (
-                  <TextField {...params} label="Source" fullWidth size="small" placeholder="192.168.1.0/24, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontFamily: 'monospace', fontSize: 13 } }} />
+                  <TextField {...params} label="Source" fullWidth size="small" placeholder="192.168.1.0/24, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontSize: 13 } }} />
                 )}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 5 }}>
-              <TextField label="Port source" value={newVMRule.sport || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, sport: e.target.value }))} fullWidth size="small" placeholder="80, 1024:65535" InputProps={{ sx: { fontFamily: 'monospace', fontSize: 13 } }} disabled={!!newVMRule.macro} />
+              <TextField label="Port source" value={newVMRule.sport || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, sport: e.target.value }))} fullWidth size="small" placeholder="80, 1024:65535" InputProps={{ sx: { fontSize: 13 } }} disabled={!!newVMRule.macro} />
             </Grid>
             <Grid size={{ xs: 12, sm: 7 }}>
               <Autocomplete
@@ -669,7 +675,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                 renderOption={(props, opt) => (
                   <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-                      <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+                      <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
                       {typeof opt !== 'string' && opt.secondary && (
                         <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
                       )}
@@ -677,26 +683,18 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                   </li>
                 )}
                 renderInput={(params) => (
-                  <TextField {...params} label="Destination" fullWidth size="small" placeholder="10.0.0.0/8, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontFamily: 'monospace', fontSize: 13 } }} />
+                  <TextField {...params} label="Destination" fullWidth size="small" placeholder="10.0.0.0/8, +ipset, alias" InputProps={{ ...params.InputProps, sx: { fontSize: 13 } }} />
                 )}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 5 }}>
-              <TextField label="Port destination" value={newVMRule.dport || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, dport: e.target.value }))} fullWidth size="small" placeholder="22, 80, 443, 8000:9000" InputProps={{ sx: { fontFamily: 'monospace', fontSize: 13 } }} disabled={!!newVMRule.macro} />
+              <TextField label="Port destination" value={newVMRule.dport || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, dport: e.target.value }))} fullWidth size="small" placeholder="22, 80, 443, 8000:9000" InputProps={{ sx: { fontSize: 13 } }} disabled={!!newVMRule.macro} />
             </Grid>
             <Grid size={{ xs: 12, sm: 9 }}>
               <TextField label="Commentaire" value={newVMRule.comment || ''} onChange={(e) => setNewVMRule(prev => ({ ...prev, comment: e.target.value }))} fullWidth size="small" />
             </Grid>
             <Grid size={{ xs: 12, sm: 3 }}>
-              <FormControl fullWidth size="small">
-                <InputLabel>Log level</InputLabel>
-                <Select value={newVMRule.log || 'nolog'} label="Log level" onChange={(e) => setNewVMRule(prev => ({ ...prev, log: e.target.value }))}>
-                  <MenuItem value="nolog">nolog</MenuItem>
-                  <MenuItem value="warning">warning</MenuItem>
-                  <MenuItem value="info">info</MenuItem>
-                  <MenuItem value="debug">debug</MenuItem>
-                </Select>
-              </FormControl>
+              <LogLevelSelect value={newVMRule.log} onChange={(v) => setNewVMRule(prev => ({ ...prev, log: v }))} />
             </Grid>
           </Grid>
         </DialogContent>
@@ -755,7 +753,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                 <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', fontSize: 11 }}>Log IN:</Typography>
                 <FormControl size="small">
                   <Select
-                    value={logDialog.vm.options?.log_level_in || 'nolog'}
+                    value={logDialog.vm.options?.log_level_in || DEFAULT_LOG_LEVEL}
                     onChange={(e) => { if (logDialog.vm) handleVMLogLevelChange(logDialog.vm, 'log_level_in', e.target.value) }}
                     sx={{ fontSize: 11, height: 28, minWidth: 90, '& .MuiSelect-select': { py: 0.3 } }}
                     disabled={!selectedConnection}
@@ -768,7 +766,7 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
                 <Typography variant="caption" sx={{ fontWeight: 600, color: 'text.secondary', fontSize: 11 }}>Log OUT:</Typography>
                 <FormControl size="small">
                   <Select
-                    value={logDialog.vm.options?.log_level_out || 'nolog'}
+                    value={logDialog.vm.options?.log_level_out || DEFAULT_LOG_LEVEL}
                     onChange={(e) => { if (logDialog.vm) handleVMLogLevelChange(logDialog.vm, 'log_level_out', e.target.value) }}
                     sx={{ fontSize: 11, height: 28, minWidth: 90, '& .MuiSelect-select': { py: 0.3 } }}
                     disabled={!selectedConnection}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
@@ -229,7 +229,11 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
     setVmDragState({ vmid, draggedPos: pos, dragOverPos: null })
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', pos.toString())
-    setTimeout(() => { (e.currentTarget as HTMLElement).style.opacity = '0.5' }, 0)
+    // React nulls the event's currentTarget as soon as the handler returns,
+    // so the row must be captured before the opacity change is deferred.
+    const draggedRow = e.currentTarget as HTMLElement
+
+    setTimeout(() => { draggedRow.style.opacity = '0.5' }, 0)
   }
   const handleDragEnd = (e: React.DragEvent) => {
     (e.currentTarget as HTMLElement).style.opacity = '1'

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/AliasIpsetAutocomplete.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/AliasIpsetAutocomplete.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for the source/destination field shared by the rule dialogs
+ * (cluster, host, VM/CT and security group) and for the hook that builds its
+ * suggestions.
+ *
+ * What the dialogs depend on: the field is free text — PVE takes a bare IP or
+ * CIDR — while still offering the connection's aliases and IPSets, each with
+ * its CIDR or entry count on the right; and every keystroke reaches the
+ * caller, because the panels hold the value in their own rule state.
+ *
+ * MUI's Autocomplete is driven the jsdom way: fire a change on the input,
+ * then await the option, which only exists once the popup is open. No
+ * automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { useState } from 'react'
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+
+import { renderWithProviders, screen, fireEvent } from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPI from '@/lib/api/firewall'
+
+import AliasIpsetAutocomplete, { useAliasIpsetOptions } from './AliasIpsetAutocomplete'
+
+const OPTIONS = [
+  { label: 'web-servers', secondary: '10.0.0.0/24' },
+  { label: '+blocklist', secondary: '12 entries' },
+]
+
+const input = () => screen.getByLabelText('Source') as HTMLInputElement
+
+/** The field as the dialogs use it: value held by the caller. */
+function ControlledField({ onChange }: { onChange?: (v: string) => void }) {
+  const [value, setValue] = useState('')
+
+  return (
+    <AliasIpsetAutocomplete
+      options={OPTIONS}
+      value={value}
+      onChange={v => { setValue(v); onChange?.(v) }}
+      label="Source"
+      placeholder="IP, CIDR, alias..."
+    />
+  )
+}
+
+describe('AliasIpsetAutocomplete', () => {
+  afterEach(cleanup)
+
+  it('renders the label, the placeholder and the incoming value', () => {
+    renderWithProviders(
+      <AliasIpsetAutocomplete options={OPTIONS} value="10.0.0.1" onChange={vi.fn()} label="Source" placeholder="IP, CIDR, alias..." />
+    )
+
+    expect(input()).toHaveValue('10.0.0.1')
+    expect(input()).toHaveAttribute('placeholder', 'IP, CIDR, alias...')
+  })
+
+  it('offers the aliases and IPSets with their CIDR or entry count', async () => {
+    renderWithProviders(
+      <AliasIpsetAutocomplete options={OPTIONS} value="" onChange={vi.fn()} label="Source" placeholder="IP, CIDR, alias..." />
+    )
+
+    fireEvent.change(input(), { target: { value: 'e' } })
+
+    expect(await screen.findByRole('option', { name: /web-servers/ })).toHaveTextContent('10.0.0.0/24')
+    expect(screen.getByRole('option', { name: /\+blocklist/ })).toHaveTextContent('12 entries')
+  })
+
+  it('hands every keystroke to the caller, free-text included', () => {
+    const onChange = vi.fn()
+
+    renderWithProviders(
+      <AliasIpsetAutocomplete options={OPTIONS} value="" onChange={onChange} label="Source" placeholder="IP, CIDR, alias..." />
+    )
+
+    fireEvent.change(input(), { target: { value: '192.168.1.0/24' } })
+
+    expect(onChange).toHaveBeenCalledWith('192.168.1.0/24')
+  })
+
+  it('filters the suggestions on what has been typed and yields the picked alias', async () => {
+    const onChange = vi.fn()
+
+    renderWithProviders(<ControlledField onChange={onChange} />)
+
+    fireEvent.change(input(), { target: { value: 'web' } })
+
+    const option = await screen.findByRole('option', { name: /web-servers/ })
+
+    expect(screen.getAllByRole('option')).toHaveLength(1)
+
+    fireEvent.click(option)
+
+    expect(onChange).toHaveBeenLastCalledWith('web-servers')
+    expect(input()).toHaveValue('web-servers')
+  })
+
+  it('applies the compact input style the VM/CT dialog asks for', () => {
+    renderWithProviders(
+      <AliasIpsetAutocomplete options={OPTIONS} value="" onChange={vi.fn()} label="Source" placeholder="net0" inputSx={{ fontSize: 13 }} />
+    )
+
+    // The override lands on the Input wrapper, not on the <input> itself.
+    expect(input().closest('.MuiInputBase-root')).toHaveStyle({ fontSize: '13px' })
+  })
+})
+
+describe('useAliasIpsetOptions', () => {
+  const aliases: firewallAPI.Alias[] = [{ name: 'web-servers', cidr: '10.0.0.0/24' }]
+
+  it('lists the aliases first, then the IPSets under their +name form', () => {
+    const ipsets: firewallAPI.IPSet[] = [{ name: 'blocklist', comment: 'known bad actors' }]
+
+    const { result } = renderHook(() => useAliasIpsetOptions(aliases, ipsets))
+
+    expect(result.current).toEqual([
+      { label: 'web-servers', secondary: '10.0.0.0/24' },
+      { label: '+blocklist', secondary: 'known bad actors' },
+    ])
+  })
+
+  it('falls back to the entry count when an IPSet has no comment', () => {
+    const ipsets: firewallAPI.IPSet[] = [
+      { name: 'blocklist', members: [{ cidr: '1.2.3.4' }, { cidr: '5.6.7.8' }] },
+      { name: 'empty' },
+    ]
+
+    const { result } = renderHook(() => useAliasIpsetOptions([], ipsets))
+
+    expect(result.current).toEqual([
+      { label: '+blocklist', secondary: '2 entries' },
+      { label: '+empty', secondary: '0 entries' },
+    ])
+  })
+
+  it('keeps the same array across renders so both fields of a dialog share it', () => {
+    const ipsets: firewallAPI.IPSet[] = []
+
+    const { result, rerender } = renderHook(() => useAliasIpsetOptions(aliases, ipsets))
+    const first = result.current
+
+    rerender()
+
+    expect(result.current).toBe(first)
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/AliasIpsetAutocomplete.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/AliasIpsetAutocomplete.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { Autocomplete, Box, TextField } from '@mui/material'
+import type { SxProps, Theme } from '@mui/material'
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+export interface AliasIpsetOption {
+  label: string
+  /** CIDR of an alias, or the IPSet's comment / entry count. */
+  secondary?: string
+}
+
+/**
+ * The suggestion list every rule dialog offers for source and destination:
+ * the firewall aliases first, then the IPSets, whose PVE reference form is
+ * `+name`. Memoised so the two fields of a dialog share one array, exactly
+ * as the panels did when they each carried this `useMemo`.
+ */
+export function useAliasIpsetOptions(aliases: firewallAPI.Alias[], ipsets: firewallAPI.IPSet[]): AliasIpsetOption[] {
+  return useMemo(() => {
+    const opts: AliasIpsetOption[] = []
+
+    for (const a of aliases) opts.push({ label: a.name, secondary: a.cidr })
+    for (const s of ipsets) opts.push({ label: `+${s.name}`, secondary: s.comment || `${s.members?.length || 0} entries` })
+
+    return opts
+  }, [aliases, ipsets])
+}
+
+interface AliasIpsetAutocompleteProps {
+  options: AliasIpsetOption[]
+  /** Raw PVE value: an IP, a CIDR, an alias or `+ipset`. */
+  value: string
+  onChange: (value: string) => void
+  label: string
+  placeholder: string
+  /**
+   * The VM/CT rule dialog compacts every field to 13px; the cluster, host and
+   * security group dialogs keep the MUI default, so the override is opt-in.
+   */
+  inputSx?: SxProps<Theme>
+}
+
+/**
+ * Source / destination field of a firewall rule dialog: free text (PVE takes
+ * an IP or a CIDR) with the aliases and IPSets of the connection as
+ * suggestions, each showing its CIDR or entry count on the right.
+ */
+export default function AliasIpsetAutocomplete({ options, value, onChange, label, placeholder, inputSx }: AliasIpsetAutocompleteProps) {
+  return (
+    <Autocomplete
+      freeSolo
+      options={options}
+      getOptionLabel={(opt) => typeof opt === 'string' ? opt : opt.label}
+      inputValue={value}
+      onInputChange={(_, v) => onChange(v)}
+      renderOption={(props, opt) => (
+        <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
+            <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
+            {typeof opt !== 'string' && opt.secondary && (
+              <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
+            )}
+          </Box>
+        </li>
+      )}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          fullWidth
+          size="small"
+          label={label}
+          placeholder={placeholder}
+          InputProps={inputSx ? { ...params.InputProps, sx: inputSx } : params.InputProps}
+        />
+      )}
+    />
+  )
+}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Tests for the rule row cells shared by the four rules tables.
+ *
+ * These cover what the four panels used to re-implement identically and what
+ * a reader of a rules table relies on: the position and Active switch, the
+ * direction chip, source/destination/service (including the "any" and
+ * dashed-out forms), the action chip, the log level — a dimmed dash when the
+ * rule logs nothing — the comment, and the edit/delete buttons.
+ *
+ * Two behaviours are asserted per panel-specific prop rather than per panel:
+ *   - `enabled` is passed in, because the VM/CT table counts only
+ *     `enable === 1` as on while the others count anything but `0`;
+ *   - `isGroupRule` turns a rule that references a security group purple and
+ *     collapses its traffic columns; the security groups table leaves it off
+ *     (PVE forbids nesting groups), which must keep the plain rendering.
+ *
+ * Dimmed text is asserted against the theme's own `text.disabled`, so the
+ * assertion follows the palette instead of hardcoding a colour. No automatic
+ * RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import type { ReactNode } from 'react'
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { Table, TableBody, TableRow } from '@mui/material'
+import { createTheme } from '@mui/material/styles'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import type * as firewallAPI from '@/lib/api/firewall'
+
+import {
+  RuleActionCell,
+  RuleLogCommentCells,
+  RuleRowActionsCell,
+  RuleRowLeadingCells,
+  RuleTrafficCells,
+} from './RuleTableCells'
+
+const { text } = createTheme().palette
+
+const RULE: firewallAPI.FirewallRule = { pos: 3, type: 'in', action: 'ACCEPT' }
+
+const rule = (overrides: Partial<firewallAPI.FirewallRule> = {}): firewallAPI.FirewallRule => ({ ...RULE, ...overrides })
+
+/** Cells only render inside a row; keep the table nesting valid. */
+function renderRow(cells: ReactNode) {
+  return renderWithProviders(<Table><TableBody><TableRow>{cells}</TableRow></TableBody></Table>)
+}
+
+const cells = () => screen.getAllByRole('cell')
+
+describe('RuleRowLeadingCells', () => {
+  afterEach(cleanup)
+
+  it('renders the drag handle, position, Active switch and direction', () => {
+    renderRow(<RuleRowLeadingCells rule={rule()} enabled onToggleEnable={vi.fn()} />)
+
+    expect(cells()).toHaveLength(4)
+    expect(cells()[1]).toHaveTextContent('3')
+    expect(screen.getByRole('switch')).toBeChecked()
+    expect(cells()[3]).toHaveTextContent('IN')
+  })
+
+  it('renders the switch off when the caller says the rule is disabled', () => {
+    renderRow(<RuleRowLeadingCells rule={rule({ enable: 0 })} enabled={false} onToggleEnable={vi.fn()} />)
+
+    expect(screen.getByRole('switch')).not.toBeChecked()
+  })
+
+  it('reports a toggle of the Active switch to the panel', async () => {
+    const onToggleEnable = vi.fn()
+
+    renderRow(<RuleRowLeadingCells rule={rule()} enabled onToggleEnable={onToggleEnable} />)
+
+    await userEvent.click(screen.getByRole('switch'))
+
+    expect(onToggleEnable).toHaveBeenCalledTimes(1)
+  })
+
+  it('uppercases the direction and falls back to IN when PVE sent none', () => {
+    renderRow(<RuleRowLeadingCells rule={{ pos: 1, type: '', action: 'DROP' }} enabled onToggleEnable={vi.fn()} />)
+
+    expect(cells()[3]).toHaveTextContent('IN')
+  })
+
+  it('labels an outbound rule OUT', () => {
+    renderRow(<RuleRowLeadingCells rule={rule({ type: 'out' })} enabled onToggleEnable={vi.fn()} />)
+
+    expect(cells()[3]).toHaveTextContent('OUT')
+  })
+
+  it('labels a security-group reference GROUP', () => {
+    renderRow(<RuleRowLeadingCells rule={rule({ type: 'group', action: 'sg-web' })} isGroupRule enabled onToggleEnable={vi.fn()} />)
+
+    expect(cells()[3]).toHaveTextContent('GROUP')
+  })
+})
+
+describe('RuleTrafficCells', () => {
+  afterEach(cleanup)
+
+  it('shows source and destination as PVE returned them', () => {
+    renderRow(<RuleTrafficCells rule={rule({ source: '10.0.0.0/8', dest: '+webservers' })} />)
+
+    expect(cells()[0]).toHaveTextContent('10.0.0.0/8')
+    expect(cells()[1]).toHaveTextContent('+webservers')
+    expect(cells()[0]).toHaveStyle({ color: text.primary })
+  })
+
+  it('reads an empty source or destination as a dimmed "any"', () => {
+    renderRow(<RuleTrafficCells rule={rule()} />)
+
+    expect(cells()[0]).toHaveTextContent('any')
+    expect(cells()[1]).toHaveTextContent('any')
+    expect(cells()[0]).toHaveStyle({ color: text.disabled })
+    expect(cells()[1]).toHaveStyle({ color: text.disabled })
+  })
+
+  it('dashes out the traffic columns of a group rule', () => {
+    renderRow(<RuleTrafficCells rule={rule({ type: 'group', action: 'sg-web', source: '10.0.0.1' })} isGroupRule />)
+
+    expect(cells()[0]).toHaveTextContent('-')
+    expect(cells()[1]).toHaveTextContent('-')
+    expect(cells()[2]).toHaveTextContent('-')
+    expect(cells()[0]).toHaveStyle({ color: text.disabled })
+  })
+
+  it.each([
+    ['the macro when the rule uses one', { macro: 'SSH', proto: 'tcp', dport: '22' }, 'SSH'],
+    ['protocol and port together', { proto: 'tcp', dport: '443' }, 'TCP/443'],
+    ['the protocol alone', { proto: 'udp' }, 'UDP'],
+    ['the port alone', { dport: '8006' }, '8006'],
+    ['"any" when the rule matches everything', {}, 'any'],
+  ])('renders %s in the Service column', (_label, overrides, expected) => {
+    renderRow(<RuleTrafficCells rule={rule(overrides)} />)
+
+    expect(cells()[2]).toHaveTextContent(expected)
+  })
+})
+
+describe('RuleActionCell', () => {
+  afterEach(cleanup)
+
+  it.each(['ACCEPT', 'DROP', 'REJECT'])('renders the %s chip', action => {
+    renderRow(<RuleActionCell rule={rule({ action })} />)
+
+    expect(cells()[0]).toHaveTextContent(action)
+  })
+
+  it('falls back to ACCEPT when PVE sent no action', () => {
+    renderRow(<RuleActionCell rule={{ pos: 1, type: 'in', action: '' }} />)
+
+    expect(cells()[0]).toHaveTextContent('ACCEPT')
+  })
+
+  it('renders an unknown action as-is rather than dropping it', () => {
+    renderRow(<RuleActionCell rule={rule({ action: 'NFLOG' })} />)
+
+    expect(cells()[0]).toHaveTextContent('NFLOG')
+  })
+
+  it('names the referenced security group for a group rule', () => {
+    renderRow(<RuleActionCell rule={rule({ type: 'group', action: 'sg-web' })} isGroupRule />)
+
+    expect(cells()[0]).toHaveTextContent('sg-web')
+  })
+})
+
+describe('RuleLogCommentCells', () => {
+  afterEach(cleanup)
+
+  it('shows the level of a rule that logs', () => {
+    renderRow(<RuleLogCommentCells rule={rule({ log: 'warning' })} />)
+
+    expect(cells()[0]).toHaveTextContent('warning')
+    expect(cells()[0]).toHaveStyle({ color: text.primary })
+  })
+
+  it.each([
+    ['nolog', 'nolog'],
+    ['absent', undefined],
+    ['empty', ''],
+    ['unrecognised', 'verbose'],
+  ])('dims a dash when the log level is %s', (_label, log) => {
+    renderRow(<RuleLogCommentCells rule={rule({ log })} />)
+
+    expect(cells()[0]).toHaveTextContent('-')
+    expect(cells()[0]).toHaveStyle({ color: text.disabled })
+  })
+
+  it('shows the comment, and a dash when there is none', () => {
+    renderRow(<RuleLogCommentCells rule={rule({ comment: 'allow monitoring' })} />)
+    expect(cells()[1]).toHaveTextContent('allow monitoring')
+
+    cleanup()
+
+    renderRow(<RuleLogCommentCells rule={rule()} />)
+    expect(cells()[1]).toHaveTextContent('-')
+  })
+})
+
+describe('RuleRowActionsCell', () => {
+  afterEach(cleanup)
+
+  it('calls the panel back when edit is clicked', async () => {
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+
+    renderRow(<RuleRowActionsCell onEdit={onEdit} onDelete={onDelete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onDelete).not.toHaveBeenCalled()
+  })
+
+  it('calls the panel back when delete is clicked', async () => {
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+
+    renderRow(<RuleRowActionsCell onEdit={onEdit} onDelete={onDelete} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    expect(onDelete).toHaveBeenCalledTimes(1)
+    expect(onEdit).not.toHaveBeenCalled()
+  })
+})
+
+describe('a full rule row', () => {
+  afterEach(cleanup)
+
+  it('fills the eleven columns of the rules tables', () => {
+    const r = rule({ source: 'any', dest: '10.0.0.5', proto: 'tcp', dport: '22', log: 'info', comment: 'ssh' })
+
+    renderRow(
+      <>
+        <RuleRowLeadingCells rule={r} enabled onToggleEnable={vi.fn()} />
+        <RuleTrafficCells rule={r} />
+        <RuleActionCell rule={r} />
+        <RuleLogCommentCells rule={r} />
+        <RuleRowActionsCell onEdit={vi.fn()} onDelete={vi.fn()} />
+      </>
+    )
+
+    // Same count as RulesTableHead renders, which is what the panels' colSpan
+    // on their section and empty rows is pinned to.
+    expect(cells()).toHaveLength(11)
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.tsx
@@ -1,0 +1,163 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
+import { Box, Chip, IconButton, Switch, TableCell, Tooltip, useTheme, alpha } from '@mui/material'
+
+import * as firewallAPI from '@/lib/api/firewall'
+import { formatLogLevel } from '@/components/firewall/logLevels'
+
+/**
+ * The cells a firewall rule row is made of, shared by the four rules tables
+ * (cluster policy, hosts, VMs/CTs, security groups).
+ *
+ * Each export is a fragment of `<TableCell>`s, not a whole `<TableRow>`: the
+ * row itself carries per-panel drag & drop wiring and the security groups
+ * table slips its own "Applied to" cell between Service and Action, so the
+ * panels keep the row and compose these groups inside it.
+ *
+ * Column widths are duplicated from RulesTableHead on purpose (MUI needs
+ * them on the cells too); the two files must stay in step.
+ */
+
+// Colour of the ACCEPT/DROP/REJECT chip. Deliberately NOT the ActionChip of
+// `@/components/firewall/shared`: that one is drawn lighter (alpha 0.15/0.3)
+// and belongs to the VM/node firewall tabs. These four tables use 0.22/0.35.
+const ActionChip = ({ action }: { action: string }) => {
+  const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
+  const color = colors[action] || '#94a3b8'
+
+  return <Chip size="small" label={action} sx={{ height: 22, fontSize: 11, fontWeight: 700, bgcolor: alpha(color, 0.22), color, border: `1px solid ${alpha(color, 0.35)}`, minWidth: 70 }} />
+}
+
+interface RuleCellsProps {
+  rule: firewallAPI.FirewallRule
+  /**
+   * A `type: 'group'` rule references a security group instead of describing
+   * traffic: source, destination and service collapse to a dash and the
+   * direction/action chips turn purple. Only cluster, host and VM/CT rules
+   * can be group rules — PVE security groups cannot nest, so the security
+   * groups table leaves this off and keeps its plain rendering.
+   */
+  isGroupRule?: boolean
+}
+
+interface RuleLeadingCellsProps extends RuleCellsProps {
+  /**
+   * Whether the rule's Active switch reads as on. Passed in rather than
+   * derived: the VM/CT table treats only `enable === 1` as enabled while the
+   * others treat anything but `0` as enabled.
+   */
+  enabled: boolean
+  onToggleEnable: () => void
+}
+
+/** Drag handle, position, Active switch and direction chip. */
+export function RuleRowLeadingCells({ rule, isGroupRule = false, enabled, onToggleEnable }: RuleLeadingCellsProps) {
+  const theme = useTheme()
+
+  return (
+    <>
+      <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
+        <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
+      </TableCell>
+      <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
+      <TableCell sx={{ p: 0.5, width: 55 }}>
+        <Switch checked={enabled} onChange={onToggleEnable} size="small" color="success" />
+      </TableCell>
+      <TableCell sx={{ p: 0.5, width: 65 }}>
+        <Chip
+          label={isGroupRule ? 'GROUP' : rule.type?.toUpperCase() || 'IN'}
+          size="small"
+          sx={{
+            height: 20, fontSize: 10, fontWeight: 600,
+            bgcolor: isGroupRule ? alpha('#8b5cf6', 0.22) : rule.type === 'in' ? alpha('#3b82f6', 0.22) : alpha('#ec4899', 0.22),
+            color: isGroupRule ? '#8b5cf6' : rule.type === 'in' ? '#3b82f6' : '#ec4899'
+          }}
+        />
+      </TableCell>
+    </>
+  )
+}
+
+/** Protocol and port merged into one "Service" column, PVE macro first. */
+function formatService(rule: firewallAPI.FirewallRule): string {
+  if (rule.type === 'group') return '-'
+  if (rule.macro) return rule.macro
+  const proto = rule.proto?.toUpperCase() || ''
+  const port = rule.dport || ''
+  if (!proto && !port) return 'any'
+  if (proto && port) return `${proto}/${port}`
+
+  return proto || port
+}
+
+/** Source, Destination and Service. */
+export function RuleTrafficCells({ rule, isGroupRule = false }: RuleCellsProps) {
+  return (
+    <>
+      <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
+        {isGroupRule ? '-' : (rule.source || 'any')}
+      </TableCell>
+      <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
+        {isGroupRule ? '-' : (rule.dest || 'any')}
+      </TableCell>
+      <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
+        {formatService(rule)}
+      </TableCell>
+    </>
+  )
+}
+
+/** ACCEPT/DROP/REJECT, or the referenced security group for a group rule. */
+export function RuleActionCell({ rule, isGroupRule = false }: RuleCellsProps) {
+  return (
+    <TableCell sx={{ p: 0.5, width: 90 }}>
+      {isGroupRule ? (
+        <Chip icon={<i className="ri-shield-line" style={{ fontSize: 10 }} />} label={rule.action} size="small" sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: alpha('#8b5cf6', 0.22), color: '#8b5cf6', '& .MuiChip-icon': { color: '#8b5cf6' } }} />
+      ) : (
+        <ActionChip action={rule.action || 'ACCEPT'} />
+      )}
+    </TableCell>
+  )
+}
+
+/** Log level (a dimmed dash when the rule logs nothing) and comment. */
+export function RuleLogCommentCells({ rule }: { rule: firewallAPI.FirewallRule }) {
+  // Resolved once: the dash is both the text and the cue to dim the cell.
+  const logLevel = formatLogLevel(rule.log)
+  const logsNothing = logLevel === '-'
+
+  return (
+    <>
+      <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: logsNothing ? 'text.disabled' : 'text.primary' }}>
+        {logLevel}
+      </TableCell>
+      <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
+        <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
+      </TableCell>
+    </>
+  )
+}
+
+/** Trailing edit / delete buttons. */
+export function RuleRowActionsCell({ onEdit, onDelete }: { onEdit: () => void; onDelete: () => void }) {
+  const t = useTranslations()
+
+  return (
+    <TableCell sx={{ p: 0.5, width: 70 }}>
+      <Box sx={{ display: 'flex', gap: 0 }}>
+        <Tooltip title={t('networkPage.edit')}>
+          <IconButton size="small" onClick={onEdit}>
+            <i className="ri-pencil-line" style={{ fontSize: 14 }} />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={t('networkPage.delete')}>
+          <IconButton size="small" color="error" onClick={onDelete}>
+            <i className="ri-delete-bin-line" style={{ fontSize: 14 }} />
+          </IconButton>
+        </Tooltip>
+      </Box>
+    </TableCell>
+  )
+}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Tests for the header row shared by the four rules tables (cluster policy,
+ * hosts, VMs/CTs and security groups), which each used to carry their own
+ * copy of it.
+ *
+ * The contract asserted here is the column list itself — labels, order, and
+ * the count — because the panels pin `colSpan` on their section and empty
+ * rows against it: 11 columns normally, 12 for security groups, whose
+ * "Applied to" column sits between Service and Action. Labels come from the
+ * real English bundle, so a missing translation key fails the test.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { Table } from '@mui/material'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+
+import RulesTableHead from './RulesTableHead'
+
+/** The nine rule columns, framed by the drag-handle and actions columns. */
+const COLUMNS = ['', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Action', 'Log level', 'Comment', '']
+
+const headers = () => screen.getAllByRole('columnheader').map(th => th.textContent)
+
+describe('RulesTableHead', () => {
+  afterEach(cleanup)
+
+  it('renders the eleven columns of a rules table, in order', () => {
+    renderWithProviders(<Table><RulesTableHead /></Table>)
+
+    expect(headers()).toEqual(COLUMNS)
+  })
+
+  it('inserts "Applied to" between Service and Action for security groups', () => {
+    renderWithProviders(<Table><RulesTableHead showAppliedTo /></Table>)
+
+    expect(headers()).toEqual([
+      '', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Applied To', 'Action', 'Log level', 'Comment', '',
+    ])
+  })
+
+  it('leaves the drag-handle and actions columns unlabelled', () => {
+    renderWithProviders(<Table><RulesTableHead /></Table>)
+
+    const cells = screen.getAllByRole('columnheader')
+
+    expect(cells[0]).toBeEmptyDOMElement()
+    expect(cells[cells.length - 1]).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
+import { TableCell, TableHead, TableRow, useTheme, alpha } from '@mui/material'
+
+// ── Column header style ──
+// Body cells are all `p: 0.5`; without the same padding here the header
+// labels sit ~12px right of their column's values (MUI's default 16px).
+// Single source of truth for the four rules tables (cluster policy, hosts,
+// VMs/CTs and security groups), which used to carry a copy each.
+const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
+
+interface RulesTableHeadProps {
+  /**
+   * Security groups get one extra column, "Applied to", between Service and
+   * Action: it counts the VMs whose rules reference the group. Every other
+   * rules table (cluster, host, VM/CT) has nothing to show there, so the
+   * column is opt-in rather than rendered empty.
+   */
+  showAppliedTo?: boolean
+}
+
+/**
+ * The header row every rules table shares: a leading drag-handle column, the
+ * nine rule columns and a trailing actions column — 11 columns, 12 with
+ * `showAppliedTo`. Column widths are part of the contract: the body cells
+ * pin the same widths, so a change here must be mirrored in the row cells
+ * (see RuleTableCells.tsx).
+ */
+export default function RulesTableHead({ showAppliedTo = false }: RulesTableHeadProps) {
+  const theme = useTheme()
+  const t = useTranslations()
+
+  return (
+    <TableHead>
+      <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
+        <TableCell sx={{ ...headCellSx, width: 30, p: 0.5 }}></TableCell>
+        <TableCell sx={{ ...headCellSx, width: 35 }}>#</TableCell>
+        <TableCell sx={{ ...headCellSx, width: 55 }}>{t('common.active')}</TableCell>
+        <TableCell sx={{ ...headCellSx, width: 65 }}>{t('firewall.direction')}</TableCell>
+        <TableCell sx={headCellSx}>{t('network.source')}</TableCell>
+        <TableCell sx={headCellSx}>{t('network.destination')}</TableCell>
+        <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
+        {showAppliedTo && <TableCell sx={{ ...headCellSx, width: 90 }}>{t('networkPage.appliedTo')}</TableCell>}
+        <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
+        <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
+        <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
+        <TableCell sx={{ width: 70 }}></TableCell>
+      </TableRow>
+    </TableHead>
+  )
+}

--- a/frontend/src/app/(dashboard)/automation/network/types.ts
+++ b/frontend/src/app/(dashboard)/automation/network/types.ts
@@ -14,8 +14,6 @@ export const GROUP_COLORS = [
 
 export const getGroupColor = (index: number): string => GROUP_COLORS[index % GROUP_COLORS.length]
 
-export const monoStyle = { fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace', fontSize: 13 }
-
 export const DEFAULT_RULE: firewallAPI.CreateRuleRequest = {
   type: 'in', action: 'ACCEPT', enable: 1, proto: '', dport: '', sport: '', source: '', dest: '', macro: '', iface: '', log: 'nolog', comment: ''
 }

--- a/frontend/src/components/VmFirewallTab.test.tsx
+++ b/frontend/src/components/VmFirewallTab.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Component tests for VmFirewallTab.tsx — the add-rule payload must carry the
+ * log level.
+ *
+ * The tab does not submit the dialog's draft rule as-is: it rebuilds the
+ * payload field by field before handing it to the shared state hook. Any
+ * field missing from that literal is silently dropped, which is exactly how
+ * the log level picked by the user used to be lost. So the assertions here
+ * are on the object handed to `addVMRule`, not on the dialog's own state
+ * (that round trip is covered in FirewallDialogs.test.tsx).
+ *
+ * The tab fetches on mount: the firewall API module is mocked wholesale, and
+ * the one raw `fetch` it does — the guest config, used to build the NIC
+ * table — is served by MSW. The jsdom setup errors on unhandled requests, so
+ * a missing fixture fails the test rather than yielding empty data.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+vi.mock('@/lib/api/firewall', () => ({
+  getVMOptions: vi.fn(),
+  getVMRules: vi.fn(),
+  getSecurityGroups: vi.fn(),
+  updateVMOptions: vi.fn(),
+  addVMRule: vi.fn(),
+  updateVMRule: vi.fn(),
+  deleteVMRule: vi.fn(),
+  getAliases: vi.fn(),
+  getIPSets: vi.fn(),
+  getVMFirewallLog: vi.fn(),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import VmFirewallTab from './VmFirewallTab'
+
+const CONN_ID = 'conn-1'
+const NODE = 'pve1'
+const VMID = 100
+
+const PROPS = { connectionId: CONN_ID, node: NODE, vmType: 'qemu' as const, vmid: VMID, vmName: 'web-01' }
+
+const api = firewallAPI as unknown as Record<string, ReturnType<typeof vi.fn>>
+
+// The log dialog auto-scrolls to its last line; jsdom implements no layout, so
+// scrollIntoView does not exist there. Stubbed locally rather than in the
+// shared jsdom setup, since only this component needs it.
+Element.prototype.scrollIntoView ??= vi.fn()
+
+const LOG_LABEL = 'Log level'
+
+/** The Log level Select inside the open add-rule dialog, found from its label. */
+function logLevel() {
+  const label = screen.queryAllByText(LOG_LABEL).find(el => el.tagName === 'LABEL')
+
+  if (!label?.parentElement) throw new Error('Log level select not rendered')
+
+  return within(label.parentElement).getByRole('combobox')
+}
+
+function seedConfig(config: Record<string, unknown> = { net0: 'virtio=AA:BB:CC:DD:EE:FF,bridge=vmbr0,firewall=1' }) {
+  server.use(
+    http.get(`*/api/v1/connections/${CONN_ID}/guests/qemu/${NODE}/${VMID}/config`, () =>
+      HttpResponse.json(config),
+    ),
+  )
+}
+
+/** Render and wait for the mount fetches to settle into the rules table. */
+async function renderTab() {
+  renderWithProviders(<VmFirewallTab {...PROPS} />)
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Add rule' })).toBeInTheDocument())
+}
+
+/** Open the add-rule dialog and wait for its Log level picker. */
+async function openAddRuleDialog() {
+  fireEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+  await waitFor(() => expect(screen.getByText('Add rule', { selector: 'h2' })).toBeInTheDocument())
+}
+
+const submitAddRule = () => fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+
+describe('VmFirewallTab', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    api.getVMOptions.mockResolvedValue({ enable: 1, policy_in: 'DROP', policy_out: 'ACCEPT', log_level_in: 'nolog', log_level_out: 'nolog' })
+    api.getVMRules.mockResolvedValue([
+      { pos: 0, type: 'in', action: 'ACCEPT', enable: 1, proto: 'tcp', dport: '22', log: 'warning', comment: 'ssh' },
+    ])
+    api.getSecurityGroups.mockResolvedValue([{ group: 'webserver' }])
+    api.getAliases.mockResolvedValue([{ name: 'web-front', cidr: '10.0.0.0/24' }])
+    api.getIPSets.mockResolvedValue([{ name: 'blocklist', members: [{ cidr: '1.2.3.4' }] }])
+    api.addVMRule.mockResolvedValue(undefined)
+    api.updateVMRule.mockResolvedValue(undefined)
+    api.updateVMOptions.mockResolvedValue(undefined)
+    api.getVMFirewallLog.mockResolvedValue([])
+    seedConfig()
+  })
+
+  it('sends the default log level when the user does not touch the picker', async () => {
+    await renderTab()
+    await openAddRuleDialog()
+
+    expect(logLevel()).toHaveTextContent('nolog')
+
+    submitAddRule()
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+
+    // The full payload, so a field silently dropped from the literal fails
+    // here too. `log` is never an empty string: PVE's default is "nolog".
+    expect(api.addVMRule).toHaveBeenCalledWith(CONN_ID, NODE, 'qemu', VMID, {
+      type: 'in',
+      action: 'ACCEPT',
+      enable: 1,
+      proto: undefined,
+      dport: undefined,
+      source: undefined,
+      dest: undefined,
+      log: 'nolog',
+      comment: undefined,
+    })
+  })
+
+  it('sends the level the user picked (the field this PR stopped dropping)', async () => {
+    await renderTab()
+    await openAddRuleDialog()
+
+    fireEvent.mouseDown(logLevel())
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'crit' }))
+
+    expect(logLevel()).toHaveTextContent('crit')
+
+    submitAddRule()
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+    expect(api.addVMRule.mock.calls[0][4]).toMatchObject({ log: 'crit', type: 'in', action: 'ACCEPT' })
+  })
+
+  it('drops "any" from source and dest while keeping the log level', async () => {
+    await renderTab()
+    await openAddRuleDialog()
+
+    // Source/dest are Autocompletes here (aliases + ipsets are loaded)
+    fireEvent.change(screen.getByLabelText('Source'), { target: { value: 'any' } })
+    fireEvent.change(screen.getByLabelText('Destination'), { target: { value: '10.0.0.9' } })
+
+    fireEvent.mouseDown(logLevel())
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'info' }))
+
+    submitAddRule()
+
+    await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
+    expect(api.addVMRule.mock.calls[0][4]).toMatchObject({ source: undefined, dest: '10.0.0.9', log: 'info' })
+  })
+
+  it('shows the rule log level in the table', async () => {
+    await renderTab()
+    expect(screen.getByText('warning')).toBeInTheDocument()
+  })
+
+  it('builds the NIC table from the guest config', async () => {
+    await renderTab()
+
+    await waitFor(() => expect(screen.getByText('net0')).toBeInTheDocument())
+    expect(screen.getByText('vmbr0')).toBeInTheDocument()
+    expect(screen.getByText('AA:BB:CC:DD:EE:FF')).toBeInTheDocument()
+    expect(screen.getByText('Enabled')).toBeInTheDocument()
+  })
+
+  it('omits the NIC card when the guest has no network device', async () => {
+    seedConfig({})
+    await renderTab()
+
+    expect(screen.queryByText('net0')).not.toBeInTheDocument()
+    expect(screen.queryByText('Network')).not.toBeInTheDocument()
+  })
+
+  it('marks a NIC without firewall as disabled', async () => {
+    seedConfig({ net0: 'e1000=11:22:33:44:55:66,bridge=vmbr1,firewall=0' })
+    await renderTab()
+
+    await waitFor(() => expect(screen.getByText('vmbr1')).toBeInTheDocument())
+    expect(screen.getByText('Disabled')).toBeInTheDocument()
+  })
+
+  it('surfaces a rules-fetch failure as a blocking alert instead of an empty table', async () => {
+    api.getVMRules.mockRejectedValue(new Error('PVE unreachable'))
+
+    renderWithProviders(<VmFirewallTab {...PROPS} />)
+
+    await waitFor(() => expect(screen.getByText('PVE unreachable')).toBeInTheDocument())
+    expect(screen.queryByRole('button', { name: 'Add rule' })).not.toBeInTheDocument()
+  })
+
+  it('updates the log level options from the log dialog', async () => {
+    await renderTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Firewall Logs' }))
+
+    await waitFor(() => expect(screen.getByText('Log IN:')).toBeInTheDocument())
+
+    const inSelect = within(screen.getByText('Log IN:').parentElement!).getByRole('combobox')
+
+    fireEvent.mouseDown(inSelect)
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'debug' }))
+
+    await waitFor(() => expect(api.updateVMOptions).toHaveBeenCalledWith(CONN_ID, NODE, 'qemu', VMID, { log_level_in: 'debug' }))
+  })
+})

--- a/frontend/src/components/VmFirewallTab.tsx
+++ b/frontend/src/components/VmFirewallTab.tsx
@@ -35,7 +35,7 @@ import {
 import * as firewallAPI from '@/lib/api/firewall'
 
 import { useFirewallState } from './firewall/useFirewallState'
-import { LOG_LEVELS, MONO_STYLE, cleanSourceDest } from './firewall/shared'
+import { LOG_LEVELS, DEFAULT_LOG_LEVEL, cleanSourceDest } from './firewall/shared'
 import FirewallRulesTable from './firewall/FirewallRulesTable'
 import FirewallDialogs from './firewall/FirewallDialogs'
 import type { FirewallAPIAdapter, NicInfo, FirewallLogEntry } from './firewall/types'
@@ -130,7 +130,6 @@ export default function VmFirewallTab({ connectionId, node, vmType, vmid, vmName
               if (key === 'model') nic.model = value
             })
 
-
             // If no explicit model, detect from first part
             if (!nic.model) {
               const firstPart = parts[0]
@@ -214,6 +213,9 @@ export default function VmFirewallTab({ connectionId, node, vmType, vmid, vmName
       dport: fw.newRule.dport || undefined,
       source: cleanSourceDest(fw.newRule.source) || undefined,
       dest: cleanSourceDest(fw.newRule.dest) || undefined,
+      // The dialog always resolves a level, but this payload is built field by
+      // field: without this line the log level picked by the user is dropped.
+      log: fw.newRule.log || DEFAULT_LOG_LEVEL,
       comment: fw.newRule.comment || undefined,
     }
 
@@ -270,9 +272,9 @@ export default function VmFirewallTab({ connectionId, node, vmType, vmid, vmName
                   <TableBody>
                     {nics.map((nic) => (
                       <TableRow key={nic.id}>
-                        <TableCell sx={MONO_STYLE}>{nic.id}</TableCell>
-                        <TableCell sx={MONO_STYLE}>{nic.bridge}</TableCell>
-                        <TableCell sx={MONO_STYLE}>{nic.mac || '-'}</TableCell>
+                        <TableCell>{nic.id}</TableCell>
+                        <TableCell>{nic.bridge}</TableCell>
+                        <TableCell>{nic.mac || '-'}</TableCell>
                         <TableCell>
                           <Chip
                             size="small"

--- a/frontend/src/components/firewall/FirewallDialogs.test.tsx
+++ b/frontend/src/components/firewall/FirewallDialogs.test.tsx
@@ -1,0 +1,360 @@
+/**
+ * Component tests for FirewallDialogs.tsx — the Log level picker added to the
+ * add-rule and edit-rule dialogs.
+ *
+ * The dialogs are controlled: every field pushes back through a setter prop.
+ * A picker wired to a setter that drops the field would still *render*, so
+ * these tests drive the real round trip through a small stateful harness —
+ * pick a level, and assert both that the control shows it and that the state
+ * the parent would submit now carries `log`. That is the defect this PR
+ * fixes, so asserting on state rather than on the DOM alone is the point.
+ *
+ * A group rule is not a filterable rule — it is a reference to a security
+ * group — so the edit dialog's group branch must NOT offer a log level. That
+ * branch gets its own test.
+ *
+ * MUI's InputLabel here carries no `id` and the Selects no `labelId`, so a
+ * combobox has no accessible name (same limitation noted in
+ * CreateLxcDialog.test.tsx). Rather than indexing into getAllByRole, which
+ * would silently follow any column reshuffle, the Log level control is found
+ * from its own rendered label — the real `firewall.logLevel` string.
+ */
+
+import { useEffect, useState } from 'react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+
+import FirewallDialogs from './FirewallDialogs'
+import type { FirewallRule, SecurityGroup } from './types'
+
+const LOG_LABEL = 'Log level'
+
+const GROUPS: SecurityGroup[] = [
+  { group: 'webserver', comment: 'HTTP + HTTPS' },
+  { group: 'dbserver' },
+]
+
+const AUTOCOMPLETE_OPTIONS = [
+  { label: 'web-front', secondary: '10.0.0.0/24' },
+  { label: '+blocklist', secondary: '12 entries' },
+]
+
+/**
+ * The FormControl that owns the Log level Select, located from its label.
+ * Returns null when the picker is absent, which the group-branch test needs.
+ */
+function logLevelControl(): HTMLElement | null {
+  const label = screen.queryAllByText(LOG_LABEL).find(el => el.tagName === 'LABEL')
+
+  if (!label?.parentElement) return null
+
+  return within(label.parentElement).getByRole('combobox')
+}
+
+const logLevel = () => {
+  const control = logLevelControl()
+
+  if (!control) throw new Error('Log level select not rendered')
+
+  return control
+}
+
+/** Open the Log level dropdown and pick a level. */
+function pickLogLevel(level: string) {
+  fireEvent.mouseDown(logLevel())
+  fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: level }))
+}
+
+/**
+ * The dialog state as the parent component holds it. The harness reports it
+ * through a spy after every commit, so a test can assert on the very object
+ * the parent would submit.
+ */
+type Observed = { newRule: Partial<FirewallRule>; editingRule: FirewallRule | null }
+
+type HarnessProps = {
+  onState: (state: Observed) => void
+  initialNewRule?: Partial<FirewallRule>
+  initialEditingRule?: FirewallRule | null
+  addRuleOpen?: boolean
+  editRuleOpen?: boolean
+  addGroupOpen?: boolean
+  deleteConfirmOpen?: boolean
+  autocompleteOptions?: typeof AUTOCOMPLETE_OPTIONS
+  directionLabel?: string
+  saving?: boolean
+  onAddRule?: () => void
+  onUpdateRule?: () => void
+  onAddSecurityGroup?: () => void
+  onDeleteRule?: () => void
+}
+
+/**
+ * Holds the dialog state the way VmFirewallTab / the host and cluster panels
+ * do, so the setter props exercised here are the real ones.
+ */
+function Harness({
+  onState,
+  initialNewRule = { type: 'in', action: 'ACCEPT', enable: 1, log: 'nolog' },
+  initialEditingRule = null,
+  addRuleOpen = false,
+  editRuleOpen = false,
+  addGroupOpen = false,
+  deleteConfirmOpen = false,
+  autocompleteOptions,
+  directionLabel,
+  saving = false,
+  onAddRule = vi.fn(),
+  onUpdateRule = vi.fn(),
+  onAddSecurityGroup = vi.fn(),
+  onDeleteRule = vi.fn(),
+}: HarnessProps) {
+  const [newRule, setNewRule] = useState<Partial<FirewallRule>>(initialNewRule)
+  const [editingRule, setEditingRule] = useState<FirewallRule | null>(initialEditingRule)
+  const [selectedGroup, setSelectedGroup] = useState('')
+
+  useEffect(() => {
+    onState({ newRule, editingRule })
+  }, [onState, newRule, editingRule])
+
+  return (
+    <FirewallDialogs
+      addRuleOpen={addRuleOpen}
+      setAddRuleOpen={vi.fn()}
+      newRule={newRule}
+      setNewRule={setNewRule}
+      saving={saving}
+      onAddRule={onAddRule}
+      addGroupOpen={addGroupOpen}
+      setAddGroupOpen={vi.fn()}
+      selectedGroup={selectedGroup}
+      setSelectedGroup={setSelectedGroup}
+      availableGroups={GROUPS}
+      onAddSecurityGroup={onAddSecurityGroup}
+      editRuleOpen={editRuleOpen}
+      setEditRuleOpen={vi.fn()}
+      editingRule={editingRule}
+      setEditingRule={setEditingRule}
+      onUpdateRule={onUpdateRule}
+      deleteConfirmOpen={deleteConfirmOpen}
+      setDeleteConfirmOpen={vi.fn()}
+      ruleToDelete={deleteConfirmOpen ? 0 : null}
+      onDeleteRule={onDeleteRule}
+      autocompleteOptions={autocompleteOptions}
+      directionLabel={directionLabel}
+    />
+  )
+}
+
+/**
+ * Renders the harness and returns a reader for the latest committed state,
+ * so assertions read `state().newRule` after an interaction.
+ */
+function renderHarness(props: Omit<HarnessProps, 'onState'> = {}) {
+  const onState = vi.fn<(state: Observed) => void>()
+
+  renderWithProviders(<Harness onState={onState} {...props} />)
+
+  return () => onState.mock.lastCall![0]
+}
+
+const RULE: FirewallRule = {
+  pos: 3,
+  type: 'out',
+  action: 'DROP',
+  enable: 1,
+  source: '10.0.0.5',
+  dest: '',
+  proto: 'tcp',
+  dport: '443',
+  log: 'warning',
+  comment: 'block egress',
+}
+
+describe('FirewallDialogs — add rule dialog', () => {
+  afterEach(cleanup)
+
+  it('offers a Log level picker defaulting to nolog', () => {
+    renderHarness({ addRuleOpen: true })
+
+    expect(screen.getByText('Add rule')).toBeInTheDocument()
+    expect(logLevel()).toHaveTextContent('nolog')
+  })
+
+  it('falls back to nolog when the draft rule has no log field yet', () => {
+    renderHarness({ addRuleOpen: true, initialNewRule: { type: 'in', action: 'ACCEPT' } })
+    expect(logLevel()).toHaveTextContent('nolog')
+  })
+
+  it('writes the picked level into the draft rule', () => {
+    const state = renderHarness({ addRuleOpen: true })
+
+    pickLogLevel('warning')
+
+    expect(state().newRule.log).toBe('warning')
+    expect(logLevel()).toHaveTextContent('warning')
+  })
+
+  it('keeps the rest of the draft rule intact when the level changes', () => {
+    const state = renderHarness({
+      addRuleOpen: true,
+      initialNewRule: { type: 'out', action: 'DROP', proto: 'tcp', dport: '22', comment: 'ssh' },
+    })
+
+    pickLogLevel('info')
+
+    expect(state().newRule).toEqual({
+      type: 'out', action: 'DROP', proto: 'tcp', dport: '22', comment: 'ssh', log: 'info',
+    })
+  })
+
+  it('renders plain Source/Destination text fields when no autocomplete catalogue is given', () => {
+    const state = renderHarness({ addRuleOpen: true })
+
+    const source = screen.getByLabelText('Source')
+
+    fireEvent.change(source, { target: { value: '10.0.0.0/8' } })
+    expect(state().newRule.source).toBe('10.0.0.0/8')
+
+    fireEvent.change(screen.getByLabelText('Destination'), { target: { value: 'web-front' } })
+    expect(state().newRule.dest).toBe('web-front')
+  })
+
+  it('renders alias/ipset autocompletes when a catalogue is given, and keeps the Log level picker', () => {
+    const state = renderHarness({ addRuleOpen: true, autocompleteOptions: AUTOCOMPLETE_OPTIONS })
+
+    const source = screen.getByLabelText('Source')
+
+    fireEvent.change(source, { target: { value: 'web' } })
+    expect(state().newRule.source).toBe('web')
+
+    // The option row renders the label and its secondary (CIDR / entry count)
+    const option = within(screen.getByRole('listbox')).getByRole('option')
+
+    expect(option).toHaveTextContent('web-front')
+    expect(option).toHaveTextContent('10.0.0.0/24')
+
+    expect(logLevel()).toHaveTextContent('nolog')
+  })
+
+  it('uses the caller-supplied direction label', () => {
+    renderHarness({ addRuleOpen: true, directionLabel: 'Direction' })
+    expect(screen.getAllByText('Direction').length).toBeGreaterThan(0)
+  })
+
+  it('defaults the direction label to Type', () => {
+    renderHarness({ addRuleOpen: true })
+    expect(screen.getAllByText('Type').length).toBeGreaterThan(0)
+  })
+
+  it('submits through onAddRule and disables the button while saving', () => {
+    const onAddRule = vi.fn()
+
+    renderHarness({ addRuleOpen: true, onAddRule })
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }))
+    expect(onAddRule).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    renderHarness({ addRuleOpen: true, saving: true })
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+  })
+})
+
+describe('FirewallDialogs — edit rule dialog', () => {
+  afterEach(cleanup)
+
+  it('shows the rule’s current level', () => {
+    renderHarness({ editRuleOpen: true, initialEditingRule: RULE })
+
+    expect(screen.getByText('Edit rule')).toBeInTheDocument()
+    expect(logLevel()).toHaveTextContent('warning')
+  })
+
+  it('shows nolog for a rule PVE returned without a log field', () => {
+    renderHarness({ editRuleOpen: true, initialEditingRule: { ...RULE, log: undefined } })
+    expect(logLevel()).toHaveTextContent('nolog')
+  })
+
+  it('writes the picked level into the edited rule without losing its position', () => {
+    const state = renderHarness({ editRuleOpen: true, initialEditingRule: RULE })
+
+    pickLogLevel('debug')
+
+    expect(state().editingRule).toEqual({ ...RULE, log: 'debug' })
+    expect(logLevel()).toHaveTextContent('debug')
+  })
+
+  it('submits through onUpdateRule', () => {
+    const onUpdateRule = vi.fn()
+
+    renderHarness({ editRuleOpen: true, initialEditingRule: RULE, onUpdateRule })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onUpdateRule).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not offer a Log level for a security-group rule', () => {
+    renderHarness({
+      editRuleOpen: true,
+      initialEditingRule: { pos: 0, type: 'group', action: 'webserver', enable: 1 },
+    })
+
+    // The group branch shows the group name and an enable switch, nothing else
+    expect(screen.getByText('Edit Security Group')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('webserver')).toBeDisabled()
+    expect(logLevelControl()).toBeNull()
+  })
+
+  it('lets a security-group rule be enabled and commented', () => {
+    const state = renderHarness({
+      editRuleOpen: true,
+      initialEditingRule: { pos: 0, type: 'group', action: 'webserver', enable: 1 },
+    })
+
+    fireEvent.click(screen.getByRole('switch'))
+    expect(state().editingRule?.enable).toBe(0)
+
+    fireEvent.change(screen.getByLabelText('Comment'), { target: { value: 'front tier' } })
+    expect(state().editingRule?.comment).toBe('front tier')
+  })
+})
+
+describe('FirewallDialogs — group and delete dialogs', () => {
+  afterEach(cleanup)
+
+  it('lists the available security groups and confirms the pick', () => {
+    renderHarness({ addGroupOpen: true })
+
+    expect(screen.getByText('Add Security Group')).toBeInTheDocument()
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+
+    const listbox = screen.getByRole('listbox')
+
+    expect(within(listbox).getByText('HTTP + HTTPS')).toBeInTheDocument()
+
+    fireEvent.click(within(listbox).getByRole('option', { name: /webserver/ }))
+
+    expect(screen.getByText(/The Security Group webserver rules will be applied/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).not.toBeDisabled()
+  })
+
+  it('keeps Add disabled until a group is selected', () => {
+    renderHarness({ addGroupOpen: true })
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled()
+  })
+
+  it('asks for confirmation before deleting a rule', () => {
+    const onDeleteRule = vi.fn()
+
+    renderHarness({ deleteConfirmOpen: true, onDeleteRule })
+
+    expect(screen.getByText('Confirm deletion')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(onDeleteRule).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/firewall/FirewallDialogs.tsx
+++ b/frontend/src/components/firewall/FirewallDialogs.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mui/material'
 
 import type { FirewallRule, SecurityGroup } from './types'
-import { MONO_STYLE } from './shared'
+import LogLevelSelect from './LogLevelSelect'
 
 interface AutocompleteOption {
   label: string
@@ -100,7 +100,7 @@ export default function FirewallDialogs({
   const renderAutocompleteOption = (props: React.HTMLAttributes<HTMLLIElement>, opt: string | AutocompleteOption) => (
     <li {...props} key={typeof opt === 'string' ? opt : opt.label}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', width: '100%' }}>
-        <code style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</code>
+        <span style={{ fontSize: 12 }}>{typeof opt === 'string' ? opt : opt.label}</span>
         {typeof opt !== 'string' && opt.secondary && (
           <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 8 }}>{opt.secondary}</span>
         )}
@@ -133,7 +133,7 @@ export default function FirewallDialogs({
                   size="small"
                   placeholder="IP, CIDR, alias, +ipset"
                   helperText="CIDR, alias, ou +ipset"
-                  InputProps={{ ...params.InputProps, sx: MONO_STYLE }}
+                 
                 />
               )}
             />
@@ -154,7 +154,7 @@ export default function FirewallDialogs({
                   size="small"
                   placeholder="IP, CIDR, alias, +ipset"
                   helperText="CIDR, alias, ou +ipset"
-                  InputProps={{ ...params.InputProps, sx: MONO_STYLE }}
+                 
                 />
               )}
             />
@@ -174,7 +174,7 @@ export default function FirewallDialogs({
             fullWidth
             size="small"
             helperText="CIDR, alias, ou +ipset"
-            InputProps={{ sx: MONO_STYLE }}
+
           />
         </Grid>
         <Grid size={{ xs: 6 }}>
@@ -186,7 +186,7 @@ export default function FirewallDialogs({
             fullWidth
             size="small"
             helperText="CIDR, alias, ou +ipset"
-            InputProps={{ sx: MONO_STYLE }}
+
           />
         </Grid>
       </>
@@ -250,7 +250,7 @@ export default function FirewallDialogs({
                 placeholder="22, 80:443"
                 fullWidth
                 size="small"
-                InputProps={{ sx: MONO_STYLE }}
+
               />
             </Grid>
             {renderSourceDestFields(
@@ -259,6 +259,12 @@ export default function FirewallDialogs({
               (v) => setNewRule((prev: Partial<FirewallRule>) => ({ ...prev, source: v })),
               (v) => setNewRule((prev: Partial<FirewallRule>) => ({ ...prev, dest: v })),
             )}
+            <Grid size={{ xs: 6, sm: 3 }}>
+              <LogLevelSelect
+                value={newRule.log}
+                onChange={(v) => setNewRule((prev: Partial<FirewallRule>) => ({ ...prev, log: v }))}
+              />
+            </Grid>
             <Grid size={{ xs: 12 }}>
               <TextField
                 label={t('network.comment')}
@@ -330,7 +336,6 @@ export default function FirewallDialogs({
                   size="small"
                   disabled
                   InputProps={{
-                    sx: MONO_STYLE,
                     startAdornment: <i className="ri-shield-check-line" style={{ marginRight: 8, color: theme.palette.primary.main }} />
                   }}
                 />
@@ -409,7 +414,7 @@ export default function FirewallDialogs({
                   onChange={(e) => setEditingRule((prev: FirewallRule | null) => prev ? { ...prev, dport: e.target.value } : null)}
                   fullWidth
                   size="small"
-                  InputProps={{ sx: MONO_STYLE }}
+
                 />
               </Grid>
               {renderSourceDestFields(
@@ -418,6 +423,12 @@ export default function FirewallDialogs({
                 (v) => setEditingRule((prev: FirewallRule | null) => prev ? { ...prev, source: v } : null),
                 (v) => setEditingRule((prev: FirewallRule | null) => prev ? { ...prev, dest: v } : null),
               )}
+              <Grid size={{ xs: 6, sm: 3 }}>
+                <LogLevelSelect
+                  value={editingRule?.log}
+                  onChange={(v) => setEditingRule((prev: FirewallRule | null) => prev ? { ...prev, log: v } : null)}
+                />
+              </Grid>
               <Grid size={{ xs: 12 }}>
                 <TextField
                   label={t('network.comment')}

--- a/frontend/src/components/firewall/FirewallRulesTable.test.tsx
+++ b/frontend/src/components/firewall/FirewallRulesTable.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Component tests for FirewallRulesTable.tsx — the Log level column.
+ *
+ * The table renders two different column layouts (`variant="vm"` for the
+ * guest firewall tab, `variant="node"` for host/cluster), and the Log level
+ * cell deliberately sits *outside* that conditional so both layouts stay in
+ * step. A column added inside one branch only is exactly the defect this
+ * suite is here to catch, so the assertions are positional: they check that
+ * the header cell and the body cell land on the same index within each
+ * layout, not merely that the text appears somewhere in the table.
+ *
+ * Log level display is asserted through the four cases PVE can produce:
+ * a real level, the explicit `nolog`, no `log` key at all, and a value the
+ * UI does not know — the last three all collapsing to a dash.
+ *
+ * Header labels come from the real English bundle (`firewall.logLevel` =
+ * "Log level"), so a missing translation key fails the test.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+
+import FirewallRulesTable, { type TableVariant } from './FirewallRulesTable'
+import type { FirewallRule, SecurityGroup } from './types'
+
+const LOG_HEADER = 'Log level'
+
+/**
+ * Index of the Log level cell in each layout. It is the second-to-last
+ * column before Comment and the actions cell, and the two layouts do not
+ * have the same number of columns before it — which is the whole point.
+ */
+const LOG_CELL_INDEX: Record<TableVariant, number> = {
+  // drag, #, Active, Dir, Source, Dest, Service, Action, [Log level], Comment, actions
+  vm: 8,
+  // drag, #, Active, Type, Action, Source, Dest, Proto, Port, [Log level], Comment, actions
+  node: 9,
+}
+
+const RULES: FirewallRule[] = [
+  // A rule that genuinely logs
+  { pos: 0, type: 'in', action: 'ACCEPT', enable: 1, source: '10.0.0.0/8', dest: '192.168.1.10', proto: 'tcp', dport: '22', log: 'warning', comment: 'ssh' },
+  // PVE's explicit "no logging" — noise in a list, so it must read as a dash
+  { pos: 1, type: 'out', action: 'DROP', enable: 0, log: 'nolog' },
+  // No `log` key at all, the common case for pre-existing rules
+  { pos: 2, type: 'in', action: 'REJECT', enable: 1, source: '', dest: '' },
+  // A security group reference, plus a level the UI does not know
+  { pos: 3, type: 'group', action: 'webserver', enable: 1, log: 'chatty' },
+]
+
+const GROUPS: SecurityGroup[] = [{ group: 'webserver' }]
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof FirewallRulesTable>> = {}) {
+  return {
+    rules: RULES,
+    saving: false,
+    draggedRule: null,
+    dragOverRule: null,
+    availableGroups: GROUPS,
+    variant: 'vm' as TableVariant,
+    onAddRuleOpen: vi.fn(),
+    onAddGroupOpen: vi.fn(),
+    onToggleRule: vi.fn(),
+    onEditRule: vi.fn(),
+    onDeleteRule: vi.fn(),
+    onDragStart: vi.fn(),
+    onDragEnd: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragLeave: vi.fn(),
+    onDrop: vi.fn(),
+    ...overrides,
+  }
+}
+
+/** [thead row, ...tbody rows] split, so header and body indexes line up. */
+function rows() {
+  const [head, body] = screen.getAllByRole('rowgroup')
+
+  return {
+    headerCells: within(within(head).getByRole('row')).getAllByRole('columnheader'),
+    bodyRows: within(body).getAllByRole('row'),
+  }
+}
+
+const logCells = (variant: TableVariant) =>
+  rows().bodyRows.map(row => within(row).getAllByRole('cell')[LOG_CELL_INDEX[variant]])
+
+describe.each<TableVariant>(['vm', 'node'])('FirewallRulesTable (variant=%s) — Log level column', (variant) => {
+  afterEach(cleanup)
+
+  it('places the Log level header between the layout columns and Comment', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ variant })} />)
+
+    const { headerCells } = rows()
+
+    expect(headerCells[LOG_CELL_INDEX[variant]]).toHaveTextContent(LOG_HEADER)
+    expect(headerCells[LOG_CELL_INDEX[variant] + 1]).toHaveTextContent('Comment')
+
+    // Exactly one Log level column, in both layouts
+    expect(headerCells.filter(c => c.textContent === LOG_HEADER)).toHaveLength(1)
+  })
+
+  it('shows the level for a rule that logs, and a dash for every rule that does not', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ variant })} />)
+
+    // Same order as RULES: warning / nolog / no log key / unknown level
+    expect(logCells(variant).map(c => c.textContent)).toEqual(['warning', '-', '-', '-'])
+  })
+
+  it('keeps the body cells aligned with the header (same column count)', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ variant })} />)
+
+    const { headerCells, bodyRows } = rows()
+
+    for (const row of bodyRows) {
+      expect(within(row).getAllByRole('cell')).toHaveLength(headerCells.length)
+    }
+  })
+})
+
+describe('FirewallRulesTable — rendering and callbacks', () => {
+  afterEach(cleanup)
+
+  it('renders the empty state instead of a table when there are no rules', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ rules: [] })} />)
+
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    expect(screen.getByText('Add a Security Group or a direct rule')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+
+  it('shows the rule count and the evaluation-order hint', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps()} />)
+
+    expect(screen.getByText(String(RULES.length))).toBeInTheDocument()
+    expect(screen.getByText(/Rules are evaluated from top to bottom/)).toBeInTheDocument()
+  })
+
+  it('disables the Security Group button when no group is available', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ availableGroups: [] })} />)
+    expect(screen.getByRole('button', { name: 'Security Group' })).toBeDisabled()
+  })
+
+  it('renders headerExtra next to the action buttons', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ headerExtra: <span>policy widgets</span> })} />)
+    expect(screen.getByText('policy widgets')).toBeInTheDocument()
+  })
+
+  it('wires the header buttons', () => {
+    const props = makeProps()
+
+    renderWithProviders(<FirewallRulesTable {...props} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add rule' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Security Group' }))
+
+    expect(props.onAddRuleOpen).toHaveBeenCalledTimes(1)
+    expect(props.onAddGroupOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('wires the per-row toggle, edit and delete controls', () => {
+    const props = makeProps()
+
+    renderWithProviders(<FirewallRulesTable {...props} />)
+
+    const firstRow = rows().bodyRows[0]
+
+    fireEvent.click(within(firstRow).getByRole('switch'))
+    expect(props.onToggleRule).toHaveBeenCalledWith(RULES[0])
+
+    const [edit, remove] = within(firstRow).getAllByRole('button')
+
+    fireEvent.click(edit)
+    expect(props.onEditRule).toHaveBeenCalledWith(RULES[0])
+
+    fireEvent.click(remove)
+    expect(props.onDeleteRule).toHaveBeenCalledWith(RULES[0].pos)
+  })
+
+  it('disables the row switches while a save is in flight', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ saving: true })} />)
+
+    for (const box of screen.getAllByRole('switch')) expect(box).toBeDisabled()
+  })
+
+  it('forwards the drag-and-drop events with the row position', () => {
+    const props = makeProps()
+
+    renderWithProviders(<FirewallRulesTable {...props} />)
+
+    const secondRow = rows().bodyRows[1]
+
+    fireEvent.dragStart(secondRow)
+    fireEvent.dragOver(secondRow)
+    fireEvent.dragLeave(secondRow)
+    fireEvent.drop(secondRow)
+    fireEvent.dragEnd(secondRow)
+
+    expect(props.onDragStart).toHaveBeenCalledWith(expect.anything(), RULES[1].pos)
+    expect(props.onDragOver).toHaveBeenCalledWith(expect.anything(), RULES[1].pos)
+    expect(props.onDrop).toHaveBeenCalledWith(expect.anything(), RULES[1].pos)
+    expect(props.onDragLeave).toHaveBeenCalledTimes(1)
+    expect(props.onDragEnd).toHaveBeenCalledTimes(1)
+  })
+
+  it('highlights the dragged and drop-target rows without dropping the Log level cell', () => {
+    renderWithProviders(
+      <FirewallRulesTable {...makeProps({ draggedRule: 0, dragOverRule: 1 })} />,
+    )
+
+    // The drag styling lives on the row; the column layout must be untouched
+    expect(logCells('vm').map(c => c.textContent)).toEqual(['warning', '-', '-', '-'])
+  })
+
+  it('renders a group rule as a GROUP chip carrying the group name', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps()} />)
+
+    expect(screen.getByText('GROUP')).toBeInTheDocument()
+    expect(screen.getByText('webserver')).toBeInTheDocument()
+  })
+
+  it('renders a group rule in the node layout with the group name spelled out', () => {
+    renderWithProviders(<FirewallRulesTable {...makeProps({ variant: 'node' })} />)
+
+    expect(screen.getByText('GROUP')).toBeInTheDocument()
+    expect(screen.getByText('webserver')).toBeInTheDocument()
+  })
+
+  it('falls back to Unknown for a group rule with no action', () => {
+    const orphan: FirewallRule = { pos: 9, type: 'group', action: '', enable: 1 }
+
+    renderWithProviders(<FirewallRulesTable {...makeProps({ rules: [orphan] })} />)
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/firewall/FirewallRulesTable.tsx
+++ b/frontend/src/components/firewall/FirewallRulesTable.tsx
@@ -21,7 +21,8 @@ import {
 } from '@mui/material'
 
 import type { FirewallRule, SecurityGroup } from './types'
-import { ActionChip, MONO_STYLE, formatService } from './shared'
+import { ActionChip, formatService } from './shared'
+import { formatLogLevel } from './logLevels'
 
 export type TableVariant = 'vm' | 'node'
 
@@ -116,27 +117,31 @@ export default function FirewallRulesTable({
             <TableHead>
               <TableRow sx={{ bgcolor: alpha(theme.palette.background.default, 0.5) }}>
                 <TableCell sx={{ fontWeight: 700, width: 30, p: 0.5 }}></TableCell>
-                <TableCell sx={{ fontWeight: 700, width: 35 }}>#</TableCell>
-                <TableCell sx={{ fontWeight: 700, width: 55 }}>Active</TableCell>
+                <TableCell sx={{ fontWeight: 700, p: 0.5, width: 35 }}>#</TableCell>
+                <TableCell sx={{ fontWeight: 700, p: 0.5, width: 55 }}>Active</TableCell>
                 {variant === 'vm' ? (
                   <>
-                    <TableCell sx={{ fontWeight: 700, width: 70 }}>{t('firewall.direction')}</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Source</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Dest</TableCell>
-                    <TableCell sx={{ fontWeight: 700, width: 100 }}>{t('firewall.service')}</TableCell>
-                    <TableCell sx={{ fontWeight: 700, width: 90 }}>{t('firewall.action')}</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 70 }}>{t('firewall.direction')}</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5 }}>Source</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5 }}>Dest</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 100 }}>{t('firewall.service')}</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 90 }}>{t('firewall.action')}</TableCell>
                   </>
                 ) : (
                   <>
-                    <TableCell sx={{ fontWeight: 700, width: 70 }}>Type</TableCell>
-                    <TableCell sx={{ fontWeight: 700, width: 180 }}>Action</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Source</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Dest</TableCell>
-                    <TableCell sx={{ fontWeight: 700, width: 60 }}>Proto</TableCell>
-                    <TableCell sx={{ fontWeight: 700, width: 70 }}>Port</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 70 }}>Type</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 180 }}>Action</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5 }}>Source</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5 }}>Dest</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 60 }}>Proto</TableCell>
+                    <TableCell sx={{ fontWeight: 700, p: 0.5, width: 70 }}>Port</TableCell>
                   </>
                 )}
-                <TableCell sx={{ fontWeight: 700 }}>{t('network.comment')}</TableCell>
+                {/* Log level + Comment are shared by both variants, so they stay
+                    outside the conditional above — that is what keeps the two
+                    column layouts in step with the body cells. */}
+                <TableCell sx={{ fontWeight: 700, p: 0.5, width: 80 }}>{t('firewall.logLevel')}</TableCell>
+                <TableCell sx={{ fontWeight: 700, p: 0.5 }}>{t('network.comment')}</TableCell>
                 <TableCell sx={{ width: 90 }}></TableCell>
               </TableRow>
             </TableHead>
@@ -208,17 +213,17 @@ export default function FirewallRulesTable({
                         </TableCell>
 
                         {/* Source */}
-                        <TableCell sx={{ ...MONO_STYLE, color: (isGroup || !rule.source) ? 'text.disabled' : 'text.primary', fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ color: (isGroup || !rule.source) ? 'text.disabled' : 'text.primary', fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.source || 'any')}
                         </TableCell>
 
                         {/* Dest */}
-                        <TableCell sx={{ ...MONO_STYLE, color: (isGroup || !rule.dest) ? 'text.disabled' : 'text.primary', fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ color: (isGroup || !rule.dest) ? 'text.disabled' : 'text.primary', fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.dest || 'any')}
                         </TableCell>
 
                         {/* Service (proto+port merged) */}
-                        <TableCell sx={{ ...MONO_STYLE, fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ fontSize: 11, p: 0.5 }}>
                           {formatService(rule)}
                         </TableCell>
 
@@ -281,26 +286,31 @@ export default function FirewallRulesTable({
                         </TableCell>
 
                         {/* Source */}
-                        <TableCell sx={{ ...MONO_STYLE, color: rule.source ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ color: rule.source ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.source || 'any')}
                         </TableCell>
 
                         {/* Dest */}
-                        <TableCell sx={{ ...MONO_STYLE, color: rule.dest ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ color: rule.dest ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.dest || 'any')}
                         </TableCell>
 
                         {/* Proto */}
-                        <TableCell sx={{ ...MONO_STYLE, fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.proto || 'any')}
                         </TableCell>
 
                         {/* Port */}
-                        <TableCell sx={{ ...MONO_STYLE, color: rule.dport ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
+                        <TableCell sx={{ color: rule.dport ? 'text.primary' : 'text.disabled', fontSize: 11, p: 0.5 }}>
                           {isGroup ? '-' : (rule.dport || '-')}
                         </TableCell>
                       </>
                     )}
+
+                    {/* Log level — shared by both variants, like the Comment cell below */}
+                    <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: formatLogLevel(rule.log) === '-' ? 'text.disabled' : 'text.primary' }}>
+                      {formatLogLevel(rule.log)}
+                    </TableCell>
 
                     {/* Comment */}
                     <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>

--- a/frontend/src/components/firewall/LogLevelSelect.test.tsx
+++ b/frontend/src/components/firewall/LogLevelSelect.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Component tests for LogLevelSelect.tsx — the shared per-rule log level
+ * picker introduced with the PVE `log` parameter support.
+ *
+ * What matters here is the contract every rule dialog now depends on:
+ *   - the nine PVE levels are all offered, in the Proxmox order;
+ *   - an absent, empty or unrecognised incoming value renders as `nolog`
+ *     rather than an out-of-range MUI value (which shows an empty control);
+ *   - picking a level hands the caller the raw PVE token, not a label;
+ *   - `disabled` reaches the control, so a saving dialog cannot be edited.
+ *
+ * The label is asserted through the real English bundle (`firewall.logLevel`
+ * = "Log level"), so a missing translation key fails the test. It cannot be
+ * used to *find* the control: MUI's InputLabel here carries no `id` and the
+ * Select no `labelId`, so the combobox has no accessible name — the same
+ * limitation documented in CreateLxcDialog.test.tsx. This component renders
+ * exactly one combobox, so `getByRole('combobox')` is unambiguous.
+ *
+ * Opening goes through `fireEvent.mouseDown`, the event MUI's Select listens
+ * to, rather than userEvent.click: emotion's `Mui-disabled` rule sets
+ * pointer-events to none and user-event refuses to click such a node, which
+ * would make the disabled assertion pass for the wrong reason.
+ *
+ * No automatic RTL cleanup is configured in this repo, hence afterEach.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, within } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+} from '@/__tests__/setup/renderWithProviders'
+
+import LogLevelSelect from './LogLevelSelect'
+import { LOG_LEVELS } from './logLevels'
+
+const LABEL = 'Log level'
+
+const trigger = () => screen.getByRole('combobox')
+
+/** Open the dropdown and return its listbox. */
+function openMenu() {
+  fireEvent.mouseDown(trigger())
+
+  return screen.getByRole('listbox')
+}
+
+describe('LogLevelSelect', () => {
+  afterEach(cleanup)
+
+  it('offers the nine PVE levels in the Proxmox order', () => {
+    renderWithProviders(<LogLevelSelect value="nolog" onChange={vi.fn()} />)
+
+    const options = within(openMenu()).getAllByRole('option')
+
+    expect(options.map(o => o.textContent)).toEqual([
+      'nolog', 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug',
+    ])
+
+    // Guards against the rendered list and the module drifting apart
+    expect(options).toHaveLength(LOG_LEVELS.length)
+  })
+
+  it('labels the control from the translation bundle', () => {
+    renderWithProviders(<LogLevelSelect value="info" onChange={vi.fn()} />)
+
+    // Rendered twice by the outlined variant (label + notched-outline legend)
+    expect(screen.getAllByText(LABEL).length).toBeGreaterThan(0)
+  })
+
+  it('shows the incoming level', () => {
+    renderWithProviders(<LogLevelSelect value="warning" onChange={vi.fn()} />)
+    expect(trigger()).toHaveTextContent('warning')
+  })
+
+  it('normalises a level PVE returned in mixed case or padded', () => {
+    renderWithProviders(<LogLevelSelect value="  WARNING  " onChange={vi.fn()} />)
+    expect(trigger()).toHaveTextContent('warning')
+  })
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['empty', ''],
+    ['unknown', 'verbose'],
+  ])('falls back to nolog when the value is %s', (_label, value) => {
+    renderWithProviders(<LogLevelSelect value={value} onChange={vi.fn()} />)
+    expect(trigger()).toHaveTextContent('nolog')
+  })
+
+  it('calls onChange with the raw PVE level when a level is picked', () => {
+    const onChange = vi.fn()
+
+    renderWithProviders(<LogLevelSelect value="nolog" onChange={onChange} />)
+
+    fireEvent.click(within(openMenu()).getByRole('option', { name: 'warning' }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith('warning')
+  })
+
+  it('honours disabled: the control cannot be opened', () => {
+    const onChange = vi.fn()
+
+    renderWithProviders(<LogLevelSelect value="crit" onChange={onChange} disabled />)
+
+    expect(trigger()).toHaveAttribute('aria-disabled', 'true')
+
+    fireEvent.mouseDown(trigger())
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('is enabled by default', () => {
+    renderWithProviders(<LogLevelSelect value="crit" onChange={vi.fn()} />)
+
+    expect(trigger()).not.toHaveAttribute('aria-disabled')
+    expect(within(openMenu()).getAllByRole('option')).not.toHaveLength(0)
+  })
+})

--- a/frontend/src/components/firewall/LogLevelSelect.tsx
+++ b/frontend/src/components/firewall/LogLevelSelect.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material'
+
+import { LOG_LEVELS, resolveLogLevel } from './logLevels'
+
+interface LogLevelSelectProps {
+  /** Current value of the rule's PVE `log` parameter. */
+  value?: string | null
+  onChange: (value: string) => void
+  disabled?: boolean
+}
+
+/**
+ * Log level picker for a single firewall rule (PVE `log` parameter).
+ *
+ * Shared by every rule dialog — cluster, host, VM/CT and security group —
+ * so the nine levels and the `nolog` default are wired the same way
+ * everywhere instead of each dialog offering its own subset.
+ */
+export default function LogLevelSelect({ value, onChange, disabled }: LogLevelSelectProps) {
+  const t = useTranslations()
+  const label = t('firewall.logLevel')
+
+  // Widened on purpose: keeps the MUI Select generic on `string`, like every
+  // other Select in the firewall dialogs.
+  const level: string = resolveLogLevel(value)
+
+  return (
+    <FormControl fullWidth size="small" disabled={disabled}>
+      <InputLabel>{label}</InputLabel>
+      <Select value={level} label={label} onChange={(e) => onChange(e.target.value)}>
+        {LOG_LEVELS.map(option => (<MenuItem key={option} value={option}>{option}</MenuItem>))}
+      </Select>
+    </FormControl>
+  )
+}

--- a/frontend/src/components/firewall/logLevels.test.ts
+++ b/frontend/src/components/firewall/logLevels.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the firewall log level constants and resolver (#682).
+ *
+ * The level list used to be duplicated (shared.tsx and VMRulesPanel), with
+ * a third dialog hardcoding only four of the nine values, so the list is
+ * asserted here as a contract: nine PVE levels, `nolog` first, no
+ * duplicates. `resolveLogLevel` guards the `<Select>` value — PVE can
+ * return nothing at all for a rule that was created without a log level,
+ * and an out-of-range value makes MUI render an empty control.
+ *
+ * `formatLogLevel` is the read-only counterpart, used by the five rules
+ * tables: it is asserted here so the `nolog` → `-` collapse stays in one
+ * place instead of being re-derived in each table.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { LOG_LEVELS, DEFAULT_LOG_LEVEL, resolveLogLevel, formatLogLevel } from './logLevels'
+
+describe('LOG_LEVELS', () => {
+  it('lists the nine levels PVE accepts, with nolog first', () => {
+    expect(LOG_LEVELS).toEqual(['nolog', 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug'])
+  })
+
+  it('contains no duplicate level', () => {
+    expect(new Set(LOG_LEVELS).size).toBe(LOG_LEVELS.length)
+  })
+
+  it('defaults to a level that is part of the list', () => {
+    expect(LOG_LEVELS).toContain(DEFAULT_LOG_LEVEL)
+    expect(DEFAULT_LOG_LEVEL).toBe('nolog')
+  })
+})
+
+describe('resolveLogLevel', () => {
+  it('keeps every level PVE can return', () => {
+    for (const level of LOG_LEVELS) {
+      expect(resolveLogLevel(level)).toBe(level)
+    }
+  })
+
+  it('falls back to nolog when the rule carries no log level', () => {
+    expect(resolveLogLevel(undefined)).toBe('nolog')
+    expect(resolveLogLevel(null)).toBe('nolog')
+    expect(resolveLogLevel('')).toBe('nolog')
+    expect(resolveLogLevel('   ')).toBe('nolog')
+  })
+
+  it('falls back to nolog on an unknown value instead of leaking it to the Select', () => {
+    expect(resolveLogLevel('verbose')).toBe('nolog')
+    expect(resolveLogLevel('WARN')).toBe('nolog')
+    expect(resolveLogLevel('4')).toBe('nolog')
+  })
+
+  it('accepts a level PVE echoed back with different case or padding', () => {
+    expect(resolveLogLevel('WARNING')).toBe('warning')
+    expect(resolveLogLevel(' Info ')).toBe('info')
+  })
+
+  it('never resolves to an empty string, which PVE rejects', () => {
+    for (const value of [undefined, null, '', ' ', 'nope', 'debug']) {
+      expect(resolveLogLevel(value)).not.toBe('')
+    }
+  })
+})
+
+describe('formatLogLevel', () => {
+  it('shows the level for every rule that actually logs', () => {
+    for (const level of LOG_LEVELS.filter(l => l !== 'nolog')) {
+      expect(formatLogLevel(level)).toBe(level)
+    }
+  })
+
+  it('collapses nolog to a dash — it is the case for most rules', () => {
+    expect(formatLogLevel('nolog')).toBe('-')
+  })
+
+  it('shows a dash when the rule carries no log level at all', () => {
+    expect(formatLogLevel(undefined)).toBe('-')
+    expect(formatLogLevel(null)).toBe('-')
+    expect(formatLogLevel('')).toBe('-')
+    expect(formatLogLevel('   ')).toBe('-')
+  })
+
+  it('shows a dash rather than an unknown value PVE echoed back', () => {
+    expect(formatLogLevel('verbose')).toBe('-')
+    expect(formatLogLevel('4')).toBe('-')
+  })
+
+  it('normalises case and padding like resolveLogLevel does', () => {
+    expect(formatLogLevel('WARNING')).toBe('warning')
+    expect(formatLogLevel(' Info ')).toBe('info')
+    expect(formatLogLevel(' NOLOG ')).toBe('-')
+  })
+
+  it('never renders an empty cell', () => {
+    for (const value of [undefined, null, '', ' ', 'nope', ...LOG_LEVELS]) {
+      expect(formatLogLevel(value)).not.toBe('')
+    }
+  })
+})

--- a/frontend/src/components/firewall/logLevels.ts
+++ b/frontend/src/components/firewall/logLevels.ts
@@ -1,0 +1,46 @@
+/**
+ * PVE firewall log levels — single source of truth.
+ *
+ * These nine values are what Proxmox accepts for the `log` parameter of a
+ * firewall rule (cluster, host, VM/CT and security group rules alike) and
+ * for the `log_level_in` / `log_level_out` firewall options. The order
+ * mirrors the Proxmox web UI: `nolog` first (the default: no logging at
+ * all), then the syslog severities from the most to the least severe.
+ *
+ * Kept in a React-free module so both the value list and the resolver can
+ * be unit tested, and re-exported from `shared.tsx` for the components
+ * that already import their firewall constants from there.
+ */
+export const LOG_LEVELS = ['nolog', 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug'] as const
+
+export type LogLevel = (typeof LOG_LEVELS)[number]
+
+/** PVE's own default. Never send an empty string as a log level. */
+export const DEFAULT_LOG_LEVEL: LogLevel = 'nolog'
+
+/**
+ * Coerce whatever PVE returned (or nothing at all) into a level a `<Select>`
+ * can render. A missing or unrecognised value falls back to `nolog` rather
+ * than leaking an out-of-range value into MUI, which would render an empty
+ * control and warn in the console.
+ */
+export function resolveLogLevel(value?: string | null): LogLevel {
+  const candidate = (value ?? '').trim().toLowerCase()
+
+  return (LOG_LEVELS as readonly string[]).includes(candidate) ? (candidate as LogLevel) : DEFAULT_LOG_LEVEL
+}
+
+/**
+ * How a rule's log level reads in a rules table: the level itself, or a dash
+ * when the rule logs nothing. `nolog` is noise in a list — most rules carry
+ * it — so it collapses to `-` (rendered dimmed) exactly like an absent,
+ * empty or unrecognised value, which all mean "no logging" too.
+ *
+ * The single source of truth for the display form: the `=== 'nolog'` check
+ * belongs here, not inlined in each of the five rules tables.
+ */
+export function formatLogLevel(value?: string | null): string {
+  const level = resolveLogLevel(value)
+
+  return level === 'nolog' ? '-' : level
+}

--- a/frontend/src/components/firewall/shared.tsx
+++ b/frontend/src/components/firewall/shared.tsx
@@ -8,9 +8,11 @@ import type { FirewallRule } from './types'
    CONSTANTS
 ═══════════════════════════════════════════════════════════════════════════ */
 
-export const LOG_LEVELS = ['nolog', 'emerg', 'alert', 'crit', 'err', 'warning', 'notice', 'info', 'debug']
-
-export const MONO_STYLE = { fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace', fontSize: 13 }
+// Log levels live in a React-free module (logLevels.ts) so they can be unit
+// tested; re-exported here because this file is the firewall constants entry
+// point every firewall component already imports from.
+export { LOG_LEVELS, DEFAULT_LOG_LEVEL, resolveLogLevel } from './logLevels'
+export type { LogLevel } from './logLevels'
 
 /* ═══════════════════════════════════════════════════════════════════════════
    HELPER COMPONENTS
@@ -19,7 +21,6 @@ export const MONO_STYLE = { fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono"
 export const ActionChip = ({ action }: { action: string }) => {
   const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
   const color = colors[action] || '#94a3b8'
-
 
 return (
     <Chip
@@ -40,7 +41,6 @@ return (
 
 export const PolicyChip = ({ policy }: { policy: string }) => {
   const color = policy === 'DROP' ? '#ef4444' : policy === 'REJECT' ? '#f59e0b' : '#22c55e'
-
 
 return (
     <Chip

--- a/frontend/src/components/firewall/useFirewallState.ts
+++ b/frontend/src/components/firewall/useFirewallState.ts
@@ -247,10 +247,12 @@ export function useFirewallState(api: FirewallAPIAdapter) {
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', pos.toString())
 
-    setTimeout(() => {
-      const row = e.currentTarget as HTMLElement
+    // React nulls the event's currentTarget as soon as the handler returns,
+    // so the row must be captured before the opacity change is deferred.
+    const draggedRow = e.currentTarget as HTMLElement
 
-      row.style.opacity = '0.5'
+    setTimeout(() => {
+      draggedRow.style.opacity = '0.5'
     }, 0)
   }
 

--- a/frontend/src/components/firewall/useFirewallState.ts
+++ b/frontend/src/components/firewall/useFirewallState.ts
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 
 import type { FirewallRule, FirewallOptions, SecurityGroup, FirewallAPIAdapter, SnackbarState } from './types'
 import { normalizeRules } from './shared'
+import { DEFAULT_LOG_LEVEL } from './logLevels'
 
 const DEFAULT_NEW_RULE: Partial<FirewallRule> = {
   type: 'in',
@@ -14,6 +15,7 @@ const DEFAULT_NEW_RULE: Partial<FirewallRule> = {
   dport: '',
   source: '',
   dest: '',
+  log: DEFAULT_LOG_LEVEL,
   comment: ''
 }
 

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5881,6 +5881,7 @@
     "interface": "Schnittstelle",
     "sourcePort": "Quellport",
     "destPort": "Zielport",
+    "logLevel": "Log-Level",
     "direction": "Richt.",
     "service": "Dienst",
     "typeIn": "IN (eingehend)",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5951,6 +5951,7 @@
     "interface": "Interface",
     "sourcePort": "Source port",
     "destPort": "Destination port",
+    "logLevel": "Log level",
     "direction": "Dir",
     "service": "Service",
     "typeIn": "IN (inbound)",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -5951,6 +5951,7 @@
     "interface": "Interfaz",
     "sourcePort": "Puerto de origen",
     "destPort": "Puerto de destino",
+    "logLevel": "Nivel de log",
     "direction": "Dir",
     "service": "Servicio",
     "typeIn": "IN (entrante)",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5951,6 +5951,7 @@
     "interface": "Interface",
     "sourcePort": "Port source",
     "destPort": "Port destination",
+    "logLevel": "Niveau de journalisation",
     "direction": "Dir",
     "service": "Service",
     "typeIn": "IN (entrant)",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -5951,6 +5951,7 @@
     "interface": "인터페이스",
     "sourcePort": "출발지 포트",
     "destPort": "목적지 포트",
+    "logLevel": "로그 수준",
     "direction": "방향",
     "service": "서비스",
     "typeIn": "IN (인바운드)",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5883,6 +5883,7 @@
     "interface": "接口",
     "sourcePort": "源端口",
     "destPort": "目标端口",
+    "logLevel": "日志级别",
     "direction": "方向",
     "service": "服务",
     "typeIn": "IN（入站）",


### PR DESCRIPTION
Closes #682

## Why

PVE accepts a `log` parameter on every firewall rule, and ProxCenter already carried it end to end: form state, `CreateRuleRequest`, the API routes, `pveDirect` and the orchestrator all handled it. No widget ever exposed it, so a log level could not be set on a security group, a cluster rule or a host rule. Only the VM rules dialog had a selector, and it offered 4 of the 9 PVE levels. An existing level set from the Proxmox GUI was read back correctly, so nothing was being overwritten, it was simply unreachable from ProxCenter.

## What changed

**Log level, editable**
- A shared `LogLevelSelect` in the six rule dialogs: security groups, cluster firewall, host rules, VM rules, and the add and edit dialogs used by the Inventory firewall tabs. Rendered for non-group rules only, as in the Proxmox UI.
- The nine PVE levels now live in a React-free `logLevels` module: `LOG_LEVELS`, `DEFAULT_LOG_LEVEL`, `resolveLogLevel()` which coerces a missing, unknown or oddly cased value to `nolog` rather than leaking an out-of-range value into the select, and `formatLogLevel()` for display. Both are unit tested (14 cases). The previous duplicate list and the 4-option hardcoded set are gone.
- The VM firewall add-rule payload rebuilt its fields one by one and dropped `log`, so a level picked in that dialog never reached PVE. Fixed.

**Log level, visible**
- A Log level column in the five rules tables, between Action and Comment as in the Proxmox grid, showing a dimmed dash when a rule logs nothing. The `colSpan` of every grouping row and empty-state row was updated to match, and header and body cell counts were verified equal for each table, including both column layouts of the Inventory table.

**Consistency fixes in the same views**
- Table headers kept MUI's default 16px horizontal padding while every value cell uses `p: 0.5`, so each column label sat about 12px to the right of its own values across the whole table.
- Monospace font removed from the rules tables, the alias and IP set lists and the rule dialogs, including 17 `<code>` tags that inherited it without any `fontFamily` declaration to grep for. The two firewall log terminals keep their monospace, they are genuine console output.
- Node names and the Host Rules tab now carry the Proxmox logo, matching the inventory tree, and the Cluster tab carries a server glyph instead of a firewall glyph that said nothing about its scope.

## Verification

- `vitest --project node logLevels`: 14 passed
- `vitest --project jsdom useFirewallState`: 6 passed
- ESLint on the 20 touched files: 0 errors (the remaining `react-hooks` warnings are pre-existing)
- Reviewed in the browser against a live cluster before this PR was opened.

## Notes

- `firewall.logLevel` added to all six locale catalogues.
- Placement in the node column layout of the Inventory table: the log level sits immediately before Comment, after Port, which matches PVE's own ordering and lets a single shared cell serve both layouts.
