### PR TITLE
Stop erasing a node's IP when that node stops answering

### DIFF
--- a/frontend/src/lib/proxmox/discoverNodeIps.test.ts
+++ b/frontend/src/lib/proxmox/discoverNodeIps.test.ts
@@ -9,7 +9,12 @@ const { pveFetchMock, upsertMock, deleteManyMock, connFindUniqueMock } = vi.hois
 }))
 
 vi.mock("./client", () => ({ pveFetch: pveFetchMock }))
-vi.mock("./resolveManagementIp", () => ({ resolveManagementIp: () => "10.0.0.5" }))
+// Faithful to the real helper: no interfaces means no management IP. A mock
+// that answers regardless of its input cannot express a node that stopped
+// answering, which is the case under test below.
+vi.mock("./resolveManagementIp", () => ({
+  resolveManagementIp: (networks: any) => (Array.isArray(networks) && networks.length > 0 ? "10.0.0.5" : null),
+}))
 vi.mock("../cache/nodeIpCache", () => ({ setNodeIps: vi.fn() }))
 vi.mock("@/lib/db/prisma", () => ({
   prisma: {
@@ -27,11 +32,15 @@ beforeEach(() => {
   upsertMock.mockResolvedValue({})
   deleteManyMock.mockResolvedValue({ count: 0 })
   connFindUniqueMock.mockResolvedValue({ tenantId: "msp-1" })
-  pveFetchMock
-    // /nodes
-    .mockResolvedValueOnce([{ node: "pve1" }])
-    // /nodes/pve1/network
-    .mockResolvedValueOnce([{ iface: "vmbr0", type: "bridge" }])
+  // Routed by path rather than by call order: discovery now also asks
+  // /cluster/status, and a sequential mock would break on any new call.
+  pveFetchMock.mockImplementation(async (_opts: any, path: string) => {
+    if (path === "/nodes") return [{ node: "pve1" }]
+    if (path === "/cluster/status") return [{ type: "node", name: "pve1", ip: "10.0.0.5" }]
+    if (path.endsWith("/network")) return [{ iface: "vmbr0", type: "bridge" }]
+
+    return null
+  })
 })
 
 describe("discoverNodeIps", () => {
@@ -44,6 +53,64 @@ describe("discoverNodeIps", () => {
         create: expect.objectContaining({ connectionId: "c-msp", tenantId: "msp-1" }),
       })
     )
+  })
+
+  // A node that just died answers nothing on /nodes/<node>/network, so the
+  // discovery used to write ip: null over a known-good address. That removed
+  // the node from the failover candidate list at the exact moment the cluster
+  // was degraded and the list mattered.
+  it("keeps the stored IP when a node no longer answers", async () => {
+    // Two nodes on purpose: persistence is skipped entirely when no node has
+    // an IP, so the overwrite only ever happened on a partially reachable
+    // cluster, which is exactly the degraded state that matters.
+    pveFetchMock.mockImplementation(async (_opts: any, path: string) => {
+      if (path === "/nodes") return [{ node: "pve1" }, { node: "pve2" }]
+      if (path === "/cluster/status") return null
+      if (path === "/nodes/pve1/network") throw new Error("host unreachable")
+      if (path.endsWith("/network")) return [{ iface: "vmbr0", type: "bridge" }]
+
+      return null
+    })
+
+    await discoverNodeIps(CONN_OPTS as any, "c-1")
+
+    const byNode = new Map(
+      upsertMock.mock.calls.map(c => [c[0].where.connectionId_node.node, c[0]]),
+    )
+
+    // The dead node keeps whatever address is on file.
+    expect(byNode.get("pve1")!.update).toEqual({})
+
+    // The live one is still refreshed.
+    expect(byNode.get("pve2")!.update).toEqual({ ip: "10.0.0.5" })
+  })
+
+  // /cluster/status reports a member's IP even when that member is offline, so
+  // it recovers the address the per-node lookup could not reach.
+  it("falls back to cluster status for an offline node", async () => {
+    pveFetchMock.mockImplementation(async (_opts: any, path: string) => {
+      if (path === "/nodes") return [{ node: "pve1" }, { node: "pve2" }]
+      if (path === "/cluster/status") {
+        return [
+          { type: "cluster", name: "lab" },
+          { type: "node", name: "pve1", ip: "10.0.0.1", online: 0 },
+          { type: "node", name: "pve2", ip: "10.0.0.2", online: 1 },
+        ]
+      }
+      if (path === "/nodes/pve1/network") throw new Error("host unreachable")
+      if (path.endsWith("/network")) return [{ iface: "vmbr0", type: "bridge" }]
+
+      return null
+    })
+
+    const ips = await discoverNodeIps(CONN_OPTS as any, "c-1")
+
+    // pve1 comes from cluster status, pve2 from its own network lookup.
+    expect(ips).toContain("10.0.0.1")
+
+    const written = upsertMock.mock.calls.map(c => c[0].update.ip).filter(Boolean)
+
+    expect(written).toContain("10.0.0.1")
   })
 
   it("falls back to the default tenant when the connection row is missing", async () => {

--- a/frontend/src/lib/proxmox/discoverNodeIps.ts
+++ b/frontend/src/lib/proxmox/discoverNodeIps.ts
@@ -18,6 +18,23 @@ export async function discoverNodeIps(
     const nodes = await pveFetch<any[]>(connOpts, "/nodes")
     if (!nodes || !Array.isArray(nodes)) return []
 
+    // /cluster/status is the only PVE surface that reports a member's IP even
+    // when that member is offline, so it is the fallback for the per-node
+    // lookup below. Without it a node that just died loses its IP here, and
+    // with it its place in the failover candidate list: the recovery mechanism
+    // would shed candidates exactly as the cluster degrades.
+    const clusterIps = new Map<string, string>()
+    try {
+      const status = await pveFetch<any[]>(connOpts, "/cluster/status")
+      for (const entry of status ?? []) {
+        if (entry?.type === "node" && entry?.name && typeof entry?.ip === "string" && entry.ip) {
+          clusterIps.set(String(entry.name), entry.ip)
+        }
+      }
+    } catch {
+      // Standalone node or a transient failure: the per-node lookup still runs.
+    }
+
     // Resolve management IPs in parallel
     const entries = await Promise.all(
       nodes.map(async (node: any) => {
@@ -28,10 +45,11 @@ export async function discoverNodeIps(
             connOpts,
             `/nodes/${encodeURIComponent(nodeName)}/network`
           ).catch(() => null)
-          const ip = resolveManagementIp(networks) || null
+          // A dead node answers nothing here, hence the cluster-wide fallback.
+          const ip = resolveManagementIp(networks) || clusterIps.get(String(nodeName)) || null
           return { node: nodeName, ip }
         } catch {
-          return { node: nodeName, ip: null }
+          return { node: nodeName, ip: clusterIps.get(String(nodeName)) || null }
         }
       })
     )
@@ -69,7 +87,11 @@ export async function discoverNodeIps(
           liveNodeNames.push(e!.node)
           return prisma.managedHost.upsert({
             where: { connectionId_node: { connectionId, node: e!.node } },
-            update: { ip: e!.ip || null },
+            // A discovery that came back empty leaves the stored IP alone
+            // rather than nulling it. Overwriting a known-good IP with null on
+            // a transient failure removes the node from the failover candidate
+            // list, which is the one moment the list matters.
+            update: e!.ip ? { ip: e!.ip } : {},
             create: { connectionId, node: e!.node, ip: e!.ip || null, tenantId: ownerTenantId },
           })
         })


### PR DESCRIPTION
Node IPs are discovered by asking each node for its own interfaces, via `/nodes/<node>/network`. A node that just died answers nothing, the lookup falls back to `null`, and the upsert wrote that null over a known-good address.

That turns the recovery mechanism against itself: it sheds candidates exactly as the cluster degrades. The frontend circuit breaker takes its candidates from these `ManagedHost` rows, the orchestrator's node failover now does too, and the SSH allowlist consults them as well.

Reproduced on a three-node lab by killing one node: its row went from `10.99.99.201` to `NULL` within one poll, while the two live nodes kept theirs.

## Changes

`/cluster/status` is now consulted as a fallback. It is the only PVE surface that reports a member's IP even while that member is offline, which was verified on the lab: it returned the dead node's address with `online=0`. So the information was available all along and our code was discarding it.

A discovery that comes back empty now leaves the stored IP alone instead of nulling it. A transient failure should not cost a node its place in the candidate list.

## A note on the test

The overwrite only ever happened on a *partially* reachable cluster: persistence is skipped entirely when no node resolves an IP. A first version of the test used a single unreachable node and passed for the wrong reason, because nothing was written at all. The committed test uses two nodes, one live and one dead, which is the degraded state that actually matters.

The `resolveManagementIp` mock also had to be made faithful to its input. It previously returned an address whatever it was given, which made "a node that stopped answering" impossible to express.

## Tests

4 tests, lint clean. The orchestrator-side failover this protects ships separately, outside this repository.
