### PR TITLE
Release notes for v1.4.7, and wire the three settings they document

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,17 @@ APP_URL=https://proxcenter.example.com
 # SESSION_ABSOLUTE_TIMEOUT=604800
 
 # ========================================
+# Optional - First-run setup secret
+# ========================================
+# POST /api/v1/auth/setup creates the first administrator and is reachable
+# without authentication for as long as no account exists. That window is how
+# a fresh install bootstraps, and it closes for good once one account exists.
+# Set this on an instance whose first boot happens on a network someone else
+# can reach: the setup request must then carry the same value in its
+# x-setup-token header. Unset keeps the historical behaviour.
+# PROXCENTER_SETUP_TOKEN=
+
+# ========================================
 # Database (Postgres)
 # ========================================
 # Postgres credentials for the bundled `postgres` compose service.

--- a/RELEASE_NOTES_v1.4.7.md
+++ b/RELEASE_NOTES_v1.4.7.md
@@ -1,0 +1,75 @@
+# ProxCenter v1.4.7
+
+**Security release: two authentication fixes, revocable sessions, disaster recovery failback, and a large batch of migration and inventory fixes.**
+
+## Security
+
+- **Dotted API paths no longer skip authentication.** The middleware classified any request path containing a dot as a static asset and answered before the session check ran, so an API path carrying a dot reached its route handler unauthenticated. Proxmox node names accept dots and the guest routes carry the node name in their path, so a cluster with an FQDN node name exposed guest notes and task data to unauthenticated callers. Reported privately as GHSA-79j6-v2r5-5pw5.
+- **Defense in depth on the guest routes.** Notes, tasks and features now carry their own permission checks, evaluated before the Proxmox connection is resolved, so a refused caller never causes the stored API token to be decrypted.
+- **First-run setup is bounded.** The setup endpoint stays reachable while no account exists, which is how a self-hosted install bootstraps, but it now enforces a rate limit, accepts an optional `PROXCENTER_SETUP_TOKEN` shared secret, and decides "no user exists" inside a serializable transaction so two concurrent bootstraps can no longer both create an administrator. Reported privately as GHSA-qxgh-pw46-6pw6.
+- **Revocable server-side sessions.** Sessions are tracked server side and can be revoked, from a session management screen for your own sessions and from the admin user view for someone else's. Session cookies carry secure flags, and idle and absolute lifetimes are configurable through `SESSION_IDLE_TIMEOUT` and `SESSION_ABSOLUTE_TIMEOUT`.
+- **Read-only API tokens.** `pxc_` tokens grant read-only access to a set of aggregated public endpoints, scoped and quota limited, for dashboards and external monitoring.
+
+## Disaster recovery
+
+- **Failback.** A plan that has failed over can now fail back: a reverse incremental sync brings the source back up to date, then an operator-driven cutover switches back, with per-VM rollback and re-protect. Failed-over plans and their jobs stay locked until failback completes.
+- **Source fencing on real failover.** A real failover fences the source VMs before starting their replicas, so the same guest cannot run on both sides.
+- **Point-in-time recovery and configurable retention** on replication plans, with per-VM failover steps surfaced on the execution results.
+- **The orchestrator survives the loss of its configured node.** It fails over to another node of the cluster instead of dying with the one it was pointed at, and it addresses guest commands to the node that actually owns the guest.
+- **A node that stops answering keeps its IP.** A failover no longer erases the recorded address of the node that went silent.
+
+## Migration
+
+- **vSphere snapshots are waited out, not abandoned.** A snapshot task on a large VM is followed to completion instead of failing at a fixed 120 second deadline, which blocked warm migrations of multi-terabyte guests.
+- **Pre-migration check for HA affinity rules**, so a guest bound by an affinity rule is caught before the move starts.
+- **Warm migrations warn before falling back to CBT** and report live progress during pre-zero and copy instead of showing an indeterminate bar.
+- **A fully copied warm target is kept** instead of being freed when cleanup runs.
+- **Windows guests boot from SATA** instead of LSI SCSI after migration.
+- **The i440fx machine type is sent as `pc`**, which unblocks guests pinned to that chipset.
+- **Custom CPU models** are handled in the CPU type selects and in the cross-cluster migration pre-check.
+- **Migrated disks can be converted to qcow2** as an option.
+- **Jobs orphaned by a server restart fail cleanly** instead of staying stuck as running.
+- **The virt-v2v temporary storage requirement is hidden in warm mode**, where it does not apply, and no longer reports a false lack of space.
+
+## Multi-tenant and vDC
+
+- **Several vDCs per tenant**, with a global vDC context to switch between them.
+- **Optional VMID ranges for MSP tenants.**
+- **Tenant selector on the storage overview**, so a provider can read one tenant's storage without leaving the page.
+
+## Access control
+
+- **Tag and pool scoped users see their guests again.** A user whose only grant was a tag or a pool saw an empty inventory since v1.4.6. The perimeter is now derived from the guests that remain visible after filtering.
+
+## Inventory and interface
+
+- **The PVE node is shown in filtered flat VM lists.**
+- **Console windows lead with the VM name** instead of the connection identifier.
+- **Numeric fields can be cleared** instead of snapping back to a default while typing.
+- **Snapshot rows follow the Proxmox task** instead of claiming success before it finishes.
+- **Firewall data is read directly from Proxmox** when no orchestrator is running.
+- **Security groups can be attached to guests**, with a corrected membership count.
+- **The Proxmox rule log level is exposed** in the firewall dialogs and rules tables.
+- **The tasks bar keeps the content reachable** when it expands.
+- **Batch actions stay available** when alerts are selected from the header checkbox.
+- **Dashboard widget filters stay reachable** when a filter empties the view.
+- **A provider-configurable maintenance banner** can be broadcast to every tenant.
+
+## Backups, reports and compliance
+
+- **vzdump archives are listed in a guest's Backups tab.**
+- **Reports carry the tenant's white label**, including the compliance PDF export, its logo and its footer.
+- **The infrastructure report includes every VM** instead of stopping at a cap.
+- **A CIS Controls v8.1 card** joins the compliance Frameworks tab.
+
+## Assistant
+
+- **AI prompts are answered in the language of the interface**, whichever provider serves them.
+
+## Dependencies
+
+Seventeen Dependabot updates consolidated into one batch, otplib migrated from 12 to 13 for TOTP, MUI X Data Grid raised to 9.9, GitHub Actions checkout, setup-node and setup-go raised to v7, and the fast-uri and brace-expansion advisories patched within their major branches.
+
+## Upgrading
+
+No migration step is required beyond the usual image pull. Two optional settings are new and unset by default, which preserves current behaviour: `PROXCENTER_SETUP_TOKEN` guards the first-run setup endpoint, and `SESSION_IDLE_TIMEOUT` and `SESSION_ABSOLUTE_TIMEOUT` override the default session lifetimes of 12 hours idle and 7 days absolute.

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -29,6 +29,17 @@ services:
       # one frontend per stack here; give each instance its own value if you
       # point several at one database.
       - PROXCENTER_INSTANCE_ID=${PROXCENTER_INSTANCE_ID:-proxcenter-frontend}
+      # Session lifetimes, in seconds. Left empty on purpose: the frontend
+      # then applies its defaults, 12 hours of inactivity and 7 days absolute.
+      # A malformed value falls back to those defaults rather than to no limit.
+      - SESSION_IDLE_TIMEOUT=${SESSION_IDLE_TIMEOUT:-}
+      - SESSION_ABSOLUTE_TIMEOUT=${SESSION_ABSOLUTE_TIMEOUT:-}
+      # Shared secret for the first-run setup endpoint, which is reachable
+      # without authentication for as long as no account exists. Empty keeps
+      # the historical behaviour. Set it when the first boot happens on a
+      # network someone else can reach, then send the same value as the
+      # x-setup-token header of the setup request.
+      - PROXCENTER_SETUP_TOKEN=${PROXCENTER_SETUP_TOKEN:-}
       # No ORCHESTRATOR_URL = Community mode
       #
       # Docker Secrets support (Swarm / file-based):

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -30,6 +30,17 @@ services:
       # point several at one database (the HA stack leaves it unset and falls
       # back to the node hostname).
       - PROXCENTER_INSTANCE_ID=${PROXCENTER_INSTANCE_ID:-proxcenter-frontend}
+      # Session lifetimes, in seconds. Left empty on purpose: the frontend
+      # then applies its defaults, 12 hours of inactivity and 7 days absolute.
+      # A malformed value falls back to those defaults rather than to no limit.
+      - SESSION_IDLE_TIMEOUT=${SESSION_IDLE_TIMEOUT:-}
+      - SESSION_ABSOLUTE_TIMEOUT=${SESSION_ABSOLUTE_TIMEOUT:-}
+      # Shared secret for the first-run setup endpoint, which is reachable
+      # without authentication for as long as no account exists. Empty keeps
+      # the historical behaviour. Set it when the first boot happens on a
+      # network someone else can reach, then send the same value as the
+      # x-setup-token header of the setup request.
+      - PROXCENTER_SETUP_TOKEN=${PROXCENTER_SETUP_TOKEN:-}
       - ORCHESTRATOR_URL=http://orchestrator:8080
       - ORCHESTRATOR_API_KEY=${ORCHESTRATOR_API_KEY:-}
       # PDF report renderer (WeasyPrint sidecar), used by Compliance > Frameworks PDF export.

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -100,6 +100,17 @@ services:
       ORCHESTRATOR_API_KEY: ${ORCHESTRATOR_API_KEY}
       PROXCENTER_REPORTING_URL: http://127.0.0.1:5000
       PG_POOL_MAX: ${PG_POOL_MAX:-}
+      # Session lifetimes, in seconds. Left empty on purpose: the frontend
+      # then applies its defaults, 12 hours of inactivity and 7 days absolute.
+      # A malformed value falls back to those defaults rather than to no limit.
+      # Set the same value on every node, a session must not outlive a failover.
+      SESSION_IDLE_TIMEOUT: ${SESSION_IDLE_TIMEOUT:-}
+      SESSION_ABSOLUTE_TIMEOUT: ${SESSION_ABSOLUTE_TIMEOUT:-}
+      # Shared secret for the first-run setup endpoint, which is reachable
+      # without authentication for as long as no account exists. Empty keeps
+      # the historical behaviour. A converted cluster already has accounts, so
+      # this only matters on a stack built as HA from the start.
+      PROXCENTER_SETUP_TOKEN: ${PROXCENTER_SETUP_TOKEN:-}
       # PROXCENTER_INSTANCE_ID is deliberately unset: with host networking the
       # container inherits the node hostname, which is exactly what the
       # orphaned-migration sweep needs (unique per node, stable across container

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -23,6 +23,12 @@ NEXTAUTH_URL="http://localhost:3000"
 # SESSION_IDLE_TIMEOUT="43200"
 # SESSION_ABSOLUTE_TIMEOUT="604800"
 
+# Shared secret for the first-run setup endpoint, which is reachable without
+# authentication for as long as no account exists. The setup request must then
+# carry the same value in its x-setup-token header. Unset keeps the historical
+# behaviour, so a local dev instance needs nothing here.
+# PROXCENTER_SETUP_TOKEN=""
+
 # Orchestrator Backend URL
 ORCHESTRATOR_URL="http://localhost:8080"
 


### PR DESCRIPTION
Prepares the v1.4.7 tag. Nothing here changes application behaviour by default.

## Curated release notes

`RELEASE_NOTES_v1.4.7.md` covers the 40 frontend commits and the 38 orchestrator commits made since v1.4.6, grouped by area: the two authentication fixes and revocable sessions, disaster recovery failback and source fencing, the migration batch, multi vDC, the tag and pool RBAC regression, inventory and interface work, reports and compliance, and the dependency batch.

The release job reads this file at the tagged SHA and hard-fails without it, so it has to be on main before the tag is pushed.

## The wiring gap the notes uncovered

Writing the upgrade section meant checking that the settings it names are actually reachable in production. Three were not.

The shipped compose files pass an explicit `environment:` list rather than an `env_file`, so a variable that lives only in `.env.example` never reaches the container. `.env.example` serves local development.

- `SESSION_IDLE_TIMEOUT` and `SESSION_ABSOLUTE_TIMEOUT`, added with revocable sessions, were pinned to their defaults of 12 hours and 7 days in every deployment, with no way to tune them.
- `PROXCENTER_SETUP_TOKEN`, added with the first-run setup hardening, could not be set at all, which left that hardening unreachable on a real deployment.

All three are now passed by the community, enterprise and HA stacks, empty by default. Empty is what the frontend already treats as unset: a session duration that does not parse as a positive number falls back to its default rather than to no limit, and an empty setup token disables the check instead of requiring an empty header. Verified with `docker compose config`, which renders the three as `""`.

The HA stack gets one extra note in its comments: the same session values belong on every node, since a session must not outlive a failover.
