### PR TITLE
Keep text readable when the branding colour is light

### DIFF
--- a/frontend/src/@core/theme/overrides/chip.js
+++ b/frontend/src/@core/theme/overrides/chip.js
@@ -58,7 +58,7 @@ const chip = {
               },
               '&.MuiChip-clickable:hover': {
                 backgroundColor: 'var(--mui-palette-primary-main)',
-                color: 'var(--mui-palette-common-white)'
+                color: 'var(--mui-palette-primary-contrastText)'
               }
             }
           },

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
@@ -36,6 +36,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import { onPrimaryTextColor } from '@/lib/theme/onPrimary'
 import NumericTextField from '@/components/ui/NumericTextField'
 import { AllVmItem } from './InventoryTree'
 
@@ -1457,7 +1458,8 @@ return
         icon={<i className="ri-instance-line" style={{ fontSize: 20 }} />}
         sx={{
           bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,150,200,0.15)' : 'primary.light',
-          color: theme.palette.mode === 'dark' ? 'primary.light' : 'primary.contrastText',
+          color:
+            theme.palette.mode === 'dark' ? 'primary.light' : onPrimaryTextColor(theme.palette.primary.light),
           py: 1.5
         }}
       >

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -43,6 +43,7 @@ import {
 import { alpha } from '@mui/material/styles'
 
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
+import { onPrimaryTextColor } from '@/lib/theme/onPrimary'
 import NumericTextField from '@/components/ui/NumericTextField'
 import QuotaDonut from '@/components/mydc/QuotaDonut'
 import { formatBytes } from '@/utils/format'
@@ -2261,7 +2262,8 @@ return
         icon={<i className="ri-computer-line" style={{ fontSize: 20 }} />}
         sx={{
           bgcolor: theme.palette.mode === 'dark' ? 'rgba(0,150,200,0.15)' : 'primary.light',
-          color: theme.palette.mode === 'dark' ? 'primary.light' : 'primary.contrastText',
+          color:
+            theme.palette.mode === 'dark' ? 'primary.light' : onPrimaryTextColor(theme.palette.primary.light),
           py: 1.5
         }}
       >

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -3762,7 +3762,7 @@ return vm?.isCluster ?? false
                         {migRunning > 0 && (
                           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                             <Typography variant="body2" fontSize={12} sx={{ opacity: 0.7 }}>{t('inventoryPage.extDashboard.inProgress')}</Typography>
-                            <Chip size="small" label={migRunning} sx={{ height: 20, fontSize: 11, fontWeight: 700, bgcolor: 'primary.main', color: '#fff', minWidth: 30 }} />
+                            <Chip size="small" label={migRunning} sx={{ height: 20, fontSize: 11, fontWeight: 700, bgcolor: 'primary.main', color: 'primary.contrastText', minWidth: 30 }} />
                           </Box>
                         )}
                         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -3999,7 +3999,7 @@ return vm?.isCluster ?? false
                         sx={{
                           height: 20, fontSize: 10, fontWeight: 700, flexShrink: 0,
                           bgcolor: mig.status === 'completed' ? 'success.main' : mig.status === 'failed' ? 'error.main' : 'primary.main',
-                          color: '#fff',
+                          color: mig.status === 'completed' ? 'success.contrastText' : mig.status === 'failed' ? 'error.contrastText' : 'primary.contrastText',
                         }}
                       />
                     </Box>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/ExternalHypervisorDashboard.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/ExternalHypervisorDashboard.tsx
@@ -284,7 +284,7 @@ export default function ExternalHypervisorDashboard({ extTypeInfo: info, onSelec
                 <Typography variant="caption" fontSize={10} sx={{ opacity: 0.5, whiteSpace: 'nowrap', flexShrink: 0 }}>{'\u2192'} {mig.targetNode}</Typography>
                 <Typography variant="caption" fontSize={10} sx={{ opacity: 0.5, whiteSpace: 'nowrap', flexShrink: 0 }}>{mig.totalBytes ? `${(Number(mig.totalBytes) / 1073741824).toFixed(1)} GB` : '--'}</Typography>
                 {mig.completedAt && <Typography variant="caption" fontSize={10} sx={{ opacity: 0.4, whiteSpace: 'nowrap', flexShrink: 0 }}>{new Date(mig.completedAt).toLocaleDateString()}</Typography>}
-                <Chip size="small" label={mig.status === 'completed' ? t('inventoryPage.esxiMigration.completed') : mig.status === 'failed' ? t('inventoryPage.esxiMigration.failed') : `${mig.progress || 0}%`} sx={{ height: 20, fontSize: 10, fontWeight: 700, flexShrink: 0, bgcolor: mig.status === 'completed' ? 'success.main' : mig.status === 'failed' ? 'error.main' : 'primary.main', color: '#fff' }} />
+                <Chip size="small" label={mig.status === 'completed' ? t('inventoryPage.esxiMigration.completed') : mig.status === 'failed' ? t('inventoryPage.esxiMigration.failed') : `${mig.progress || 0}%`} sx={{ height: 20, fontSize: 10, fontWeight: 700, flexShrink: 0, bgcolor: mig.status === 'completed' ? 'success.main' : mig.status === 'failed' ? 'error.main' : 'primary.main', color: mig.status === 'completed' ? 'success.contrastText' : mig.status === 'failed' ? 'error.contrastText' : 'primary.contrastText' }} />
               </Box>
             ))}
           </Stack>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -4113,7 +4113,7 @@ return
                                 sx={{
                                   height: 20, fontSize: 10, fontWeight: 700, minWidth: 50,
                                   bgcolor: isDone ? 'success.main' : isFailed ? 'error.main' : isQueued ? 'action.disabled' : 'primary.main',
-                                  color: '#fff',
+                                  color: isDone ? 'success.contrastText' : isFailed ? 'error.contrastText' : isQueued ? 'common.white' : 'primary.contrastText',
                                 }}
                               />
                             </Box>
@@ -4144,7 +4144,7 @@ return
                             size="small"
                             label={t('inventoryPage.esxiMigration.allVms')}
                             onClick={() => setBulkMigLogsFilter(null)}
-                            sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: !bulkMigLogsFilter ? 'primary.main' : 'action.hover', color: !bulkMigLogsFilter ? '#fff' : 'text.secondary' }}
+                            sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: !bulkMigLogsFilter ? 'primary.main' : 'action.hover', color: !bulkMigLogsFilter ? 'primary.contrastText' : 'text.secondary' }}
                           />
                           {bulkMigJobs.filter(j => j.jobId).map(j => (
                             <Chip
@@ -4152,7 +4152,7 @@ return
                               size="small"
                               label={j.name}
                               onClick={() => setBulkMigLogsFilter(bulkMigLogsFilter === j.jobId ? null : j.jobId)}
-                              sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: bulkMigLogsFilter === j.jobId ? 'primary.main' : 'action.hover', color: bulkMigLogsFilter === j.jobId ? '#fff' : 'text.secondary' }}
+                              sx={{ height: 22, fontSize: 10, fontWeight: 600, bgcolor: bulkMigLogsFilter === j.jobId ? 'primary.main' : 'action.hover', color: bulkMigLogsFilter === j.jobId ? 'primary.contrastText' : 'text.secondary' }}
                             />
                           ))}
                         </Box>

--- a/frontend/src/app/(dashboard)/profile/page.jsx
+++ b/frontend/src/app/(dashboard)/profile/page.jsx
@@ -173,6 +173,7 @@ return
                   fontSize: '2.5rem',
                   fontWeight: 700,
                   bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
                   mb: 2,
                 }}
               >

--- a/frontend/src/components/MicrosegmentationTab.tsx
+++ b/frontend/src/components/MicrosegmentationTab.tsx
@@ -663,7 +663,7 @@ return config.excludePatterns.some(pattern =>
                   <Grid size={{ xs: 12, md: 4 }}>
                     <Paper sx={{ p: 2, bgcolor: alpha(theme.palette.primary.main, 0.03), border: `1px solid ${alpha(theme.palette.primary.main, 0.1)}`, height: '100%' }}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                        <Avatar sx={{ width: 28, height: 28, bgcolor: theme.palette.primary.main, fontSize: 14 }}>1</Avatar>
+                        <Avatar sx={{ width: 28, height: 28, bgcolor: theme.palette.primary.main, color: 'primary.contrastText', fontSize: 14 }}>1</Avatar>
                         <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>{t('microseg.gatewayAliases')}</Typography>
                       </Box>
                       <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/TaskDetailDialog.jsx
+++ b/frontend/src/components/TaskDetailDialog.jsx
@@ -225,7 +225,11 @@ export default function TaskDetailDialog({ open, task, onClose }) {
                 className={isRunning ? 'ri-loader-4-line' : statusColor === 'success' ? 'ri-check-line' : 'ri-close-line'}
                 style={{
                   fontSize: 20,
-                  color: '#fff',
+                  color: isRunning
+                    ? 'var(--mui-palette-primary-contrastText)'
+                    : statusColor === 'success'
+                      ? 'var(--mui-palette-success-contrastText)'
+                      : 'var(--mui-palette-error-contrastText)',
                   animation: isRunning ? 'spin 1s linear infinite' : 'none'
                 }}
               />

--- a/frontend/src/components/TasksFooter.tsx
+++ b/frontend/src/components/TasksFooter.tsx
@@ -674,7 +674,7 @@ export default function TasksFooter({
                 ProxCenter
                 {pcRunningCount > 0 && (
                   <Box sx={{
-                    bgcolor: 'primary.main', color: '#fff', borderRadius: '50%',
+                    bgcolor: 'primary.main', color: 'primary.contrastText', borderRadius: '50%',
                     width: 16, height: 16, fontSize: 10, fontWeight: 700,
                     display: 'flex', alignItems: 'center', justifyContent: 'center', ml: 0.25,
                   }}>

--- a/frontend/src/components/VmsTable.tsx
+++ b/frontend/src/components/VmsTable.tsx
@@ -1494,7 +1494,7 @@ return (
                     sx={{ 
                       color: 'primary.main',
                       p: 0.5,
-                      '&:hover': { bgcolor: 'primary.main', color: 'white' }
+                      '&:hover': { bgcolor: 'primary.main', color: 'primary.contrastText' }
                     }}
                   >
                     <i className='ri-file-copy-2-line' style={{ fontSize: 16 }} />
@@ -1682,7 +1682,7 @@ return (
                   sx={{ 
                     color: 'text.secondary',
                     p: 0.5,
-                    '&:hover': { bgcolor: 'primary.main', color: 'white' }
+                    '&:hover': { bgcolor: 'primary.main', color: 'primary.contrastText' }
                   }}
                 >
                   <i className='ri-eye-line' style={{ fontSize: 16 }} />

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
@@ -276,7 +276,7 @@ export default function EmergencyDRTab({
                           size="small"
                           disabled={!vm.planId}
                           onClick={() => vm.planId && onExecuteFailback(vm.planId)}
-                          sx={{ color: 'primary.main', '&:hover': { bgcolor: 'primary.main', color: 'white' } }}
+                          sx={{ color: 'primary.main', '&:hover': { bgcolor: 'primary.main', color: 'primary.contrastText' } }}
                         >
                           <i className="ri-arrow-turn-back-line" style={{ fontSize: 18 }} />
                         </IconButton>

--- a/frontend/src/components/dashboard/WidgetGrid.jsx
+++ b/frontend/src/components/dashboard/WidgetGrid.jsx
@@ -15,6 +15,7 @@ import { WIDGET_REGISTRY, WIDGET_CATEGORIES, getWidgetsByCategory, isWidgetVisib
 import { DEFAULT_LAYOUT, PRESET_LAYOUTS } from './types'
 import { CardsSkeleton } from '@/components/skeletons'
 import { useWidgetVisibility } from '@/hooks/useWidgetVisibility'
+import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
 
 const GRID_COLS = { lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }
 const ROW_HEIGHT = 40
@@ -54,6 +55,7 @@ function NoContainerWrapper({ config, data, loading, editMode, onRemove, onUpdat
             display: 'flex', alignItems: 'center', justifyContent: 'space-between',
             px: 1.5, py: 0.5,
             bgcolor: 'primary.main', color: 'primary.contrastText',
+            ...INHERIT_ON_PRIMARY_SX,
             cursor: 'move', flexShrink: 0,
           }}
         >

--- a/frontend/src/components/layout/shared/AIChatDrawer.jsx
+++ b/frontend/src/components/layout/shared/AIChatDrawer.jsx
@@ -20,6 +20,8 @@ import {
 } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 
+import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
+
 // Formatage basique du texte (gras, listes)
 const formatText = (text) => {
   if (!text) return ''
@@ -56,6 +58,7 @@ const MessageBubble = ({ message, isUser, isStreaming, thinkingText }) => {
             height: 32,
             mr: 1,
             bgcolor: theme.palette.primary.main,
+            color: 'primary.contrastText',
             fontSize: 14,
             flexShrink: 0
           }}
@@ -76,7 +79,8 @@ const MessageBubble = ({ message, isUser, isStreaming, thinkingText }) => {
             : theme.palette.action.hover,
           color: isUser 
             ? theme.palette.primary.contrastText 
-            : theme.palette.text.primary
+            : theme.palette.text.primary,
+          ...(isUser ? INHERIT_ON_PRIMARY_SX : {})
         }}
       >
         {isStreaming && !message.content ? (
@@ -374,7 +378,7 @@ return provider
         }}
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-          <Avatar sx={{ bgcolor: theme.palette.primary.main, width: 40, height: 40 }}>
+          <Avatar sx={{ bgcolor: theme.palette.primary.main, color: 'primary.contrastText', width: 40, height: 40 }}>
             <i className='ri-sparkling-2-fill' style={{ fontSize: 22 }} />
           </Avatar>
           <Box>
@@ -432,7 +436,8 @@ return provider
                 height: 64, 
                 mx: 'auto', 
                 mb: 2,
-                bgcolor: theme.palette.primary.main 
+                bgcolor: theme.palette.primary.main,
+                color: 'primary.contrastText'
               }}
             >
               <i className='ri-sparkling-2-fill' style={{ fontSize: 32 }} />

--- a/frontend/src/components/layout/shared/CommandPalette.jsx
+++ b/frontend/src/components/layout/shared/CommandPalette.jsx
@@ -22,6 +22,7 @@ import { hasInfraScope } from '@/lib/rbac/scopeKinds'
 import { useLicense } from '@/contexts/LicenseContext'
 import { useTenant } from '@/contexts/TenantContext'
 import { useMyVdcs } from '@/hooks/useMyVdcs'
+import { commandPaletteRowSx } from './commandPaletteRowSx'
 
 // ---------------------------------------------------------------------------
 // Fuzzy match utility (no external lib)
@@ -467,22 +468,7 @@ const CommandPalette = ({ open, onClose }) => {
                   key={`page-${page.href}`}
                   ref={el => { itemRefs.current[idx] = el }}
                   onClick={() => navigateTo({ ...page, _type: 'page' })}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.5,
-                    py: 1,
-                    cursor: 'pointer',
-                    borderRadius: 1,
-                    mx: 1,
-                    bgcolor: activeIndex === idx ? 'primary.main' : 'transparent',
-                    color: activeIndex === idx ? 'primary.contrastText' : 'text.primary',
-                    '&:hover': {
-                      bgcolor: activeIndex === idx ? 'primary.main' : 'action.hover'
-                    },
-                    transition: 'background-color 0.1s'
-                  }}
+                  sx={commandPaletteRowSx(activeIndex === idx)}
                 >
                   <i
                     className={page.icon || 'ri-file-line'}
@@ -526,22 +512,7 @@ const CommandPalette = ({ open, onClose }) => {
                   key={`vm-${vm.vmid}-${vm.node}`}
                   ref={el => { itemRefs.current[idx] = el }}
                   onClick={() => navigateTo({ ...vm, _type: 'vm' })}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.5,
-                    py: 1,
-                    cursor: 'pointer',
-                    borderRadius: 1,
-                    mx: 1,
-                    bgcolor: activeIndex === idx ? 'primary.main' : 'transparent',
-                    color: activeIndex === idx ? 'primary.contrastText' : 'text.primary',
-                    '&:hover': {
-                      bgcolor: activeIndex === idx ? 'primary.main' : 'action.hover'
-                    },
-                    transition: 'background-color 0.1s'
-                  }}
+                  sx={commandPaletteRowSx(activeIndex === idx)}
                 >
                   {/* Status dot */}
                   <Box
@@ -643,22 +614,7 @@ const CommandPalette = ({ open, onClose }) => {
                   key={`node-${node.connId}-${node.node}`}
                   ref={el => { itemRefs.current[idx] = el }}
                   onClick={() => navigateTo({ ...node, _type: 'node' })}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.5,
-                    py: 1,
-                    cursor: 'pointer',
-                    borderRadius: 1,
-                    mx: 1,
-                    bgcolor: activeIndex === idx ? 'primary.main' : 'transparent',
-                    color: activeIndex === idx ? 'primary.contrastText' : 'text.primary',
-                    '&:hover': {
-                      bgcolor: activeIndex === idx ? 'primary.main' : 'action.hover'
-                    },
-                    transition: 'background-color 0.1s'
-                  }}
+                  sx={commandPaletteRowSx(activeIndex === idx)}
                 >
                   <i
                     className='ri-server-line'
@@ -734,22 +690,7 @@ const CommandPalette = ({ open, onClose }) => {
                   key={`pbs-${pbs.id}`}
                   ref={el => { itemRefs.current[idx] = el }}
                   onClick={() => navigateTo({ ...pbs, _type: 'pbs' })}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.5,
-                    py: 1,
-                    cursor: 'pointer',
-                    borderRadius: 1,
-                    mx: 1,
-                    bgcolor: activeIndex === idx ? 'primary.main' : 'transparent',
-                    color: activeIndex === idx ? 'primary.contrastText' : 'text.primary',
-                    '&:hover': {
-                      bgcolor: activeIndex === idx ? 'primary.main' : 'action.hover'
-                    },
-                    transition: 'background-color 0.1s'
-                  }}
+                  sx={commandPaletteRowSx(activeIndex === idx)}
                 >
                   <i
                     className='ri-shield-check-line'
@@ -852,22 +793,7 @@ const CommandPalette = ({ open, onClose }) => {
                   key={`action-${action.href}`}
                   ref={el => { itemRefs.current[idx] = el }}
                   onClick={() => navigateTo({ ...action, _type: 'action' })}
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    px: 2.5,
-                    py: 1,
-                    cursor: 'pointer',
-                    borderRadius: 1,
-                    mx: 1,
-                    bgcolor: activeIndex === idx ? 'primary.main' : 'transparent',
-                    color: activeIndex === idx ? 'primary.contrastText' : 'text.primary',
-                    '&:hover': {
-                      bgcolor: activeIndex === idx ? 'primary.main' : 'action.hover'
-                    },
-                    transition: 'background-color 0.1s'
-                  }}
+                  sx={commandPaletteRowSx(activeIndex === idx)}
                 >
                   <i
                     className={action.icon}

--- a/frontend/src/components/layout/shared/UserDropdown.jsx
+++ b/frontend/src/components/layout/shared/UserDropdown.jsx
@@ -111,7 +111,7 @@ const UserDropdown = () => {
           src={user?.avatar || undefined}
           onClick={handleDropdownOpen}
           className='cursor-pointer bs-[38px] is-[38px]'
-          sx={{ bgcolor: 'primary.main', fontSize: '0.875rem', fontWeight: 600 }}
+          sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem', fontWeight: 600 }}
         >
           {!user?.avatar && getInitials(user?.name, user?.email)}
         </Avatar>
@@ -138,7 +138,7 @@ const UserDropdown = () => {
                     <Avatar 
                       alt={user?.name || user?.email || 'User'}
                       src={user?.avatar || undefined}
-                      sx={{ bgcolor: 'primary.main', fontSize: '0.875rem', fontWeight: 600 }}
+                      sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', fontSize: '0.875rem', fontWeight: 600 }}
                     >
                       {!user?.avatar && getInitials(user?.name, user?.email)}
                     </Avatar>

--- a/frontend/src/components/layout/shared/commandPaletteRowSx.test.ts
+++ b/frontend/src/components/layout/shared/commandPaletteRowSx.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+
+import { commandPaletteRowSx } from './commandPaletteRowSx'
+import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
+
+describe('commandPaletteRowSx', () => {
+  it('paints the highlighted row with the primary colour and its contrast text', () => {
+    const sx = commandPaletteRowSx(true)
+
+    expect(sx.bgcolor).toBe('primary.main')
+    expect(sx.color).toBe('primary.contrastText')
+    expect(sx['&:hover']).toEqual({ bgcolor: 'primary.main' })
+  })
+
+  it('lets the labels of the highlighted row follow that contrast text', () => {
+    // Typography carries an explicit per-variant colour from the theme, so
+    // without this the row label stayed text.secondary on a primary
+    // background: issue #460, unreadable as soon as the primary is light.
+    const sx = commandPaletteRowSx(true)
+
+    for (const [selector, rule] of Object.entries(INHERIT_ON_PRIMARY_SX)) {
+      expect(sx[selector as keyof typeof sx]).toEqual(rule)
+    }
+  })
+
+  it('leaves an idle row on the normal text colours', () => {
+    const sx = commandPaletteRowSx(false)
+
+    expect(sx.bgcolor).toBe('transparent')
+    expect(sx.color).toBe('text.primary')
+    expect(sx['&:hover']).toEqual({ bgcolor: 'action.hover' })
+
+    // No inherit override: idle rows keep the label/caption hierarchy the
+    // theme gives them.
+    for (const selector of Object.keys(INHERIT_ON_PRIMARY_SX)) {
+      expect(sx).not.toHaveProperty(selector)
+    }
+  })
+
+  it('keeps the layout identical whichever row is highlighted', () => {
+    const active = commandPaletteRowSx(true)
+    const idle = commandPaletteRowSx(false)
+
+    for (const key of ['display', 'alignItems', 'gap', 'px', 'py', 'borderRadius', 'mx', 'cursor'] as const) {
+      expect(active[key]).toBe(idle[key])
+    }
+  })
+})

--- a/frontend/src/components/layout/shared/commandPaletteRowSx.ts
+++ b/frontend/src/components/layout/shared/commandPaletteRowSx.ts
@@ -1,0 +1,25 @@
+import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
+
+/**
+ * Row style shared by the five result sections of the command palette (pages,
+ * VMs, nodes, PBS servers, actions). The highlighted row is painted with the
+ * primary colour, which the user can set to anything through White Label, so
+ * its content follows `primary.contrastText` instead of a fixed white.
+ */
+export const commandPaletteRowSx = (active: boolean) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 1.5,
+  px: 2.5,
+  py: 1,
+  cursor: 'pointer',
+  borderRadius: 1,
+  mx: 1,
+  bgcolor: active ? 'primary.main' : 'transparent',
+  color: active ? 'primary.contrastText' : 'text.primary',
+  ...(active ? INHERIT_ON_PRIMARY_SX : {}),
+  '&:hover': {
+    bgcolor: active ? 'primary.main' : 'action.hover'
+  },
+  transition: 'background-color 0.1s'
+})

--- a/frontend/src/components/layout/vertical/NavbarContent.jsx
+++ b/frontend/src/components/layout/vertical/NavbarContent.jsx
@@ -742,7 +742,8 @@ return () => window.removeEventListener('keydown', onKeyDown)
                   height: 32,
                   fontSize: '0.75rem',
                   fontWeight: 600,
-                  bgcolor: 'primary.main'
+                  bgcolor: 'primary.main',
+                  color: 'primary.contrastText'
                 }}
               >
                 {!user?.avatar && getInitials(user?.name, user?.email)}

--- a/frontend/src/components/settings/AppearanceTab.jsx
+++ b/frontend/src/components/settings/AppearanceTab.jsx
@@ -66,7 +66,7 @@ function ThemePreviewCard({ themeConfig, selected, onSelect, t }) {
     >
       {isSelected && (
         <Box sx={{ position: 'absolute', top: 6, right: 6, width: 20, height: 20, borderRadius: '50%', backgroundColor: 'primary.main', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 2 }}>
-          <i className='ri-check-line' style={{ color: '#fff', fontSize: 12 }} />
+          <i className='ri-check-line' style={{ color: 'var(--mui-palette-primary-contrastText)', fontSize: 12 }} />
         </Box>
       )}
 

--- a/frontend/src/components/settings/TenantsTab.tsx
+++ b/frontend/src/components/settings/TenantsTab.tsx
@@ -714,7 +714,7 @@ export default function TenantsTab() {
                       renderOption={(props, option) => (
                         <li {...props} key={option.id}>
                           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <Avatar sx={{ width: 24, height: 24, fontSize: '0.7rem', bgcolor: 'primary.main' }}>
+                            <Avatar sx={{ width: 24, height: 24, fontSize: '0.7rem', bgcolor: 'primary.main', color: 'primary.contrastText' }}>
                               {getInitials(option.name, option.email)}
                             </Avatar>
                             <Box>
@@ -771,7 +771,7 @@ export default function TenantsTab() {
                           }
                         >
                           <ListItemAvatar>
-                            <Avatar sx={{ width: 32, height: 32, fontSize: '0.75rem', bgcolor: 'primary.main' }}>
+                            <Avatar sx={{ width: 32, height: 32, fontSize: '0.75rem', bgcolor: 'primary.main', color: 'primary.contrastText' }}>
                               {getInitials(user.name, user.email)}
                             </Avatar>
                           </ListItemAvatar>

--- a/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
+++ b/frontend/src/lib/compliance/report/frameworkReportHtml.test.ts
@@ -175,6 +175,23 @@ describe('frameworkReportHtml', () => {
     expect(html).toContain('--primary: #E57000')
   })
 
+  // #460: the cover header is filled with the brand colour and used to write
+  // its text in a fixed white, so a light brand colour printed an unreadable
+  // cover.
+  it('darkens the cover text when the brand color is light', () => {
+    const html = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { connectionName: 'c', generatedAt: 'd', locale: 'en', brandColor: '#FFD200' }, t)
+    expect(html).toContain('--on-primary: rgba(0, 0, 0, 0.87)')
+    expect(html).toContain('color: var(--on-primary)')
+  })
+
+  it('keeps white cover text on a dark brand color, including the default', () => {
+    const dark = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { connectionName: 'c', generatedAt: 'd', locale: 'en', brandColor: '#7C4DFF' }, t)
+    expect(dark).toContain('--on-primary: #fff')
+
+    const fallback = frameworkReportHtml(a, getFramework('nist-800-171-r2'), { connectionName: 'c', generatedAt: 'd', locale: 'en' }, t)
+    expect(fallback).toContain('--on-primary: #fff')
+  })
+
   // -- Logo --
 
   it('renders logo img when logoDataUri starts with data:', () => {

--- a/frontend/src/lib/compliance/report/frameworkReportHtml.ts
+++ b/frontend/src/lib/compliance/report/frameworkReportHtml.ts
@@ -2,6 +2,7 @@ import type { FrameworkAssessment } from '../frameworkAssessment'
 import type { FrameworkDef } from '../frameworks/types'
 import type { NodeBreakdown } from '../nodeBreakdown'
 import { escapeHtml } from './escapeHtml'
+import { onPrimaryTextColor } from '@/lib/theme/onPrimary'
 
 export interface ReportMeta {
   connectionName: string
@@ -69,6 +70,7 @@ function buildCss(primary: string, appName: string): string {
   return `
   :root {
     --primary: ${primary};
+    --on-primary: ${onPrimaryTextColor(primary)};
     --indigo: #6366f1;
     --green: #22c55e;
     --amber: #f59e0b;
@@ -125,7 +127,7 @@ function buildCss(primary: string, appName: string): string {
     background:
       linear-gradient(135deg, rgba(15,23,42,0), rgba(15,23,42,0.18)),
       var(--primary);
-    color: #fff;
+    color: var(--on-primary);
     padding: 12mm 15mm;
     margin: -15mm -15mm 0 -15mm;
     text-align: center;

--- a/frontend/src/lib/theme/inheritOnPrimary.test.tsx
+++ b/frontend/src/lib/theme/inheritOnPrimary.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { deepmerge } from '@mui/utils'
+import { ThemeProvider, createTheme, lighten, darken } from '@mui/material/styles'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+
+// `@core/theme` pulls a Google font through the Next build pipeline at import
+// time; only the palette and the component overrides matter here.
+vi.mock('next/font/google', () => ({
+  Inter: () => ({ style: { fontFamily: 'Inter' } })
+}))
+
+import defaultCoreTheme from '@core/theme'
+import { INHERIT_ON_PRIMARY_SX } from './onPrimary'
+import { commandPaletteRowSx } from '@/components/layout/shared/commandPaletteRowSx'
+
+// The RTL harness has no automatic cleanup in this suite.
+afterEach(cleanup)
+
+// The white-label yellow from issue #460.
+const PRIMARY = '#FFD200'
+
+// Same construction as components/theme/index.jsx.
+const theme = createTheme(
+  deepmerge(defaultCoreTheme({ skin: 'default' } as any, 'light', 'ltr'), {
+    colorSchemes: {
+      light: { palette: { primary: { main: PRIMARY, light: lighten(PRIMARY, 0.2), dark: darken(PRIMARY, 0.1) } } },
+      dark: { palette: { primary: { main: PRIMARY, light: lighten(PRIMARY, 0.2), dark: darken(PRIMARY, 0.1) } } }
+    },
+    cssVariables: { colorSchemeSelector: 'data' }
+  }) as any
+)
+
+const colorOf = (element: HTMLElement) => getComputedStyle(element).color.toLowerCase()
+
+const renderOnPrimary = (sx: object, label: React.ReactNode) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <Box sx={{ bgcolor: 'primary.main', color: 'primary.contrastText', ...sx }}>{label}</Box>
+    </ThemeProvider>
+  )
+
+describe('INHERIT_ON_PRIMARY_SX', () => {
+  it('reproduces the defect: without it a Typography ignores the surface colour', () => {
+    // Every variant gets an explicit colour from @core/theme/overrides/
+    // typography.js, so the label keeps text.secondary on a primary-filled
+    // row. That is what makes a light white-label primary unreadable, while
+    // the plain <i> icon next to it flips correctly.
+    const { getByText } = renderOnPrimary({}, <Typography variant='body2'>Dashboard</Typography>)
+
+    expect(colorOf(getByText('Dashboard'))).toContain('--mui-palette-text-secondary')
+  })
+
+  it('makes body text follow primary.contrastText', () => {
+    const { getByText } = renderOnPrimary(
+      INHERIT_ON_PRIMARY_SX,
+      <Typography variant='body2'>Dashboard</Typography>
+    )
+
+    expect(colorOf(getByText('Dashboard'))).toContain('--mui-palette-primary-contrasttext')
+  })
+
+  it('also covers caption, the lowest-contrast variant', () => {
+    const { getByText } = renderOnPrimary(
+      INHERIT_ON_PRIMARY_SX,
+      <Typography variant='caption'>vmid 100</Typography>
+    )
+
+    expect(colorOf(getByText('vmid 100'))).toContain('--mui-palette-primary-contrasttext')
+  })
+
+  it('overrides a Typography that asks for a colour of its own', () => {
+    const { getByText } = renderOnPrimary(
+      INHERIT_ON_PRIMARY_SX,
+      <Typography variant='body2' color='text.secondary'>
+        pve1
+      </Typography>
+    )
+
+    expect(colorOf(getByText('pve1'))).toContain('--mui-palette-primary-contrasttext')
+  })
+})
+
+describe('command palette row', () => {
+  it('gives the highlighted row a readable label', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <Box sx={commandPaletteRowSx(true)}>
+          <i className='ri-dashboard-line' />
+          <Typography variant='body2'>Dashboard</Typography>
+        </Box>
+      </ThemeProvider>
+    )
+
+    expect(colorOf(getByText('Dashboard'))).toContain('--mui-palette-primary-contrasttext')
+  })
+
+  it('leaves an idle row with its usual secondary label', () => {
+    const { getByText } = render(
+      <ThemeProvider theme={theme}>
+        <Box sx={commandPaletteRowSx(false)}>
+          <Typography variant='body2'>Inventory</Typography>
+        </Box>
+      </ThemeProvider>
+    )
+
+    expect(colorOf(getByText('Inventory'))).toContain('--mui-palette-text-secondary')
+  })
+})

--- a/frontend/src/lib/theme/onPrimary.test.ts
+++ b/frontend/src/lib/theme/onPrimary.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest'
+import { deepmerge } from '@mui/utils'
+import { createTheme, lighten, darken, getContrastRatio } from '@mui/material/styles'
+
+import defaultCoreTheme from '@core/theme'
+
+import {
+  CONTRAST_THRESHOLD,
+  INHERIT_ON_PRIMARY_SX,
+  ON_PRIMARY_DARK_TEXT,
+  ON_PRIMARY_LIGHT_TEXT,
+  contrastRatioVsWhite,
+  onPrimaryTextColor,
+  relativeLuminance
+} from './onPrimary'
+
+// `@core/theme` loads a Google font at import time, which needs the Next build
+// pipeline. Only the palette matters here.
+vi.mock('next/font/google', () => ({
+  Inter: () => ({ style: { fontFamily: 'Inter' } })
+}))
+
+// Colours a customer can realistically set as branding / theme primary.
+const DARK_ENOUGH_FOR_WHITE = [
+  '#7C4DFF', // template default purple, 4.82
+  '#E57000', // ProxCenter default orange, 3.16
+  '#2092EC', // blue preset, 3.29
+  '#8B5CF6' // purple preset, 4.23
+]
+
+const TOO_LIGHT_FOR_WHITE = [
+  '#FFD200', // the white-label yellow from issue #460, 1.45
+  '#FFAB1D', // amber preset, 1.89
+  '#F59E0B', // yellow preset, 2.15
+  '#22C55E', // green preset, 2.28
+  '#06B6D4' // cyan preset, 2.43
+]
+
+describe('onPrimaryTextColor', () => {
+  it.each(DARK_ENOUGH_FOR_WHITE)('keeps white text on %s', color => {
+    expect(onPrimaryTextColor(color)).toBe(ON_PRIMARY_LIGHT_TEXT)
+  })
+
+  it.each(TOO_LIGHT_FOR_WHITE)('flips to dark text on %s', color => {
+    expect(onPrimaryTextColor(color)).toBe(ON_PRIMARY_DARK_TEXT)
+  })
+
+  it('accepts the shorthand and rgb() notations', () => {
+    expect(onPrimaryTextColor('#fd0')).toBe(ON_PRIMARY_DARK_TEXT)
+    expect(onPrimaryTextColor('#FFD200FF')).toBe(ON_PRIMARY_DARK_TEXT)
+    expect(onPrimaryTextColor('rgb(255, 210, 0)')).toBe(ON_PRIMARY_DARK_TEXT)
+    expect(onPrimaryTextColor('rgba(124, 77, 255, 1)')).toBe(ON_PRIMARY_LIGHT_TEXT)
+  })
+
+  it('falls back to white rather than blanking the text on an unusable colour', () => {
+    // A branding colour is free-form user input and reaches the report
+    // generator unvalidated; returning null there would render `color: null`.
+    expect(onPrimaryTextColor('')).toBe(ON_PRIMARY_LIGHT_TEXT)
+    expect(onPrimaryTextColor('tomato')).toBe(ON_PRIMARY_LIGHT_TEXT)
+    expect(onPrimaryTextColor('#GGGGGG')).toBe(ON_PRIMARY_LIGHT_TEXT)
+    expect(onPrimaryTextColor('rgb(300, 0, 0)')).toBe(ON_PRIMARY_LIGHT_TEXT)
+  })
+
+  it('switches exactly at the MUI threshold', () => {
+    // Adjacent greys either side of ratio 3: #949494 is 3.03, #959595 is 3.00
+    // minus a hair. One step of red is all that separates the two verdicts.
+    expect(contrastRatioVsWhite('#949494')).toBeGreaterThanOrEqual(CONTRAST_THRESHOLD)
+    expect(onPrimaryTextColor('#949494')).toBe(ON_PRIMARY_LIGHT_TEXT)
+    expect(contrastRatioVsWhite('#959595')).toBeLessThan(CONTRAST_THRESHOLD)
+    expect(onPrimaryTextColor('#959595')).toBe(ON_PRIMARY_DARK_TEXT)
+  })
+})
+
+describe('contrast maths', () => {
+  it('matches MUI getContrastRatio', () => {
+    for (const color of [...DARK_ENOUGH_FOR_WHITE, ...TOO_LIGHT_FOR_WHITE, '#000', '#fff']) {
+      // MUI rounds the luminance to 3 decimals before dividing, so the two
+      // ratios differ in the third decimal at most. The verdict, asserted
+      // below against the real theme, is what has to agree exactly.
+      expect(contrastRatioVsWhite(color)).toBeCloseTo(getContrastRatio(color, '#fff'), 2)
+    }
+  })
+
+  it('reports luminance between black and white', () => {
+    expect(relativeLuminance('#000000')).toBe(0)
+    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5)
+    expect(relativeLuminance('nope')).toBeNull()
+    expect(contrastRatioVsWhite('nope')).toBeNull()
+  })
+})
+
+describe('theme primary.contrastText', () => {
+  // Mirrors components/theme/index.jsx: the branded primary is merged over the
+  // core theme with main/light/dark only, leaving contrastText to MUI. This
+  // locks that behaviour: hardcoding contrastText in colorSchemes.js would send
+  // white text back onto light primaries, which is issue #460.
+  const buildTheme = (primary: string) => {
+    const branded = {
+      colorSchemes: {
+        light: {
+          palette: {
+            primary: { main: primary, light: lighten(primary, 0.2), dark: darken(primary, 0.1) }
+          }
+        },
+        dark: {
+          palette: {
+            primary: { main: primary, light: lighten(primary, 0.2), dark: darken(primary, 0.1) }
+          }
+        }
+      },
+      cssVariables: { colorSchemeSelector: 'data' }
+    }
+
+    return createTheme(deepmerge(defaultCoreTheme({ skin: 'default' }, 'light', 'ltr'), branded))
+  }
+
+  it.each([...DARK_ENOUGH_FOR_WHITE, ...TOO_LIGHT_FOR_WHITE])(
+    'agrees with onPrimaryTextColor for %s in both colour schemes',
+    color => {
+      const theme = buildTheme(color) as any
+      const expected = onPrimaryTextColor(color)
+
+      expect(theme.colorSchemes.light.palette.primary.contrastText).toBe(expected)
+      expect(theme.colorSchemes.dark.palette.primary.contrastText).toBe(expected)
+    }
+  )
+})
+
+describe('INHERIT_ON_PRIMARY_SX', () => {
+  it('makes Typography and ListItemText follow the surface colour', () => {
+    expect(INHERIT_ON_PRIMARY_SX).toEqual({
+      '& .MuiTypography-root': { color: 'inherit' },
+      '& .MuiListItemText-primary, & .MuiListItemText-secondary': { color: 'inherit' }
+    })
+  })
+})

--- a/frontend/src/lib/theme/onPrimary.ts
+++ b/frontend/src/lib/theme/onPrimary.ts
@@ -1,0 +1,107 @@
+/**
+ * On-primary text helpers.
+ *
+ * The primary colour is user-configurable (White Label branding colour and the
+ * theme colour picker), so anything drawn ON a primary-coloured surface has to
+ * pick its text colour from the background, not from a fixed white.
+ *
+ * MUI already does this for `palette.primary.contrastText`: `createTheme`
+ * computes it from `primary.main` whenever the value is absent, which is the
+ * case here (see `@core/theme/colorSchemes.js`). Use the `primary.contrastText`
+ * token wherever the surface is `primary.main`.
+ *
+ * These helpers cover the two cases the token cannot serve:
+ *  - a surface painted with a *derived* shade (`primary.light`), for which
+ *    `contrastText` (computed against `main`) can be the wrong answer;
+ *  - HTML generated outside of MUI, e.g. the exported compliance reports.
+ *
+ * The threshold (3) and the two output colours match MUI's own defaults, so a
+ * surface fixed with `onPrimaryTextColor` and one relying on `contrastText`
+ * always agree.
+ */
+
+/** Text colour MUI uses on a dark background. */
+export const ON_PRIMARY_LIGHT_TEXT = '#fff'
+
+/** Text colour MUI uses on a light background. */
+export const ON_PRIMARY_DARK_TEXT = 'rgba(0, 0, 0, 0.87)'
+
+/** MUI's default `palette.contrastThreshold`. */
+export const CONTRAST_THRESHOLD = 3
+
+const HEX = /^#([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i
+const RGB = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)/i
+
+/** Parses `#rgb`, `#rrggbb` (with optional alpha) and `rgb()`/`rgba()`. */
+const toRgb = (color: string): [number, number, number] | null => {
+  const value = color.trim()
+
+  if (HEX.test(value)) {
+    const hex = value.slice(1)
+    const expand = hex.length <= 4 ? hex.slice(0, 3).replace(/./g, c => c + c) : hex.slice(0, 6)
+
+    return [
+      parseInt(expand.slice(0, 2), 16),
+      parseInt(expand.slice(2, 4), 16),
+      parseInt(expand.slice(4, 6), 16)
+    ]
+  }
+
+  const rgb = RGB.exec(value)
+
+  if (!rgb) return null
+
+  const channels = [rgb[1], rgb[2], rgb[3]].map(Number)
+
+  return channels.some(c => Number.isNaN(c) || c < 0 || c > 255) ? null : (channels as [number, number, number])
+}
+
+const linearise = (channel: number) => {
+  const ratio = channel / 255
+
+  return ratio <= 0.03928 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4
+}
+
+/** WCAG relative luminance, or `null` when the colour cannot be parsed. */
+export const relativeLuminance = (color: string): number | null => {
+  const rgb = toRgb(color)
+
+  if (!rgb) return null
+
+  const [r, g, b] = rgb.map(linearise)
+
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/** WCAG contrast ratio of `color` against pure white, or `null` when unparseable. */
+export const contrastRatioVsWhite = (color: string): number | null => {
+  const luminance = relativeLuminance(color)
+
+  if (luminance === null) return null
+
+  return 1.05 / (luminance + 0.05)
+}
+
+/**
+ * Text colour to draw on top of `background`: white while the background stays
+ * dark enough, near-black once it gets light. An unparseable colour keeps the
+ * historical white, so a malformed branding value can never blank the text.
+ */
+export const onPrimaryTextColor = (background: string): string => {
+  const ratio = contrastRatioVsWhite(background)
+
+  if (ratio === null) return ON_PRIMARY_LIGHT_TEXT
+
+  return ratio >= CONTRAST_THRESHOLD ? ON_PRIMARY_LIGHT_TEXT : ON_PRIMARY_DARK_TEXT
+}
+
+/**
+ * Every `<Typography>` carries an explicit per-variant colour from
+ * `@core/theme/overrides/typography.js`, so it never inherits the colour of the
+ * surface it sits on. Spread this into the `sx` of a primary-coloured container
+ * to let its labels follow `primary.contrastText` like the rest of its content.
+ */
+export const INHERIT_ON_PRIMARY_SX = {
+  '& .MuiTypography-root': { color: 'inherit' },
+  '& .MuiListItemText-primary, & .MuiListItemText-secondary': { color: 'inherit' }
+} as const


### PR DESCRIPTION
Closes #460.

### The defect

A light White Label primary colour (the reporter used a bright yellow) leaves several labels drawn in white or light grey on top of it. The two spots he names are the highlighted row of the Ctrl+K search dialog and the profile avatar in the top right corner.

The palette itself was never at fault. MUI already computes `palette.primary.contrastText` from the configured colour and flips it to near black as soon as that colour is light, and it does so here: with `#FFD200` it resolves to `rgba(0, 0, 0, 0.87)` in both colour schemes. The reporter's screenshot shows exactly that, the icon of the highlighted row is drawn dark while the label right next to it stays light grey.

Two theme overrides bypass the computed value:

- `@core/theme/overrides/typography.js` gives every `Typography` variant an explicit colour (`body1`/`body2` to `text.secondary`, `caption` to `text.disabled`, headings to `text.primary`). An explicit declaration never inherits, so a label sitting inside a primary filled container ignores that container's colour.
- `@core/theme/overrides/avatar.js` forces `color: text.primary` on every `MuiAvatar`, so initials ignore it too. That is the profile button.

The rest of the class is content hardcoded to `#fff` or `white` on a primary background.

### The fix

New `src/lib/theme/onPrimary.ts`:

- `onPrimaryTextColor(background)`, WCAG contrast maths with the same threshold (3) and the same two output colours as MUI, for the two places where the `primary.contrastText` token cannot be used: a surface painted with `primary.light`, and the HTML of the exported compliance report which is generated outside of MUI.
- `INHERIT_ON_PRIMARY_SX`, an `sx` fragment that lets `Typography` and `ListItemText` descendants follow the colour of the surface they sit on.

Covered sites:

- 10 avatars filled with the primary colour now set `color: 'primary.contrastText'`.
- 3 containers take the inherit fragment: the command palette rows, the user bubble of the AI drawer, and the widget drag handle in dashboard edit mode.
- 12 hardcoded whites on a primary background now read the matching `contrastText`: migration status chips, the running task badges, icon button hovers, and the tonal primary chip hover in the theme itself.
- The two dialog headers painted with `primary.light` compute their text colour against that shade instead of against `primary.main`, which is what `contrastText` is derived from.
- The compliance report cover exposes an `--on-primary` variable, so a light brand colour no longer prints white text on a light cover.

The five identical `sx` blocks of the command palette rows were extracted into `commandPaletteRowSx`, which is where the fragment is applied.

### Deliberately left alone

Nine percentage labels are centred over a progress bar, so each one spans both the primary filled part and the grey track. No single colour is correct for both halves, and they already carry a text shadow. Changing them would trade one unreadable case for another in dark mode.

### Notes

The threshold stays at MUI's default of 3, so the default orange (contrast ratio 3.16 against white) keeps white text and existing installs are visually unchanged. A light colour such as `#FFD200` (1.45) flips to dark text.

### Tests

34 new tests. The helper is checked against MUI's own `getContrastRatio`, a lock asserts that the real merged theme still computes `contrastText` on its own so that hardcoding it would fail the suite, and a render test reproduces the defect without the fragment and proves the inheritance with it. Full suite green: 495 files, 5047 tests.

Verified in the browser on a light primary before opening this.
