### PR TITLE
chore(ci): run CI on Node 26 and declare a Node floor

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '26'
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,9 @@
     "clean": "rm -rf .next",
     "clear": "rm -rf node_modules .next"
   },
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
     "@emotion/cache": "11.14.0",

--- a/frontend/src/__tests__/setup/jsdom-setup.ts
+++ b/frontend/src/__tests__/setup/jsdom-setup.ts
@@ -14,6 +14,31 @@ class RO { observe() {} unobserve() {} disconnect() {} }
 globalThis.ResizeObserver ||= RO as any
 globalThis.IntersectionObserver ||= RO as any
 
+// Node 24+ ships its own localStorage global, inert unless the process was
+// started with --localstorage-file. On that Node, the jsdom environment comes
+// up WITHOUT a usable window.localStorage (sessionStorage survives), so any
+// `localStorage.getItem(...)` throws on undefined. Browsers have no such split,
+// so this is a harness gap rather than product behaviour, and the product code
+// under test is what a browser would run. Supply a real in-memory Storage when
+// the environment did not.
+class MemoryStorage implements Storage {
+  #items = new Map<string, string>()
+  get length() { return this.#items.size }
+  key(i: number) { return [...this.#items.keys()][i] ?? null }
+  getItem(k: string) { return this.#items.get(String(k)) ?? null }
+  setItem(k: string, v: string) { this.#items.set(String(k), String(v)) }
+  removeItem(k: string) { this.#items.delete(String(k)) }
+  clear() { this.#items.clear() }
+  [key: string]: any
+}
+for (const name of ['localStorage', 'sessionStorage'] as const) {
+  const existing = (() => { try { return window[name] } catch { return undefined } })()
+  const storage = existing ?? new MemoryStorage()
+  for (const target of [window, globalThis]) {
+    Object.defineProperty(target, name, { value: storage, configurable: true, writable: true })
+  }
+}
+
 // Start MSW for the jsdom lane. Unhandled requests error loudly so a missing
 // fixture fails the test instead of silently returning empty data.
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))


### PR DESCRIPTION
Three related changes, all about the version of Node this project is actually run on.

## CI now runs the version that ships

The workflows ran on Node 22 while the production image is built `FROM node:26-alpine` and `frontend/.nvmrc` asks for 26. Nothing in CI ever exercised the runtime that reaches customers. `sonarcloud.yml`, `docker-publish.yml` and `lint.yml` move to 26.

## package.json declares a Node floor

There was no `engines` field, so no combination was ever refused or even flagged. The floor is set to `>=22.12.0`, which is what the dependency tree actually imposes: Prisma 7 accepts `^20.19 || ^22.12 || >=24`, and `@prisma/streams-local` requires `>=22.0.0`. That last one had been running outside its supported range on a development box still on Node 20, silently, because nothing declared anything. The floor is deliberately not `>=26`: CI has been green on 22 for a long time and there is no evidence 22 is broken, so the field records the real minimum rather than the preferred version.

## The jsdom harness needed a fill for Node 24 and later

Bumping CI is not free, which is why it was tested before being proposed. On Node 26 the build and the lint pass, but five suites and 42 assertions fail on `Cannot read properties of undefined`.

Node 24 and later ship their own `localStorage` global, inert unless the process is started with `--localstorage-file`. On that Node the jsdom environment comes up without a usable `window.localStorage`, while `sessionStorage` survives, so any `localStorage.getItem(...)` throws. This is a harness gap and not product behaviour: the code under test is what a browser runs, and a browser has no such split.

`jsdom-setup.ts` now supplies an in-memory `Storage` when the environment did not, alongside the `matchMedia`, `ResizeObserver` and `IntersectionObserver` fills it already carries. It is conditional, so it changes nothing on Node 20 or 22, where jsdom provides the real one.

## Verification

On Node 26: `npm run build` green, `npm run lint` green with 0 errors, and the full suite at 487 files and 4928 tests passing, exit code read directly rather than through a pipe. The five suites that failed before the fill pass at 42 out of 42.

## Follow-up, not included

#669 (nanoid 6) and #636 (concurrently 10) both drop Node 18 and 20 and are unblocked by this on any machine that follows `.nvmrc`, but they are dependency updates and belong in their own pass.
