### PR TITLE
Attach security groups to guests, and fix the membership count

### DIFF
--- a/frontend/src/app/(dashboard)/automation/network/components/RulesTab.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/RulesTab.tsx
@@ -158,6 +158,7 @@ export default function RulesTab({
       {currentTab === 2 && (
         <VMRulesPanel
           vmFirewallData={vmFirewallData}
+          securityGroups={securityGroups}
           loadingVMRules={loadingVMRules}
           selectedConnection={selectedConnection}
           loadVMFirewallData={loadVMFirewallData}

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
@@ -39,6 +39,10 @@ vi.mock('@/lib/api/firewall', () => ({
   deleteSecurityGroupRule: vi.fn(),
   createSecurityGroup: vi.fn(),
   deleteSecurityGroup: vi.fn(),
+
+  // Used by the members dialog this panel opens, not by the panel itself.
+  addVMRule: vi.fn(),
+  deleteVMRule: vi.fn(),
 }))
 
 vi.mock('@/contexts/ToastContext', () => ({
@@ -72,16 +76,26 @@ const WEB_VM: VMFirewallInfo = {
   rules: [{ pos: 0, type: 'group', action: 'sg-web', enable: 1 }],
 }
 
+/** A group rule pointing at `group`, as PVE stores membership. */
+const groupRule = (group: string, pos = 0): firewallAPIType.FirewallRule => ({
+  pos, type: 'group', action: group, enable: 1,
+})
+
 function props(overrides: Partial<React.ComponentProps<typeof SecurityGroupsPanel>> = {}) {
   return {
     securityGroups: GROUPS,
     vmFirewallData: [WEB_VM],
+    loadingVMRules: false,
+    guestsNotScanned: 0,
+    clusterRules: [] as firewallAPIType.FirewallRule[],
+    hostRulesByNode: {} as Record<string, firewallAPIType.FirewallRule[]>,
     firewallMode: 'cluster' as firewallAPIType.FirewallMode,
     selectedConnection: CONN,
     totalRules: 2,
     aliases: [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }] as firewallAPIType.Alias[],
     ipsets: [] as firewallAPIType.IPSet[],
     reload: vi.fn(),
+    reloadVMFirewallRules: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   }
 }
@@ -97,6 +111,9 @@ function renderPanel(overrides: Parameters<typeof props>[0] = {}) {
 const expandGroup = (name: string) => fireEvent.click(screen.getByText(name))
 
 const ruleRow = (text: string) => screen.getAllByRole('row').find(r => within(r).queryByText(text))!
+
+/** The header row of a group, which carries the membership chips and actions. */
+const sectionRow = (group: string) => screen.getAllByRole('row').find(r => within(r).queryByText(group))!
 
 /** A Select inside the open rule dialog, found from its rendered label. */
 function selectByLabel(label: string) {
@@ -304,6 +321,89 @@ describe('SecurityGroupsPanel', () => {
     fireEvent.click(dialog.getByRole('button', { name: 'Create' }))
 
     await waitFor(() => expect(api.createSecurityGroup).toHaveBeenCalledWith(CONN, { group: 'sg-new', comment: 'from test' }))
+  })
+
+  it('flags a group a cluster rule references, which the guest count alone would call unused', () => {
+    renderPanel({
+      clusterRules: [
+        { pos: 0, type: 'in', action: 'ACCEPT', enable: 1 },
+        groupRule('sg-web', 1),
+      ],
+    })
+
+    // "1 VMs" is true and yet incomplete: deleting sg-web would also drop a
+    // cluster-wide rule, so the scope is shown next to the count.
+    expect(within(sectionRow('sg-web')).getByText('Cluster')).toBeInTheDocument()
+
+    // sg-db is referenced nowhere, so it carries no scope chip at all.
+    expect(within(sectionRow('sg-db')).queryByText('Cluster')).not.toBeInTheDocument()
+  })
+
+  it('counts the nodes whose own rules reference the group', () => {
+    renderPanel({
+      hostRulesByNode: {
+        pve2: [groupRule('sg-web')],
+        pve1: [groupRule('sg-web')],
+        pve3: [{ pos: 0, type: 'in', action: 'DROP', enable: 1 }],
+      },
+    })
+
+    const section = sectionRow('sg-web')
+
+    // Two nodes reference it, and no cluster rule does: the chip counts nodes.
+    expect(within(section).getByText('2')).toBeInTheDocument()
+
+    // The nodes are named in the tooltip, in a stable order.
+    expect(within(section).getByLabelText('Referenced by node rules: pve1, pve2')).toBeInTheDocument()
+  })
+
+  it('opens the members dialog from the guest chip and refreshes the guests it changed', async () => {
+    api.deleteVMRule.mockResolvedValue(undefined)
+
+    const p = renderPanel()
+
+    fireEvent.click(screen.getByText('1 VMs'))
+
+    await waitFor(() => expect(screen.getByText('Members of sg-web')).toBeInTheDocument())
+
+    const dialog = within(screen.getByRole('dialog'))
+
+    fireEvent.click(dialog.getByRole('button', { name: 'Detach' }))
+
+    await waitFor(() => expect(api.deleteVMRule).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, 0))
+
+    // Only the guest that actually changed is refetched, not the whole scan.
+    await waitFor(() => expect(p.reloadVMFirewallRules).toHaveBeenCalledWith(WEB_VM))
+    expect(p.reloadVMFirewallRules).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(dialog.getByRole('button', { name: 'Close' }))
+    await waitFor(() => expect(screen.queryByText('Members of sg-web')).not.toBeInTheDocument())
+  })
+
+  it('opens the same dialog from the group row action, on a group with no member', async () => {
+    renderPanel()
+
+    fireEvent.click(within(sectionRow('sg-db')).getByRole('button', { name: 'Members of sg-db' }))
+
+    await waitFor(() => expect(screen.getByText('No guest references this group yet')).toBeInTheDocument())
+  })
+
+  it('holds the membership count back while the guest scan is still running', () => {
+    renderPanel({ loadingVMRules: true })
+
+    // A "0 VMs" shown mid-scan reads as "unused" on a group that may well be
+    // in use, so the count waits.
+    expect(screen.queryByText('1 VMs')).not.toBeInTheDocument()
+    expect(screen.getAllByText('…')).toHaveLength(GROUPS.length)
+    expect(screen.getAllByRole('button', { name: 'Loading...' })).toHaveLength(GROUPS.length)
+  })
+
+  it('says the membership count is partial when the scan skipped guests', () => {
+    renderPanel({ guestsNotScanned: 3 })
+
+    expect(screen.getByRole('button', {
+      name: 'web-01 (100) — 3 guests were not scanned, this count may be incomplete',
+    })).toBeInTheDocument()
   })
 
   it('explains that security groups need a cluster when the node is standalone', () => {

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.test.tsx
@@ -2,10 +2,11 @@
  * Component tests for SecurityGroupsPanel.tsx — the security groups rules
  * table.
  *
- * Two things are specific to this panel and asserted here. First, it owns an
- * extra "Applied To" column: the count of guests whose rules reference the
- * group, derived from the VM firewall data rather than given by the caller,
- * so a wrong derivation shows an operator the wrong blast radius. Second, a
+ * Two things are specific to this panel and asserted here. First, membership:
+ * the count of guests whose rules reference the group is derived from the VM
+ * firewall data rather than given by the caller, and it lives on the group
+ * header row — a wrong derivation shows an operator the wrong blast radius.
+ * Second, a
  * security group cannot itself hold a group rule (PVE forbids nesting), so
  * the shared row cells are rendered without `isGroupRule` and a rule that
  * names a group keeps the plain rendering.
@@ -133,10 +134,14 @@ describe('SecurityGroupsPanel', () => {
     expect(screen.queryByText('https in')).not.toBeInTheDocument()
   })
 
-  it('carries an Applied To column the other rules tables do not have', () => {
+  it('keeps membership on the group header, not as a per-rule column', () => {
     renderPanel()
 
-    expect(screen.getByText('Applied To')).toBeInTheDocument()
+    // The count belongs to the group, so repeating it on every rule row said
+    // nothing; the column was dropped and this table now has the same eleven
+    // columns as the other three.
+    expect(screen.queryByText('Applied To')).not.toBeInTheDocument()
+    expect(screen.getByText('1 VMs')).toBeInTheDocument()
   })
 
   it('reveals a group\'s rules, with their log level, when expanded', () => {

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/SecurityGroupsPanel.tsx
@@ -16,6 +16,7 @@ import { useToast } from '@/contexts/ToastContext'
 import { PolicySection } from '../../types'
 import RuleFormDialog, { RuleFormData } from './RuleFormDialog'
 import RulesTableHead from './shared/RulesTableHead'
+import SecurityGroupMembersDialog from './shared/SecurityGroupMembersDialog'
 import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeadingCells, RuleTrafficCells } from './shared/RuleTableCells'
 
 // ── Props ──
@@ -23,12 +24,18 @@ import { RuleActionCell, RuleLogCommentCells, RuleRowActionsCell, RuleRowLeading
 interface SecurityGroupsPanelProps {
   securityGroups: firewallAPI.SecurityGroup[]
   vmFirewallData: VMFirewallInfo[]
+  loadingVMRules: boolean
+  /** Guests the firewall scan left out, so the membership count can say it is partial. */
+  guestsNotScanned: number
+  clusterRules: firewallAPI.FirewallRule[]
+  hostRulesByNode: Record<string, firewallAPI.FirewallRule[]>
   firewallMode: firewallAPI.FirewallMode
   selectedConnection: string
   totalRules: number
   aliases: firewallAPI.Alias[]
   ipsets: firewallAPI.IPSet[]
   reload: () => void
+  reloadVMFirewallRules: (vm: VMFirewallInfo) => Promise<void>
 }
 
 // ── Helpers ──
@@ -42,11 +49,34 @@ function computeAppliedTo(sgName: string, vmFirewallData: VMFirewallInfo[]): { v
   return vms
 }
 
+/**
+ * A security group can also be referenced outside guests: by a cluster rule or
+ * by a node's own rules. Both are supported elsewhere in this UI, and a group
+ * used that way used to read "0 VMs", which reads as "unused" and invites
+ * deleting a group that is in fact enforcing traffic.
+ */
+function computeScopeRefs(
+  sgName: string,
+  clusterRules: firewallAPI.FirewallRule[],
+  hostRulesByNode: Record<string, firewallAPI.FirewallRule[]>
+): { cluster: boolean; nodes: string[] } {
+  const referencesGroup = (rules: firewallAPI.FirewallRule[] | undefined) =>
+    (rules || []).some(r => r.type === 'group' && r.action === sgName)
+
+  return {
+    cluster: referencesGroup(clusterRules),
+    nodes: Object.entries(hostRulesByNode || {})
+      .filter(([, rules]) => referencesGroup(rules))
+      .map(([node]) => node)
+      .sort((a, b) => a.localeCompare(b)),
+  }
+}
+
 // ── Main Component ──
 
 export default function SecurityGroupsPanel({
-  securityGroups, vmFirewallData, firewallMode, selectedConnection, totalRules,
-  aliases, ipsets, reload
+  securityGroups, vmFirewallData, loadingVMRules, guestsNotScanned, clusterRules, hostRulesByNode,
+  firewallMode, selectedConnection, totalRules, aliases, ipsets, reload, reloadVMFirewallRules
 }: SecurityGroupsPanelProps) {
   const theme = useTheme()
   const t = useTranslations()
@@ -69,6 +99,9 @@ export default function SecurityGroupsPanel({
 
   // Delete confirm
   const [deleteConfirm, setDeleteConfirm] = useState<{ groupName: string; pos: number } | null>(null)
+
+  // Members (which guests this group is attached to)
+  const [membersOf, setMembersOf] = useState<string | null>(null)
 
   // Drag & drop
   const [dragState, setDragState] = useState<{ sectionId: string; draggedPos: number | null; dragOverPos: number | null }>({ sectionId: '', draggedPos: null, dragOverPos: null })
@@ -274,20 +307,9 @@ export default function SecurityGroupsPanel({
           onToggleEnable={() => handleToggleEnable(section, rule)}
         />
         <RuleTrafficCells rule={rule} />
-        <TableCell sx={{ p: 0.5, width: 90 }}>
-          <Tooltip
-            title={section.appliedTo.length > 0
-              ? section.appliedTo.map(v => `${v.name} (${v.vmid})`).join(', ')
-              : t('networkPage.noVmsReferencing')
-            }
-          >
-            <Chip
-              label={t('networkPage.vmCount', { count: section.appliedTo.length })}
-              size="small" variant="outlined"
-              sx={{ height: 20, fontSize: 10, cursor: 'help' }}
-            />
-          </Tooltip>
-        </TableCell>
+        {/* No "Applied to" cell per rule: membership belongs to the group, not
+            to one of its rules, and repeating the same count on every row said
+            nothing. It lives on the group header, next to the members action. */}
         <RuleActionCell rule={rule} />
         <RuleLogCommentCells rule={rule} />
         <RuleRowActionsCell
@@ -313,7 +335,7 @@ export default function SecurityGroupsPanel({
         }}
         onClick={() => toggleSection(section.id)}
       >
-        <TableCell colSpan={12} sx={{ py: 1, px: 2 }}>
+        <TableCell colSpan={11} sx={{ py: 1, px: 2 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, minWidth: 0 }}>
               <i
@@ -332,22 +354,59 @@ export default function SecurityGroupsPanel({
                 sx={{ height: 20, fontSize: 10, ml: 0.5 }}
               />
               <Tooltip
-                title={section.appliedTo.length > 0
-                  ? section.appliedTo.map(v => `${v.name} (${v.vmid})`).join(', ')
-                  : t('networkPage.noVmsReferencing')
+                title={loadingVMRules
+                  ? t('networkPage.loading')
+                  : [
+                    section.appliedTo.length > 0
+                      ? section.appliedTo.map(v => `${v.name} (${v.vmid})`).join(', ')
+                      : t('networkPage.noVmsReferencing'),
+                    guestsNotScanned > 0 ? t('firewall.membersPartial', { count: guestsNotScanned }) : '',
+                  ].filter(Boolean).join(' — ')
                 }
               >
                 <Chip
                   icon={<i className="ri-computer-line" style={{ fontSize: 12 }} />}
-                  label={t('networkPage.vmCount', { count: section.appliedTo.length })}
+                  label={loadingVMRules ? '…' : t('networkPage.vmCount', { count: section.appliedTo.length })}
                   size="small"
                   variant="outlined"
-                  sx={{ height: 20, fontSize: 10, cursor: 'help' }}
+                  onClick={() => setMembersOf(section.id)}
+                  sx={{ height: 20, fontSize: 10 }}
                 />
               </Tooltip>
+              {/* A group can also be attached at cluster or node scope; without
+                  this the chip above would read "0 VMs" on a group that is very
+                  much in use. */}
+              {(() => {
+                const scope = computeScopeRefs(section.id, clusterRules, hostRulesByNode)
+
+                if (!scope.cluster && scope.nodes.length === 0) return null
+
+                const parts = [
+                  scope.cluster ? t('firewall.membersScopeCluster') : '',
+                  scope.nodes.length > 0 ? t('firewall.membersScopeNodes', { nodes: scope.nodes.join(', ') }) : '',
+                ].filter(Boolean)
+
+                return (
+                  <Tooltip title={parts.join(' — ')}>
+                    <Chip
+                      icon={<i className="ri-server-line" style={{ fontSize: 12 }} />}
+                      label={scope.cluster ? t('firewall.cluster') : scope.nodes.length}
+                      size="small"
+                      variant="outlined"
+                      color="primary"
+                      sx={{ height: 20, fontSize: 10, cursor: 'help' }}
+                    />
+                  </Tooltip>
+                )
+              })()}
             </Box>
 
             <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center', flexShrink: 0 }} onClick={e => e.stopPropagation()}>
+              <Tooltip title={t('firewall.membersTitle', { group: section.name })}>
+                <IconButton size="small" onClick={() => setMembersOf(section.id)}>
+                  <i className="ri-links-line" style={{ fontSize: 16 }} />
+                </IconButton>
+              </Tooltip>
               <Tooltip title={t('networkPage.addRule')}>
                 <IconButton size="small" onClick={() => openAddRule(section.id)}>
                   <i className="ri-add-line" style={{ fontSize: 16 }} />
@@ -372,7 +431,7 @@ export default function SecurityGroupsPanel({
     if (section.rules.length === 0) {
       return (
         <TableRow key={`empty-${section.id}`}>
-          <TableCell colSpan={12} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
+          <TableCell colSpan={11} sx={{ py: 3, textAlign: 'center', color: 'text.secondary' }}>
             <Typography variant="body2">{t('networkPage.noRules')}</Typography>
             <Button size="small" sx={{ mt: 1 }} onClick={() => openAddRule(section.id)}>
               {t('networkPage.addRule')}
@@ -398,7 +457,9 @@ export default function SecurityGroupsPanel({
         </Typography>
         <Box sx={{ p: 3, bgcolor: alpha(theme.palette.divider, 0.05), borderRadius: 2, maxWidth: 600, mx: 'auto' }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 2 }}>{t('network.availableAlternatives')}</Typography>
-          <Stack spacing={1.5} alignItems="flex-start">
+          {/* Centred as a group: the panel is textAlign center, so leaving the
+              rows flex-start gave centred labels above left-anchored rows. */}
+          <Stack spacing={1.5} alignItems="center">
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
               <Avatar sx={{ width: 32, height: 32, bgcolor: alpha('#8b5cf6', 0.15) }}>
                 <i className="ri-price-tag-3-line" style={{ fontSize: 16, color: '#8b5cf6' }} />
@@ -463,7 +524,7 @@ export default function SecurityGroupsPanel({
       {filteredSections.length > 0 ? (
         <TableContainer component={Paper} sx={{ border: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
           <Table size="small">
-            <RulesTableHead showAppliedTo />
+            <RulesTableHead />
             <TableBody>
               {filteredSections.map(section => (
                 <Fragment key={section.id}>{renderSectionRow(section)}{renderSGRuleRows(section)}</Fragment>
@@ -494,6 +555,19 @@ export default function SecurityGroupsPanel({
         aliases={aliases}
         ipsets={ipsets}
       />
+
+      {/* Members: which guests carry a rule referencing this group */}
+      {membersOf && (
+        <SecurityGroupMembersDialog
+          open
+          groupName={membersOf}
+          connectionId={selectedConnection}
+          guests={vmFirewallData}
+          guestsNotScanned={guestsNotScanned}
+          onClose={() => setMembersOf(null)}
+          onChanged={touched => { touched.forEach(guest => { reloadVMFirewallRules(guest) }) }}
+        />
+      )}
 
       {/* Create Security Group */}
       <Dialog open={groupDialogOpen} onClose={() => setGroupDialogOpen(false)} maxWidth="sm" fullWidth>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
@@ -89,9 +89,15 @@ const DB: VMFirewallInfo = {
 const ALIASES: firewallAPIType.Alias[] = [{ name: 'net-mgmt', cidr: '10.99.99.0/24' }]
 const IPSETS: firewallAPIType.IPSet[] = [{ name: 'trusted', members: [{ cidr: '1.2.3.4' }] }]
 
+const SECURITY_GROUPS: firewallAPIType.SecurityGroup[] = [
+  { group: 'sg-web', comment: 'front tier', rules: [] },
+  { group: 'sg-db', rules: [] },
+]
+
 function props(overrides: Partial<React.ComponentProps<typeof VMRulesPanel>> = {}) {
   return {
     vmFirewallData: [WEB, DB],
+    securityGroups: SECURITY_GROUPS,
     loadingVMRules: false,
     selectedConnection: CONN,
     loadVMFirewallData: vi.fn().mockResolvedValue(undefined),
@@ -301,6 +307,27 @@ describe('VMRulesPanel', () => {
 
     await waitFor(() => expect(api.addVMRule).toHaveBeenCalledTimes(1))
     expect(api.addVMRule.mock.calls[0][4]).toMatchObject({ log: 'crit', type: 'in', action: 'ACCEPT' })
+  })
+
+  it('swaps the Action choices for the security groups on a GROUP rule', async () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Add rule' }))
+    await waitForRuleDialog()
+
+    fireEvent.mouseDown(selectByLabel('Action'))
+    expect(within(screen.getByRole('listbox')).getAllByRole('option').map(o => o.textContent))
+      .toEqual(['ACCEPT', 'DROP', 'REJECT'])
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'Escape' })
+
+    fireEvent.mouseDown(selectByLabel('Direction'))
+    fireEvent.click(within(screen.getByRole('listbox')).getByRole('option', { name: 'GROUP' }))
+
+    // PVE carries the group name in `action` for a GROUP rule, so offering
+    // ACCEPT/DROP/REJECT there could only produce an invalid rule.
+    fireEvent.mouseDown(selectByLabel('Action'))
+    expect(within(screen.getByRole('listbox')).getAllByRole('option').map(o => o.textContent))
+      .toEqual(['sg-web', 'sg-db'])
   })
 
   it('edits the dialog fields, including source through the suggestions', async () => {

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
@@ -22,6 +22,7 @@ import AliasIpsetAutocomplete, { useAliasIpsetOptions } from './shared/AliasIpse
 
 interface VMRulesPanelProps {
   vmFirewallData: VMFirewallInfo[]
+  securityGroups: firewallAPI.SecurityGroup[]
   loadingVMRules: boolean
   selectedConnection: string
   loadVMFirewallData: () => Promise<void>
@@ -40,7 +41,7 @@ function getVlanColor(vlanKey: string, index: number): string {
 
 // ── Main Component ──
 
-export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedConnection, loadVMFirewallData, reloadVMFirewallRules, aliases, ipsets }: VMRulesPanelProps) {
+export default function VMRulesPanel({ vmFirewallData, securityGroups, loadingVMRules, selectedConnection, loadVMFirewallData, reloadVMFirewallRules, aliases, ipsets }: VMRulesPanelProps) {
   const theme = useTheme()
   const t = useTranslations()
   const { showToast } = useToast()
@@ -518,10 +519,13 @@ export default function VMRulesPanel({ vmFirewallData, loadingVMRules, selectedC
             <Grid size={{ xs: 6, sm: 2.5 }}>
               <FormControl fullWidth size="small">
                 <InputLabel>Action</InputLabel>
+                {/* PVE carries the security group name in `action` for a GROUP
+                    rule, so offering ACCEPT/DROP/REJECT there could only produce
+                    an invalid rule. Same swap as the host and cluster dialogs. */}
                 <Select value={newVMRule.action} label="Action" onChange={(e) => setNewVMRule(prev => ({ ...prev, action: e.target.value }))}>
-                  <MenuItem value="ACCEPT">ACCEPT</MenuItem>
-                  <MenuItem value="DROP">DROP</MenuItem>
-                  <MenuItem value="REJECT">REJECT</MenuItem>
+                  {newVMRule.type === 'group'
+                    ? securityGroups.map(sg => <MenuItem key={sg.group} value={sg.group}>{sg.group}</MenuItem>)
+                    : ['ACCEPT', 'DROP', 'REJECT'].map(a => <MenuItem key={a} value={a}>{a}</MenuItem>)}
                 </Select>
               </FormControl>
             </Grid>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RuleTableCells.tsx
@@ -23,6 +23,12 @@ import { formatLogLevel } from '@/components/firewall/logLevels'
 // Colour of the ACCEPT/DROP/REJECT chip. Deliberately NOT the ActionChip of
 // `@/components/firewall/shared`: that one is drawn lighter (alpha 0.15/0.3)
 // and belongs to the VM/node firewall tabs. These four tables use 0.22/0.35.
+/**
+ * Font size of the rules tables, shared with RulesTableHead. Was 11px, which
+ * read noticeably smaller than the rest of the page.
+ */
+export const RULE_CELL_FONT_SIZE = 13
+
 const ActionChip = ({ action }: { action: string }) => {
   const colors: Record<string, string> = { ACCEPT: '#22c55e', DROP: '#ef4444', REJECT: '#f59e0b' }
   const color = colors[action] || '#94a3b8'
@@ -61,7 +67,7 @@ export function RuleRowLeadingCells({ rule, isGroupRule = false, enabled, onTogg
       <TableCell sx={{ p: 0.5, cursor: 'grab', width: 30 }}>
         <i className="ri-draggable" style={{ fontSize: 14, color: theme.palette.text.disabled }} />
       </TableCell>
-      <TableCell sx={{ fontSize: 11, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
+      <TableCell sx={{ fontSize: RULE_CELL_FONT_SIZE, color: 'text.secondary', p: 0.5, width: 35 }}>{rule.pos}</TableCell>
       <TableCell sx={{ p: 0.5, width: 55 }}>
         <Switch checked={enabled} onChange={onToggleEnable} size="small" color="success" />
       </TableCell>
@@ -96,13 +102,13 @@ function formatService(rule: firewallAPI.FirewallRule): string {
 export function RuleTrafficCells({ rule, isGroupRule = false }: RuleCellsProps) {
   return (
     <>
-      <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
+      <TableCell sx={{ fontSize: RULE_CELL_FONT_SIZE, p: 0.5, color: (isGroupRule || !rule.source) ? 'text.disabled' : 'text.primary' }}>
         {isGroupRule ? '-' : (rule.source || 'any')}
       </TableCell>
-      <TableCell sx={{ fontSize: 11, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
+      <TableCell sx={{ fontSize: RULE_CELL_FONT_SIZE, p: 0.5, color: (isGroupRule || !rule.dest) ? 'text.disabled' : 'text.primary' }}>
         {isGroupRule ? '-' : (rule.dest || 'any')}
       </TableCell>
-      <TableCell sx={{ fontSize: 11, p: 0.5, width: 100 }}>
+      <TableCell sx={{ fontSize: RULE_CELL_FONT_SIZE, p: 0.5, width: 100 }}>
         {formatService(rule)}
       </TableCell>
     </>
@@ -130,11 +136,11 @@ export function RuleLogCommentCells({ rule }: { rule: firewallAPI.FirewallRule }
 
   return (
     <>
-      <TableCell sx={{ fontSize: 11, p: 0.5, width: 80, color: logsNothing ? 'text.disabled' : 'text.primary' }}>
+      <TableCell sx={{ fontSize: RULE_CELL_FONT_SIZE, p: 0.5, width: 80, color: logsNothing ? 'text.disabled' : 'text.primary' }}>
         {logLevel}
       </TableCell>
       <TableCell sx={{ maxWidth: 120, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', p: 0.5 }}>
-        <Tooltip title={rule.comment || ''}><span style={{ fontSize: 11 }}>{rule.comment || '-'}</span></Tooltip>
+        <Tooltip title={rule.comment || ''}><span style={{ fontSize: RULE_CELL_FONT_SIZE }}>{rule.comment || '-'}</span></Tooltip>
       </TableCell>
     </>
   )

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.test.tsx
@@ -6,7 +6,9 @@
  * The contract asserted here is the column list itself — labels, order, and
  * the count — because the panels pin `colSpan` on their section and empty
  * rows against it: 11 columns normally, 12 for security groups, whose
- * "Applied to" column sits between Service and Action. Labels come from the
+ * "Applied to" column sits between Service and Action (a capability of the
+ * component: no table opts into it today). The log column carries the short
+ * label, the full one being reserved for the rule dialogs. Labels come from the
  * real English bundle, so a missing translation key fails the test.
  *
  * No automatic RTL cleanup is configured in this repo, hence afterEach.
@@ -21,7 +23,7 @@ import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProvide
 import RulesTableHead from './RulesTableHead'
 
 /** The nine rule columns, framed by the drag-handle and actions columns. */
-const COLUMNS = ['', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Action', 'Log level', 'Comment', '']
+const COLUMNS = ['', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Action', 'Log', 'Comment', '']
 
 const headers = () => screen.getAllByRole('columnheader').map(th => th.textContent)
 
@@ -38,7 +40,7 @@ describe('RulesTableHead', () => {
     renderWithProviders(<Table><RulesTableHead showAppliedTo /></Table>)
 
     expect(headers()).toEqual([
-      '', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Applied To', 'Action', 'Log level', 'Comment', '',
+      '', '#', 'Active', 'Dir', 'Source', 'Destination', 'Service', 'Applied To', 'Action', 'Log', 'Comment', '',
     ])
   })
 

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/RulesTableHead.tsx
@@ -4,12 +4,14 @@ import { useTranslations } from 'next-intl'
 
 import { TableCell, TableHead, TableRow, useTheme, alpha } from '@mui/material'
 
+import { RULE_CELL_FONT_SIZE } from './RuleTableCells'
+
 // ── Column header style ──
 // Body cells are all `p: 0.5`; without the same padding here the header
 // labels sit ~12px right of their column's values (MUI's default 16px).
 // Single source of truth for the four rules tables (cluster policy, hosts,
 // VMs/CTs and security groups), which used to carry a copy each.
-const headCellSx = { fontWeight: 700, fontSize: 11, whiteSpace: 'nowrap', p: 0.5 } as const
+const headCellSx = { fontWeight: 700, fontSize: RULE_CELL_FONT_SIZE, whiteSpace: 'nowrap', p: 0.5 } as const
 
 interface RulesTableHeadProps {
   /**
@@ -44,7 +46,7 @@ export default function RulesTableHead({ showAppliedTo = false }: RulesTableHead
         <TableCell sx={{ ...headCellSx, width: 100 }}>{t('firewall.service')}</TableCell>
         {showAppliedTo && <TableCell sx={{ ...headCellSx, width: 90 }}>{t('networkPage.appliedTo')}</TableCell>}
         <TableCell sx={{ ...headCellSx, width: 90 }}>{t('firewall.action')}</TableCell>
-        <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevel')}</TableCell>
+        <TableCell sx={{ ...headCellSx, width: 80 }}>{t('firewall.logLevelShort')}</TableCell>
         <TableCell sx={headCellSx}>{t('network.comment')}</TableCell>
         <TableCell sx={{ width: 70 }}></TableCell>
       </TableRow>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
@@ -196,6 +196,74 @@ describe('SecurityGroupMembersDialog', () => {
     expect(showToast).toHaveBeenCalledWith('sg-web detached from web-02 (140)', 'success')
   })
 
+  it('keeps a member listed when PVE refuses the detach', async () => {
+    const member = guest(141, { name: 'web-03', rules: [groupRule(GROUP, 1)] })
+
+    deleteVMRule.mockRejectedValueOnce(new Error('PVE rejected the delete'))
+
+    const { dialogProps } = renderDialog({ guests: [member] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detach' }))
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Could not detach: web-03 (141)', 'error')
+    })
+
+    // Nothing changed on PVE, so the caller has nothing to refetch and the
+    // guest stays in the list rather than disappearing optimistically.
+    expect(dialogProps.onChanged).not.toHaveBeenCalled()
+    expect(screen.getByText('web-03 (141)')).toBeInTheDocument()
+  })
+
+  it('ignores a detach on a group rule PVE returned without a position', async () => {
+    const member = guest(142, {
+      name: 'posless-01',
+      rules: [{ type: 'group', action: GROUP, enable: 1 } as FirewallRule],
+    })
+
+    renderDialog({ guests: [member] })
+
+    // The guest counts as a member — it carries the rule — but the delete
+    // endpoint is addressed by position, so there is nothing to send.
+    expect(screen.getByText('posless-01 (142)')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detach' }))
+
+    await waitFor(() => expect(showToast).not.toHaveBeenCalled())
+    expect(deleteVMRule).not.toHaveBeenCalled()
+  })
+
+  it('reports a failure without claiming a success when every attach fails', async () => {
+    const first = guest(143, { name: 'down-01' })
+    const second = guest(144, { name: 'down-02' })
+
+    addVMRule.mockRejectedValue(new Error('PVE unreachable'))
+
+    const { dialogProps } = renderDialog({ guests: [first, second] })
+
+    await chooseGuest('down-01 (143)')
+    await chooseGuest('down-02 (144)')
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }))
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith('Could not attach: down-01 (143), down-02 (144)', 'error')
+    })
+    expect(showToast).toHaveBeenCalledTimes(1)
+    expect(dialogProps.onChanged).not.toHaveBeenCalled()
+  })
+
+  it('tells a container member apart from a virtual machine', () => {
+    const vm = guest(145, { name: 'vm-01', rules: [groupRule(GROUP, 0)] })
+    const container = guest(146, { name: 'ct-01', type: 'lxc', rules: [groupRule(GROUP, 0)] })
+
+    renderDialog({ guests: [vm, container] })
+
+    const dialog = screen.getByRole('dialog')
+
+    expect(dialog.querySelectorAll('.ri-computer-line')).toHaveLength(1)
+    expect(dialog.querySelectorAll('.ri-instance-line')).toHaveLength(1)
+  })
+
   it('shows the partial-scan notice only when guests were skipped', () => {
     const initialProps = props({ guestsNotScanned: 12 })
     const { rerender } = renderWithProviders(<SecurityGroupMembersDialog {...initialProps} />)

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Tests for listing, attaching and detaching security-group guest members.
+ *
+ * PVE stores membership as a group rule on each guest. These tests therefore
+ * drive the dialog with real guest rule lists and assert the exact VM firewall
+ * adapter calls. MUI Autocomplete needs scrollIntoView in a browser, but jsdom
+ * does not provide it.
+ */
+
+import type { ComponentProps } from 'react'
+
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  fireEvent,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from '@/__tests__/setup/renderWithProviders'
+import type { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
+import type { FirewallRule } from '@/lib/api/firewall'
+
+const { showToast } = vi.hoisted(() => ({ showToast: vi.fn() }))
+
+vi.mock('@/lib/api/firewall', () => ({
+  addVMRule: vi.fn(),
+  deleteVMRule: vi.fn(),
+}))
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({ showToast }),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import SecurityGroupMembersDialog from './SecurityGroupMembersDialog'
+
+Element.prototype.scrollIntoView ??= vi.fn()
+
+const addVMRule = vi.mocked(firewallAPI.addVMRule)
+const deleteVMRule = vi.mocked(firewallAPI.deleteVMRule)
+
+const GROUP = 'sg-web'
+const CONNECTION = 'conn-1'
+
+const groupRule = (group: string, pos = 0, enable = 1): FirewallRule => ({
+  pos,
+  type: 'group',
+  action: group,
+  enable,
+})
+
+function guest(vmid: number, overrides: Partial<VMFirewallInfo> = {}): VMFirewallInfo {
+  return {
+    vmid,
+    name: `guest-${vmid}`,
+    node: 'pve1',
+    type: 'qemu',
+    status: 'running',
+    firewallEnabled: true,
+    rules: [],
+    options: null,
+    vlans: [],
+    ...overrides,
+  }
+}
+
+function props(overrides: Partial<ComponentProps<typeof SecurityGroupMembersDialog>> = {}) {
+  return {
+    open: true,
+    groupName: GROUP,
+    connectionId: CONNECTION,
+    guests: [],
+    guestsNotScanned: 0,
+    onClose: vi.fn(),
+    onChanged: vi.fn(),
+    ...overrides,
+  }
+}
+
+function renderDialog(overrides: Parameters<typeof props>[0] = {}) {
+  const dialogProps = props(overrides)
+  const rendered = renderWithProviders(<SecurityGroupMembersDialog {...dialogProps} />)
+
+  return { dialogProps, rendered }
+}
+
+async function chooseGuest(label: string) {
+  const input = screen.getByLabelText('Guests to attach')
+
+  fireEvent.change(input, { target: { value: label } })
+  fireEvent.click(await screen.findByRole('option', { name: label }))
+}
+
+beforeEach(() => {
+  addVMRule.mockReset().mockResolvedValue(undefined)
+  deleteVMRule.mockReset().mockResolvedValue(undefined)
+  showToast.mockReset()
+})
+
+afterEach(cleanup)
+
+describe('SecurityGroupMembersDialog', () => {
+  it('derives the current members from exact group rules on the guests', () => {
+    const member = guest(100, { name: 'web-01', rules: [groupRule(GROUP, 4, 0)] })
+    const otherGroup = guest(101, { name: 'db-01', rules: [groupRule('sg-db', 2)] })
+    const ordinaryRule = guest(102, {
+      name: 'worker-01',
+      rules: [{ pos: 1, type: 'in', action: GROUP, enable: 1 }],
+    })
+
+    renderDialog({ guests: [member, otherGroup, ordinaryRule] })
+
+    expect(screen.getByText('Members of sg-web')).toBeInTheDocument()
+    expect(screen.getByText('web-01 (100)')).toBeInTheDocument()
+    expect(screen.queryByText('db-01 (101)')).not.toBeInTheDocument()
+    expect(screen.queryByText('worker-01 (102)')).not.toBeInTheDocument()
+    expect(screen.getByText('Attached guests').parentElement).toHaveTextContent('1')
+  })
+
+  it('shows the empty state when no guest references the group', () => {
+    renderDialog({ guests: [guest(110, { rules: [groupRule('sg-other')] })] })
+
+    expect(screen.getByText('No guest references this group yet')).toBeInTheDocument()
+    expect(screen.getByText('Attached guests').parentElement).toHaveTextContent('0')
+  })
+
+  it('attaches two selected guests sequentially with one group rule each', async () => {
+    const first = guest(120, { name: 'app-01' })
+    const second = guest(121, { name: 'app-02', node: 'pve2', type: 'lxc' })
+    let finishFirst: (() => void) | undefined
+
+    addVMRule
+      .mockImplementationOnce(() => new Promise<void>(resolve => { finishFirst = resolve }))
+      .mockResolvedValueOnce(undefined)
+
+    const { dialogProps } = renderDialog({ guests: [first, second] })
+
+    await chooseGuest('app-01 (120)')
+    await chooseGuest('app-02 (121)')
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }))
+
+    await waitFor(() => expect(addVMRule).toHaveBeenCalledTimes(1))
+    expect(addVMRule).toHaveBeenNthCalledWith(1, CONNECTION, 'pve1', 'qemu', 120, {
+      type: 'group',
+      action: GROUP,
+      enable: 1,
+    })
+
+    await act(async () => finishFirst?.())
+
+    await waitFor(() => expect(addVMRule).toHaveBeenCalledTimes(2))
+    expect(addVMRule).toHaveBeenNthCalledWith(2, CONNECTION, 'pve2', 'lxc', 121, {
+      type: 'group',
+      action: GROUP,
+      enable: 1,
+    })
+    await waitFor(() => expect(dialogProps.onChanged).toHaveBeenCalledWith([first, second]))
+  })
+
+  it('keeps successful attachments and reports the guests that failed', async () => {
+    const failed = guest(130, { name: 'broken-01' })
+    const attached = guest(131, { name: 'healthy-01' })
+
+    addVMRule
+      .mockRejectedValueOnce(new Error('PVE rejected the rule'))
+      .mockResolvedValueOnce(undefined)
+
+    const { dialogProps } = renderDialog({ guests: [failed, attached] })
+
+    await chooseGuest('broken-01 (130)')
+    await chooseGuest('healthy-01 (131)')
+    fireEvent.click(screen.getByRole('button', { name: 'Attach' }))
+
+    await waitFor(() => expect(dialogProps.onChanged).toHaveBeenCalledWith([attached]))
+    expect(addVMRule).toHaveBeenCalledTimes(2)
+    expect(showToast).toHaveBeenCalledWith('sg-web attached to 1 guest(s)', 'success')
+    expect(showToast).toHaveBeenCalledWith('Could not attach: broken-01 (130)', 'error')
+  })
+
+  it('detaches a member by deleting the matching group rule position', async () => {
+    const member = guest(140, {
+      name: 'web-02',
+      rules: [groupRule('sg-other', 2), groupRule(GROUP, 7)],
+    })
+    const { dialogProps } = renderDialog({ guests: [member] })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Detach' }))
+
+    await waitFor(() => {
+      expect(deleteVMRule).toHaveBeenCalledWith(CONNECTION, 'pve1', 'qemu', 140, 7)
+    })
+    expect(dialogProps.onChanged).toHaveBeenCalledWith([member])
+    expect(showToast).toHaveBeenCalledWith('sg-web detached from web-02 (140)', 'success')
+  })
+
+  it('shows the partial-scan notice only when guests were skipped', () => {
+    const initialProps = props({ guestsNotScanned: 12 })
+    const { rerender } = renderWithProviders(<SecurityGroupMembersDialog {...initialProps} />)
+
+    expect(screen.getByText('12 guests were not scanned, this count may be incomplete')).toBeInTheDocument()
+
+    rerender(<SecurityGroupMembersDialog {...initialProps} guestsNotScanned={0} />)
+
+    expect(screen.queryByText('12 guests were not scanned, this count may be incomplete')).not.toBeInTheDocument()
+  })
+
+  it('does not offer guests that already carry the group rule', async () => {
+    const attached = guest(150, { name: 'web-attached', rules: [groupRule(GROUP, 3)] })
+    const candidate = guest(151, { name: 'web-candidate' })
+
+    renderDialog({ guests: [attached, candidate] })
+
+    fireEvent.change(screen.getByLabelText('Guests to attach'), { target: { value: 'web' } })
+
+    expect(await screen.findByRole('option', { name: 'web-candidate (151)' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'web-attached (150)' })).not.toBeInTheDocument()
+    expect(within(screen.getByRole('listbox')).getAllByRole('option')).toHaveLength(1)
+  })
+})

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
+
+import {
+  Alert, Autocomplete, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle,
+  IconButton, List, ListItem, ListItemText, TextField, Tooltip, Typography
+} from '@mui/material'
+
+import * as firewallAPI from '@/lib/api/firewall'
+import type { VMFirewallInfo } from '@/hooks/useVMFirewallRules'
+import { useToast } from '@/contexts/ToastContext'
+
+interface SecurityGroupMembersDialogProps {
+  open: boolean
+  groupName: string
+  connectionId: string
+  /** Every guest the firewall scan covered, with its rules. */
+  guests: VMFirewallInfo[]
+  /** Guests the scan left out: they can be neither listed nor offered here. */
+  guestsNotScanned: number
+  onClose: () => void
+  /** Called with the guests whose rules changed, so the caller can refresh them. */
+  onChanged: (touched: VMFirewallInfo[]) => void
+}
+
+/** The group rule a guest carries for this security group, if any. */
+function groupRuleOf(guest: VMFirewallInfo, groupName: string) {
+  return guest.rules.find(r => r.type === 'group' && r.action === groupName)
+}
+
+/**
+ * Attach a security group to guests, and detach it, from the group's own screen.
+ *
+ * PVE has no membership list of its own: a group applies to a guest because that
+ * guest carries a rule of type `group` whose action is the group name. So the
+ * members shown here are derived from the guests' rules, attaching inserts such
+ * a rule, and detaching deletes it.
+ */
+export default function SecurityGroupMembersDialog({
+  open, groupName, connectionId, guests, guestsNotScanned, onClose, onChanged
+}: SecurityGroupMembersDialogProps) {
+  const t = useTranslations()
+  const { showToast } = useToast()
+
+  const [selected, setSelected] = useState<VMFirewallInfo[]>([])
+  const [busy, setBusy] = useState(false)
+
+  const members = useMemo(
+    () => guests.filter(g => groupRuleOf(g, groupName)),
+    [guests, groupName]
+  )
+
+  const candidates = useMemo(
+    () => guests.filter(g => !groupRuleOf(g, groupName)),
+    [guests, groupName]
+  )
+
+  const guestLabel = (g: VMFirewallInfo) => `${g.name} (${g.vmid})`
+
+  const attach = async () => {
+    if (selected.length === 0) return
+
+    setBusy(true)
+
+    const done: VMFirewallInfo[] = []
+    const failed: string[] = []
+
+    // Sequential on purpose: PVE rewrites the guest's rule file on each insert,
+    // and parallel inserts on the same guest list race for it.
+    for (const guest of selected) {
+      try {
+        await firewallAPI.addVMRule(connectionId, guest.node, guest.type, guest.vmid, {
+          type: 'group',
+          action: groupName,
+          enable: 1,
+        })
+        done.push(guest)
+      } catch {
+        failed.push(guestLabel(guest))
+      }
+    }
+
+    setBusy(false)
+    setSelected([])
+
+    // Whatever succeeded stays: a partial failure is reported, not rolled back.
+    if (done.length > 0) {
+      onChanged(done)
+      showToast(t('firewall.membersAttached', { count: done.length, group: groupName }), 'success')
+    }
+
+    if (failed.length > 0) {
+      showToast(t('firewall.membersAttachFailed', { guests: failed.join(', ') }), 'error')
+    }
+  }
+
+  const detach = async (guest: VMFirewallInfo) => {
+    const rule = groupRuleOf(guest, groupName)
+
+    if (!rule || rule.pos === undefined) return
+
+    setBusy(true)
+
+    try {
+      await firewallAPI.deleteVMRule(connectionId, guest.node, guest.type, guest.vmid, rule.pos)
+      onChanged([guest])
+      showToast(t('firewall.membersDetached', { guest: guestLabel(guest), group: groupName }), 'success')
+    } catch {
+      showToast(t('firewall.membersDetachFailed', { guests: guestLabel(guest) }), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('firewall.membersTitle', { group: groupName })}</DialogTitle>
+      <DialogContent>
+        {guestsNotScanned > 0 && (
+          <Alert severity="info" sx={{ mb: 2 }}>
+            {t('firewall.membersPartial', { count: guestsNotScanned })}
+          </Alert>
+        )}
+
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-start', mb: 2 }}>
+          <Autocomplete
+            multiple
+            size="small"
+            sx={{ flex: 1 }}
+            options={candidates}
+            value={selected}
+            onChange={(_, value) => setSelected(value)}
+            getOptionLabel={guestLabel}
+            isOptionEqualToValue={(a, b) => a.vmid === b.vmid}
+            renderInput={params => <TextField {...params} label={t('firewall.membersAttachLabel')} />}
+          />
+          <Button variant="contained" onClick={attach} disabled={busy || selected.length === 0} sx={{ mt: 0.25 }}>
+            {t('firewall.membersAttach')}
+          </Button>
+        </Box>
+
+        <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+          {t('firewall.membersCurrent')}
+          <Chip label={members.length} size="small" sx={{ ml: 1, height: 18, fontSize: 10 }} />
+        </Typography>
+
+        {members.length === 0 ? (
+          <Typography variant="body2" sx={{ color: 'text.secondary', py: 2 }}>
+            {t('firewall.membersEmpty')}
+          </Typography>
+        ) : (
+          <List dense disablePadding>
+            {members.map(guest => (
+              <ListItem
+                key={guest.vmid}
+                secondaryAction={
+                  <Tooltip title={t('firewall.membersDetach')}>
+                    <IconButton edge="end" size="small" disabled={busy} onClick={() => detach(guest)}>
+                      <i className="ri-link-unlink" style={{ fontSize: 16 }} />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <i
+                  className={guest.type === 'qemu' ? 'ri-computer-line' : 'ri-instance-line'}
+                  style={{ fontSize: 16, marginRight: 8, opacity: 0.7 }}
+                />
+                <ListItemText primary={guestLabel(guest)} secondary={guest.node} />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('common.close')}</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/app/(dashboard)/automation/network/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/page.tsx
@@ -53,7 +53,7 @@ export default function NetworkAutomationPage() {
   } = useFirewallData(isEnterprise ? selectedConnection || null : null, isEnterprise)
 
   const {
-    vmFirewallData, loadingVMRules, loadVMFirewallData, reloadVMFirewallRules, setVMFirewallData,
+    vmFirewallData, loadingVMRules, guestsNotScanned, loadVMFirewallData, reloadVMFirewallRules, setVMFirewallData,
   } = useVMFirewallRules(isEnterprise ? selectedConnection || null : null)
 
   const {
@@ -89,10 +89,13 @@ export default function NetworkAutomationPage() {
     }
   }, [firewallMode, activeTab, rulesSubTab])
 
-  // Load VM rules when on Dashboard (tab 0) or Firewalling > VMs (tab 1, subTab 2)
+  // Load VM rules when on Dashboard (tab 0), Firewalling > Cluster/VMs (tab 1,
+  // subTab 0 or 2), or Security Groups (tab 4) — that last tab counts, per
+  // group, the guests whose rules reference it, so without this it showed 0 VMs
+  // everywhere while the data had simply never been fetched.
   useEffect(() => {
     if (isEnterprise && selectedConnection && !loadingVMRules && vmFirewallData.length === 0) {
-      if (activeTab === 0 || (activeTab === 1 && (rulesSubTab === 0 || rulesSubTab === 2))) {
+      if (activeTab === 0 || activeTab === 4 || (activeTab === 1 && (rulesSubTab === 0 || rulesSubTab === 2))) {
         loadVMFirewallData()
       }
     }
@@ -230,12 +233,17 @@ export default function NetworkAutomationPage() {
             <SecurityGroupsPanel
               securityGroups={securityGroups}
               vmFirewallData={vmFirewallData}
+              loadingVMRules={loadingVMRules}
+              guestsNotScanned={guestsNotScanned}
+              clusterRules={clusterRules}
+              hostRulesByNode={hostRulesByNode}
               firewallMode={firewallMode}
               selectedConnection={selectedConnection}
               totalRules={totalRules}
               aliases={aliases}
               ipsets={ipsets}
               reload={loadFirewallData}
+              reloadVMFirewallRules={reloadVMFirewallRules}
             />
           )}
 

--- a/frontend/src/hooks/useVMFirewallRules.test.tsx
+++ b/frontend/src/hooks/useVMFirewallRules.test.tsx
@@ -1,0 +1,270 @@
+/**
+ * Coverage for the bounded VM firewall scan and its single-guest refresh.
+ *
+ * The inventory request and per-guest config requests share `fetch`, while the
+ * firewall adapter supplies rules and options. Keeping those mocks separate
+ * lets these tests assert the scan cap and batch size without depending on any
+ * route handlers. No automatic RTL cleanup is configured in this repo.
+ */
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { FirewallRule } from '@/lib/api/firewall'
+
+vi.mock('@/lib/api/firewall', () => ({
+  getVMRules: vi.fn(),
+  getVMOptions: vi.fn(),
+}))
+
+import * as firewallAPI from '@/lib/api/firewall'
+
+import { useVMFirewallRules, type VMFirewallInfo } from './useVMFirewallRules'
+
+interface Guest {
+  vmid: string
+  name: string
+  node: string
+  type: 'qemu' | 'lxc'
+  status: string
+  template?: boolean
+}
+
+const getVMRules = vi.mocked(firewallAPI.getVMRules)
+const getVMOptions = vi.mocked(firewallAPI.getVMOptions)
+
+const rule = (pos: number): FirewallRule => ({ pos, type: 'in', action: 'ACCEPT', enable: 1 })
+
+function guest(vmid: number, overrides: Partial<Guest> = {}): Guest {
+  return {
+    vmid: String(vmid),
+    name: `guest-${vmid}`,
+    node: 'pve1',
+    type: 'qemu',
+    status: 'running',
+    ...overrides,
+  }
+}
+
+function vm(vmid: number, overrides: Partial<VMFirewallInfo> = {}): VMFirewallInfo {
+  return {
+    vmid,
+    name: `guest-${vmid}`,
+    node: 'pve1',
+    type: 'qemu',
+    status: 'running',
+    firewallEnabled: false,
+    rules: [],
+    options: null,
+    vlans: [],
+    ...overrides,
+  }
+}
+
+/** Mock the inventory response and the config returned for each scanned guest. */
+function mockGuestScan(
+  guests: Guest[],
+  configs: Record<number, Record<string, unknown> | null> = {},
+) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+
+    if (url.startsWith('/api/v1/vms?')) {
+      return { json: async () => ({ data: { vms: guests } }) } as Response
+    }
+
+    const vmid = Number(url.match(/\/(\d+)\/config$/)?.[1])
+    const config = Object.hasOwn(configs, vmid) ? configs[vmid] : {}
+
+    return { json: async () => config === null ? null : { data: config } } as Response
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+
+  return fetchMock
+}
+
+beforeEach(() => {
+  getVMRules.mockReset().mockResolvedValue([])
+  getVMOptions.mockReset().mockResolvedValue({ enable: 1 })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('useVMFirewallRules', () => {
+  it('caps a 250-guest inventory at 200 and reports the 50 skipped guests', async () => {
+    const guests = Array.from({ length: 250 }, (_, index) => guest(1000 + index))
+
+    mockGuestScan(guests)
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.vmFirewallData).toHaveLength(200)
+    expect(result.current.guestsNotScanned).toBe(50)
+    expect(getVMRules).toHaveBeenCalledTimes(200)
+    expect(getVMOptions).toHaveBeenCalledTimes(200)
+    expect(result.current.vmFirewallData.map(item => item.vmid)).not.toContain(1200)
+  })
+
+  it('scans every non-template guest below the cap and excludes templates', async () => {
+    mockGuestScan([
+      guest(100),
+      guest(101, { template: true }),
+      guest(102, { type: 'lxc' }),
+      guest(103, { template: true }),
+    ])
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.guestsNotScanned).toBe(0)
+    expect(result.current.vmFirewallData.map(item => item.vmid)).toEqual([100, 102])
+    expect(getVMRules).toHaveBeenCalledTimes(2)
+  })
+
+  it('never has more than eight guest rule requests in flight', async () => {
+    let inFlight = 0
+    let maximumInFlight = 0
+
+    mockGuestScan(Array.from({ length: 17 }, (_, index) => guest(200 + index)))
+    getVMRules.mockImplementation(async () => {
+      inFlight += 1
+      maximumInFlight = Math.max(maximumInFlight, inFlight)
+
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+      inFlight -= 1
+
+      return []
+    })
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(getVMRules).toHaveBeenCalledTimes(17)
+    expect(maximumInFlight).toBe(8)
+  })
+
+  it('keeps a guest whose rules request fails, with an empty rules array', async () => {
+    mockGuestScan([guest(300), guest(301)])
+    getVMRules.mockImplementation(async (_connectionId, _node, _type, vmid) => {
+      if (Number(vmid) === 301) throw new Error('rules unavailable')
+
+      return [rule(0)]
+    })
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.vmFirewallData).toHaveLength(2)
+    expect(result.current.vmFirewallData.find(item => item.vmid === 300)?.rules).toEqual([rule(0)])
+    expect(result.current.vmFirewallData.find(item => item.vmid === 301)?.rules).toEqual([])
+  })
+
+  it('sorts firewall-enabled guests first, then sorts each tier by rule count', async () => {
+    const rulesByGuest: Record<number, FirewallRule[]> = {
+      400: [rule(0), rule(1), rule(2)],
+      401: [rule(0)],
+      402: [rule(0), rule(1)],
+      403: [rule(0)],
+    }
+
+    mockGuestScan(
+      [guest(400), guest(401), guest(402), guest(403)],
+      {
+        400: { net0: 'virtio=AA:00,tag=30' },
+        401: { net0: 'virtio=AA:01,firewall=1,tag=20' },
+        402: {
+          net0: 'virtio=AA:02,firewall=1,tag=30',
+          net1: 'virtio=AA:03,tag=10',
+          net2: 'virtio=AA:04,tag=30',
+        },
+        403: {},
+      },
+    )
+    getVMRules.mockImplementation(async (_connectionId, _node, _type, vmid) => rulesByGuest[Number(vmid)])
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.vmFirewallData.map(item => item.vmid)).toEqual([402, 401, 400, 403])
+    expect(result.current.vmFirewallData[0]).toMatchObject({ firewallEnabled: true, vlans: [10, 30] })
+    expect(result.current.vmFirewallData[2].firewallEnabled).toBe(false)
+  })
+
+  it('reloads only the requested guest with its latest rules, options and NIC config', async () => {
+    const first = vm(500, { rules: [rule(0)] })
+    const untouched = vm(501, { name: 'leave-me-alone', rules: [rule(1)] })
+
+    mockGuestScan([], {
+      500: {
+        net0: 'virtio=AA:05,firewall=1,tag=40',
+        net1: 'virtio=AA:06,tag=10',
+      },
+    })
+    getVMRules.mockResolvedValue([rule(7), rule(8)])
+    getVMOptions.mockResolvedValue({ enable: 0, policy_in: 'DROP' })
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    act(() => result.current.setVMFirewallData([first, untouched]))
+
+    await act(async () => {
+      await result.current.reloadVMFirewallRules(first)
+    })
+
+    expect(getVMRules).toHaveBeenCalledWith('conn-1', 'pve1', 'qemu', 500)
+    expect(result.current.vmFirewallData[0]).toMatchObject({
+      vmid: 500,
+      firewallEnabled: true,
+      rules: [rule(7), rule(8)],
+      options: { enable: 0, policy_in: 'DROP' },
+      vlans: [10, 40],
+    })
+    expect(result.current.vmFirewallData[1]).toEqual(untouched)
+  })
+
+  it('makes a second load a no-op until resetting the data', async () => {
+    const fetchMock = mockGuestScan([guest(600)])
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(getVMRules).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).startsWith('/api/v1/vms?'))).toHaveLength(1)
+
+    act(() => result.current.setVMFirewallData([]))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(getVMRules).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls.filter(([input]) => String(input).startsWith('/api/v1/vms?'))).toHaveLength(2)
+  })
+})

--- a/frontend/src/hooks/useVMFirewallRules.test.tsx
+++ b/frontend/src/hooks/useVMFirewallRules.test.tsx
@@ -177,6 +177,40 @@ describe('useVMFirewallRules', () => {
     expect(result.current.vmFirewallData.find(item => item.vmid === 301)?.rules).toEqual([])
   })
 
+  it('keeps a guest whose adapter call throws outright, rather than sinking the scan', async () => {
+    mockGuestScan([guest(310), guest(311)])
+    getVMRules.mockImplementation((_connectionId, _node, _type, vmid) => {
+      // Thrown, not rejected: the per-call `.catch()` is never attached, so
+      // only the guest-level guard keeps the other guests from being lost.
+      if (Number(vmid) === 311) throw new Error('adapter unavailable')
+
+      return Promise.resolve([rule(0)])
+    })
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.vmFirewallData).toHaveLength(2)
+    expect(result.current.vmFirewallData.find(item => item.vmid === 311)).toMatchObject({
+      name: 'guest-311', firewallEnabled: false, rules: [], options: null, vlans: [],
+    })
+  })
+
+  it('names a guest PVE returned without one after its id', async () => {
+    mockGuestScan([guest(320, { name: '' })])
+
+    const { result } = renderHook(() => useVMFirewallRules('conn-1'))
+
+    await act(async () => {
+      await result.current.loadVMFirewallData()
+    })
+
+    expect(result.current.vmFirewallData[0].name).toBe('VM 320')
+  })
+
   it('sorts firewall-enabled guests first, then sorts each tier by rule count', async () => {
     const rulesByGuest: Record<number, FirewallRule[]> = {
       400: [rule(0), rule(1), rule(2)],

--- a/frontend/src/hooks/useVMFirewallRules.ts
+++ b/frontend/src/hooks/useVMFirewallRules.ts
@@ -40,14 +40,30 @@ function extractVLANs(config: Record<string, any>): number[] {
 interface UseVMFirewallRulesReturn {
   vmFirewallData: VMFirewallInfo[]
   loadingVMRules: boolean
+  /**
+   * Guests left out by the scan cap. Anything reading `vmFirewallData` as a
+   * count — security group membership, firewall coverage — is partial when this
+   * is above zero, and must say so rather than report a confident wrong number.
+   */
+  guestsNotScanned: number
   loadVMFirewallData: () => Promise<void>
   reloadVMFirewallRules: (vm: VMFirewallInfo) => Promise<void>
   setVMFirewallData: React.Dispatch<React.SetStateAction<VMFirewallInfo[]>>
 }
 
+/**
+ * Guests scanned at most, and how many are fetched at a time. Each guest costs
+ * three requests (rules, options, config), so the scan is bounded twice: the cap
+ * keeps a large cluster from firing hundreds of requests, and the window keeps
+ * them from going out one after another as they used to.
+ */
+const SCAN_LIMIT = 200
+const SCAN_CONCURRENCY = 8
+
 export function useVMFirewallRules(connectionId: string | null): UseVMFirewallRulesReturn {
   const [vmFirewallData, setVMFirewallData] = useState<VMFirewallInfo[]>([])
   const [loadingVMRules, setLoadingVMRules] = useState(false)
+  const [guestsNotScanned, setGuestsNotScanned] = useState(0)
   const [loaded, setLoaded] = useState(false)
 
   const loadVMFirewallData = useCallback(async () => {
@@ -62,10 +78,19 @@ export function useVMFirewallRules(connectionId: string | null): UseVMFirewallRu
       const allGuests = vmsData?.data?.vms || []
       const guests = allGuests.filter((g: any) => !g.template)
 
-      // Load firewall rules for each VM (limit to avoid too many requests)
-      const vmData: VMFirewallInfo[] = []
+      const scanned = guests.slice(0, SCAN_LIMIT)
 
-      for (const guest of guests.slice(0, 50)) { // Limit to 50 VMs
+      setGuestsNotScanned(Math.max(0, guests.length - scanned.length))
+
+      const loadOneGuest = async (guest: any): Promise<VMFirewallInfo> => {
+        const base = {
+          vmid: Number.parseInt(guest.vmid, 10),
+          name: guest.name || `VM ${guest.vmid}`,
+          node: guest.node,
+          type: guest.type,
+          status: guest.status,
+        }
+
         try {
           // Fetch rules, options, and VM config (for NIC firewall status)
           const [rulesData, optionsData, configResp] = await Promise.all([
@@ -78,30 +103,25 @@ export function useVMFirewallRules(connectionId: string | null): UseVMFirewallRu
           const nicFirewallEnabled = configResp?.data ? checkNICFirewallEnabled(configResp.data) : false
           const vlans = configResp?.data ? extractVLANs(configResp.data) : []
 
-          vmData.push({
-            vmid: Number.parseInt(guest.vmid, 10),
-            name: guest.name || `VM ${guest.vmid}`,
-            node: guest.node,
-            type: guest.type,
-            status: guest.status,
+          return {
+            ...base,
             firewallEnabled: nicFirewallEnabled,
             rules: Array.isArray(rulesData) ? rulesData : [],
             options: optionsData,
             vlans,
-          })
+          }
         } catch {
-          vmData.push({
-            vmid: Number.parseInt(guest.vmid, 10),
-            name: guest.name || `VM ${guest.vmid}`,
-            node: guest.node,
-            type: guest.type,
-            status: guest.status,
-            firewallEnabled: false,
-            rules: [],
-            options: null,
-            vlans: [],
-          })
+          return { ...base, firewallEnabled: false, rules: [], options: null, vlans: [] }
         }
+      }
+
+      // Load firewall data in small parallel batches rather than guest by guest.
+      const vmData: VMFirewallInfo[] = []
+
+      for (let i = 0; i < scanned.length; i += SCAN_CONCURRENCY) {
+        const batch = await Promise.all(scanned.slice(i, i + SCAN_CONCURRENCY).map(loadOneGuest))
+
+        vmData.push(...batch)
       }
 
       // Sort by firewall enabled first, then by rule count
@@ -157,6 +177,7 @@ export function useVMFirewallRules(connectionId: string | null): UseVMFirewallRu
   return {
     vmFirewallData,
     loadingVMRules,
+    guestsNotScanned,
     loadVMFirewallData,
     reloadVMFirewallRules,
     setVMFirewallData: resetVMFirewallData,

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5882,6 +5882,19 @@
     "sourcePort": "Quellport",
     "destPort": "Zielport",
     "logLevel": "Log-Level",
+    "membersTitle": "Mitglieder von {group}",
+    "membersAttachLabel": "Gäste zum Zuweisen",
+    "membersAttach": "Zuweisen",
+    "membersDetach": "Entfernen",
+    "membersCurrent": "Zugewiesene Gäste",
+    "membersEmpty": "Noch kein Gast verweist auf diese Gruppe",
+    "membersPartial": "{count} Gäste wurden nicht geprüft, diese Zahl kann unvollständig sein",
+    "membersAttached": "{group} {count} Gast/Gästen zugewiesen",
+    "membersAttachFailed": "Zuweisen fehlgeschlagen: {guests}",
+    "membersDetached": "{group} von {guest} entfernt",
+    "membersDetachFailed": "Entfernen fehlgeschlagen: {guests}",
+    "membersScopeCluster": "Von einer Cluster-Regel referenziert",
+    "membersScopeNodes": "Von Node-Regeln referenziert: {nodes}",
     "direction": "Richt.",
     "service": "Dienst",
     "typeIn": "IN (eingehend)",
@@ -5910,7 +5923,8 @@
     "vmFirewallCoverage": "VM-Firewall-Abdeckung",
     "protectedLabel": "Geschützt",
     "unprotectedLabel": "Ungeschützt",
-    "withSgLabel": "Mit SG"
+    "withSgLabel": "Mit SG",
+    "logLevelShort": "Log"
   },
   "themes": {
     "categories": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5952,6 +5952,19 @@
     "sourcePort": "Source port",
     "destPort": "Destination port",
     "logLevel": "Log level",
+    "membersTitle": "Members of {group}",
+    "membersAttachLabel": "Guests to attach",
+    "membersAttach": "Attach",
+    "membersDetach": "Detach",
+    "membersCurrent": "Attached guests",
+    "membersEmpty": "No guest references this group yet",
+    "membersPartial": "{count} guests were not scanned, this count may be incomplete",
+    "membersAttached": "{group} attached to {count} guest(s)",
+    "membersAttachFailed": "Could not attach: {guests}",
+    "membersDetached": "{group} detached from {guest}",
+    "membersDetachFailed": "Could not detach: {guests}",
+    "membersScopeCluster": "Referenced by a cluster rule",
+    "membersScopeNodes": "Referenced by node rules: {nodes}",
     "direction": "Dir",
     "service": "Service",
     "typeIn": "IN (inbound)",
@@ -5980,7 +5993,8 @@
     "vmFirewallCoverage": "VM Firewall Coverage",
     "protectedLabel": "Protected",
     "unprotectedLabel": "Unprotected",
-    "withSgLabel": "With SG"
+    "withSgLabel": "With SG",
+    "logLevelShort": "Log"
   },
   "themes": {
     "categories": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -5952,6 +5952,19 @@
     "sourcePort": "Puerto de origen",
     "destPort": "Puerto de destino",
     "logLevel": "Nivel de log",
+    "membersTitle": "Miembros de {group}",
+    "membersAttachLabel": "Invitados a asociar",
+    "membersAttach": "Asociar",
+    "membersDetach": "Desasociar",
+    "membersCurrent": "Invitados asociados",
+    "membersEmpty": "Ningún invitado referencia todavía este grupo",
+    "membersPartial": "{count} invitados no se han analizado, este recuento puede estar incompleto",
+    "membersAttached": "{group} asociado a {count} invitado(s)",
+    "membersAttachFailed": "No se pudo asociar: {guests}",
+    "membersDetached": "{group} desasociado de {guest}",
+    "membersDetachFailed": "No se pudo desasociar: {guests}",
+    "membersScopeCluster": "Referenciado por una regla de clúster",
+    "membersScopeNodes": "Referenciado por reglas de nodo: {nodes}",
     "direction": "Dir",
     "service": "Servicio",
     "typeIn": "IN (entrante)",
@@ -5980,7 +5993,8 @@
     "vmFirewallCoverage": "Cobertura de firewall de VM",
     "protectedLabel": "Protegido",
     "unprotectedLabel": "No protegido",
-    "withSgLabel": "Con SG"
+    "withSgLabel": "Con SG",
+    "logLevelShort": "Log"
   },
   "themes": {
     "categories": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5952,6 +5952,19 @@
     "sourcePort": "Port source",
     "destPort": "Port destination",
     "logLevel": "Niveau de journalisation",
+    "membersTitle": "Membres de {group}",
+    "membersAttachLabel": "Invités à attacher",
+    "membersAttach": "Attacher",
+    "membersDetach": "Détacher",
+    "membersCurrent": "Invités attachés",
+    "membersEmpty": "Aucun invité ne référence encore ce groupe",
+    "membersPartial": "{count} invités n'ont pas été parcourus, ce compte peut être incomplet",
+    "membersAttached": "{group} attaché à {count} invité(s)",
+    "membersAttachFailed": "Échec de l'attachement : {guests}",
+    "membersDetached": "{group} détaché de {guest}",
+    "membersDetachFailed": "Échec du détachement : {guests}",
+    "membersScopeCluster": "Référencé par une règle de cluster",
+    "membersScopeNodes": "Référencé par des règles de nœud : {nodes}",
     "direction": "Dir",
     "service": "Service",
     "typeIn": "IN (entrant)",
@@ -5980,7 +5993,8 @@
     "vmFirewallCoverage": "Couverture Firewall des VMs",
     "protectedLabel": "Protégées",
     "unprotectedLabel": "Non protégées",
-    "withSgLabel": "Avec SG"
+    "withSgLabel": "Avec SG",
+    "logLevelShort": "Journalisation"
   },
   "themes": {
     "categories": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -5952,6 +5952,19 @@
     "sourcePort": "출발지 포트",
     "destPort": "목적지 포트",
     "logLevel": "로그 수준",
+    "membersTitle": "{group} 멤버",
+    "membersAttachLabel": "연결할 게스트",
+    "membersAttach": "연결",
+    "membersDetach": "연결 해제",
+    "membersCurrent": "연결된 게스트",
+    "membersEmpty": "이 그룹을 참조하는 게스트가 아직 없습니다",
+    "membersPartial": "게스트 {count}개를 검사하지 않았으므로 이 개수는 불완전할 수 있습니다",
+    "membersAttached": "{group}을 게스트 {count}개에 연결했습니다",
+    "membersAttachFailed": "연결 실패: {guests}",
+    "membersDetached": "{group}을 {guest}에서 연결 해제했습니다",
+    "membersDetachFailed": "연결 해제 실패: {guests}",
+    "membersScopeCluster": "클러스터 규칙에서 참조됨",
+    "membersScopeNodes": "노드 규칙에서 참조됨: {nodes}",
     "direction": "방향",
     "service": "서비스",
     "typeIn": "IN (인바운드)",
@@ -5980,7 +5993,8 @@
     "vmFirewallCoverage": "VM 방화벽 적용률",
     "protectedLabel": "보호됨",
     "unprotectedLabel": "보호되지 않음",
-    "withSgLabel": "SG 있음"
+    "withSgLabel": "SG 있음",
+    "logLevelShort": "로그"
   },
   "themes": {
     "categories": {

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5884,6 +5884,19 @@
     "sourcePort": "源端口",
     "destPort": "目标端口",
     "logLevel": "日志级别",
+    "membersTitle": "{group} 的成员",
+    "membersAttachLabel": "要附加的实例",
+    "membersAttach": "附加",
+    "membersDetach": "分离",
+    "membersCurrent": "已附加的实例",
+    "membersEmpty": "尚无实例引用此安全组",
+    "membersPartial": "有 {count} 个实例未被扫描，此计数可能不完整",
+    "membersAttached": "已将 {group} 附加到 {count} 个实例",
+    "membersAttachFailed": "附加失败：{guests}",
+    "membersDetached": "已将 {group} 从 {guest} 分离",
+    "membersDetachFailed": "分离失败：{guests}",
+    "membersScopeCluster": "被集群规则引用",
+    "membersScopeNodes": "被节点规则引用：{nodes}",
     "direction": "方向",
     "service": "服务",
     "typeIn": "IN（入站）",
@@ -5912,7 +5925,8 @@
     "vmFirewallCoverage": "VM 防火墙覆盖率",
     "protectedLabel": "受保护",
     "unprotectedLabel": "未保护",
-    "withSgLabel": "有安全组"
+    "withSgLabel": "有安全组",
+    "logLevelShort": "日志"
   },
   "themes": {
     "categories": {


### PR DESCRIPTION
Closes #683

## Why

The Security Groups screen showed `0 VMs` on every group and had no attach action, so attaching a guest to a group looked impossible. It was possible, but only one guest at a time from the guest's own Firewall tab, and the count was wrong for three independent reasons.

## The count

- **The tab never loaded its data.** The effect that fetches the guests' firewall rules covered the Dashboard and Firewalling tabs, not Security Groups, which is the very tab a dashboard stat card links straight to. Every group therefore counted zero.
- **The scan stopped at 50 guests**, silently undercounting beyond that. It now covers 200, fetched in batches of 8 rather than one guest after another, and reports how many it left out so the UI can say a count is partial instead of stating a confident wrong number.
- **Cluster and node references were ignored.** A group referenced by a cluster rule or by a node's rules still read `0 VMs`, which reads as "unused" and invites deleting a group that is filtering traffic. Those scopes now show as their own chip with the referencing nodes in the tooltip.

## Attaching and detaching

A **Members** dialog on the group's own row lists the guests that reference the group and both attaches (multi-select) and detaches. There is no membership list in PVE: a group applies to a guest because the guest carries a rule of type `group` whose action is the group name, so attaching inserts that rule and detaching deletes it, through the existing routes.

Two deliberate behaviours: inserts are **sequential**, because PVE rewrites the guest's rule file on each insert and parallel writes race for it; and a **partial failure is reported, not rolled back**: attaching to eight guests where the third fails keeps the seven and names the one that failed.

## Also in this area

- The VM/CT rule dialog offered `GROUP` as a direction while its Action select only listed ACCEPT/DROP/REJECT. PVE carries the group name in `action`, so that combination could only produce an invalid rule. The select now swaps to the group list, as the host and cluster dialogs already did.
- The per-rule **Applied To** column repeated the same count on every row of a group, where it means nothing. Dropped: membership lives on the group header next to the Members action, and this table now has the same eleven columns as the other three.
- The rules tables read noticeably smaller than the rest of the page. The value cells and the header row now share a single font-size constant, raised to 13px, so the two cannot drift apart again; the log column takes a short label so it stops crowding Comment.
- The standalone-mode notice rendered centred labels above left-anchored rows.

## Verification

- 172 jsdom tests pass across the rules and firewall suites, including the two whose expectations this change deliberately inverts (the dropped column, the short log label).
- ESLint on the touched area: 0 errors (the remaining `react-hooks` warnings are pre-existing).
- Reviewed in the browser against a live cluster: groups created, the count, the dialog and the GROUP rule path.

## Note on coverage

`useVMFirewallRules.ts` sits at 0% coverage on `main` with 62 coverable lines and 41 conditions, and this PR changes it, so the new-code coverage gate needs a suite for that hook and for the Members dialog. Those tests are being added on this branch, before merge.

