### PR TITLE
fix(pbs): capture the TLS fingerprint when PBS is declared by IP

### DIFF
--- a/frontend/src/lib/proxmox/pbsFingerprint.test.ts
+++ b/frontend/src/lib/proxmox/pbsFingerprint.test.ts
@@ -1,5 +1,43 @@
-import { describe, it, expect } from 'vitest'
-import { parseHostPort, formatFingerprint } from './pbsFingerprint'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createHash } from 'crypto'
+
+const { connect } = vi.hoisted(() => ({ connect: vi.fn() }))
+
+vi.mock('tls', () => {
+  const mod = { connect: (...args: unknown[]) => connect(...args) }
+  return { ...mod, default: mod }
+})
+
+import { parseHostPort, formatFingerprint, captureFingerprint } from './pbsFingerprint'
+
+type SocketHandler = (arg?: unknown) => void
+
+/** Stands in for the TLS socket, handing back `cert` from getPeerCertificate. */
+function installSocket(cert: unknown) {
+  const handlers: Record<string, SocketHandler> = {}
+  const socket = {
+    on(event: string, cb: SocketHandler) {
+      handlers[event] = cb
+      return socket
+    },
+    end: vi.fn(),
+    destroy: vi.fn(),
+    getPeerCertificate: vi.fn(() => cert),
+    handlers,
+  }
+  connect.mockImplementation((_opts: unknown, cb: () => void) => {
+    // Real tls fires secureConnect on a later tick. Calling it synchronously
+    // would hit the TDZ on the `socket` const inside captureFingerprint.
+    setImmediate(cb)
+    return socket
+  })
+  return socket
+}
+
+/** Options object handed to tls.connect on the first (only) call. */
+function connectOptions(): Record<string, unknown> {
+  return connect.mock.calls[0][0] as Record<string, unknown>
+}
 
 describe('pbsFingerprint helpers', () => {
   it('parses https://host:port', () => {
@@ -14,8 +52,64 @@ describe('pbsFingerprint helpers', () => {
   it('throws on non-https', () => {
     expect(() => parseHostPort('http://pbs.example')).toThrow(/https required/i)
   })
+  it('throws on an unparseable url', () => {
+    expect(() => parseHostPort('not a url')).toThrow(/https required/i)
+  })
+  it('unbrackets an IPv6 literal, keeping the explicit port', () => {
+    expect(parseHostPort('https://[2001:db8::1]:8007')).toEqual({ host: '2001:db8::1', port: 8007 })
+  })
+  it('unbrackets an IPv6 literal with no port', () => {
+    expect(parseHostPort('https://[2001:db8::1]')).toEqual({ host: '2001:db8::1', port: 8007 })
+  })
   it('formats raw hash as colon-separated uppercase', () => {
     const raw = 'aabbccdd'
     expect(formatFingerprint(raw)).toBe('AA:BB:CC:DD')
+  })
+})
+
+describe('captureFingerprint SNI handling', () => {
+  beforeEach(() => {
+    connect.mockReset()
+  })
+
+  // Node 26 turned "SNI must not be an IP" from a deprecation warning into a
+  // synchronous ERR_INVALID_ARG_VALUE throw, which broke every PBS declared
+  // by IP the moment the image moved off node:22-alpine.
+  it('omits servername for an IPv4 host', async () => {
+    installSocket({ raw: Buffer.from('cert') })
+    await captureFingerprint('https://10.2.250.18:8007')
+    const opts = connectOptions()
+    expect(opts).not.toHaveProperty('servername')
+    expect(opts.host).toBe('10.2.250.18')
+    expect(opts.port).toBe(8007)
+  })
+
+  it('omits servername for an IPv6 host', async () => {
+    installSocket({ raw: Buffer.from('cert') })
+    await captureFingerprint('https://[2001:db8::1]:8007')
+    const opts = connectOptions()
+    expect(opts).not.toHaveProperty('servername')
+    expect(opts.host).toBe('2001:db8::1')
+  })
+
+  it('sends servername for a DNS host', async () => {
+    installSocket({ raw: Buffer.from('cert') })
+    await captureFingerprint('https://pbs.example')
+    const opts = connectOptions()
+    expect(opts.servername).toBe('pbs.example')
+    expect(opts.port).toBe(8007)
+  })
+
+  it('returns the SHA256 of the leaf certificate, colon-formatted', async () => {
+    const raw = Buffer.from('leaf-cert-bytes')
+    const socket = installSocket({ raw })
+    const expected = formatFingerprint(createHash('sha256').update(raw).digest('hex'))
+    await expect(captureFingerprint('https://10.2.250.18:8007')).resolves.toBe(expected)
+    expect(socket.end).toHaveBeenCalled()
+  })
+
+  it('rejects when the peer sends no certificate', async () => {
+    installSocket({})
+    await expect(captureFingerprint('https://10.2.250.18:8007')).rejects.toThrow(/no certificate/i)
   })
 })

--- a/frontend/src/lib/proxmox/pbsFingerprint.ts
+++ b/frontend/src/lib/proxmox/pbsFingerprint.ts
@@ -1,10 +1,23 @@
+import net from 'net'
 import tls from 'tls'
 import { createHash } from 'crypto'
 
+/**
+ * Splits an https base URL into the host to dial and its port. IPv6 literals
+ * come back unbracketed (`2001:db8::1`, not `[2001:db8::1]`) because both
+ * `net.isIP()` and `tls.connect({ host })` expect the bare address.
+ */
 export function parseHostPort(baseUrl: string): { host: string; port: number } {
-  const m = baseUrl.match(/^https:\/\/([^/:?#]+)(?::(\d+))?/i)
-  if (!m) throw new Error(`Invalid PBS baseUrl (https required): ${baseUrl}`)
-  return { host: m[1], port: m[2] ? Number(m[2]) : 8007 }
+  let url: URL
+  try {
+    url = new URL(baseUrl)
+  } catch {
+    throw new Error(`Invalid PBS baseUrl (https required): ${baseUrl}`)
+  }
+  if (url.protocol !== 'https:' || !url.hostname) {
+    throw new Error(`Invalid PBS baseUrl (https required): ${baseUrl}`)
+  }
+  return { host: url.hostname.replace(/^\[|\]$/g, ''), port: url.port ? Number(url.port) : 8007 }
 }
 
 export function formatFingerprint(hex: string): string {
@@ -18,11 +31,17 @@ export function formatFingerprint(hex: string): string {
  */
 export async function captureFingerprint(baseUrl: string, timeoutMs = 5000): Promise<string> {
   const { host, port } = parseHostPort(baseUrl)
+  // SNI carries a hostname only: RFC 6066 forbids IP literals, and Node 26
+  // turned the long-standing deprecation warning into a hard synchronous
+  // throw (ERR_INVALID_ARG_VALUE) inside tls.connect. PBS is very commonly
+  // declared by IP, so omit servername entirely there rather than let the
+  // capture die before the handshake even starts.
+  const sni = net.isIP(host) === 0 ? { servername: host } : {}
   return await new Promise<string>((resolve, reject) => {
     const socket = tls.connect({
       host,
       port,
-      servername: host,
+      ...sni,
       rejectUnauthorized: false,
       timeout: timeoutMs,
     }, () => {


### PR DESCRIPTION
## Problem

A trial user reported that the TLS fingerprint of their PBS server could never be captured. The dialog showed `The property 'options.servername' Setting the TLS ServerName to an IP address is not permitted.. Received '10.x.x.x'` while the connection itself was Online and its version correctly detected.

`captureFingerprint()` has passed `servername: host` to `tls.connect()` since it was written. RFC 6066 forbids an IP literal in SNI, and Node treated that as a deprecation warning for years, silently ignoring the value. Node 26 turned it into a synchronous `ERR_INVALID_ARG_VALUE` throw, so the call now dies before the handshake even starts whenever the PBS base URL is an IP address, which is the common case.

Measured on the official images with the exact same call:

| Image | Result |
| --- | --- |
| `node:20-alpine` (v20.20.2) | connects, SNI ignored, deprecation warning |
| `node:22-alpine` (v22.23.2) | connects, SNI ignored |
| `node:24-alpine` (v24.19.0) | connects, SNI ignored |
| `node:26-alpine` (v26.3.0) | throws `ERR_INVALID_ARG_VALUE` |

The helper landed in April, the base image moved from `node:22-alpine` to `node:26-alpine` in May. That bump is what turned a latent bug into a user facing one. Instances that captured their fingerprint before it keep working, because nothing ever recomputes a stored fingerprint, which is why this went unnoticed for a while.

## Impact

Both call sites are affected on a current image. At connection create time the capture is best effort and only warns, so a PBS added by IP is saved with `fingerprint=null` and nothing surfaces. The explicit Capture fingerprint button returns 502 with the raw Node message.

A missing fingerprint later blocks vDC PBS auto-binding (namespace, sub-token and ACL provisioning) and the PBS datastore attachment on PVE, both of which require it.

## Fix

Set `servername` only when the host is not an IP literal, using `net.isIP()`. Everything else about the handshake is unchanged.

`parseHostPort()` is rebuilt on `URL` at the same time: its regex stopped at the first colon, so `https://[2001:db8::1]:8007` parsed to host `[2001`, which would have defeated the `net.isIP()` check anyway. IPv6 literals now come back unbracketed, which is what both `net.isIP()` and `tls.connect({ host })` expect. The error contract is unchanged, a non https URL and an unparseable URL still raise the same message.

## Tests

Seven new unit tests cover the SNI decision (IPv4, IPv6, DNS host), the SHA256 of the leaf certificate, the missing certificate path, and the two new `parseHostPort` cases.

Verification beyond the mocks:

- End to end against a real self-signed TLS server reached over `127.0.0.1` on Node 26, returning a fingerprint byte for byte identical to `openssl x509 -fingerprint -sha256`.
- Counter check with the old line restored: the live test then fails with exactly the reported error, and the IPv4 and IPv6 unit tests fail too. The fix is what makes them pass.
- The direct caller suite (`connections/route.test.ts`) stays green.

Manually validated in the UI: Re-capture on an existing PBS declared by IP now returns its fingerprint.

## Note for existing installations

Connections already stored with `fingerprint=null` do not repair themselves. Users hit by this need to press Capture fingerprint once after upgrading. No migration required.
