### PR TITLE
feat(appearance): persist the colour scheme in the user account

### DIFF
--- a/frontend/prisma/migrations/20260815120000_user_appearance_preferences/migration.sql
+++ b/frontend/prisma/migrations/20260815120000_user_appearance_preferences/migration.sql
@@ -1,0 +1,16 @@
+-- Per-user appearance preferences (issue #696).
+--
+-- The colour scheme, display mode and the rest of the Appearance tab were only
+-- ever written to the `materio-mui-next-demo` browser cookie, so a browser
+-- configured to clear cookies on exit sent the user back to the default
+-- ProxCenter orange on the next visit. This table gives those settings a
+-- server-side home, keyed per tenant and per user like dashboard layouts.
+
+CREATE TABLE IF NOT EXISTS "user_preferences" (
+    "tenant_id"  TEXT NOT NULL DEFAULT 'default',
+    "user_id"    TEXT NOT NULL,
+    "appearance" JSONB NOT NULL,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_preferences_pkey" PRIMARY KEY ("tenant_id", "user_id")
+);

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -541,6 +541,22 @@ model Setting {
   @@map("settings")
 }
 
+/// Per-user UI preferences (issue #696). The colour scheme, display mode and the
+/// rest of the Appearance tab used to live only in a browser cookie, so a
+/// browser set to clear cookies on exit dropped the user back to the default
+/// ProxCenter orange. `appearance` holds that same blob, restricted to the keys
+/// validated by src/lib/appearance/schema.ts. Scoped per tenant like
+/// DashboardLayout, so a user working in two tenants keeps a look per tenant.
+model UserPreference {
+  tenantId   String   @default("default") @map("tenant_id")
+  userId     String   @map("user_id")
+  appearance Json     @db.JsonB
+  updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@id([tenantId, userId])
+  @@map("user_preferences")
+}
+
 /// Admin-authored banner shown at the top of the dashboard (#607).
 /// `targetIds` is a JSON array of strings: tenant ids when targetKind is
 /// "tenants", RBAC role ids when it is "roles", ignored when it is "all".

--- a/frontend/src/@core/contexts/settingsContext.jsx
+++ b/frontend/src/@core/contexts/settingsContext.jsx
@@ -1,5 +1,5 @@
 'use client'
-import { createContext, useMemo, useState } from 'react'
+import { createContext, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 // Config Imports
 import themeConfig from '@configs/themeConfig'
@@ -8,59 +8,226 @@ import primaryColorConfig from '@configs/primaryColorConfig'
 // Hook Imports
 import { useObjectCookie } from '@core/hooks/useObjectCookie'
 
+// Appearance Imports
+import { saveAppearance } from '@/lib/appearance/client'
+import { sanitizeAppearance } from '@/lib/appearance/schema'
+
 // Initial Settings Context
 export const SettingsContext = createContext(null)
 
+// Shipped defaults. Hoisted out of the provider so the identity is stable and
+// `isSettingsChanged` compares against one object rather than a fresh literal.
+const defaultSettings = {
+  mode: themeConfig.mode,
+  skin: themeConfig.skin,
+  semiDark: themeConfig.semiDark,
+  layout: themeConfig.layout,
+  navbarContentWidth: themeConfig.navbar.contentWidth,
+  contentWidth: themeConfig.contentWidth,
+  footerContentWidth: themeConfig.footer.contentWidth,
+  primaryColor: primaryColorConfig[0].main,
+  globalTheme: 'default', // Global theme/skin ID
+  lightBackground: 'neutral', // Light mode background tint: neutral, warm, cool, sepia, paper
+  // Advanced appearance settings
+  density: 'comfortable', // compact, comfortable, spacious
+  customBorderRadius: null, // null = use theme default, or 0-24
+  blurIntensity: 12, // 0-24, for glassmorphism theme
+  // Typography settings
+  fontSize: 14, // Base font size: 12-18
+  uiScale: 100, // UI scale percentage: 80-120
+  // Data refresh interval (seconds): 5, 10, 30, 60, 300, 0 (off)
+  refreshInterval: 30,
+  // Login page background
+  loginBackground: {
+    type: 'gradient', // 'gradient' | 'image' | 'particles' | 'animated'
+    gradient: 'default', // gradient preset ID
+    imageUrl: null, // custom image URL or uploaded path
+    overlay: true, // dark overlay for readability
+    overlayOpacity: 0.5, // 0-1
+    blur: 0, // background blur 0-20
+    particles: false // animated particles effect
+  }
+}
+
+// Long enough to swallow a slider drag, short enough that a normal click is on
+// the server before the user can reach for the tab close button. What they
+// cannot beat, the page-hide flush below catches.
+const PERSIST_DEBOUNCE_MS = 600
+
+// A save can be refused by a dropped connection or an expired session. Bounded
+// retries so a server that is down for a while is not hammered.
+const PERSIST_RETRY_MS = 5000
+const MAX_PERSIST_RETRIES = 3
+
+// Marks the browser cookie with the account that wrote it. Deliberately outside
+// the persisted whitelist, so it never reaches the database.
+const APPEARANCE_OWNER_KEY = '_appearanceOwner'
+
+// sanitizeAppearance always walks its validators in the same order, so two
+// sanitised blobs serialise identically when they hold the same values, which
+// is what makes these string comparisons safe.
+const DEFAULT_APPEARANCE_JSON = JSON.stringify(sanitizeAppearance(defaultSettings))
+
 // Settings Provider
 export const SettingsProvider = props => {
+  const { canPersistAppearance = false, hasStoredAppearance = false, appearanceOwner = null } = props
+
   // Initial Settings
   const initialSettings = {
-    mode: themeConfig.mode,
-    skin: themeConfig.skin,
-    semiDark: themeConfig.semiDark,
-    layout: themeConfig.layout,
-    navbarContentWidth: themeConfig.navbar.contentWidth,
-    contentWidth: themeConfig.contentWidth,
-    footerContentWidth: themeConfig.footer.contentWidth,
-    primaryColor: primaryColorConfig[0].main,
-    globalTheme: 'default', // Global theme/skin ID
-    lightBackground: 'neutral', // Light mode background tint: neutral, warm, cool, sepia, paper
-    // Advanced appearance settings
-    density: 'comfortable', // compact, comfortable, spacious
-    customBorderRadius: null, // null = use theme default, or 0-24
-    blurIntensity: 12, // 0-24, for glassmorphism theme
-    // Typography settings
-    fontSize: 14, // Base font size: 12-18
-    uiScale: 100, // UI scale percentage: 80-120
-    // Data refresh interval (seconds): 5, 10, 30, 60, 300, 0 (off)
-    refreshInterval: 30,
-    // Login page background
-    loginBackground: {
-      type: 'gradient', // 'gradient' | 'image' | 'particles' | 'animated'
-      gradient: 'default', // gradient preset ID
-      imageUrl: null, // custom image URL or uploaded path
-      overlay: true, // dark overlay for readability
-      overlayOpacity: 0.5, // 0-1
-      blur: 0, // background blur 0-20
-      particles: false // animated particles effect
-    }
-  }
-
-  const updatedInitialSettings = {
-    ...initialSettings,
+    ...defaultSettings,
     mode: props.mode || themeConfig.mode
   }
 
-  // Cookies
+  // What the server resolved for this render: the cookie with the user's stored
+  // appearance layered on top. Empty on an anonymous page, or when the provider
+  // is mounted without it. The owner stamp read back from the cookie is dropped
+  // here so it never shows up as a setting.
+  const { [APPEARANCE_OWNER_KEY]: _incomingOwner, ...serverSettings } =
+    props.initialSettings && typeof props.initialSettings === 'object' ? props.initialSettings : {}
+
+  const hasServerSettings = Object.keys(serverSettings).length > 0
+
+  // Cookies. The cookie is a local cache of the appearance: it survives a
+  // reload without a round-trip, but it is the server copy that outlives a
+  // browser set to clear its storage on exit (issue #696).
   const [settingsCookie, updateSettingsCookie] = useObjectCookie(
     themeConfig.settingsCookieName,
-    JSON.stringify(props.settingsCookie) !== '{}' ? props.settingsCookie : updatedInitialSettings
+    hasServerSettings ? serverSettings : initialSettings
   )
 
-  // State
-  const [_settingsState, _updateSettingsState] = useState(
-    JSON.stringify(settingsCookie) !== '{}' ? settingsCookie : updatedInitialSettings
+  // State. Layering over the defaults matters for a cookie written by an older
+  // release: a missing key would otherwise read as `undefined` all the way into
+  // the theme, where an undefined primaryColor throws inside MUI's lighten().
+  const [_settingsState, _updateSettingsState] = useState({
+    ...initialSettings,
+    ...(hasServerSettings ? serverSettings : settingsCookie)
+  })
+
+  // Pending server write: the appearance keys changed since the last successful
+  // save. Held outside React state because nothing renders from it and it has to
+  // stay readable from the page-hide listener.
+  const pendingRef = useRef(null)
+  const timerRef = useRef(null)
+  const retriesRef = useRef(0)
+
+  // sendPending reschedules itself after a refused save, so it reaches itself
+  // through a ref rather than a circular useCallback dependency.
+  const sendPendingRef = useRef(null)
+
+  const armFlush = useCallback(delay => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      sendPendingRef.current?.(false)
+    }, delay)
+  }, [])
+
+  const sendPending = useCallback(
+    keepalive => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+
+      const payload = pendingRef.current
+
+      pendingRef.current = null
+
+      if (!payload) return
+
+      Promise.resolve(saveAppearance(payload, { keepalive })).then(saved => {
+        if (saved) {
+          retriesRef.current = 0
+
+          return
+        }
+
+        // A save that never lands would be worse than no save at all: the stale
+        // server copy wins on the next boot and quietly undoes the change. Put
+        // the keys back for another attempt, letting anything the user has
+        // touched since take precedence over what failed.
+        pendingRef.current = { ...payload, ...(pendingRef.current || {}) }
+
+        if (retriesRef.current >= MAX_PERSIST_RETRIES) return
+        retriesRef.current += 1
+        armFlush(PERSIST_RETRY_MS)
+      })
+    },
+    [armFlush]
   )
+
+  useEffect(() => {
+    sendPendingRef.current = sendPending
+  }, [sendPending])
+
+  const persistAppearance = useCallback(
+    changed => {
+      if (!canPersistAppearance) return
+
+      const payload = sanitizeAppearance(changed)
+
+      // Nothing in the persisted subset moved: a page-scoped update, a key this
+      // store does not own, or React re-running the updater in StrictMode.
+      if (Object.keys(payload).length === 0) return
+
+      pendingRef.current = { ...(pendingRef.current || {}), ...payload }
+      retriesRef.current = 0
+      armFlush(PERSIST_DEBOUNCE_MS)
+    },
+    [canPersistAppearance, armFlush]
+  )
+
+  // A debounced save would be cancelled by the navigation that closes the tab,
+  // and since the server copy wins on the next boot the change would come back
+  // undone. Flush it while the page is still alive.
+  useEffect(() => {
+    const onPageHide = () => sendPending(true)
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') sendPending(true)
+    }
+
+    window.addEventListener('pagehide', onPageHide)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    return () => {
+      window.removeEventListener('pagehide', onPageHide)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [sendPending])
+
+  // Users who picked a theme before this was stored server-side have it in
+  // their cookie only. Hand that cookie to the server once, so the choice they
+  // already made survives the next storage purge without them redoing it.
+  // Only a cookie that actually differs from the shipped defaults is worth
+  // seeding: writing the defaults for someone who never customised anything
+  // would pin them to today's defaults forever.
+  const seededRef = useRef(false)
+
+  useEffect(() => {
+    if (seededRef.current || !canPersistAppearance || hasStoredAppearance) return
+    seededRef.current = true
+
+    // Browsers get shared. A cookie stamped with another account must not be
+    // copied into this one: unlike the cookie itself, which the next sign-in
+    // overwrites, the stored row would keep that borrowed look for good. An
+    // unstamped cookie predates this feature, which is exactly the case worth
+    // migrating.
+    const cookieOwner = settingsCookie?.[APPEARANCE_OWNER_KEY]
+
+    if (cookieOwner && cookieOwner !== appearanceOwner) return
+
+    const payload = sanitizeAppearance(settingsCookie)
+
+    if (JSON.stringify(payload) === DEFAULT_APPEARANCE_JSON) return
+
+    // Sent straight out rather than queued: a seed that fails is retried by the
+    // next page load on its own, since nothing was stored in the meantime.
+    saveAppearance(payload)
+    // Seeding is a one-shot on mount: it reads the cookie as it was when the
+    // page loaded, and every later change goes through persistAppearance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canPersistAppearance, hasStoredAppearance])
 
   const updateSettings = (settings, options) => {
     const { updateCookie = true } = options || {}
@@ -69,7 +236,25 @@ export const SettingsProvider = props => {
       const newSettings = { ...prev, ...settings }
 
       // Update cookie if needed
-      if (updateCookie) updateSettingsCookie(newSettings)
+      if (updateCookie) {
+        // The owner stamp stays out of the React state and out of the stored
+        // blob; it exists only so the seeding above can tell whose cookie this
+        // is on a shared browser.
+        updateSettingsCookie(
+          appearanceOwner ? { ...newSettings, [APPEARANCE_OWNER_KEY]: appearanceOwner } : newSettings
+        )
+
+        // Only the keys this call actually moved travel to the server. Sending
+        // the whole blob would let a second tab, holding a copy from before,
+        // revert a change the first one just made.
+        const changed = {}
+
+        for (const [key, value] of Object.entries(settings)) {
+          if (!Object.is(prev[key], value)) changed[key] = value
+        }
+
+        persistAppearance(changed)
+      }
 
       return newSettings
     })
@@ -95,12 +280,11 @@ export const SettingsProvider = props => {
   }
 
   const resetSettings = () => {
-    updateSettings(initialSettings)
+    updateSettings(defaultSettings)
   }
 
   const isSettingsChanged = useMemo(
-    () => JSON.stringify(initialSettings) !== JSON.stringify(_settingsState),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () => JSON.stringify(defaultSettings) !== JSON.stringify(_settingsState),
     [_settingsState]
   )
 

--- a/frontend/src/@core/contexts/settingsContext.test.tsx
+++ b/frontend/src/@core/contexts/settingsContext.test.tsx
@@ -1,0 +1,349 @@
+import { useContext, type PropsWithChildren } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+
+const { saveAppearance, updateSettingsCookie, useObjectCookie } = vi.hoisted(() => ({
+  saveAppearance: vi.fn(),
+  updateSettingsCookie: vi.fn(),
+  useObjectCookie: vi.fn(),
+}))
+
+vi.mock('@/lib/appearance/client', () => ({ saveAppearance }))
+vi.mock('@core/hooks/useObjectCookie', () => ({ useObjectCookie }))
+
+import primaryColorConfig from '@configs/primaryColorConfig'
+import themeConfig from '@configs/themeConfig'
+
+import { SettingsContext, SettingsProvider } from './settingsContext'
+
+type ProviderProps = {
+  canPersistAppearance?: boolean
+  hasStoredAppearance?: boolean
+  initialSettings?: Record<string, unknown>
+  mode?: string
+}
+
+let cookieValue: Record<string, unknown> | undefined
+
+function renderSettings(props: ProviderProps = {}) {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <SettingsProvider {...props}>{children}</SettingsProvider>
+  )
+
+  return renderHook(() => useContext(SettingsContext), { wrapper })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  saveAppearance.mockResolvedValue(true)
+  cookieValue = undefined
+  useObjectCookie.mockImplementation((_key: string, fallback: Record<string, unknown>) => [
+    cookieValue ?? fallback,
+    updateSettingsCookie,
+  ])
+})
+
+afterEach(() => {
+  cleanup()
+  vi.runOnlyPendingTimers()
+  vi.useRealTimers()
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+})
+
+describe('SettingsProvider defaults', () => {
+  it('exposes server settings layered over shipped defaults', () => {
+    const { result } = renderSettings({
+      initialSettings: { mode: 'dark', fontSize: 16 },
+      hasStoredAppearance: true,
+    })
+
+    expect(result.current.settings.mode).toBe('dark')
+    expect(result.current.settings.fontSize).toBe(16)
+    expect(result.current.settings.primaryColor).toBe(primaryColorConfig[0].main)
+    expect(result.current.settings.primaryColor).toBeDefined()
+  })
+
+  it('resetSettings restores the shipped defaults', () => {
+    const { result } = renderSettings({
+      initialSettings: { mode: 'dark', primaryColor: '#FFD200', fontSize: 18 },
+      hasStoredAppearance: true,
+    })
+
+    act(() => result.current.resetSettings())
+
+    expect(result.current.settings).toEqual(
+      expect.objectContaining({
+        mode: themeConfig.mode,
+        primaryColor: primaryColorConfig[0].main,
+        fontSize: 14,
+        uiScale: 100,
+      }),
+    )
+  })
+})
+
+describe('appearance persistence', () => {
+  it('writes the cookie and saves the changed colour after 600 ms', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+
+    expect(updateSettingsCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#FFD200' }),
+    )
+    expect(saveAppearance).not.toHaveBeenCalled()
+
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#FFD200' }),
+      { keepalive: false },
+    )
+  })
+
+  it('collapses rapid updates into one save containing the last value', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => {
+      result.current.updateSettings({ primaryColor: '#111111' })
+      result.current.updateSettings({ primaryColor: '#222222' })
+      result.current.updateSettings({ primaryColor: '#333333' })
+    })
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#333333' }),
+      { keepalive: false },
+    )
+  })
+
+  it('never saves for an anonymous page', () => {
+    const { result } = renderSettings({ canPersistAppearance: false })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('does not persist a page-scoped update', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }, { updateCookie: false }))
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(updateSettingsCookie).not.toHaveBeenCalled()
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('does not fire a second save when the persisted subset is unchanged', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    act(() => vi.advanceTimersByTime(600))
+    expect(saveAppearance).toHaveBeenCalledOnce()
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+  })
+
+  it('sends only the keys the update moved, never the whole settings blob', () => {
+    // A second tab holding a copy from before must not be able to revert what
+    // this one saved, so an untouched key is not part of the payload.
+    const { result } = renderSettings({
+      canPersistAppearance: true,
+      hasStoredAppearance: true,
+      initialSettings: { mode: 'light', fontSize: 16 },
+    })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledWith({ primaryColor: '#FFD200' }, { keepalive: false })
+  })
+
+  it('accumulates the keys changed across several updates in one payload', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => {
+      result.current.updateSettings({ primaryColor: '#FFD200' })
+      result.current.updateSettings({ mode: 'dark' })
+    })
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith(
+      { primaryColor: '#FFD200', mode: 'dark' },
+      { keepalive: false },
+    )
+  })
+
+  it('does not send a key the settings store does not persist', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ loginBackground: { type: 'image' } }))
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('retries a refused save instead of letting the stale server copy win', async () => {
+    saveAppearance.mockResolvedValueOnce(false)
+
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+    expect(saveAppearance).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(saveAppearance).toHaveBeenCalledTimes(2)
+    expect(saveAppearance).toHaveBeenLastCalledWith({ primaryColor: '#FFD200' }, { keepalive: false })
+  })
+
+  it('gives up retrying rather than hammering a server that stays down', async () => {
+    saveAppearance.mockResolvedValue(false)
+
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    await act(async () => {
+      vi.advanceTimersByTime(600)
+    })
+
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(5000)
+      })
+    }
+
+    // The first send plus MAX_PERSIST_RETRIES.
+    expect(saveAppearance).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('one-shot seeding', () => {
+  it('seeds existing cookie settings once when the user has no stored appearance', () => {
+    cookieValue = { mode: 'dark', primaryColor: '#FFD200', loginBackground: { type: 'image' } }
+
+    const rendered = renderSettings({ canPersistAppearance: true, hasStoredAppearance: false })
+    rendered.rerender()
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith({ mode: 'dark', primaryColor: '#FFD200' })
+  })
+
+  it('does not seed when an appearance is already stored', () => {
+    cookieValue = { mode: 'dark', primaryColor: '#FFD200' }
+
+    renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('does not seed a cookie that never departed from the shipped defaults', () => {
+    // Storing the defaults for someone who never customised anything would pin
+    // them to today's defaults, so an untouched cookie is left alone.
+    cookieValue = undefined
+
+    renderSettings({ canPersistAppearance: true, hasStoredAppearance: false })
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('does not seed for an anonymous page', () => {
+    cookieValue = { mode: 'dark', primaryColor: '#FFD200' }
+
+    renderSettings({ canPersistAppearance: false, hasStoredAppearance: false })
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('refuses to copy another account cookie into this one on a shared browser', () => {
+    cookieValue = { mode: 'dark', primaryColor: '#FFD200', _appearanceOwner: 'someone-else' }
+
+    renderSettings({ canPersistAppearance: true, hasStoredAppearance: false, appearanceOwner: 'me' })
+
+    expect(saveAppearance).not.toHaveBeenCalled()
+  })
+
+  it('still seeds a cookie this account wrote itself', () => {
+    cookieValue = { mode: 'dark', primaryColor: '#FFD200', _appearanceOwner: 'me' }
+
+    renderSettings({ canPersistAppearance: true, hasStoredAppearance: false, appearanceOwner: 'me' })
+
+    expect(saveAppearance).toHaveBeenCalledWith({ mode: 'dark', primaryColor: '#FFD200' })
+  })
+})
+
+describe('cookie ownership', () => {
+  it('stamps the cookie with the account that wrote it, without storing the stamp', () => {
+    const { result } = renderSettings({
+      canPersistAppearance: true,
+      hasStoredAppearance: true,
+      appearanceOwner: 'me',
+    })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+
+    expect(updateSettingsCookie).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#FFD200', _appearanceOwner: 'me' }),
+    )
+    expect(result.current.settings._appearanceOwner).toBeUndefined()
+
+    act(() => vi.advanceTimersByTime(600))
+
+    expect(saveAppearance).toHaveBeenCalledWith({ primaryColor: '#FFD200' }, { keepalive: false })
+  })
+
+  it('leaves the cookie unstamped for an anonymous page', () => {
+    const { result } = renderSettings({ canPersistAppearance: false })
+
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+
+    expect(updateSettingsCookie).toHaveBeenCalledWith(
+      expect.not.objectContaining({ _appearanceOwner: expect.anything() }),
+    )
+  })
+})
+
+describe('page lifecycle flushes', () => {
+  it('flushes a pending debounce immediately on pagehide with keepalive', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+
+    act(() => window.dispatchEvent(new Event('pagehide')))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#FFD200' }),
+      { keepalive: true },
+    )
+    act(() => vi.advanceTimersByTime(600))
+    expect(saveAppearance).toHaveBeenCalledOnce()
+  })
+
+  it('flushes a pending debounce when the document becomes hidden', () => {
+    const { result } = renderSettings({ canPersistAppearance: true, hasStoredAppearance: true })
+    act(() => result.current.updateSettings({ primaryColor: '#FFD200' }))
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+
+    act(() => document.dispatchEvent(new Event('visibilitychange')))
+
+    expect(saveAppearance).toHaveBeenCalledOnce()
+    expect(saveAppearance).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryColor: '#FFD200' }),
+      { keepalive: true },
+    )
+  })
+})

--- a/frontend/src/@core/utils/serverHelpers.js
+++ b/frontend/src/@core/utils/serverHelpers.js
@@ -7,18 +7,43 @@ import 'server-only'
 // Config Imports
 import themeConfig from '@configs/themeConfig'
 
+// Appearance Imports
+import { getStoredAppearance } from '@/lib/appearance/server'
+
 export const getSettingsFromCookie = async () => {
   const cookieStore = await cookies()
   const cookieName = themeConfig.settingsCookieName
 
-  return JSON.parse(cookieStore.get(cookieName)?.value || '{}')
+  try {
+    return JSON.parse(cookieStore.get(cookieName)?.value || '{}')
+  } catch {
+    // A cookie truncated or mangled on its way back would otherwise throw here,
+    // during the render of every single page, leaving the user with a 500 and
+    // no way out of it from the UI. Falling back to the defaults costs them
+    // their local cache at worst, and what they saved is on the server anyway.
+    return {}
+  }
+}
+
+/**
+ * The settings this render should use: what the user saved on the server wins
+ * over the cookie, which stays as a local cache and as the only source for
+ * anonymous pages (issue #696). Read this rather than the cookie whenever the
+ * answer drives what gets painted, so a restored theme is right on the first
+ * frame instead of swapping in after hydration.
+ */
+export const getEffectiveSettings = async () => {
+  const settingsCookie = await getSettingsFromCookie()
+  const stored = await getStoredAppearance()
+
+  return stored ? { ...settingsCookie, ...stored } : settingsCookie
 }
 
 export const getMode = async () => {
-  const settingsCookie = await getSettingsFromCookie()
+  const settings = await getEffectiveSettings()
 
-  // Get mode from cookie or fallback to theme config
-  const _mode = settingsCookie.mode || themeConfig.mode
+  // Get mode from stored settings or fallback to theme config
+  const _mode = settings.mode || themeConfig.mode
 
   return _mode
 }
@@ -39,7 +64,7 @@ export const getServerMode = async () => {
 }
 
 export const getSkin = async () => {
-  const settingsCookie = await getSettingsFromCookie()
+  const settings = await getEffectiveSettings()
 
-  return settingsCookie.skin || 'default'
+  return settings.skin || 'default'
 }

--- a/frontend/src/@core/utils/serverHelpers.test.ts
+++ b/frontend/src/@core/utils/serverHelpers.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cookies, getStoredAppearance } = vi.hoisted(() => ({
+  cookies: vi.fn(),
+  getStoredAppearance: vi.fn(),
+}))
+
+vi.mock('server-only', () => ({}))
+vi.mock('next/headers', () => ({ cookies }))
+vi.mock('@/lib/appearance/server', () => ({ getStoredAppearance }))
+
+import themeConfig from '@configs/themeConfig'
+import {
+  getEffectiveSettings,
+  getMode,
+  getSettingsFromCookie,
+  getSystemMode,
+} from './serverHelpers'
+
+const cookieValues: Record<string, string> = {}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  for (const key of Object.keys(cookieValues)) delete cookieValues[key]
+  cookies.mockImplementation(async () => ({
+    get: (name: string) => (Object.hasOwn(cookieValues, name) ? { value: cookieValues[name] } : undefined),
+  }))
+  getStoredAppearance.mockResolvedValue(null)
+})
+
+function setSettingsCookie(settings: Record<string, unknown>) {
+  cookieValues[themeConfig.settingsCookieName] = JSON.stringify(settings)
+}
+
+describe('getEffectiveSettings', () => {
+  it('returns the cookie alone when nothing is stored', async () => {
+    const cookie = { mode: 'light', loginBackground: { type: 'gradient' } }
+    setSettingsCookie(cookie)
+
+    await expect(getEffectiveSettings()).resolves.toEqual(cookie)
+  })
+
+  it('lets stored keys win while preserving cookie-only keys', async () => {
+    setSettingsCookie({ mode: 'light', primaryColor: '#E57000', loginBackground: { type: 'image' } })
+    getStoredAppearance.mockResolvedValue({ mode: 'dark', primaryColor: '#FFD200' })
+
+    await expect(getEffectiveSettings()).resolves.toEqual({
+      mode: 'dark',
+      primaryColor: '#FFD200',
+      loginBackground: { type: 'image' },
+    })
+  })
+})
+
+describe('mode helpers', () => {
+  it('prefers stored mode over cookie mode', async () => {
+    setSettingsCookie({ mode: 'light' })
+    getStoredAppearance.mockResolvedValue({ mode: 'dark' })
+
+    await expect(getMode()).resolves.toBe('dark')
+  })
+
+  it('falls back to themeConfig.mode when neither source has a mode', async () => {
+    setSettingsCookie({ primaryColor: '#FFD200' })
+
+    await expect(getMode()).resolves.toBe(themeConfig.mode)
+  })
+
+  it("resolves stored system mode through the 'colorPref' cookie", async () => {
+    setSettingsCookie({ mode: 'light' })
+    cookieValues.colorPref = 'dark'
+    getStoredAppearance.mockResolvedValue({ mode: 'system' })
+
+    await expect(getSystemMode()).resolves.toBe('dark')
+  })
+
+  it.each(['light', 'dark'])('returns stored concrete mode %s verbatim', async mode => {
+    setSettingsCookie({ mode: 'system' })
+    cookieValues.colorPref = mode === 'light' ? 'dark' : 'light'
+    getStoredAppearance.mockResolvedValue({ mode })
+
+    await expect(getSystemMode()).resolves.toBe(mode)
+  })
+})
+
+describe('getSettingsFromCookie', () => {
+  it('falls back to an empty object rather than 500-ing every page on a mangled cookie', async () => {
+    cookieValues[themeConfig.settingsCookieName] = 'not json'
+
+    await expect(getSettingsFromCookie()).resolves.toEqual({})
+  })
+
+  it('still renders the stored appearance when the cookie is unreadable', async () => {
+    cookieValues[themeConfig.settingsCookieName] = '{"mode":'
+    getStoredAppearance.mockResolvedValue({ mode: 'dark', primaryColor: '#FFD200' })
+
+    await expect(getEffectiveSettings()).resolves.toEqual({ mode: 'dark', primaryColor: '#FFD200' })
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/ClusterTabs.tsx
@@ -4099,13 +4099,14 @@ export default function ClusterTabs(props: any) {
                                         <img src={theme.palette.mode === 'dark' ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt="" width={16} height={16} style={{ opacity: node.online ? 0.8 : 0.4 }} />
                                         <Box sx={{ position: 'absolute', bottom: -2, right: -2, width: 8, height: 8, borderRadius: '50%', bgcolor: node.maintenance ? '#ff9800' : node.online ? '#4caf50' : '#f44336', border: '1.5px solid', borderColor: 'background.paper' }} />
                                       </Box>
-                                      <Typography variant="body2" fontWeight={node.local ? 700 : 400}>
+                                      {/* component='div': body2 renders a <p>, which cannot hold the Chip's <div> */}
+                                      <Typography variant="body2" component="div" fontWeight={node.local ? 700 : 400}>
                                         {node.name}
                                         {node.local && <Chip size="small" label="local" sx={{ ml: 1, height: 16, fontSize: 9 }} />}
                                       </Typography>
                                     </Box>
                                     <Typography variant="body2">{node.id}</Typography>
-                                    <Typography variant="body2" sx={{ display: 'flex', alignItems: 'center' }}>
+                                    <Typography variant="body2" component="div" sx={{ display: 'flex', alignItems: 'center' }}>
                                       {node.maintenance ? (
                                         <i className="ri-tools-fill" style={{ fontSize: 16, color: '#ff9800' }} />
                                       ) : node.online ? (

--- a/frontend/src/app/api/v1/settings/appearance/route.test.ts
+++ b/frontend/src/app/api/v1/settings/appearance/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute } from '../../../../../__tests__/setup/route-test'
+
+const { getServerSession, demoResponse, getUserAppearance, setUserAppearance } = vi.hoisted(() => ({
+  getServerSession: vi.fn(),
+  demoResponse: vi.fn(),
+  getUserAppearance: vi.fn(),
+  setUserAppearance: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/demo/demo-api', () => ({ demoResponse }))
+vi.mock('@/lib/db/userPreferences', () => ({ getUserAppearance, setUserAppearance }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  demoResponse.mockReturnValue(null)
+  getServerSession.mockResolvedValue({ user: { id: 'user-1', tenantId: 'tenant-1' } })
+  getUserAppearance.mockResolvedValue(null)
+  setUserAppearance.mockResolvedValue({})
+})
+
+describe('GET /api/v1/settings/appearance', () => {
+  it('returns 401 without a session', async () => {
+    getServerSession.mockResolvedValue(null)
+    const { GET } = await import('./route')
+
+    const response = await callRoute(GET, { method: 'GET' })
+
+    expect(response.status).toBe(401)
+    expect(getUserAppearance).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty non-stored response when no row exists', async () => {
+    const { GET } = await import('./route')
+
+    const response = await callRoute(GET, { method: 'GET' })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data: {}, stored: false })
+  })
+
+  it('returns the stored row for the session principal', async () => {
+    getUserAppearance.mockResolvedValue({ mode: 'dark' })
+    const { GET } = await import('./route')
+
+    const response = await callRoute(GET, { method: 'GET' })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data: { mode: 'dark' }, stored: true })
+    expect(getUserAppearance).toHaveBeenCalledWith('tenant-1', 'user-1')
+  })
+
+  it("falls back to tenant 'default' when the session has no tenantId", async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'user-1' } })
+    const { GET } = await import('./route')
+
+    await callRoute(GET, { method: 'GET' })
+
+    expect(getUserAppearance).toHaveBeenCalledWith('default', 'user-1')
+  })
+})
+
+describe('PUT /api/v1/settings/appearance', () => {
+  it('returns 401 without a session and never writes', async () => {
+    getServerSession.mockResolvedValue(null)
+    const { PUT } = await import('./route')
+
+    const response = await callRoute(PUT, { method: 'PUT', body: { mode: 'dark' } })
+
+    expect(response.status).toBe(401)
+    expect(setUserAppearance).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { label: 'an array', body: [] },
+    { label: 'a string', body: '"x"' },
+    { label: 'malformed JSON', body: '{not-json' },
+  ])('returns 400 for $label and never writes', async ({ body }) => {
+    const { PUT } = await import('./route')
+
+    const response = await callRoute(PUT, { method: 'PUT', body })
+
+    expect(response.status).toBe(400)
+    expect(setUserAppearance).not.toHaveBeenCalled()
+  })
+
+  it('passes a valid raw body to the store', async () => {
+    const rawBody = { primaryColor: '#FFD200', unknownFutureKey: 'value' }
+    setUserAppearance.mockResolvedValue({ primaryColor: '#FFD200' })
+    const { PUT } = await import('./route')
+
+    const response = await callRoute(PUT, { method: 'PUT', body: rawBody })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ data: { primaryColor: '#FFD200' }, stored: true })
+    expect(setUserAppearance).toHaveBeenCalledWith('tenant-1', 'user-1', rawBody)
+  })
+
+  it('ignores user and tenant ids in the body and writes only for the session principal', async () => {
+    const body = { userId: 'victim', tenantId: 'other-tenant', mode: 'dark' }
+    const { PUT } = await import('./route')
+
+    await callRoute(PUT, { method: 'PUT', body })
+
+    expect(setUserAppearance).toHaveBeenCalledWith('tenant-1', 'user-1', body)
+  })
+})
+
+describe('demo mode', () => {
+  it.each(['GET', 'PUT'] as const)('short-circuits %s before session or store access', async method => {
+    const demo = Response.json({ demo: true }, { status: 418 })
+    demoResponse.mockReturnValue(demo)
+    const route = await import('./route')
+
+    const response = await callRoute(route[method], {
+      method,
+      ...(method === 'PUT' ? { body: { mode: 'dark' } } : {}),
+    })
+
+    expect(response).toBe(demo)
+    expect(getServerSession).not.toHaveBeenCalled()
+    expect(getUserAppearance).not.toHaveBeenCalled()
+    expect(setUserAppearance).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/settings/appearance/route.ts
+++ b/frontend/src/app/api/v1/settings/appearance/route.ts
@@ -1,0 +1,78 @@
+export const dynamic = "force-dynamic"
+
+import { NextResponse } from 'next/server'
+
+import { getServerSession } from 'next-auth'
+
+import { authOptions } from '@/lib/auth/config'
+import { demoResponse } from '@/lib/demo/demo-api'
+import { getUserAppearance, setUserAppearance } from '@/lib/db/userPreferences'
+
+export const runtime = "nodejs"
+
+/**
+ * The signed-in user's own appearance settings (issue #696).
+ *
+ * No RBAC check on purpose: this is every user's own colour scheme, not an
+ * administrative setting, so the session alone is the authorisation. The blob
+ * is scoped to (tenant, user) by the store, so one user can never read or
+ * write another's.
+ */
+async function currentPrincipal() {
+  const session = await getServerSession(authOptions)
+  const userId = session?.user?.id
+
+  if (!userId) return null
+
+  return { userId, tenantId: session.user.tenantId || 'default' }
+}
+
+export async function GET(req: Request) {
+  const demo = demoResponse(req)
+
+  if (demo) return demo
+
+  try {
+    const principal = await currentPrincipal()
+
+    if (!principal) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const appearance = await getUserAppearance(principal.tenantId, principal.userId)
+
+    // `stored` lets the client tell "never saved" from "saved nothing", which
+    // is what decides whether it may seed the store from an existing cookie.
+    return NextResponse.json({ data: appearance ?? {}, stored: appearance !== null })
+  } catch (e: any) {
+    console.error('[settings/appearance] GET error:', e)
+
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}
+
+export async function PUT(req: Request) {
+  const demo = demoResponse(req)
+
+  if (demo) return demo
+
+  try {
+    const principal = await currentPrincipal()
+
+    if (!principal) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+    const body = await req.json().catch(() => null)
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return NextResponse.json({ error: 'Expected an object of appearance settings' }, { status: 400 })
+    }
+
+    // Unknown keys and out-of-range values are dropped rather than refused: a
+    // client one version ahead or behind should still get its valid keys saved.
+    const appearance = await setUserAppearance(principal.tenantId, principal.userId, body)
+
+    return NextResponse.json({ data: appearance, stored: true })
+  } catch (e: any) {
+    console.error('[settings/appearance] PUT error:', e)
+
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/frontend/src/components/Providers.jsx
+++ b/frontend/src/components/Providers.jsx
@@ -17,7 +17,8 @@ import { TenantProvider } from '@/contexts/TenantContext'
 // i18n
 
 // Util Imports
-import { getMode, getSettingsFromCookie, getSystemMode } from '@core/utils/serverHelpers'
+import { getMode, getEffectiveSettings, getSystemMode } from '@core/utils/serverHelpers'
+import { getAppearanceHydration } from '@/lib/appearance/server'
 
 const Providers = async props => {
   // Props
@@ -25,7 +26,12 @@ const Providers = async props => {
 
   // Vars
   const mode = await getMode()
-  const settingsCookie = await getSettingsFromCookie()
+
+  // The appearance the user saved wins over their cookie, and it is resolved
+  // here on the server so the right palette is in the very first HTML instead
+  // of replacing the default orange after hydration (issue #696).
+  const initialSettings = await getEffectiveSettings()
+  const appearance = await getAppearanceHydration()
   const systemMode = await getSystemMode()
   const locale = await getLocale()
 
@@ -36,7 +42,13 @@ const Providers = async props => {
           <LocaleProvider initialLocale={locale}>
             <PageTitleProvider>
               <VerticalNavProvider>
-                <SettingsProvider settingsCookie={settingsCookie} mode={mode}>
+                <SettingsProvider
+                  initialSettings={initialSettings}
+                  canPersistAppearance={appearance.authenticated}
+                  hasStoredAppearance={appearance.stored !== null}
+                  appearanceOwner={appearance.userId}
+                  mode={mode}
+                >
                   <ThemeProvider direction={direction} systemMode={systemMode}>
                     <ToastProvider>
                       {children}

--- a/frontend/src/components/VMIsolationPanel.tsx
+++ b/frontend/src/components/VMIsolationPanel.tsx
@@ -638,7 +638,8 @@ return true
                           {securityLevel === 'standard' && <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: theme.palette.primary.main }} />}
                         </Box>
                         <Box sx={{ flex: 1 }}>
-                          <Typography variant="body2" sx={{ fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {/* component='div': body2 renders a <p>, which cannot hold the Chip's <div> */}
+                          <Typography variant="body2" component="div" sx={{ fontWeight: 600, display: 'flex', alignItems: 'center', gap: 1 }}>
                             🟢 {t('vmIsolation.standard')}
                             <Chip size="small" label={t('vmIsolation.recommended')} color="success" sx={{ height: 18, fontSize: 10 }} />
                           </Typography>

--- a/frontend/src/components/settings/AppearanceTab.jsx
+++ b/frontend/src/components/settings/AppearanceTab.jsx
@@ -404,7 +404,11 @@ return (
                 <>
                   <Divider sx={{ my: 2 }} />
                   <Box sx={{ mb: 3 }}>
-                    <Typography variant='body2' fontWeight={500} sx={{ mb: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {/* component='div': body2 renders a <p>, which cannot legally hold the
+                        Chip's <div>. The browser closes the paragraph early and the markup
+                        stops matching what the server sent, which React reports as a
+                        hydration error. */}
+                    <Typography variant='body2' component='div' fontWeight={500} sx={{ mb: 1.5, display: 'flex', alignItems: 'center', gap: 1 }}>
                       {t('settings.blurIntensity')}
                       <Chip label='Glassmorphism' size='small' color='info' sx={{ height: 18, fontSize: 10 }} />
                     </Typography>

--- a/frontend/src/lib/appearance/client.test.ts
+++ b/frontend/src/lib/appearance/client.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { APPEARANCE_ENDPOINT, saveAppearance } from './client'
+
+describe('saveAppearance', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('PUTs the settings as JSON to the appearance endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    const saved = await saveAppearance({ primaryColor: '#FFD200', mode: 'dark' })
+
+    expect(saved).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+
+    expect(url).toBe(APPEARANCE_ENDPOINT)
+    expect(init.method).toBe('PUT')
+    expect(init.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(JSON.parse(init.body)).toEqual({ primaryColor: '#FFD200', mode: 'dark' })
+  })
+
+  it('does not ask to outlive the page by default', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    await saveAppearance({ mode: 'light' })
+
+    expect(fetchMock.mock.calls[0][1].keepalive).toBe(false)
+  })
+
+  it('sets keepalive so a flush at page-hide time still reaches the server', async () => {
+    fetchMock.mockResolvedValue({ ok: true })
+
+    await saveAppearance({ mode: 'light' }, { keepalive: true })
+
+    expect(fetchMock.mock.calls[0][1].keepalive).toBe(true)
+  })
+
+  it('reports a refused save without throwing', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 401 })
+
+    await expect(saveAppearance({ mode: 'dark' })).resolves.toBe(false)
+  })
+
+  it('swallows a network failure: the colour is already applied locally', async () => {
+    fetchMock.mockRejectedValue(new Error('offline'))
+
+    await expect(saveAppearance({ mode: 'dark' })).resolves.toBe(false)
+  })
+})

--- a/frontend/src/lib/appearance/client.ts
+++ b/frontend/src/lib/appearance/client.ts
@@ -1,0 +1,36 @@
+// src/lib/appearance/client.ts
+//
+// Browser-side write of the appearance settings (issue #696). The cookie stays
+// the local cache that makes the next render instant; this call is what makes
+// the choice outlive the cookie.
+
+export const APPEARANCE_ENDPOINT = '/api/v1/settings/appearance'
+
+type SaveOptions = {
+  /**
+   * Let the request outlive the page. Used when flushing a pending save as the
+   * tab is being hidden or closed, where a normal fetch would be cancelled and
+   * the user's last change would be lost.
+   */
+  keepalive?: boolean
+}
+
+/**
+ * Persist the given appearance keys for the signed-in user. Never rejects:
+ * appearance is cosmetic, the value is already applied locally and kept in the
+ * cookie, so a failed save is not worth interrupting anyone over.
+ */
+export async function saveAppearance(appearance: Record<string, unknown>, options: SaveOptions = {}): Promise<boolean> {
+  try {
+    const response = await fetch(APPEARANCE_ENDPOINT, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(appearance),
+      keepalive: options.keepalive === true,
+    })
+
+    return response.ok
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/lib/appearance/schema.test.ts
+++ b/frontend/src/lib/appearance/schema.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+
+import globalThemesConfig, { densityConfig } from '@configs/globalThemesConfig'
+import lightBackgroundConfig from '@configs/lightBackgroundConfig'
+
+import { APPEARANCE_VALIDATORS, PERSISTED_APPEARANCE_KEYS, sanitizeAppearance } from './schema'
+
+describe('sanitizeAppearance', () => {
+  it('keeps known valid keys and drops unknown keys', () => {
+    expect(sanitizeAppearance({ evil: 1, primaryColor: '#FFD200' })).toEqual({
+      primaryColor: '#FFD200',
+    })
+  })
+
+  it.each([null, undefined, 'x', 42, []])('returns an empty object for non-object input %#', input => {
+    expect(sanitizeAppearance(input)).toEqual({})
+  })
+
+  it.each(['#E57000', '#ffd200'])('accepts the six-digit colour %s', primaryColor => {
+    expect(sanitizeAppearance({ primaryColor })).toEqual({ primaryColor })
+  })
+
+  it.each(['red', '#FFF', '#GGGGGG', '#E57000; background:url(x)', 123, null])(
+    'rejects the invalid colour %j',
+    primaryColor => {
+      expect(sanitizeAppearance({ primaryColor })).toEqual({})
+    },
+  )
+
+  it.each(['light', 'dark', 'system'])('accepts the mode %s', mode => {
+    expect(sanitizeAppearance({ mode })).toEqual({ mode })
+  })
+
+  it('rejects an unknown mode', () => {
+    expect(sanitizeAppearance({ mode: 'sepia' })).toEqual({})
+  })
+
+  it.each(['vertical', 'collapsed', 'horizontal', 'hidden'])('accepts the layout %s', layout => {
+    expect(sanitizeAppearance({ layout })).toEqual({ layout })
+  })
+
+  it.each(Object.keys(densityConfig))('accepts the configured density %s', density => {
+    expect(sanitizeAppearance({ density })).toEqual({ density })
+  })
+
+  it('derives valid global theme ids from the shipped config', () => {
+    const globalTheme = globalThemesConfig[0].id
+
+    expect(sanitizeAppearance({ globalTheme })).toEqual({ globalTheme })
+    expect(sanitizeAppearance({ globalTheme: 'nope' })).toEqual({})
+  })
+
+  it('derives valid light background ids from the shipped config', () => {
+    const lightBackground = lightBackgroundConfig[0].id
+
+    expect(sanitizeAppearance({ lightBackground })).toEqual({ lightBackground })
+    expect(sanitizeAppearance({ lightBackground: 'nope' })).toEqual({})
+  })
+
+  it.each([
+    ['fontSize', 12, 18, 11, 19, 14.4, 14],
+    ['uiScale', 80, 120, 79, 121, 100.4, 100],
+    ['blurIntensity', 0, 24, -1, 25, 14.6, 15],
+  ] as const)(
+    'validates and rounds %s within its numeric range',
+    (key, minimum, maximum, below, above, decimal, rounded) => {
+      expect(sanitizeAppearance({ [key]: minimum })).toEqual({ [key]: minimum })
+      expect(sanitizeAppearance({ [key]: maximum })).toEqual({ [key]: maximum })
+      expect(sanitizeAppearance({ [key]: below })).toEqual({})
+      expect(sanitizeAppearance({ [key]: above })).toEqual({})
+      expect(sanitizeAppearance({ [key]: String(rounded) })).toEqual({})
+      expect(sanitizeAppearance({ [key]: Number.NaN })).toEqual({})
+      expect(sanitizeAppearance({ [key]: Number.POSITIVE_INFINITY })).toEqual({})
+      expect(sanitizeAppearance({ [key]: decimal })).toEqual({ [key]: rounded })
+    },
+  )
+
+  it('preserves null customBorderRadius as an explicit inherited value', () => {
+    const result = sanitizeAppearance({ customBorderRadius: null })
+
+    expect(Object.hasOwn(result, 'customBorderRadius')).toBe(true)
+    expect(result.customBorderRadius).toBeNull()
+  })
+
+  it.each([undefined, -1, 25])('drops an invalid customBorderRadius value %j', customBorderRadius => {
+    const result = sanitizeAppearance({ customBorderRadius })
+
+    expect(Object.hasOwn(result, 'customBorderRadius')).toBe(false)
+  })
+
+  it.each([0, 5, 10, 30, 60, 300])('accepts refreshInterval %d', refreshInterval => {
+    expect(sanitizeAppearance({ refreshInterval })).toEqual({ refreshInterval })
+  })
+
+  it.each([7, 3600])('rejects refreshInterval %d', refreshInterval => {
+    expect(sanitizeAppearance({ refreshInterval })).toEqual({})
+  })
+
+  it.each([true, false])('accepts boolean semiDark value %s', semiDark => {
+    expect(sanitizeAppearance({ semiDark })).toEqual({ semiDark })
+  })
+
+  it.each(['true', 1])('rejects non-boolean semiDark value %j', semiDark => {
+    expect(sanitizeAppearance({ semiDark })).toEqual({})
+  })
+
+  it('drops a present invalid key instead of replacing it with a default', () => {
+    const result = sanitizeAppearance({ mode: 'sepia', fontSize: 99, primaryColor: 'red' })
+
+    expect(result).toEqual({})
+    expect(Object.hasOwn(result, 'mode')).toBe(false)
+  })
+})
+
+describe('PERSISTED_APPEARANCE_KEYS', () => {
+  it('lists exactly the validator-backed keys', () => {
+    expect(PERSISTED_APPEARANCE_KEYS).toEqual(Object.keys(APPEARANCE_VALIDATORS))
+  })
+
+  it('excludes the cookie-only login background', () => {
+    expect(PERSISTED_APPEARANCE_KEYS).not.toContain('loginBackground')
+  })
+})

--- a/frontend/src/lib/appearance/schema.ts
+++ b/frontend/src/lib/appearance/schema.ts
@@ -1,0 +1,109 @@
+// src/lib/appearance/schema.ts
+//
+// Whitelist + validation for the per-user appearance settings that are stored
+// server-side (issue #696).
+//
+// The blob travels browser -> API -> JSONB and comes back through server-side
+// rendering, where `primaryColor` is handed straight to MUI's lighten()/darken()
+// in components/theme/index.jsx. A malformed value there throws while the page
+// is being rendered on the server, which would take the whole app down for that
+// user with no way to fix it from the UI. So nothing is stored without being
+// checked first, and anything unknown or out of range is dropped rather than
+// clamped: a rejected key simply falls back to the shipped default.
+//
+// This module is deliberately dependency-free (configs only, no Prisma, no
+// next/headers) so both the API route and the browser can import it.
+
+import globalThemesConfig, { densityConfig } from '@configs/globalThemesConfig'
+import lightBackgroundConfig from '@configs/lightBackgroundConfig'
+
+type Validator = (value: unknown) => unknown
+
+// Six-digit hex only: the colour pickers never emit shorthand or alpha, and a
+// bounded, anchored pattern keeps this linear-time on hostile input.
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/
+
+const enumOf =
+  (allowed: readonly string[]): Validator =>
+  value =>
+    typeof value === 'string' && allowed.includes(value) ? value : undefined
+
+const numberIn =
+  (allowed: readonly number[]): Validator =>
+  value =>
+    typeof value === 'number' && allowed.includes(value) ? value : undefined
+
+const boolean: Validator = value => (typeof value === 'boolean' ? value : undefined)
+
+const intBetween =
+  (min: number, max: number): Validator =>
+  value => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+    const rounded = Math.round(value)
+
+    return rounded >= min && rounded <= max ? rounded : undefined
+  }
+
+// `customBorderRadius: null` means "inherit the global theme's radius" and is a
+// legitimate stored value, so it has to survive validation.
+const nullableIntBetween = (min: number, max: number): Validator => {
+  const inner = intBetween(min, max)
+
+  return value => (value === null ? null : inner(value))
+}
+
+const hexColor: Validator = value =>
+  typeof value === 'string' && HEX_COLOR.test(value) ? value : undefined
+
+// Domains come from the same configs the settings UI renders from, so adding a
+// theme or a background tint never needs a second edit here.
+const GLOBAL_THEME_IDS = globalThemesConfig.map((theme: { id: string }) => theme.id)
+const LIGHT_BACKGROUND_IDS = lightBackgroundConfig.map((background: { id: string }) => background.id)
+const DENSITY_IDS = Object.keys(densityConfig)
+
+/**
+ * The appearance keys that get a server-side home, each with the validator that
+ * guards it. Keys of the settings blob that are absent here (`loginBackground`,
+ * which is a provider-wide setting with its own API) stay cookie-only.
+ */
+export const APPEARANCE_VALIDATORS: Record<string, Validator> = {
+  mode: enumOf(['light', 'dark', 'system']),
+  skin: enumOf(['default', 'bordered']),
+  semiDark: boolean,
+  layout: enumOf(['vertical', 'collapsed', 'horizontal', 'hidden']),
+  navbarContentWidth: enumOf(['compact', 'wide']),
+  contentWidth: enumOf(['compact', 'wide']),
+  footerContentWidth: enumOf(['compact', 'wide']),
+  primaryColor: hexColor,
+  globalTheme: enumOf(GLOBAL_THEME_IDS),
+  lightBackground: enumOf(LIGHT_BACKGROUND_IDS),
+  density: enumOf(DENSITY_IDS),
+  customBorderRadius: nullableIntBetween(0, 24),
+  blurIntensity: intBetween(0, 24),
+  fontSize: intBetween(12, 18),
+  uiScale: intBetween(80, 120),
+  refreshInterval: numberIn([0, 5, 10, 30, 60, 300]),
+}
+
+export const PERSISTED_APPEARANCE_KEYS = Object.keys(APPEARANCE_VALIDATORS)
+
+/**
+ * Keep the known, well-formed appearance keys of `input` and drop everything
+ * else. Always returns a plain object, so callers can spread the result without
+ * guarding for null.
+ */
+export function sanitizeAppearance(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return {}
+
+  const source = input as Record<string, unknown>
+  const sanitized: Record<string, unknown> = {}
+
+  for (const [key, validate] of Object.entries(APPEARANCE_VALIDATORS)) {
+    if (!Object.hasOwn(source, key)) continue
+    const value = validate(source[key])
+
+    if (value !== undefined) sanitized[key] = value
+  }
+
+  return sanitized
+}

--- a/frontend/src/lib/appearance/server.test.ts
+++ b/frontend/src/lib/appearance/server.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `server-only` throws by design outside a Server Component; neutralise the
+// marker so this module can be exercised under the node test project.
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+
+const getServerSession = vi.fn()
+
+vi.mock('next-auth', () => ({ getServerSession: (...args: unknown[]) => getServerSession(...args) }))
+
+const getUserAppearance = vi.fn()
+
+vi.mock('@/lib/db/userPreferences', () => ({
+  getUserAppearance: (...args: unknown[]) => getUserAppearance(...args),
+}))
+
+const { getAppearanceHydration, getStoredAppearance } = await import('./server')
+
+describe('getAppearanceHydration', () => {
+  beforeEach(() => {
+    getServerSession.mockReset()
+    getUserAppearance.mockReset()
+  })
+
+  it('reports an anonymous request without touching the store', async () => {
+    getServerSession.mockResolvedValue(null)
+
+    await expect(getAppearanceHydration()).resolves.toEqual({ authenticated: false, userId: null, stored: null })
+    expect(getUserAppearance).not.toHaveBeenCalled()
+  })
+
+  it('treats a session with no user id as anonymous', async () => {
+    getServerSession.mockResolvedValue({ user: { email: 'a@b.c' } })
+
+    await expect(getAppearanceHydration()).resolves.toEqual({ authenticated: false, userId: null, stored: null })
+    expect(getUserAppearance).not.toHaveBeenCalled()
+  })
+
+  it('reads the store with the session tenant and user', async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'u1', tenantId: 'acme' } })
+    getUserAppearance.mockResolvedValue({ primaryColor: '#FFD200' })
+
+    await expect(getAppearanceHydration()).resolves.toEqual({
+      authenticated: true,
+      userId: 'u1',
+      stored: { primaryColor: '#FFD200' },
+    })
+    expect(getUserAppearance).toHaveBeenCalledWith('acme', 'u1')
+  })
+
+  it('falls back to the default tenant when the session carries none', async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'u1' } })
+    getUserAppearance.mockResolvedValue(null)
+
+    await expect(getAppearanceHydration()).resolves.toEqual({ authenticated: true, userId: 'u1', stored: null })
+    expect(getUserAppearance).toHaveBeenCalledWith('default', 'u1')
+  })
+
+  it('keeps a signed-in user distinguishable from one who never saved anything', async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'u1', tenantId: 'default' } })
+    getUserAppearance.mockResolvedValue(null)
+
+    const hydration = await getAppearanceHydration()
+
+    expect(hydration.authenticated).toBe(true)
+    expect(hydration.stored).toBeNull()
+  })
+
+  it('never lets a database failure take the layout down', async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'u1', tenantId: 'default' } })
+    getUserAppearance.mockRejectedValue(new Error('connection refused'))
+
+    await expect(getAppearanceHydration()).resolves.toEqual({ authenticated: false, userId: null, stored: null })
+  })
+
+  it('never lets a broken session take the layout down', async () => {
+    getServerSession.mockRejectedValue(new Error('bad JWT'))
+
+    await expect(getAppearanceHydration()).resolves.toEqual({ authenticated: false, userId: null, stored: null })
+  })
+})
+
+describe('getStoredAppearance', () => {
+  beforeEach(() => {
+    getServerSession.mockReset()
+    getUserAppearance.mockReset()
+  })
+
+  it('returns the stored blob alone', async () => {
+    getServerSession.mockResolvedValue({ user: { id: 'u1', tenantId: 'default' } })
+    getUserAppearance.mockResolvedValue({ mode: 'dark' })
+
+    await expect(getStoredAppearance()).resolves.toEqual({ mode: 'dark' })
+  })
+
+  it('returns null for an anonymous request', async () => {
+    getServerSession.mockResolvedValue(null)
+
+    await expect(getStoredAppearance()).resolves.toBeNull()
+  })
+})

--- a/frontend/src/lib/appearance/server.ts
+++ b/frontend/src/lib/appearance/server.ts
@@ -1,0 +1,54 @@
+// src/lib/appearance/server.ts
+//
+// Server-side read of the stored appearance, used while rendering (issue #696).
+// Reading it on the server rather than fetching it after hydration is the whole
+// point: the palette is baked into the first HTML, so a user whose colour is
+// restored from the database never sees a frame of the default orange.
+//
+// Wrapped in React's `cache` so the root layout, the dashboard layout and
+// Providers, which all ask for the mode during a single render, share one
+// query.
+
+import 'server-only'
+
+import { cache } from 'react'
+
+import { getServerSession } from 'next-auth'
+
+import { authOptions } from '@/lib/auth/config'
+import { getUserAppearance } from '@/lib/db/userPreferences'
+
+export type AppearanceHydration = {
+  /** There is a session, so the browser is allowed to save its appearance. */
+  authenticated: boolean
+  /** The signed-in user, used to tell whose settings a shared browser holds. */
+  userId: string | null
+  /** The stored blob, or `null` when this user has never saved one. */
+  stored: Record<string, unknown> | null
+}
+
+const ANONYMOUS: AppearanceHydration = { authenticated: false, userId: null, stored: null }
+
+/**
+ * What the current request knows about the user's appearance. Never throws:
+ * appearance is cosmetic, and taking a layout down over it, or over a database
+ * blip, would be a poor trade.
+ */
+export const getAppearanceHydration = cache(async (): Promise<AppearanceHydration> => {
+  try {
+    const session = await getServerSession(authOptions)
+    const userId = session?.user?.id
+
+    if (!userId) return ANONYMOUS
+
+    const stored = await getUserAppearance(session.user.tenantId || 'default', userId)
+
+    return { authenticated: true, userId, stored }
+  } catch {
+    return ANONYMOUS
+  }
+})
+
+/** The stored appearance alone, for callers that only need to merge it. */
+export const getStoredAppearance = async (): Promise<Record<string, unknown> | null> =>
+  (await getAppearanceHydration()).stored

--- a/frontend/src/lib/db/userPreferences.test.ts
+++ b/frontend/src/lib/db/userPreferences.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { findUnique, upsert } = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  upsert: vi.fn(),
+}))
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    userPreference: { findUnique, upsert },
+  },
+}))
+
+import { getUserAppearance, setUserAppearance } from './userPreferences'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  upsert.mockResolvedValue({})
+})
+
+describe('getUserAppearance', () => {
+  it('returns null for a missing row and uses the composite tenant/user key', async () => {
+    findUnique.mockResolvedValue(null)
+
+    await expect(getUserAppearance('tenant-1', 'user-1')).resolves.toBeNull()
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { tenantId_userId: { tenantId: 'tenant-1', userId: 'user-1' } },
+      select: { appearance: true },
+    })
+  })
+
+  it('sanitizes a hostile stored row before returning it', async () => {
+    findUnique.mockResolvedValue({
+      appearance: { primaryColor: 'not-a-colour', fontSize: 99, mode: 'dark' },
+    })
+
+    await expect(getUserAppearance('tenant-1', 'user-1')).resolves.toEqual({ mode: 'dark' })
+  })
+})
+
+describe('setUserAppearance', () => {
+  it('merges an incoming partial update over the stored appearance', async () => {
+    findUnique.mockResolvedValue({ appearance: { mode: 'dark', primaryColor: '#E57000' } })
+
+    const result = await setUserAppearance('tenant-1', 'user-1', { primaryColor: '#FFD200' })
+    const appearance = { mode: 'dark', primaryColor: '#FFD200' }
+
+    expect(upsert).toHaveBeenCalledWith({
+      where: { tenantId_userId: { tenantId: 'tenant-1', userId: 'user-1' } },
+      create: { tenantId: 'tenant-1', userId: 'user-1', appearance },
+      update: { appearance },
+    })
+    expect(result).toEqual(appearance)
+  })
+
+  it('drops invalid incoming keys before writing', async () => {
+    findUnique.mockResolvedValue({ appearance: { mode: 'dark' } })
+
+    await setUserAppearance('tenant-1', 'user-1', {
+      mode: 'sepia',
+      primaryColor: 'javascript:alert(1)',
+      evil: true,
+    })
+
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ appearance: { mode: 'dark' } }),
+        update: { appearance: { mode: 'dark' } },
+      }),
+    )
+  })
+
+  it('creates the first stored appearance when no row exists', async () => {
+    findUnique.mockResolvedValue(null)
+    const appearance = { mode: 'light', primaryColor: '#FFD200' }
+
+    await expect(setUserAppearance('tenant-2', 'user-2', appearance)).resolves.toEqual(appearance)
+    expect(upsert).toHaveBeenCalledWith({
+      where: { tenantId_userId: { tenantId: 'tenant-2', userId: 'user-2' } },
+      create: { tenantId: 'tenant-2', userId: 'user-2', appearance },
+      update: { appearance },
+    })
+  })
+})

--- a/frontend/src/lib/db/userPreferences.ts
+++ b/frontend/src/lib/db/userPreferences.ts
@@ -1,0 +1,64 @@
+// src/lib/db/userPreferences.ts
+//
+// Read/write of the per-user appearance blob stored in `user_preferences`
+// (issue #696). Kept next to lib/db/settings.ts, which does the same job for
+// tenant-wide settings, so both key/value stores read alike at the call sites.
+//
+// Everything crossing this module is run through sanitizeAppearance, on write
+// because the payload comes from the browser, and on read as well, because a
+// row written by another version of the app (or edited by hand) must not be
+// able to hand an unusable colour to the server-side render.
+//
+// Known limitation: the tenant comes from the session at the moment the write
+// lands. A save still inside its debounce window when the user switches tenant
+// is therefore stored against the tenant they arrived in, not the one they were
+// looking at. The window is a few hundred milliseconds and the damage is a
+// colour in the wrong place, so it is left as is rather than carried through
+// the API as a client-chosen tenant, which would weaken the authorisation.
+
+import { prisma } from '@/lib/db/prisma'
+import { sanitizeAppearance } from '@/lib/appearance/schema'
+
+import type { Prisma } from '@prisma/client'
+
+/**
+ * The user's stored appearance, or `null` when they have never saved one.
+ * The null case matters: it is what tells the client it may seed the store
+ * from a cookie left over from before this table existed.
+ */
+export async function getUserAppearance(
+  tenantId: string,
+  userId: string,
+): Promise<Record<string, unknown> | null> {
+  const row = await prisma.userPreference.findUnique({
+    where: { tenantId_userId: { tenantId, userId } },
+    select: { appearance: true },
+  })
+
+  if (!row) return null
+
+  return sanitizeAppearance(row.appearance)
+}
+
+/**
+ * Merge `appearance` into the user's stored blob and return what is now on
+ * record. Merging rather than replacing keeps a client that only knows about
+ * some of the keys (an older tab, a partial update) from wiping the rest.
+ */
+export async function setUserAppearance(
+  tenantId: string,
+  userId: string,
+  appearance: unknown,
+): Promise<Record<string, unknown>> {
+  const incoming = sanitizeAppearance(appearance)
+  const current = (await getUserAppearance(tenantId, userId)) ?? {}
+  const merged = { ...current, ...incoming }
+
+  await prisma.userPreference.upsert({
+    where: { tenantId_userId: { tenantId, userId } },
+    create: { tenantId, userId, appearance: merged as Prisma.InputJsonValue },
+    update: { appearance: merged as Prisma.InputJsonValue },
+  })
+
+  return merged
+}


### PR DESCRIPTION
Closes #696.

## The problem

The colour scheme, the display mode and every other control of the Appearance tab had exactly one persistence layer: the `materio-mui-next-demo` browser cookie, written from JavaScript by `useObjectCookie`. Nothing was ever stored server side and nothing was ever read back at boot, so a browser configured to clear cookies on exit dropped the whole thing and `SettingsProvider` fell back to `primaryColorConfig[0].main`, the default orange. Browsers that cap the lifetime of script-written cookies at around seven days produce the same result without any manual clearing, which is the "it reverts after a day or two" half of the report.

## What changes

Appearance settings get a server side home, keyed per tenant and per user like dashboard layouts already are.

* New `user_preferences` table and its migration, holding one sanitised JSONB blob per (tenant, user).
* `GET` and `PUT` on `/api/v1/settings/appearance`. Authorisation comes from the session alone: the tenant and user ids in the request body are ignored, so no caller can write into somebody else's row. No RBAC permission is required, since this is each user's own colour scheme rather than an administrative setting.
* `src/lib/appearance/schema.ts` whitelists the sixteen persisted keys and validates each one. This is not decoration: `primaryColor` is fed to MUI's `lighten()` during server side rendering, so a malformed value in the database would throw while rendering and lock that user out of every page with no way to fix it from the UI. Unknown keys and out of range values are dropped rather than clamped, and the domains for themes, tints and densities are derived from the same configs the settings UI renders from.
* The stored blob is resolved on the server in `Providers`, so the restored palette is already in the first HTML instead of replacing the orange after hydration.
* Saves are debounced by 600 ms and flushed with `keepalive` on `pagehide` and `visibilitychange`, because a save cancelled by the tab closing would be undone by the stale server copy on the next boot. A refused save is retried, bounded to three attempts.
* Only the keys an update actually moved are sent, so a second tab holding an older copy cannot revert what the first one just saved.
* Users who already picked a theme have it in their cookie only. That cookie is handed to the store once, on the first load after upgrading, so nobody has to set their theme again. The cookie carries the id of the account that wrote it, so a shared browser never copies one person's look into another's account.

## Two bugs of the same family, found on the way

* `SettingsProvider` used the cookie verbatim instead of layering it over the defaults. A cookie written by an older release, missing `primaryColor`, therefore reached the theme as `undefined` and threw inside `lighten()` during server side rendering.
* `getSettingsFromCookie` let a malformed cookie throw, which turned into a 500 on every single page with no way out from the UI. It now falls back to the defaults.

## Unrelated fix carried along

Four `<Typography variant="body2">` elements wrapped a `<Chip>`, which puts a `<div>` inside a `<p>`. The browser closes the paragraph early, the markup stops matching what the server sent, and React reports a hydration error. One of them sits in the Appearance tab and shows up while testing this change. All four now render as a `div`, which leaves the styling untouched.

## Tests

111 new tests across the validation schema, the store, the route, the server helpers and the provider, including the round trip of a refused save, the shared browser case and the two tab case. Full suite green at 502 files and 5158 tests.

## Notes

The migration is applied automatically at container start by `migrate-with-lock.js`, so nothing manual is needed on upgrade.

One limitation is documented in the store rather than fixed: a save still inside its debounce window when the user switches tenant is recorded against the tenant they arrive in. Closing that would mean letting the client name the tenant it wants to write to, which weakens the authorisation model for what amounts to a colour landing in the wrong place for a few hundred milliseconds of exposure.
