### PR TITLE
Never treat a dotted API path as a static asset

### DIFF
--- a/frontend/src/app/api/v1/auth/setup/route.test.ts
+++ b/frontend/src/app/api/v1/auth/setup/route.test.ts
@@ -1,0 +1,239 @@
+/**
+ * GHSA-qxgh-pw46-6pw6: first-run bootstrap hardening.
+ *
+ * The endpoint stays unauthenticated by nature (there is no account to
+ * authenticate against yet), so what is tested here is everything that bounds
+ * it: the optional shared secret, the global rate limit, and the fact that
+ * "no user exists" is now decided INSIDE the transaction that creates the
+ * super admin. The read-then-write gap was raceable.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+import { _resetRateLimitCounters } from "@/lib/api-tokens/rateLimit"
+
+// vi.hoisted: the vi.mock factories below are hoisted above these
+// declarations, so plain consts would not be initialized yet when the route
+// under test is imported.
+const {
+  userCountMock, userCreateMock, userTenantCreateMock,
+  rbacUserRoleCreateMock, txUserCountMock, transactionMock,
+} = vi.hoisted(() => ({
+  userCountMock: vi.fn<() => Promise<number>>(),
+  userCreateMock: vi.fn(async (args: any) => ({ __op: "user.create", args })),
+  userTenantCreateMock: vi.fn(async (args: any) => ({ __op: "userTenant.create", args })),
+  rbacUserRoleCreateMock: vi.fn(async (args: any) => ({ __op: "rbacUserRole.create", args })),
+  txUserCountMock: vi.fn<() => Promise<number>>(),
+  transactionMock: vi.fn<(...a: any[]) => Promise<any>>(),
+}))
+
+vi.mock("@/lib/auth/password", () => ({ hashPassword: vi.fn(async () => "hashed") }))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    user: { count: userCountMock, create: userCreateMock },
+    userTenant: { create: userTenantCreateMock },
+    rbacUserRole: { create: rbacUserRoleCreateMock },
+    $transaction: transactionMock,
+  },
+}))
+
+import { POST, GET } from "./route"
+
+const VALID = { email: "admin@example.com", password: "correct horse", name: "Admin" }
+
+/** Runs the route's transaction callback for real, against the tx-side mocks. */
+function runTransaction() {
+  transactionMock.mockImplementation(async (fn: any, _opts: any) =>
+    fn({
+      user: { count: txUserCountMock, create: userCreateMock },
+      userTenant: { create: userTenantCreateMock },
+      rbacUserRole: { create: rbacUserRoleCreateMock },
+    })
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  _resetRateLimitCounters()
+  delete process.env.PROXCENTER_SETUP_TOKEN
+  userCountMock.mockResolvedValue(0)
+  txUserCountMock.mockResolvedValue(0)
+  runTransaction()
+})
+
+afterEach(() => {
+  delete process.env.PROXCENTER_SETUP_TOKEN
+})
+
+describe("POST /api/v1/auth/setup: first run", () => {
+  it("creates the super admin, its default membership and its global grant", async () => {
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res)).user).toMatchObject({
+      email: "admin@example.com",
+      role: "super_admin",
+    })
+    expect(userCreateMock).toHaveBeenCalledTimes(1)
+    expect(userTenantCreateMock).toHaveBeenCalledTimes(1)
+    expect(rbacUserRoleCreateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs the writes at serializable isolation", async () => {
+    await callRoute(POST, { body: VALID })
+
+    expect(transactionMock.mock.calls[0][1]).toEqual({ isolationLevel: "Serializable" })
+  })
+
+  it("refuses once a user exists", async () => {
+    userCountMock.mockResolvedValue(1)
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(400)
+    expect(userCreateMock).not.toHaveBeenCalled()
+  })
+
+  it("stores a null name when none is supplied", async () => {
+    const { name, ...withoutName } = VALID
+
+    const res = await callRoute(POST, { body: withoutName })
+
+    expect(res.status).toBe(200)
+    expect(userCreateMock.mock.calls[0][0].data.name).toBeNull()
+  })
+})
+
+describe("POST /api/v1/auth/setup: the raceable window", () => {
+  // The pre-transaction count is the fast path; the one that decides is the
+  // one inside. A concurrent bootstrap that lands between the two sees 0 then 1.
+  it("still refuses when the user appears after the fast-path check", async () => {
+    userCountMock.mockResolvedValue(0)
+    txUserCountMock.mockResolvedValue(1)
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(400)
+    expect(await readJson<any>(res)).toEqual({ error: "Le setup initial a déjà été effectué" })
+    expect(userCreateMock).not.toHaveBeenCalled()
+  })
+
+  it("maps a serialization failure (P2034) to the already-initialised answer", async () => {
+    transactionMock.mockRejectedValue(Object.assign(new Error("write conflict"), { code: "P2034" }))
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(400)
+    expect(await readJson<any>(res)).toEqual({ error: "Le setup initial a déjà été effectué" })
+  })
+
+  it("still reports a genuine failure as a 500", async () => {
+    transactionMock.mockRejectedValue(new Error("connection refused"))
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(500)
+  })
+})
+
+describe("POST /api/v1/auth/setup: optional shared secret", () => {
+  it("requires nothing when PROXCENTER_SETUP_TOKEN is unset", async () => {
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(200)
+  })
+
+  it("rejects a wrong token", async () => {
+    process.env.PROXCENTER_SETUP_TOKEN = "s3cret"
+
+    const res = await callRoute(POST, { body: VALID, headers: { "x-setup-token": "wrong!" } })
+
+    expect(res.status).toBe(403)
+    expect(userCreateMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects an absent token", async () => {
+    process.env.PROXCENTER_SETUP_TOKEN = "s3cret"
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(403)
+  })
+
+  it("rejects a token that is merely a prefix of the real one", async () => {
+    process.env.PROXCENTER_SETUP_TOKEN = "s3cret"
+
+    const res = await callRoute(POST, { body: VALID, headers: { "x-setup-token": "s3c" } })
+
+    expect(res.status).toBe(403)
+  })
+
+  it("accepts the right token", async () => {
+    process.env.PROXCENTER_SETUP_TOKEN = "s3cret"
+
+    const res = await callRoute(POST, { body: VALID, headers: { "x-setup-token": "s3cret" } })
+
+    expect(res.status).toBe(200)
+  })
+})
+
+describe("POST /api/v1/auth/setup: rate limit", () => {
+  it("cuts the 11th attempt of a window with a Retry-After", async () => {
+    userCountMock.mockResolvedValue(1) // keep every attempt cheap and identical
+
+    for (let i = 0; i < 10; i++) {
+      const res = await callRoute(POST, { body: VALID })
+
+      expect(res.status).toBe(400)
+    }
+
+    const res = await callRoute(POST, { body: VALID })
+
+    expect(res.status).toBe(429)
+    expect(Number(res.headers.get("Retry-After"))).toBeGreaterThan(0)
+  })
+})
+
+describe("POST /api/v1/auth/setup: input validation", () => {
+  it.each([
+    ["missing password", { email: "a@b.co" }],
+    ["missing email", { password: "longenough" }],
+    ["malformed email", { email: "not-an-email", password: "longenough" }],
+    ["short password", { email: "a@b.co", password: "short" }],
+  ])("rejects %s", async (_label, body) => {
+    const res = await callRoute(POST, { body })
+
+    expect(res.status).toBe(400)
+    expect(userCreateMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("GET /api/v1/auth/setup", () => {
+  it("says whether setup is required without leaking the user count", async () => {
+    userCountMock.mockResolvedValue(7)
+
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson<any>(res)
+
+    expect(body).toEqual({ setupRequired: false })
+    expect(body).not.toHaveProperty("userCount")
+  })
+
+  it("reports setup required on an empty instance", async () => {
+    userCountMock.mockResolvedValue(0)
+
+    expect(await readJson<any>(await callRoute(GET, { method: "GET" }))).toEqual({
+      setupRequired: true,
+    })
+  })
+
+  // A database that cannot be reached must not strand the installer on a page
+  // that refuses to show the form. The safe answer is "setup required".
+  it("falls back to setup required when the count cannot be read", async () => {
+    userCountMock.mockRejectedValue(new Error("db unreachable"))
+
+    expect(await readJson<any>(await callRoute(GET, { method: "GET" }))).toEqual({
+      setupRequired: true,
+    })
+  })
+})

--- a/frontend/src/app/api/v1/auth/setup/route.ts
+++ b/frontend/src/app/api/v1/auth/setup/route.ts
@@ -1,10 +1,48 @@
 export const dynamic = "force-dynamic"
+import { timingSafeEqual } from "crypto"
+
 import { NextResponse } from "next/server"
 
 import { nanoid } from "nanoid"
 
 import { prisma } from "@/lib/db/prisma"
 import { hashPassword } from "@/lib/auth/password"
+import { consumeRateLimit } from "@/lib/api-tokens/rateLimit"
+
+/**
+ * First-run bootstrap is unauthenticated by nature: there is no account to
+ * authenticate against yet. What bounds it (GHSA-qxgh-pw46-6pw6):
+ *
+ *  - PROXCENTER_SETUP_TOKEN, when set, turns the window into a shared-secret
+ *    one. Unset keeps the historical behavior, so no existing install breaks.
+ *  - A global rate limit, because this endpoint can legitimately be called
+ *    once in the life of an instance: nothing here needs per-IP fairness.
+ *  - The "no user exists yet" test now runs INSIDE a serializable transaction
+ *    with the three writes, so two concurrent calls cannot both pass it and
+ *    end up with two super admins.
+ */
+const SETUP_ATTEMPTS_PER_MINUTE = 10
+const RATE_LIMIT_KEY = "auth:setup"
+
+/** Sentinel: the instance already has a user, thrown from inside the tx. */
+const ALREADY_INITIALISED = "SETUP_ALREADY_DONE"
+
+/**
+ * Optional shared secret for the first-run window. Compared in constant time,
+ * length included: a length-only mismatch must not be observable either.
+ */
+function setupTokenDenied(req: Request): boolean {
+  const expected = process.env.PROXCENTER_SETUP_TOKEN || ""
+
+  if (!expected) return false
+
+  const provided = Buffer.from(req.headers.get("x-setup-token") || "", "utf8")
+  const wanted = Buffer.from(expected, "utf8")
+
+  if (provided.length !== wanted.length) return true
+
+  return !timingSafeEqual(provided, wanted)
+}
 
 /**
  * POST /api/v1/auth/setup
@@ -16,7 +54,25 @@ import { hashPassword } from "@/lib/auth/password"
  */
 export async function POST(req: Request) {
   try {
-    // Vérifier s'il y a déjà des utilisateurs
+    const verdict = consumeRateLimit(RATE_LIMIT_KEY, SETUP_ATTEMPTS_PER_MINUTE)
+
+    if (!verdict.allowed) {
+      return NextResponse.json(
+        { error: "Trop de tentatives, réessayez dans une minute" },
+        { status: 429, headers: { "Retry-After": String(verdict.retryAfter) } }
+      )
+    }
+
+    if (setupTokenDenied(req)) {
+      return NextResponse.json(
+        { error: "Jeton d'initialisation invalide" },
+        { status: 403 }
+      )
+    }
+
+    // Fast path: an initialised instance answers without hashing a password
+    // or opening a serializable transaction. The authoritative check is the
+    // one inside the transaction below.
     const userCount = await prisma.user.count()
     if (userCount > 0) {
       return NextResponse.json(
@@ -53,48 +109,54 @@ export async function POST(req: Request) {
       )
     }
 
-    // Hasher le mot de passe
+    // Hasher le mot de passe (hors transaction : le hash est coûteux et n'a
+    // pas à tenir un verrou sérialisable ouvert).
     const hashedPassword = await hashPassword(password)
 
     // Créer l'utilisateur admin + son adhésion + le grant super_admin
-    // dans une seule transaction.
+    // dans une seule transaction, avec le contrôle "aucun utilisateur" DEDANS.
     const id = nanoid()
     const now = new Date()
     const normalisedEmail = email.toLowerCase().trim()
 
-    await prisma.$transaction([
-      prisma.user.create({
-        data: {
-          id,
-          email: normalisedEmail,
-          password: hashedPassword,
-          name: name || null,
-          role: "super_admin",
-          enabled: true,
-          createdAt: now,
-          updatedAt: now,
-        },
-      }),
-      prisma.userTenant.create({
-        data: {
-          userId: id,
-          tenantId: "default",
-          isDefault: true,
-          joinedAt: now,
-        },
-      }),
-      prisma.rbacUserRole.create({
-        data: {
-          id: nanoid(),
-          userId: id,
-          roleId: "role_super_admin",
-          scopeType: "global",
-          scopeTarget: null,
-          tenantId: "default",
-          grantedAt: now,
-        },
-      }),
-    ])
+    await prisma.$transaction(
+      async tx => {
+        if ((await tx.user.count()) > 0) throw new Error(ALREADY_INITIALISED)
+
+        await tx.user.create({
+          data: {
+            id,
+            email: normalisedEmail,
+            password: hashedPassword,
+            name: name || null,
+            role: "super_admin",
+            enabled: true,
+            createdAt: now,
+            updatedAt: now,
+          },
+        })
+        await tx.userTenant.create({
+          data: {
+            userId: id,
+            tenantId: "default",
+            isDefault: true,
+            joinedAt: now,
+          },
+        })
+        await tx.rbacUserRole.create({
+          data: {
+            id: nanoid(),
+            userId: id,
+            roleId: "role_super_admin",
+            scopeType: "global",
+            scopeTarget: null,
+            tenantId: "default",
+            grantedAt: now,
+          },
+        })
+      },
+      { isolationLevel: "Serializable" }
+    )
 
     return NextResponse.json({
       success: true,
@@ -107,6 +169,17 @@ export async function POST(req: Request) {
       },
     })
   } catch (error: any) {
+    // Both branches mean the same thing to the caller: someone else got there
+    // first. P2034 is the serialization failure Postgres raises when two
+    // concurrent bootstraps race, exactly the case this transaction exists
+    // to lose safely.
+    if (error?.message === ALREADY_INITIALISED || error?.code === "P2034") {
+      return NextResponse.json(
+        { error: "Le setup initial a déjà été effectué" },
+        { status: 400 }
+      )
+    }
+
     console.error("Erreur setup:", error)
 
     return NextResponse.json(
@@ -118,19 +191,17 @@ export async function POST(req: Request) {
 
 /**
  * GET /api/v1/auth/setup
- * Vérifie si le setup initial est nécessaire
+ * Vérifie si le setup initial est nécessaire.
+ *
+ * Ne renvoie QUE le booléen : le compte exact d'utilisateurs n'a jamais servi
+ * à la page de setup et n'a pas à être lisible sans authentification.
  */
 export async function GET() {
   try {
     const userCount = await prisma.user.count()
-    return NextResponse.json({
-      setupRequired: userCount === 0,
-      userCount,
-    })
+
+    return NextResponse.json({ setupRequired: userCount === 0 })
   } catch (error) {
-    return NextResponse.json({
-      setupRequired: true,
-      userCount: 0,
-    })
+    return NextResponse.json({ setupRequired: true })
   }
 }

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.test.ts
@@ -12,6 +12,15 @@ vi.mock('@/lib/proxmox/client', () => ({
   pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
 }))
 
+// Permission granted by default: this file covers the route's behaviour, the
+// guard itself (denial, ordering) is covered in guestRoutesGuard.test.ts.
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn(async () => null),
+  buildVmResourceId: (connId: string, node: string, type: string, vmid: string) =>
+    `${connId}:${node}:${type}:${vmid}`,
+  PERMISSIONS: { VM_VIEW: 'vm.view', VM_CONFIG: 'vm.config' },
+}))
+
 import { GET } from './route'
 import { getConnectionByIdOrNull } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'

--- a/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/features/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionByIdOrNull } from "@/lib/connections/getConnection"
 import { safeLog } from "@/lib/log/sanitize"
+import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
 
@@ -37,6 +38,16 @@ export async function GET(
   try {
     const params = await ctx.params
     const { connId, type, node, vmid } = parseVmKey(params.vmid)
+
+    // RBAC: vm.view, checked first, before the constant-answer shortcut
+    // below, so this route cannot be used as an unauthenticated oracle either.
+    const denied = await checkPermission(
+      PERMISSIONS.VM_VIEW,
+      "vm",
+      buildVmResourceId(connId, node, type, vmid)
+    )
+
+    if (denied) return denied
 
     const url = new URL(req.url)
     const feature = url.searchParams.get('feature')

--- a/frontend/src/app/api/v1/guests/[vmid]/notes/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/notes/route.test.ts
@@ -10,6 +10,15 @@ vi.mock('@/lib/proxmox/client', () => ({
   pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
 }))
 
+// Permission granted by default: this file covers the route's behaviour, the
+// guard itself (denial, ordering) is covered in guestRoutesGuard.test.ts.
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn(async () => null),
+  buildVmResourceId: (connId: string, node: string, type: string, vmid: string) =>
+    `${connId}:${node}:${type}:${vmid}`,
+  PERMISSIONS: { VM_VIEW: 'vm.view', VM_CONFIG: 'vm.config' },
+}))
+
 import { GET, PUT } from './route'
 import { getConnectionById } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'

--- a/frontend/src/app/api/v1/guests/[vmid]/notes/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/notes/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
+import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
 
@@ -36,6 +37,17 @@ export async function GET(
   try {
     const params = await ctx.params
     const { connId, type, node, vmid } = parseVmKey(params.vmid)
+
+    // RBAC: vm.view, checked BEFORE the connection is resolved. That
+    // resolution decrypts the Proxmox API token, so it must never run for a
+    // caller who has no right to this guest.
+    const denied = await checkPermission(
+      PERMISSIONS.VM_VIEW,
+      "vm",
+      buildVmResourceId(connId, node, type, vmid)
+    )
+
+    if (denied) return denied
 
     // Use the shared resolver so tenants can reach connections they only
     // access via vDC assignment (not only the ones they own).
@@ -75,6 +87,17 @@ export async function PUT(
   try {
     const params = await ctx.params
     const { connId, type, node, vmid } = parseVmKey(params.vmid)
+
+    // RBAC: vm.config. This writes the guest's description on Proxmox.
+    // Checked before the body is read and before the connection is resolved.
+    const denied = await checkPermission(
+      PERMISSIONS.VM_CONFIG,
+      "vm",
+      buildVmResourceId(connId, node, type, vmid)
+    )
+
+    if (denied) return denied
+
     const body = await req.json()
 
     const { content } = body

--- a/frontend/src/app/api/v1/guests/[vmid]/tasks/route.test.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/tasks/route.test.ts
@@ -10,6 +10,15 @@ vi.mock('@/lib/proxmox/client', () => ({
   pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
 }))
 
+// Permission granted by default: this file covers the route's behaviour, the
+// guard itself (denial, ordering) is covered in guestRoutesGuard.test.ts.
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn(async () => null),
+  buildVmResourceId: (connId: string, node: string, type: string, vmid: string) =>
+    `${connId}:${node}:${type}:${vmid}`,
+  PERMISSIONS: { VM_VIEW: 'vm.view', VM_CONFIG: 'vm.config' },
+}))
+
 import { GET } from './route'
 import { getConnectionById } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'

--- a/frontend/src/app/api/v1/guests/[vmid]/tasks/route.ts
+++ b/frontend/src/app/api/v1/guests/[vmid]/tasks/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
+import { checkPermission, buildVmResourceId, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
 
@@ -64,6 +65,17 @@ export async function GET(
   try {
     const params = await ctx.params
     const { connId, type, node, vmid } = parseVmKey(params.vmid)
+
+    // RBAC: vm.view, checked BEFORE the connection is resolved. That
+    // resolution decrypts the Proxmox API token, so it must never run for a
+    // caller who has no right to this guest.
+    const denied = await checkPermission(
+      PERMISSIONS.VM_VIEW,
+      "vm",
+      buildVmResourceId(connId, node, type, vmid)
+    )
+
+    if (denied) return denied
 
     const conn = await getConnection(connId)
 

--- a/frontend/src/app/api/v1/guests/guestRoutesGuard.test.ts
+++ b/frontend/src/app/api/v1/guests/guestRoutesGuard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * GHSA-79j6-v2r5-5pw5, defense in depth.
+ *
+ * notes / tasks / features were the three guest routes that carried no
+ * authorization of their own and relied entirely on the middleware. When the
+ * middleware's dot rule let a request past, they resolved a connection
+ * (which decrypts the Proxmox API token) and proxied it to the hypervisor for
+ * an anonymous caller.
+ *
+ * What is asserted here is the ORDER as much as the check: the permission
+ * decision must land before getConnectionById, so a denied caller never
+ * causes a secret to be decrypted, and before the features route's
+ * constant-answer shortcut, so it cannot be used as an oracle either.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { NextResponse } from "next/server"
+
+import { callRoute } from "@/__tests__/setup/route-test"
+
+// vi.hoisted: the vi.mock factories below are hoisted above these
+// declarations, so plain consts would not be initialized yet when the routes
+// under test are imported.
+const { checkPermissionMock, getConnectionByIdMock, getConnectionByIdOrNullMock, pveFetchMock } =
+  vi.hoisted(() => ({
+    checkPermissionMock: vi.fn<(...a: any[]) => Promise<Response | null>>(),
+    getConnectionByIdMock: vi.fn<(...a: any[]) => Promise<any>>(),
+    getConnectionByIdOrNullMock: vi.fn<(...a: any[]) => Promise<any>>(),
+    pveFetchMock: vi.fn<(...a: any[]) => Promise<any>>(),
+  }))
+
+// Mirrors the real helpers (lib/rbac/index.ts:531), kept as a stub so this
+// file needs no DB for a pure ordering assertion.
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: checkPermissionMock,
+  buildVmResourceId: (connId: string, node: string, type: string, vmid: string) =>
+    `${connId}:${node}:${type}:${vmid}`,
+  PERMISSIONS: { VM_VIEW: "vm.view", VM_CONFIG: "vm.config" },
+}))
+
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: getConnectionByIdMock,
+  getConnectionByIdOrNull: getConnectionByIdOrNullMock,
+}))
+
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: pveFetchMock }))
+
+import { GET as notesGet, PUT as notesPut } from "./[vmid]/notes/route"
+import { GET as tasksGet } from "./[vmid]/tasks/route"
+import { GET as featuresGet } from "./[vmid]/features/route"
+
+/** A guest whose node name carries a dot, the shape that defeated the middleware. */
+const VM_KEY = "conn1:qemu:pve1.internal:100"
+const LXC_KEY = "conn1:lxc:pve1.internal:100"
+
+const CONN = { id: "conn1", name: "c", baseUrl: "https://pve", apiToken: "secret", insecureDev: false, behindProxy: false }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue(CONN)
+  getConnectionByIdOrNullMock.mockResolvedValue(CONN)
+  pveFetchMock.mockResolvedValue({})
+})
+
+function denial() {
+  return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+}
+
+describe("guest proxy routes check a permission before touching a connection", () => {
+  const cases = [
+    {
+      name: "GET notes",
+      permission: "vm.view",
+      key: VM_KEY,
+      run: () => callRoute(notesGet, { params: { vmid: VM_KEY }, method: "GET" }),
+    },
+    {
+      name: "PUT notes",
+      permission: "vm.config",
+      key: VM_KEY,
+      run: () =>
+        callRoute(notesPut, { params: { vmid: VM_KEY }, method: "PUT", body: { content: "x" } }),
+    },
+    {
+      name: "GET tasks",
+      permission: "vm.view",
+      key: VM_KEY,
+      run: () => callRoute(tasksGet, { params: { vmid: VM_KEY }, method: "GET" }),
+    },
+    {
+      name: "GET features",
+      permission: "vm.view",
+      key: LXC_KEY,
+      run: () =>
+        callRoute(featuresGet, {
+          params: { vmid: LXC_KEY },
+          method: "GET",
+          searchParams: { feature: "snapshot" },
+        }),
+    },
+  ]
+
+  for (const c of cases) {
+    it(`${c.name} returns the denial and resolves no connection`, async () => {
+      checkPermissionMock.mockResolvedValue(denial())
+
+      const res = await c.run()
+
+      expect(res.status).toBe(403)
+      expect(getConnectionByIdMock).not.toHaveBeenCalled()
+      expect(getConnectionByIdOrNullMock).not.toHaveBeenCalled()
+      expect(pveFetchMock).not.toHaveBeenCalled()
+    })
+
+    it(`${c.name} asks for ${c.permission} on the guest resource`, async () => {
+      await c.run()
+
+      const [permission, kind, resourceId] = checkPermissionMock.mock.calls[0]
+
+      expect(permission).toBe(c.permission)
+      expect(kind).toBe("vm")
+      // buildVmResourceId reorders the key to connId:node:type:vmid
+      const [connId, type, node, vmid] = c.key.split(":")
+
+      expect(resourceId).toBe(`${connId}:${node}:${type}:${vmid}`)
+    })
+  }
+
+  it("still serves an authorized caller", async () => {
+    pveFetchMock.mockResolvedValue({ description: "hello" })
+
+    const res = await callRoute(notesGet, { params: { vmid: VM_KEY }, method: "GET" })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ data: { content: "hello" } })
+  })
+
+  // The qemu shortcut answers without any lookup, so the permission check has
+  // to come first or the route stays an unauthenticated 200.
+  it("denies the features shortcut for a qemu guest too", async () => {
+    checkPermissionMock.mockResolvedValue(denial())
+
+    const res = await callRoute(featuresGet, {
+      params: { vmid: VM_KEY },
+      method: "GET",
+      searchParams: { feature: "snapshot" },
+    })
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/frontend/src/middleware.dotPath.test.ts
+++ b/frontend/src/middleware.dotPath.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { getTokenMock } = vi.hoisted(() => ({
+  getTokenMock: vi.fn<() => Promise<any>>(),
+}))
+
+vi.mock('next-auth/jwt', () => ({ getToken: getTokenMock }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
+
+import { NextRequest } from 'next/server'
+
+import { middleware } from './middleware'
+
+function request(path: string, init: { method?: string; headers?: Record<string, string> } = {}) {
+  return new NextRequest(`http://test.local${path}`, {
+    method: init.method ?? 'GET',
+    headers: init.headers,
+  })
+}
+
+/** A middleware pass-through, i.e. the handler behind the path will run. */
+function passedThrough(res: Response): boolean {
+  return res.headers.get('x-middleware-next') === '1'
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getTokenMock.mockResolvedValue(null)
+  delete process.env.DEMO_MODE
+})
+
+// GHSA-79j6-v2r5-5pw5: isAsset classified ANY path containing a dot as a
+// static asset, so a dotted /api path was forwarded to its route handler
+// before the JWT check ran. Proxmox node names accept dots (assertNodeName in
+// lib/ssh/validate.ts), and several guest routes embed the node name in their
+// dynamic segment, so a dot in an API path is a normal shape here, not an
+// exotic one an attacker has to force.
+describe('dotted API paths never bypass authentication', () => {
+  const dotted = [
+    '/api/v1/guests/conn1:qemu:pve1.internal:100/notes',
+    '/api/v1/guests/conn1:qemu:pve1.internal:100/tasks',
+    '/api/v1/guests/conn1:lxc:pve1.internal:100/features',
+    '/api/v1/nodes/pve1.internal/storage',
+    '/api/v1/storage/conn1:local/content/local:iso/debian-12.iso',
+  ]
+
+  for (const path of dotted) {
+    it(`answers 401 to an unauthenticated GET ${path}`, async () => {
+      const res = await middleware(request(path) as any)
+
+      expect(res.status).toBe(401)
+      expect(await res.json()).toEqual({ error: 'Not authenticated' })
+    })
+  }
+
+  it('answers 401 to an unauthenticated write on a dotted API path', async () => {
+    const res = await middleware(
+      request('/api/v1/guests/conn1:qemu:pve1.internal:100/notes', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+      }) as any
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('lets an authenticated caller through a dotted API path', async () => {
+    getTokenMock.mockResolvedValue({ sub: 'u1', authAt: Date.now() })
+
+    const res = await middleware(request('/api/v1/guests/conn1:qemu:pve1.internal:100/notes') as any)
+
+    expect(passedThrough(res)).toBe(true)
+  })
+})
+
+// The dot rule still has a job to do OUTSIDE /api: it is what keeps static
+// files off the login redirect. Narrowing it must not cost that.
+describe('static assets and public routes keep passing', () => {
+  const assets = ['/logo.png', '/fonts/inter.woff2', '/_next/static/chunk.js', '/favicon.ico']
+
+  for (const path of assets) {
+    it(`passes ${path} through unauthenticated`, async () => {
+      const res = await middleware(request(path) as any)
+
+      expect(passedThrough(res)).toBe(true)
+    })
+  }
+
+  const publicApi = [
+    '/api/auth/session',
+    '/api/health',
+    '/api/v1/auth/setup',
+    '/api/v1/settings/branding/uploads/logo.png',
+    '/api/v1/settings/login-background/serve?name=bg.jpg',
+  ]
+
+  for (const path of publicApi) {
+    it(`keeps the public API route ${path} reachable unauthenticated`, async () => {
+      const res = await middleware(request(path) as any)
+
+      expect(passedThrough(res)).toBe(true)
+    })
+  }
+})

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -100,6 +100,14 @@ const publicApiRoutes = [
   "/api/internal", // API internes (proxy WS, etc.)
 ]
 
+// Extensions that make a NON-API path a static file (see isAsset). Anchored at
+// the end of the path on purpose: only the last segment can be a file name.
+// Covers what public/ actually ships: the static console pages (.html), the
+// logos and backgrounds, the worker bundles, plus the usual font and media
+// types a browser asks for directly.
+const STATIC_FILE_EXT =
+  /\.(?:js|mjs|css|map|svg|png|jpe?g|gif|webp|avif|ico|html|json|ya?ml|txt|xml|pdf|woff2?|ttf|otf|eot|wasm|webmanifest|mp4)$/i
+
 // Detect locale from Accept-Language header
 function getLocaleFromHeader(request: NextRequest): string {
   const acceptLanguage = request.headers.get('accept-language')
@@ -243,11 +251,21 @@ export async function middleware(request: NextRequest) {
   const isPublicRoute = publicRoutes.some(route => pathname.startsWith(route))
   const isPublicApiRoute = publicApiRoutes.some(route => pathname.startsWith(route))
 
-  // Assets et fichiers statiques
+  // Assets et fichiers statiques.
+  //
+  // The extension rule used to be a bare pathname.includes("."), which made a
+  // dot ANYWHERE in the path enough to be called an asset, including in an
+  // /api path, which then rode the early return below and reached its route
+  // handler without ever passing the JWT check (GHSA-79j6-v2r5-5pw5). Dots in
+  // an API path are ordinary here, not exotic: Proxmox node names accept them
+  // (assertNodeName, lib/ssh/validate.ts) and the guest routes carry the node
+  // name inside their connId:type:node:vmid segment. Two things changed: /api
+  // is never an asset, and elsewhere only a real trailing file extension from
+  // the list below counts, so a dotted dynamic segment cannot pose as a file.
   const isAsset = pathname.startsWith("/_next") ||
                   pathname.startsWith("/images") ||
                   pathname.startsWith("/favicon") ||
-                  pathname.includes(".")
+                  (!isApiPath && STATIC_FILE_EXT.test(pathname))
 
   // Handle locale detection for non-API routes
   if (!pathname.startsWith("/api/") && !isAsset) {
@@ -313,9 +331,8 @@ export async function middleware(request: NextRequest) {
     return response
   }
 
-  // Gesture 3: bounded API-token derogation, placed BEFORE the early return
-  // below on purpose: isAsset includes pathname.includes('.') and an
-  // allowlisted path containing a dot would otherwise skip this gate. The
+  // Gesture 3: bounded API-token derogation, kept BEFORE the early return
+  // below so the OPTIONS 405 and the header stamping always win over it. The
   // middleware never validates the token (edge runtime, no DB): it only
   // matches the path via the shared matcher and stamps the internal headers;
   // hash, license, tenant, scopes and quota live in getPrincipal().
@@ -344,12 +361,12 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // A Bearer pxc_ outside the allowlist derogates to NOTHING: it must not
-  // even ride the isAsset dot rescue (pathname.includes('.')) below, it falls
-  // through to the existing JWT check and its cookie 401 instead. Cookie
-  // browser requests never carry a Bearer pxc_, so their behavior here is
-  // strictly unchanged.
-  if (isPublicRoute || isPublicApiRoute || (isAsset && !hasApiTokenBearer)) {
+  // A Bearer pxc_ outside the allowlist derogates to NOTHING: it falls through
+  // to the JWT check below and gets the same cookie 401 as anyone else. It no
+  // longer needs to be excluded from the asset branch by hand either: isAsset
+  // and isApiPath are now mutually exclusive by construction, so no /api path
+  // can be rescued as a file.
+  if (isPublicRoute || isPublicApiRoute || isAsset) {
     return NextResponse.next(isApiPath ? { request: { headers: requestHeaders } } : undefined)
   }
 


### PR DESCRIPTION
Closes two security advisories reported in triage: GHSA-79j6-v2r5-5pw5 (authentication bypass, CVSS 7.7, CWE-287) and GHSA-qxgh-pw46-6pw6 (unauthenticated first-run setup, CVSS 8.1, CWE-306).

## The bypass

`isAsset` in the middleware treated any path containing a dot as a static file, and that branch returned before `getToken()` ran. Every `/api` path carrying a dot therefore reached its route handler with no authentication.

Dots in an API path are ordinary here rather than exotic. Proxmox node names accept them (`assertNodeName`), and the guest routes embed the node name in their `connId:type:node:vmid` segment, so a cluster whose node is named `pve1.internal` exposes its guest routes to anyone. Reproduced before the fix: an unauthenticated `GET /api/v1/guests/conn1:qemu:pve1.internal:100/notes` was proxied to the hypervisor instead of being refused.

The hole is generic to the whole `/api` surface. The three guest routes are the symptom that was reported, not the extent of it.

## What changed

`/api` is never an asset. Outside `/api`, only a real file extension at the end of the path counts, from an explicit list that covers what `public/` actually ships (console pages, logos, backgrounds, worker bundles) plus the usual font and media types. A dotted dynamic segment can no longer pose as a file.

`isAsset` and `isApiPath` are now mutually exclusive by construction, so the early return simplifies to `isPublicRoute || isPublicApiRoute || isAsset`, and the hand-written exclusion that kept API-token bearers out of the asset branch is no longer needed.

`notes`, `tasks` and `features` carried no authorization of their own and relied entirely on the middleware, which is exactly the invariant the bug broke (`getConnection.ts` documents it in so many words to justify its fail-open on a 401). They now carry their own `vm.view` and `vm.config` checks. Placement matters as much as the check: it lands before the connection is resolved, since resolving it decrypts the Proxmox API token, and before the `features` shortcut, so the route cannot answer as an unauthenticated oracle either.

## First-run setup

`POST /api/v1/auth/setup` creates a super admin with no authentication while no user exists. That window is how a self-hosted install bootstraps and it stays open, but it is now bounded:

- a global rate limit through `consumeRateLimit("auth:setup", 10)`
- an optional `PROXCENTER_SETUP_TOKEN`, compared in constant time; unset means the historical behaviour, so existing installs are unaffected
- the "no user exists" decision moved inside a `Serializable` transaction, with `P2034` mapped to the same 400 as a late caller, so two concurrent bootstraps can no longer both succeed
- `GET` no longer returns `userCount`

## Verification

- 3 new test files: the middleware dotted-path matrix, an ordering-and-refusal suite for the three guest routes, and the setup endpoint bounds. The three existing guest route suites needed an `@/lib/rbac` mock now that the guard runs.
- Checked over HTTP against a production build, before and after: the bypass reproduces on the base branch and is closed here, while the console pages, favicon, login chunks, public API routes and `/api/v1/settings/branding/uploads/logo.png` (an API path with a dot that is legitimately public) all still return 200, and `/home` and `/vms` still redirect to `/login`.
- Browser pass on the running app: login with its branding, guest Notes in read and write, Tasks, LXC snapshot.
