### PR TITLE
Carry the white label into the compliance PDF export

### DIFF
--- a/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.test.ts
+++ b/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.test.ts
@@ -307,6 +307,82 @@ describe('GET /api/v1/compliance/frameworks/[frameworkId]/report', () => {
     expect(capturedHtml).toContain('data:image/png;base64,')
   })
 
+  // #681: this export is a second PDF pipeline. It already honoured the brand
+  // colour and the logo, but wrote "ProxCenter" literally on the cover, in the
+  // running header and in the document title, so a white-labelled install still
+  // got reports carrying our name.
+  describe('white label app name (#681)', () => {
+    /** Render a report and hand back the HTML sent to the sidecar. */
+    async function renderedHtml(): Promise<string> {
+      let capturedHtml = ''
+
+      renderPdfMock.mockImplementation(async (html: string) => {
+        capturedHtml = html
+        return { ok: true, pdf: Buffer.from([1, 2, 3]) }
+      })
+
+      const { GET } = await import('./route')
+      const res = await callRoute(GET, {
+        params: { frameworkId: 'nist-800-171-r2' },
+        searchParams: { connectionId: 'c1' },
+      })
+
+      expect(res.status).toBe(200)
+
+      return capturedHtml
+    }
+
+    it('names the tenant on the cover, the running header and the title', async () => {
+      getSettingMock.mockResolvedValue({
+        enabled: true,
+        appName: 'ACME Cloud',
+        primaryColor: '#123456',
+      })
+
+      const html = await renderedHtml()
+
+      expect(html).toContain('<div class="cover-app-name">ACME Cloud</div>')
+      expect(html).toContain('content: "ACME Cloud  |  Compliance Report"')
+      expect(html).toContain('<title>ACME Cloud - ')
+      expect(html).not.toContain('ProxCenter')
+    })
+
+    it('keeps ProxCenter when white label is off, even with a name saved', async () => {
+      // The toggle is the master switch, as it already was for the colour.
+      getSettingMock.mockResolvedValue({
+        enabled: false,
+        appName: 'ACME Cloud',
+        primaryColor: '#123456',
+      })
+
+      const html = await renderedHtml()
+
+      expect(html).toContain('<div class="cover-app-name">ProxCenter</div>')
+      expect(html).not.toContain('ACME Cloud')
+    })
+
+    it('keeps ProxCenter when branding carries no name', async () => {
+      getSettingMock.mockResolvedValue({ enabled: true, primaryColor: '#123456' })
+
+      expect(await renderedHtml()).toContain('<div class="cover-app-name">ProxCenter</div>')
+    })
+
+    it('cannot break the stylesheet out of an operator-supplied name', async () => {
+      // The name lands in a CSS string inside a <style> block, where escapeHtml
+      // is no help: the HTML parser closes that block on </style> wherever it
+      // appears, string literal or not.
+      getSettingMock.mockResolvedValue({
+        enabled: true,
+        appName: '</style><script>alert(1)</script>',
+      })
+
+      const html = await renderedHtml()
+
+      expect(html.match(/<\/style>/g)).toHaveLength(1)
+      expect(html).not.toContain('<script>alert(1)</script>')
+    })
+  })
+
   it('still returns 200 when getSetting throws (branding hiccup)', async () => {
     getSettingMock.mockRejectedValue(new Error('DB connection lost'))
     const { GET } = await import('./route')

--- a/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.ts
+++ b/frontend/src/app/api/v1/compliance/frameworks/[frameworkId]/report/route.ts
@@ -71,11 +71,18 @@ export async function GET(req: Request, ctx: { params: Promise<{ frameworkId: st
     // hiccup never crashes the report; falls back to defaults.
     let brandColor = '#E57000'
     let logoDataUri = ''
+    let appName = ''
     try {
       const tenantId = await getCurrentTenantId()
       const branding = await getSetting<any>('branding', tenantId)
       if (branding?.enabled && branding?.primaryColor) {
         brandColor = String(branding.primaryColor)
+      }
+
+      // #681: the colour and the logo were already honoured here, the name was
+      // not, so a white-labelled report still read "ProxCenter" on its cover.
+      if (branding?.enabled && branding?.appName) {
+        appName = String(branding.appName)
       }
 
       const brandingLogoUrl = branding?.enabled ? branding?.logoUrl : ''
@@ -153,6 +160,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ frameworkId: st
         brandColor,
         logoDataUri,
         frameworkLogoDataUri,
+        appName,
       },
       reportT,
       nodeBreakdown,

--- a/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
+++ b/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
@@ -43,6 +43,74 @@ describe('frameworkReportHtml', () => {
     expect(html).toContain('&lt;b&gt;none&lt;/b&gt;')
   })
 
+  // -- White labeling (#681) --
+
+  // This export is a second PDF pipeline: it already honoured the brand colour
+  // and logo but wrote "ProxCenter" literally on the cover, in the running
+  // header and in the document title, so a white-labelled install still got
+  // reports carrying our name.
+  describe('white label', () => {
+    const meta = { connectionName: 'prod', generatedAt: '2026-06-22', locale: 'en' }
+
+    it('carries the app name on the cover, the running header and the title', () => {
+      const html = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { ...meta, appName: 'ACME Cloud' }, t)
+
+      expect(html).toContain('<div class="cover-app-name">ACME Cloud</div>')
+      expect(html).toContain('content: "ACME Cloud  |  Compliance Report"')
+      expect(html).toContain('<title>ACME Cloud - ')
+      expect(html).not.toContain('ProxCenter')
+    })
+
+    it('keeps ProxCenter when no name is configured, or when it is blank', () => {
+      for (const appName of [undefined, '', '   ']) {
+        const html = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { ...meta, appName }, t)
+
+        expect(html).toContain('<div class="cover-app-name">ProxCenter</div>')
+        expect(html).toContain('content: "ProxCenter  |  Compliance Report"')
+      }
+    })
+
+    it('escapes the app name in HTML, where it is operator-supplied text', () => {
+      const html = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { ...meta, appName: '<script>x</script>' }, t)
+
+      expect(html).not.toContain('<script>x</script>')
+      expect(html).toContain('&lt;script&gt;')
+    })
+
+    // The running header interpolates the name into a CSS string literal, where
+    // escapeHtml is no help: an unescaped quote closes the literal and lets the
+    // rest of the value be parsed as CSS.
+    it('escapes the app name for the CSS string it lands in', () => {
+      const html = frameworkReportHtml(
+        a,
+        getFramework('nist-800-171-r2'),
+        { ...meta, appName: 'Ac"me" }\n@page { size: A5 }' },
+        t,
+      )
+
+      // The quote is escaped, so the injected rule stays inert text inside the
+      // literal instead of becoming a rule of its own.
+      expect(html).toContain('content: "Ac\\"me\\" }')
+      expect(html).not.toMatch(/content: "Ac"/)
+    })
+
+    // The literal lives inside a <style> block, and the HTML parser closes that
+    // block on </style> wherever it appears — a CSS string is no shelter.
+    it('cannot break out of the style block through the app name', () => {
+      const html = frameworkReportHtml(
+        a,
+        getFramework('nist-800-171-r2'),
+        { ...meta, appName: '</style><script>alert(1)</script>' },
+        t,
+      )
+
+      // Exactly one closing style tag: the real one.
+      expect(html.match(/<\/style>/g)).toHaveLength(1)
+      expect(html).not.toContain('<script>alert(1)</script>')
+      expect(html).toContain('\\3c ')
+    })
+  })
+
   // -- Not-assessed hiding --
 
   it('hides not_assessed controls from the control table', () => {

--- a/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
+++ b/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
@@ -95,7 +95,7 @@ describe('frameworkReportHtml', () => {
     })
 
     // The literal lives inside a <style> block, and the HTML parser closes that
-    // block on </style> wherever it appears — a CSS string is no shelter.
+    // block on </style> wherever it appears: a CSS string is no shelter.
     it('cannot break out of the style block through the app name', () => {
       const html = frameworkReportHtml(
         a,

--- a/frontend/src/lib/compliance/report/frameworkReportHtml.ts
+++ b/frontend/src/lib/compliance/report/frameworkReportHtml.ts
@@ -10,6 +10,28 @@ export interface ReportMeta {
   brandColor?: string
   logoDataUri?: string
   frameworkLogoDataUri?: string
+
+  /** White-label application name. Defaults to ProxCenter when unset. */
+  appName?: string
+}
+
+/**
+ * Escape a value interpolated into a CSS *string* literal, as in
+ * `content: "..."`. The app name is operator-supplied text, and escapeHtml is
+ * no help inside a stylesheet, so three things are neutralised here:
+ *
+ * - `"` and `\`, which would end the literal and let the rest be read as CSS;
+ * - newlines, which are invalid inside a CSS string;
+ * - `<`, as `\3c`, because the literal sits inside a `<style>` block and the
+ *   HTML parser closes that block on `</style>` wherever it appears, string or
+ *   not. WeasyPrint runs no JavaScript, but a broken style block breaks the
+ *   PDF, and this file's output should not depend on the renderer being inert.
+ */
+function cssString(value: string): string {
+  return value
+    .replace(/[\\"]/g, m => `\\${m}`)
+    .replace(/</g, '\\3c ')
+    .replace(/[\r\n]+/g, ' ')
 }
 
 function scoreColor(score: number | null): string {
@@ -43,7 +65,7 @@ const STATUS_LABEL: Record<string, string> = {
   skip: 'Skip',
 }
 
-function buildCss(primary: string): string {
+function buildCss(primary: string, appName: string): string {
   return `
   :root {
     --primary: ${primary};
@@ -63,7 +85,7 @@ function buildCss(primary: string): string {
     size: A4 portrait;
     margin: 15mm;
     @top-center {
-      content: "ProxCenter  |  Compliance Report";
+      content: "${cssString(appName)}  |  Compliance Report";
       font-family: Inter, sans-serif;
       font-size: 8pt;
       color: var(--slate-500);
@@ -242,6 +264,11 @@ export function frameworkReportHtml(
   // Validate brand color to prevent CSS injection; validated value goes directly into CSS (not escaped).
   const primary = /^#[0-9a-fA-F]{3,8}$/.test(meta.brandColor ?? '') ? meta.brandColor! : '#E57000'
 
+  // #681: this export is a second PDF pipeline and used to write "ProxCenter"
+  // literally, so a white-labelled install got a correctly coloured report
+  // still carrying our name on the cover, the running header and the title.
+  const appName = meta.appName?.trim() || 'ProxCenter'
+
   // Logo: only allow data: URIs. Never escapeHtml a data URI (corrupts base64).
   const safeLogoUri = (meta.logoDataUri && meta.logoDataUri.startsWith('data:')) ? meta.logoDataUri : ''
   const safeFwLogoUri = (meta.frameworkLogoDataUri && meta.frameworkLogoDataUri.startsWith('data:')) ? meta.frameworkLogoDataUri : ''
@@ -264,7 +291,7 @@ export function frameworkReportHtml(
   const cover = `
 <div class="cover">
   <div class="cover-header">
-    <div class="cover-app-name">ProxCenter</div>
+    <div class="cover-app-name">${e(appName)}</div>
     <div class="cover-subtitle">Compliance Assessment Report</div>
   </div>
   <div class="cover-body">
@@ -448,8 +475,8 @@ export function frameworkReportHtml(
 <html lang="${e(meta.locale)}">
 <head>
 <meta charset="utf-8">
-<title>ProxCenter - ${e(def.name)} Compliance Report</title>
-<style>${buildCss(primary)}</style>
+<title>${e(appName)} - ${e(def.name)} Compliance Report</title>
+<style>${buildCss(primary, appName)}</style>
 </head>
 <body>
 ${cover}

--- a/frontend/src/lib/license/features.test.ts
+++ b/frontend/src/lib/license/features.test.ts
@@ -60,7 +60,7 @@ describe('registry and edition mapping invariants', () => {
   // enterprise_plus is the higher tier, so it can add features but must never
   // drop one. `white_label` was missing from it while present in `enterprise`,
   // and effectiveHasFeature has no inheritance between editions, so paying more
-  // silently removed white labeling — and with it any hope of branded reports.
+  // silently removed white labeling, and with it any hope of branded reports.
   it('enterprise_plus is a superset of enterprise', () => {
     const missing = EDITION_FEATURES.enterprise.filter(f => !EDITION_FEATURES.enterprise_plus.includes(f))
 

--- a/frontend/src/lib/license/features.test.ts
+++ b/frontend/src/lib/license/features.test.ts
@@ -57,6 +57,27 @@ describe('registry and edition mapping invariants', () => {
       expect(list.includes(Features.HA), `HA leaked into ${edition}`).toBe(false)
     }
   })
+  // enterprise_plus is the higher tier, so it can add features but must never
+  // drop one. `white_label` was missing from it while present in `enterprise`,
+  // and effectiveHasFeature has no inheritance between editions, so paying more
+  // silently removed white labeling — and with it any hope of branded reports.
+  it('enterprise_plus is a superset of enterprise', () => {
+    const missing = EDITION_FEATURES.enterprise.filter(f => !EDITION_FEATURES.enterprise_plus.includes(f))
+
+    expect(missing, `enterprise_plus is missing ${missing.join(', ')}`).toEqual([])
+  })
+
+  it('grants white labeling on both enterprise tiers without an option', () => {
+    for (const edition of ['enterprise', 'enterprise_plus']) {
+      expect(
+        effectiveHasFeature({ licensed: true, edition }, 'white_label'),
+        `white_label denied on ${edition}`,
+      ).toBe(true)
+    }
+
+    expect(effectiveHasFeature({ licensed: true, edition: 'community' }, 'white_label')).toBe(false)
+  })
+
   it('isEnterpriseEdition matches both enterprise tiers only', () => {
     expect(isEnterpriseEdition('enterprise')).toBe(true)
     expect(isEnterpriseEdition('enterprise_plus')).toBe(true)

--- a/frontend/src/lib/license/features.ts
+++ b/frontend/src/lib/license/features.ts
@@ -92,6 +92,7 @@ export const EDITION_FEATURES: Record<string, readonly FeatureId[]> = {
     'compliance',
     'oidc',
     'change_tracking',
+    'white_label',
     'multi_tenancy',
     'sflow_monitoring',
   ],


### PR DESCRIPTION
Part of #681. The orchestrator side of the same issue ships separately, outside this repository.

Reported during an Enterprise evaluation: reports come out with the default identity even with white labeling configured. Branding was already wired into the report pipeline, so the feature looked absent because of several independent defects rather than a missing capability.

## The compliance-framework export

This export is a second PDF pipeline: it does not share the orchestrator's base template, so fixing branding there does not fix it here. It already honoured the brand colour and the logo, but wrote "ProxCenter" literally in three places (the cover, the running page header and the document title), so a white-labelled install got a correctly coloured report still carrying our name.

The route already resolves the tenant's branding row for the colour and the logo; it now reads the app name from it too. The generator takes it as `meta.appName` and falls back to ProxCenter when white label is off or carries no name. The toggle stays the master switch, exactly as it already was for the colour: a saved name does not leak into reports once branding is disabled.

## Escaping, and a hole the tests found

The running header interpolates that name into a CSS string literal, where `escapeHtml` is no help. Escaping the quote and the backslash is not enough: the literal sits inside a `<style>` block, and the HTML parser closes that block on `</style>` wherever the sequence appears, string literal or not. `<` is therefore escaped as `\3c`.

WeasyPrint runs no JavaScript, so this was not an XSS. But a name containing that sequence would have broken the stylesheet and with it the PDF, and this output should not depend on the renderer being inert. The gap surfaced because a first, naive assertion (checking that a substring was absent) failed for the wrong reason.

## A licence defect that likely caused the report

`white_label` was listed on `enterprise` but not on `enterprise_plus`, and `effectiveHasFeature` has no inheritance between editions. The higher tier therefore had *fewer* features than the one below it: an Enterprise Plus customer could not use white labeling at all without an explicit option grant, which is a plausible reason one could not brand reports in the first place.

A test now asserts that `enterprise_plus` stays a superset of `enterprise`, so this class of bug cannot come back silently.

## Tests

139 tests green across the compliance and licence modules. New-code coverage measured at 100% before pushing.

The existing 15-case suite for the export route is preserved; the four white-label cases were added to it.

## Verified

Checked in the browser against the PDF renderer: a branded export carries the configured name on the cover, in the running header and in the document title, and reverts to ProxCenter when the toggle is switched off.

## Not included, deliberately

The chart and badge palette of the report templates is fixed, so a customer with a blue brand still gets orange charts. It is real, but it would mean changing the colours of ten report types that have no visual regression coverage. Tracked in the issue rather than bundled here.

Also still ignored by reports: `faviconUrl`, `loginLogoUrl`, `footerText`, `poweredByVisible` and `hideVersion`.
