### PR TITLE
fix(rbac): let a pool-scoped user create a guest (#262)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
@@ -82,6 +82,9 @@ function CreateLxcDialog({
   const [templates, setTemplates] = useState<any[]>([])
   const [loadingTemplates, setLoadingTemplates] = useState(false)
   const [pools, setPools] = useState<any[]>([])
+  // True when the API narrowed the list to the caller's own pools: the
+  // container must land in one of them, so the picker is shown to non-admins.
+  const [poolsRestricted, setPoolsRestricted] = useState(false)
   const [bridges, setBridges] = useState<string[]>([])
   const [loadingData, setLoadingData] = useState(false)
 
@@ -243,7 +246,10 @@ return
     setLoadingData(true)
 
     try {
-      const connRes = await fetch('/api/v1/connections?type=pve')
+      // includeGuestScoped: a tag/pool scoped user is absent from the plain
+      // connection list, which would leave the Node picker empty and block the
+      // wizard on its first tab (issue #262).
+      const connRes = await fetch('/api/v1/connections?type=pve&includeGuestScoped=1')
       const connJson = await connRes.json()
       const connectionsList = connJson.data || []
 
@@ -422,6 +428,7 @@ return
   useEffect(() => {
     if (!open || !selectedConnection) {
       setPools([])
+      setPoolsRestricted(false)
       return
     }
 
@@ -432,10 +439,17 @@ return
 
         if (json.data && Array.isArray(json.data)) {
           setPools(json.data.map((p: any) => ({ poolid: p.poolid, comment: p.comment })))
+
+          // Pool-scoped caller: the list is their whole scope and the container
+          // has to land in it, so preselect when there is only one candidate
+          // instead of showing a one-option dropdown (issue #262).
+          setPoolsRestricted(!!json.restricted)
+          if (json.restricted && json.data.length === 1) setResourcePool(json.data[0].poolid)
         }
       } catch (e) {
         console.error('Error loading pools:', e)
         setPools([])
+        setPoolsRestricted(false)
       }
     }
 
@@ -825,12 +839,14 @@ return
               </Select>
             </FormControl>
             )}
-            {/* Resource pool selector — hidden for vDC tenants (pool assigned automatically) */}
-            {isAdmin && (
+            {/* Resource pool selector, hidden for vDC tenants (pool assigned
+                automatically). Pool-scoped callers keep it: the list is their
+                own scope and the container has to land inside it (issue #262). */}
+            {(isAdmin || poolsRestricted) && (
               <FormControl fullWidth size="small">
                 <InputLabel>{t('inventory.createLxc.resourcePool')}</InputLabel>
                 <Select value={resourcePool} onChange={(e) => setResourcePool(e.target.value)} label={t('inventory.createLxc.resourcePool')}>
-                  <MenuItem value="">({t('common.none')})</MenuItem>
+                  {!poolsRestricted && <MenuItem value="">({t('common.none')})</MenuItem>}
                   {pools.map((p) => (
                     <MenuItem key={p.poolid} value={p.poolid}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -152,6 +152,9 @@ function CreateVmDialog({
   const [networks, setNetworks] = useState<any[]>([])
   const [bridges, setBridges] = useState<any[]>([])
   const [pools, setPools] = useState<any[]>([])
+  // True when the API narrowed the list to the caller's own pools: the guest
+  // must land in one of them, so the picker is shown even to a non-admin.
+  const [poolsRestricted, setPoolsRestricted] = useState(false)
   const [loadingData, setLoadingData] = useState(false)
   
   // Formulaire - Général
@@ -453,6 +456,7 @@ function CreateVmDialog({
   useEffect(() => {
     if (!open || !selectedConnection) {
       setPools([])
+      setPoolsRestricted(false)
       return
     }
 
@@ -463,10 +467,17 @@ function CreateVmDialog({
 
         if (json.data && Array.isArray(json.data)) {
           setPools(json.data.map((p: any) => ({ poolid: p.poolid, comment: p.comment })))
+
+          // Pool-scoped caller: the list is their whole scope and the guest has
+          // to land in it, so preselect when there is only one candidate
+          // instead of showing a one-option dropdown (issue #262).
+          setPoolsRestricted(!!json.restricted)
+          if (json.restricted && json.data.length === 1) setResourcePool(json.data[0].poolid)
         }
       } catch (e) {
         console.error('Error loading pools:', e)
         setPools([])
+        setPoolsRestricted(false)
       }
     }
 
@@ -541,7 +552,10 @@ return
 
     try {
       // 1. Charger les connexions
-      const connRes = await fetch('/api/v1/connections?type=pve')
+      // includeGuestScoped: a tag/pool scoped user is absent from the plain
+      // connection list, which would leave the Node picker empty and block the
+      // wizard on its first tab (issue #262).
+      const connRes = await fetch('/api/v1/connections?type=pve&includeGuestScoped=1')
       const connJson = await connRes.json()
       const connectionsList = connJson.data || []
 
@@ -1069,12 +1083,14 @@ return
               </Select>
             </FormControl>
             )}
-            {/* Resource pool selector — hidden for vDC tenants (pool assigned automatically) */}
-            {isAdmin && (
+            {/* Resource pool selector, hidden for vDC tenants (pool assigned
+                automatically). Pool-scoped callers keep it: the list is their
+                own scope and the guest has to land inside it (issue #262). */}
+            {(isAdmin || poolsRestricted) && (
               <FormControl fullWidth size="small">
                 <InputLabel>{t('inventory.createVm.resourcePool')}</InputLabel>
                 <Select value={resourcePool} onChange={(e) => setResourcePool(e.target.value)} label={t('inventory.createVm.resourcePool')}>
-                  <MenuItem value="">({t('common.none')})</MenuItem>
+                  {!poolsRestricted && <MenuItem value="">({t('common.none')})</MenuItem>}
                   {pools.map((p) => (
                     <MenuItem key={p.poolid} value={p.poolid}>
                       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/route.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
 
 const checkPermissionMock = vi.fn<(...args: any[]) => Promise<Response | null>>()
+const getRequestGuestScopePerimeterMock = vi.fn<(...args: any[]) => Promise<any>>()
 const getConnectionByIdMock = vi.fn<(id: string) => Promise<any>>()
 const pveFetchMock = vi.fn<(...args: any[]) => Promise<any>>()
 
-vi.mock('@/lib/rbac', () => ({ checkPermission: checkPermissionMock, PERMISSIONS: { VM_CREATE: 'vm.create' } }))
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  getRequestGuestScopePerimeter: getRequestGuestScopePerimeterMock,
+  PERMISSIONS: { VM_CREATE: 'vm.create' },
+}))
 vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: getConnectionByIdMock }))
 vi.mock('@/lib/proxmox/client', () => ({ pveFetch: pveFetchMock }))
 vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: async () => 'tenant-1' }))
@@ -31,6 +36,7 @@ const baseParams = { id: 'conn-1', type: 'qemu', node: 'pve1' }
 
 beforeEach(() => {
   checkPermissionMock.mockReset().mockResolvedValue(null)
+  getRequestGuestScopePerimeterMock.mockReset().mockResolvedValue(null)
   getConnectionByIdMock.mockReset().mockResolvedValue({ id: 'conn-1' })
   pveFetchMock.mockReset().mockResolvedValue('UPID:x')
   checkVmidAgainstTenantRangeMock.mockReset().mockResolvedValue({ ok: true })
@@ -73,5 +79,72 @@ describe('POST guests create — MSP VMID range enforcement', () => {
     expect(res.status).toBe(400)
     expect(checkVmidAgainstTenantRangeMock).toHaveBeenCalledWith('tenant-1', 190)
     expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST guests create: flat-scoped pool containment', () => {
+  function restrictedTo(pools: string[]) {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue({
+      restricted: true,
+      holdsPermission: true,
+      hasVisibleGuests: true,
+      pools: new Set(pools),
+      nodes: new Set(['pve1']),
+    })
+  }
+
+  function createdBody() {
+    const createCall = pveFetchMock.mock.calls.find(
+      (c) => c[1] === '/nodes/pve1/qemu' && c[2]?.method === 'POST',
+    )
+    expect(createCall).toBeTruthy()
+
+    return JSON.parse(String(createCall![2].body))
+  }
+
+  it('injects the only accessible pool when the body carries none', async () => {
+    restrictedTo(['p1'])
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { vmid: 190 } })
+    expect(res.status).toBe(200)
+    expect(createdBody().pool).toBe('p1')
+  })
+
+  it('403: rejects a pool outside the caller scope, PVE create never called', async () => {
+    restrictedTo(['p1'])
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { vmid: 190, pool: 'other' } })
+    expect(res.status).toBe(403)
+    const json = await readJson<{ error: string }>(res)
+    expect(json?.error).toBe('Resource pool outside your scope')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('400: asks for a pool when several are accessible and none was chosen', async () => {
+    restrictedTo(['p1', 'p2'])
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { vmid: 190 } })
+    expect(res.status).toBe(400)
+    const json = await readJson<{ error: string }>(res)
+    expect(json?.error).toBe('A resource pool within your scope is required')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('lets through a pool that belongs to the caller scope', async () => {
+    restrictedTo(['p1', 'p2'])
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { vmid: 190, pool: 'p2' } })
+    expect(res.status).toBe(200)
+    expect(createdBody().pool).toBe('p2')
+  })
+
+  it('leaves the body untouched for a connection-scoped creator', async () => {
+    const POST = await loadPost()
+    const res = await callRoute(POST, { params: baseParams, body: { vmid: 190 } })
+    expect(res.status).toBe(200)
+    expect(createdBody().pool).toBeUndefined()
+    // No fallback needed, so the perimeter is never resolved.
+    expect(getRequestGuestScopePerimeterMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/guests/[type]/[node]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, getRequestGuestScopePerimeter, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { resolveVdcForTenant, checkVdcQuota } from "@/lib/vdc/quota"
 import { getAllowedBridgesForTenant, resolveSubnetForBridge, parseBridgeFromNet } from "@/lib/vdc/vnets"
@@ -56,8 +56,15 @@ export async function POST(
       return NextResponse.json({ error: "Type must be 'qemu' or 'lxc'" }, { status: 400 })
     }
 
+    // Flat-scoped creators (vm/tag/pool) never match a connection-scoped check
+    // and used to 403 here, so the wizard failed on submit even once its
+    // dropdowns were populated (issue #262). They come in through the
+    // guest-derived perimeter, and the pool guard below keeps their new guest
+    // inside their own scope.
     const denied = await checkPermission(PERMISSIONS.VM_CREATE, "connection", id)
-    if (denied) return denied
+    const perimeter = denied ? await getRequestGuestScopePerimeter(id, PERMISSIONS.VM_CREATE) : null
+
+    if (denied && !(perimeter?.holdsPermission && perimeter.hasVisibleGuests)) return denied
 
     const conn = await getConnectionById(id)
     const body = await req.json()
@@ -65,6 +72,23 @@ export async function POST(
     // Valider les champs requis
     if (!body.vmid) {
       return NextResponse.json({ error: "vmid is required" }, { status: 400 })
+    }
+
+    // Pool containment for flat-scoped creators: a guest created outside their
+    // pools would be invisible to them the moment it exists. A single
+    // accessible pool is applied implicitly, mirroring the vDC forcing below.
+    if (perimeter?.restricted) {
+      const requestedPool = typeof body.pool === 'string' ? body.pool.trim() : ''
+
+      if (requestedPool) {
+        if (!perimeter.pools.has(requestedPool)) {
+          return NextResponse.json({ error: "Resource pool outside your scope" }, { status: 403 })
+        }
+      } else if (perimeter.pools.size === 1) {
+        body.pool = [...perimeter.pools][0]
+      } else {
+        return NextResponse.json({ error: "A resource pool within your scope is required" }, { status: 400 })
+      }
     }
 
     // vDC quota enforcement

--- a/frontend/src/app/api/v1/connections/[id]/network-choices/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/network-choices/route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute } from "@/__tests__/setup/route-test"
+
+const {
+  checkPermissionMock,
+  guestPerimeterAllowsMock,
+  getConnectionByIdMock,
+  pveFetchMock,
+  getCurrentTenantIdMock,
+  getTenantInfrastructureScopeMock,
+  maskingScopeMock,
+  connectionFindUniqueMock,
+  vdcVnetFindManyMock,
+  vdcSharedBridgeFindManyMock,
+} = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn(),
+  guestPerimeterAllowsMock: vi.fn(),
+  getConnectionByIdMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+  getCurrentTenantIdMock: vi.fn(),
+  getTenantInfrastructureScopeMock: vi.fn(),
+  maskingScopeMock: vi.fn(),
+  connectionFindUniqueMock: vi.fn(),
+  vdcVnetFindManyMock: vi.fn(),
+  vdcSharedBridgeFindManyMock: vi.fn(),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  guestPerimeterAllows: (...a: any[]) => guestPerimeterAllowsMock(...a),
+  buildNodeResourceId: (id: string, node: string) => `${id}/${node}`,
+  PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: (...a: any[]) => getConnectionByIdMock(...a),
+}))
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...a: any[]) => pveFetchMock(...a),
+}))
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: (...a: any[]) => getCurrentTenantIdMock(...a),
+}))
+vi.mock("@/lib/tenant/infraScope", () => ({
+  getTenantInfrastructureScope: (...a: any[]) => getTenantInfrastructureScopeMock(...a),
+  maskingScope: (...a: any[]) => maskingScopeMock(...a),
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    connection: { findUnique: (...a: any[]) => connectionFindUniqueMock(...a) },
+    vdcVnet: { findMany: (...a: any[]) => vdcVnetFindManyMock(...a) },
+    vdcSharedBridge: { findMany: (...a: any[]) => vdcSharedBridgeFindManyMock(...a) },
+  },
+}))
+
+const PARAMS = { id: "conn-1" }
+const QUERY = { node: "pve1" }
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  // Flat-scoped fallback off by default: the denial path stays the denial path.
+  guestPerimeterAllowsMock.mockReset().mockResolvedValue(false)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: "c", baseUrl: "https://x:8006", apiToken: "t" })
+  pveFetchMock.mockReset().mockImplementation((_conn: any, path: string) => {
+    if (path.endsWith("/network")) {
+      return Promise.resolve([{ iface: "vmbr0", type: "bridge" }])
+    }
+    if (path === "/cluster/sdn/vnets") return Promise.resolve([])
+    return Promise.resolve([])
+  })
+  getCurrentTenantIdMock.mockReset().mockResolvedValue("provider-tenant")
+  getTenantInfrastructureScopeMock.mockReset().mockResolvedValue({ kind: "provider" })
+  // provider: no vDC masking, so the route takes the full-cluster branch.
+  maskingScopeMock.mockReset().mockReturnValue(null)
+  connectionFindUniqueMock.mockReset().mockResolvedValue({ tenantId: "provider-tenant" })
+  vdcVnetFindManyMock.mockReset().mockResolvedValue([])
+  vdcSharedBridgeFindManyMock.mockReset().mockResolvedValue([])
+})
+
+describe("GET /api/v1/connections/[id]/network-choices", () => {
+  it("returns the cluster bridges when the caller holds connection.view", async () => {
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual([{ kind: "bridge", name: "vmbr0", type: "bridge" }])
+    // Permission granted, so the guest-derived fallback is never consulted.
+    expect(guestPerimeterAllowsMock).not.toHaveBeenCalled()
+  })
+
+  it("returns the RBAC denial without calling PVE when no guest opens the perimeter", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  // Issue #262: a pool-scoped user matches no node resource, so the Network tab
+  // of the creation wizard needs the guest-derived fallback to answer.
+  it("serves a flat-scoped caller whose guests live on this cluster", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+    guestPerimeterAllowsMock.mockResolvedValue(true)
+
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual([{ kind: "bridge", name: "vmbr0", type: "bridge" }])
+    expect(guestPerimeterAllowsMock).toHaveBeenCalledWith("conn-1", "connection.view")
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/network-choices/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/network-choices/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 
 import { getCurrentTenantId } from "@/lib/tenant"
-import { checkPermission, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
+import { checkPermission, guestPerimeterAllows, PERMISSIONS, buildNodeResourceId } from "@/lib/rbac"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
@@ -26,9 +26,13 @@ export async function GET(req: Request, ctx: RouteContext) {
     // the endpoint only returns names a tenant is already authorised to
     // attach to (their vDC VNets + shared bridges). node.network would gate
     // real network-management operations, not this read-only helper.
+    // A flat-scoped caller (vm/tag/pool) matches no node resource either, so
+    // the Network tab of the creation wizard used to 403 (issue #262). Their
+    // guests on this cluster are what opens it.
     const resourceId = buildNodeResourceId(connId, node)
     const denied = await checkPermission(PERMISSIONS.CONNECTION_VIEW, "node", resourceId)
-    if (denied) return denied
+
+    if (denied && !(await guestPerimeterAllows(connId, PERMISSIONS.CONNECTION_VIEW))) return denied
 
     const tenantId = await getCurrentTenantId()
     const infra = await getTenantInfrastructureScope(tenantId)

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.test.ts
@@ -2,14 +2,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "@/__tests__/setup/route-test"
 
-const { checkPermissionMock, getConnectionByIdMock, pveFetchMock } = vi.hoisted(() => ({
+const { checkPermissionMock, getConnectionByIdMock, pveFetchMock, guestPerimeterAllowsMock } = vi.hoisted(() => ({
   checkPermissionMock: vi.fn(),
   getConnectionByIdMock: vi.fn(),
   pveFetchMock: vi.fn(),
+  guestPerimeterAllowsMock: vi.fn(),
 }))
 
 vi.mock("@/lib/rbac", () => ({
   checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  guestPerimeterAllows: (...a: any[]) => guestPerimeterAllowsMock(...a),
   buildNodeResourceId: (id: string, node: string) => `${id}/${node}`,
   PERMISSIONS: { NODE_VIEW: "node.view" },
 }))
@@ -24,6 +26,8 @@ const PARAMS = { id: "conn-1", node: "pve1" }
 
 beforeEach(() => {
   checkPermissionMock.mockReset().mockResolvedValue(null)
+  // Flat-scoped fallback off by default: the denial path stays the denial path.
+  guestPerimeterAllowsMock.mockReset().mockResolvedValue(false)
   getConnectionByIdMock.mockReset().mockResolvedValue({ id: "c", baseUrl: "https://x:8006", apiToken: "t" })
   pveFetchMock.mockReset()
 })
@@ -58,6 +62,18 @@ describe("GET .../nodes/[node]/cpu-models", () => {
     const res = await callRoute(GET, { params: PARAMS })
     expect(res.status).toBe(403)
     expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  // Issue #262: a pool-scoped user matches no node resource, so the CPU tab of
+  // the creation wizard needs the guest-derived fallback to answer.
+  it("serves a flat-scoped caller whose guests live on this cluster", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+    guestPerimeterAllowsMock.mockResolvedValue(true)
+    pveFetchMock.mockResolvedValue([{ name: "kvm64" }])
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS })
+    expect(res.status).toBe(200)
+    expect(guestPerimeterAllowsMock).toHaveBeenCalledWith("conn-1", "node.view")
   })
 
   it("returns 500 with an error message when the PVE call fails", async () => {

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/cpu-models/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, buildNodeResourceId, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, buildNodeResourceId, guestPerimeterAllows, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = "nodejs"
 
@@ -16,9 +16,12 @@ export async function GET(
   try {
     const { id, node } = await ctx.params
 
+    // Flat-scoped callers (vm/tag/pool) match no node resource, which used to
+    // 403 the CPU tab of the creation wizard (issue #262).
     const resourceId = buildNodeResourceId(id, node)
     const denied = await checkPermission(PERMISSIONS.NODE_VIEW, "node", resourceId)
-    if (denied) return denied
+
+    if (denied && !(await guestPerimeterAllows(id, PERMISSIONS.NODE_VIEW))) return denied
 
     const conn = await getConnectionById(id)
 

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/route.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute } from "@/__tests__/setup/route-test"
+
+const {
+  checkPermissionMock,
+  guestPerimeterAllowsMock,
+  getConnectionByIdMock,
+  pveFetchMock,
+  getCurrentTenantIdMock,
+  getTenantInfrastructureScopeMock,
+  maskingScopeMock,
+  tenantFindUniqueMock,
+} = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn(),
+  guestPerimeterAllowsMock: vi.fn(),
+  getConnectionByIdMock: vi.fn(),
+  pveFetchMock: vi.fn(),
+  getCurrentTenantIdMock: vi.fn(),
+  getTenantInfrastructureScopeMock: vi.fn(),
+  maskingScopeMock: vi.fn(),
+  tenantFindUniqueMock: vi.fn(),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  guestPerimeterAllows: (...a: any[]) => guestPerimeterAllowsMock(...a),
+  PERMISSIONS: { VM_VIEW: "vm.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: (...a: any[]) => getConnectionByIdMock(...a),
+}))
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...a: any[]) => pveFetchMock(...a),
+}))
+vi.mock("@/lib/tenant", () => ({
+  getCurrentTenantId: (...a: any[]) => getCurrentTenantIdMock(...a),
+}))
+vi.mock("@/lib/tenant/infraScope", () => ({
+  getTenantInfrastructureScope: (...a: any[]) => getTenantInfrastructureScopeMock(...a),
+  maskingScope: (...a: any[]) => maskingScopeMock(...a),
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    tenant: { findUnique: (...a: any[]) => tenantFindUniqueMock(...a) },
+  },
+}))
+
+const PARAMS = { id: "conn-1", node: "pve1", storage: "local" }
+const QUERY = { content: "iso" }
+const ISOS = [{ volid: "local:iso/debian.iso", content: "iso" }]
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  // Flat-scoped fallback off by default: the denial path stays the denial path.
+  guestPerimeterAllowsMock.mockReset().mockResolvedValue(false)
+  getConnectionByIdMock.mockReset().mockResolvedValue({ id: "c", baseUrl: "https://x:8006", apiToken: "t" })
+  pveFetchMock.mockReset().mockResolvedValue(ISOS)
+  getCurrentTenantIdMock.mockReset().mockResolvedValue("provider-tenant")
+  getTenantInfrastructureScopeMock.mockReset().mockResolvedValue({ kind: "provider" })
+  // provider: no vDC mask, so neither the storage gate nor the slug lookup runs.
+  maskingScopeMock.mockReset().mockReturnValue(null)
+  tenantFindUniqueMock.mockReset().mockResolvedValue({ slug: "acme" })
+})
+
+describe("GET .../nodes/[node]/storage/[storage]/content", () => {
+  it("returns the storage listing when the caller holds vm.view", async () => {
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual(ISOS)
+    // Permission granted, so the guest-derived fallback is never consulted.
+    expect(guestPerimeterAllowsMock).not.toHaveBeenCalled()
+  })
+
+  it("returns the RBAC denial without calling PVE when no guest opens the perimeter", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+
+    expect(res.status).toBe(403)
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  // Issue #262: a pool-scoped user matches no connection resource, so the ISO
+  // picker of the creation wizard needs the guest-derived fallback to answer.
+  it("serves a flat-scoped caller whose guests live on this cluster", async () => {
+    checkPermissionMock.mockResolvedValue(Response.json({ error: "forbidden" }, { status: 403 }))
+    guestPerimeterAllowsMock.mockResolvedValue(true)
+
+    const GET = (await import("./route")).GET as Parameters<typeof callRoute>[0]
+    const res = await callRoute(GET, { params: PARAMS, searchParams: QUERY })
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.data).toEqual(ISOS)
+    expect(guestPerimeterAllowsMock).toHaveBeenCalledWith("conn-1", "vm.view")
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/content/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, guestPerimeterAllows, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 import { prisma } from "@/lib/db/prisma"
@@ -26,8 +26,12 @@ export async function GET(
   try {
     const { id, node, storage } = await ctx.params
 
+    // Flat-scoped callers (vm/tag/pool) never match a connection resource, so
+    // the ISO picker of the creation wizard used to 403 (issue #262). The vDC
+    // storage mask below still applies to them unchanged.
     const denied = await checkPermission(PERMISSIONS.VM_VIEW, "connection", id)
-    if (denied) return denied
+
+    if (denied && !(await guestPerimeterAllows(id, PERMISSIONS.VM_VIEW))) return denied
 
     // Tenants may browse content (mainly ISOs for the VM create picker) ONLY
     // on storages assigned to their vDC — super admins are unrestricted

--- a/frontend/src/app/api/v1/connections/[id]/pools/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/pools/route.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  getRequestGuestScopePerimeter: vi.fn<(...args: any[]) => Promise<any>>(),
+  PERMISSIONS: {
+    CONNECTION_VIEW: 'connection.view',
+  },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+import { GET } from './route'
+import { checkPermission, getRequestGuestScopePerimeter } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+
+const checkPermissionMock = checkPermission as any
+const getRequestGuestScopePerimeterMock = getRequestGuestScopePerimeter as any
+const getConnectionByIdMock = getConnectionById as any
+const pveFetchMock = pveFetch as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getRequestGuestScopePerimeterMock.mockResolvedValue(null)
+  getConnectionByIdMock.mockResolvedValue({ id: 'c1' })
+  pveFetchMock.mockResolvedValue([
+    { poolid: 'p1', comment: 'first pool' },
+    { poolid: 'p2', comment: null },
+  ])
+})
+
+describe('GET /api/v1/connections/[id]/pools', () => {
+  it('returns the full pool list to a connection-scoped caller', async () => {
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.data.map((p: any) => p.poolid)).toEqual(['p1', 'p2'])
+    expect(body.restricted).toBe(false)
+    // No fallback needed, so the perimeter is never resolved.
+    expect(getRequestGuestScopePerimeterMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/v1/connections/[id]/pools: flat-scoped fallback', () => {
+  it('lets a flat-scoped caller through and narrows the list to their pools', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue({
+      restricted: true,
+      holdsPermission: true,
+      hasVisibleGuests: true,
+      pools: new Set(['p1']),
+      nodes: new Set(['n1']),
+    })
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.data).toEqual([{ poolid: 'p1', comment: 'first pool' }])
+    expect(body.restricted).toBe(true)
+  })
+
+  it('keeps the 403 when the caller owns no visible guest on this connection', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue({
+      restricted: true,
+      holdsPermission: true,
+      hasVisibleGuests: false,
+      pools: new Set(['p1']),
+      nodes: new Set<string>(),
+    })
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(403)
+    expect(body.error).toBe('Permission denied')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the 403 when the caller holds the permission nowhere', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue({
+      restricted: true,
+      holdsPermission: false,
+      hasVisibleGuests: true,
+      pools: new Set(['p1']),
+      nodes: new Set(['n1']),
+    })
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(403)
+    expect(body.error).toBe('Permission denied')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the 403 when there is no perimeter at all (token or anonymous caller)', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue(null)
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(403)
+    expect(body.error).toBe('Permission denied')
+    expect(pveFetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/pools/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/pools/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { pveFetch } from '@/lib/proxmox/client'
 import { getConnectionById } from '@/lib/connections/getConnection'
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, getRequestGuestScopePerimeter, PERMISSIONS } from "@/lib/rbac"
 
 export const runtime = 'nodejs'
 
@@ -13,8 +13,15 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
 
     if (!connId) return NextResponse.json({ error: 'Missing params.id' }, { status: 400 })
 
+    // A flat-scoped caller (vm/tag/pool) can never satisfy a connection-scoped
+    // check, so they used to 403 here and the Create VM wizard showed an empty
+    // Resource Pool dropdown (issue #262). Fall back to the guest-derived
+    // perimeter: through only if they hold connection.view somewhere AND own a
+    // guest on this cluster, and then only their own pools are returned.
     const denied = await checkPermission(PERMISSIONS.CONNECTION_VIEW, "connection", connId)
-    if (denied) return denied
+    const perimeter = denied ? await getRequestGuestScopePerimeter(connId) : null
+
+    if (denied && !(perimeter?.holdsPermission && perimeter.hasVisibleGuests)) return denied
 
     const conn = await getConnectionById(connId)
 
@@ -25,11 +32,19 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // Récupérer la liste des pools - pveFetch retourne directement data
     const pools = await pveFetch<any[]>(conn, '/pools')
 
+    const visiblePools = perimeter?.restricted
+      ? (pools || []).filter((p: any) => p?.poolid && perimeter.pools.has(p.poolid))
+      : pools || []
+
     return NextResponse.json({
-      data: (pools || []).map((p: any) => ({
+      data: visiblePools.map((p: any) => ({
         poolid: p.poolid,
         comment: p.comment || null
-      }))
+      })),
+      // Tells the provisioning wizards that this list IS the caller's scope,
+      // so they surface the pool choice (and drop the "no pool" option) even
+      // for a non-admin: their guest has to land in one of these.
+      restricted: !!perimeter?.restricted,
     })
   } catch (error: any) {
     console.error('Error fetching pools:', error)

--- a/frontend/src/app/api/v1/connections/[id]/storage/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/storage/route.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  getRequestGuestScopePerimeter: vi.fn<(...args: any[]) => Promise<any>>(),
   PERMISSIONS: {
     CONNECTION_VIEW: 'connection.view',
   },
@@ -27,13 +28,14 @@ vi.mock('@/lib/tenant/infraScope', () => ({
 }))
 
 import { GET } from './route'
-import { checkPermission } from '@/lib/rbac'
+import { checkPermission, getRequestGuestScopePerimeter } from '@/lib/rbac'
 import { getConnectionById } from '@/lib/connections/getConnection'
 import { pveFetch } from '@/lib/proxmox/client'
 import { getCurrentTenantId } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
 
 const checkPermissionMock = checkPermission as any
+const getRequestGuestScopePerimeterMock = getRequestGuestScopePerimeter as any
 const getConnectionByIdMock = getConnectionById as any
 const pveFetchMock = pveFetch as any
 const getCurrentTenantIdMock = getCurrentTenantId as any
@@ -43,6 +45,7 @@ const maskingScopeMock = maskingScope as any
 beforeEach(() => {
   vi.clearAllMocks()
   checkPermissionMock.mockResolvedValue(null)
+  getRequestGuestScopePerimeterMock.mockResolvedValue(null)
   getConnectionByIdMock.mockResolvedValue({ id: 'c1' })
   pveFetchMock.mockImplementation((_conn: any, path: string) => {
     if (path === '/cluster/resources') {
@@ -84,5 +87,93 @@ describe('GET /api/v1/connections/[id]/storage', () => {
     const body = await readJson<any>(res)
 
     expect(body.data.find((s: any) => s.storage === 'zpool')).toBeUndefined()
+  })
+})
+
+describe('GET /api/v1/connections/[id]/storage: flat-scoped narrowing', () => {
+  // A cluster with one shared storage spread over two nodes, plus one local
+  // storage per node. The flat-scoped caller only owns a guest on n1.
+  const withThreeStorages = () => {
+    pveFetchMock.mockImplementation((_conn: any, path: string) => {
+      if (path === '/cluster/resources') {
+        return Promise.resolve([
+          { type: 'storage', storage: 'shared-nfs', node: 'n1', disk: 1, maxdisk: 4, status: 'available' },
+          { type: 'storage', storage: 'shared-nfs', node: 'n2', disk: 1, maxdisk: 4, status: 'available' },
+          { type: 'storage', storage: 'local-n1', node: 'n1', disk: 1, maxdisk: 2, status: 'available' },
+          { type: 'storage', storage: 'local-n2', node: 'n2', disk: 1, maxdisk: 2, status: 'available' },
+        ])
+      }
+      if (path === '/storage') {
+        return Promise.resolve([
+          { storage: 'shared-nfs', type: 'nfs', content: 'images' },
+          { storage: 'local-n1', type: 'dir', content: 'images' },
+          { storage: 'local-n2', type: 'dir', content: 'images' },
+        ])
+      }
+      return Promise.resolve([])
+    })
+  }
+
+  const restrictedPerimeter = () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    getRequestGuestScopePerimeterMock.mockResolvedValue({
+      restricted: true,
+      holdsPermission: true,
+      hasVisibleGuests: true,
+      pools: new Set(['p1']),
+      nodes: new Set(['n1']),
+    })
+  }
+
+  it('keeps every shared storage, usable from anywhere on the cluster', async () => {
+    withThreeStorages()
+    restrictedPerimeter()
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+    const shared = body.data.find((s: any) => s.storage === 'shared-nfs')
+
+    expect(res.status).toBe(200)
+    expect(shared).toBeDefined()
+    expect(shared.shared).toBe(true)
+    expect(shared.nodes).toEqual(['n1', 'n2'])
+  })
+
+  it('keeps a local storage sitting on a node that hosts one of their guests', async () => {
+    withThreeStorages()
+    restrictedPerimeter()
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+    const local = body.data.find((s: any) => s.storage === 'local-n1')
+
+    expect(res.status).toBe(200)
+    expect(local).toBeDefined()
+    expect(local.shared).toBe(false)
+    expect(local.node).toBe('n1')
+  })
+
+  it('drops a local storage on a node outside their perimeter', async () => {
+    withThreeStorages()
+    restrictedPerimeter()
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.data.find((s: any) => s.storage === 'local-n2')).toBeUndefined()
+    expect(body.data.map((s: any) => s.storage).sort()).toEqual(['local-n1', 'shared-nfs'])
+  })
+
+  it('leaves the list untouched for a connection-scoped caller', async () => {
+    withThreeStorages()
+
+    const res = await callRoute(GET as any, { method: 'GET', params: { id: 'c1' } })
+    const body = await readJson<any>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.data.map((s: any) => s.storage).sort()).toEqual(['local-n1', 'local-n2', 'shared-nfs'])
+    // No fallback needed, so the perimeter is never resolved.
+    expect(getRequestGuestScopePerimeterMock).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/storage/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/storage/route.ts
@@ -4,7 +4,7 @@ import { pveFetch } from "@/lib/proxmox/client"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { isSharedStorage } from "@/lib/proxmox/storage"
 import { formatBytes } from "@/utils/format"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, getRequestGuestScopePerimeter, PERMISSIONS } from "@/lib/rbac"
 import { getCurrentTenantId } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 
@@ -20,8 +20,15 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
     // connection.view (not storage.view) so tenant admins can see the list.
     // The endpoint already filters results by vDC scope below, so a tenant
     // only sees the storages actually assigned to their vDC.
+    //
+    // Flat-scoped callers (vm/tag/pool) never match a connection-scoped check,
+    // so they used to 403 here and the Create VM wizard showed an empty
+    // Storage dropdown (issue #262). They come in through the guest-derived
+    // perimeter instead, and the payload is narrowed to it further down.
     const denied = await checkPermission(PERMISSIONS.CONNECTION_VIEW, "connection", id)
-    if (denied) return denied
+    const perimeter = denied ? await getRequestGuestScopePerimeter(id) : null
+
+    if (denied && !(perimeter?.holdsPermission && perimeter.hasVisibleGuests)) return denied
 
     const conn = await getConnectionById(id)
 
@@ -191,6 +198,20 @@ export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> 
       } else {
         result = []
       }
+    }
+
+    // RBAC narrowing for flat-scoped callers (vm/tag/pool). A PVE storage
+    // belongs to no pool, so filtering by pool membership would return an
+    // empty list and leave the Create VM wizard with nothing to pick
+    // (issue #262). Return the shared storages, usable from anywhere on the
+    // cluster, plus the local ones sitting on a node that already hosts one of
+    // their guests. Everything else stays hidden.
+    if (perimeter?.restricted) {
+      result = result.filter((s: any) => {
+        if (s.shared) return true
+        const nodes: string[] = Array.isArray(s.nodes) ? s.nodes : s.node ? [s.node] : []
+        return nodes.some(n => perimeter.nodes.has(n))
+      })
     }
 
     // Trier: partagés d'abord, puis par utilisation décroissante

--- a/frontend/src/app/api/v1/connections/connectionListScope.test.ts
+++ b/frontend/src/app/api/v1/connections/connectionListScope.test.ts
@@ -2,14 +2,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../__tests__/setup/route-test"
 
-const { findManyGlobalMock, findManySessionMock, getInfraMock, checkPermissionMock, getRBACContextMock, getRbacInfraScopeMock } = vi.hoisted(() => ({
+const { findManyGlobalMock, findManySessionMock, getInfraMock, checkPermissionMock, getRBACContextMock, getRbacInfraScopeMock, getGuestVisibleConnectionIdsMock } = vi.hoisted(() => ({
   findManyGlobalMock: vi.fn(),
   findManySessionMock: vi.fn(),
   getInfraMock: vi.fn(),
   checkPermissionMock: vi.fn(),
   getRBACContextMock: vi.fn(),
   getRbacInfraScopeMock: vi.fn(),
+  getGuestVisibleConnectionIdsMock: vi.fn(),
 }))
+
+/** Minimal connection row, only the columns the route selects. */
+const connRow = (id: string) => ({
+  id, name: id, type: "pve", tenantId: null, baseUrl: "", behindProxy: false, insecureTLS: false,
+  hasCeph: false, latitude: null, longitude: null, locationLabel: null, country: null,
+  fingerprint: null, sshEnabled: false, sshPort: 22, sshUser: "root", sshAuthMethod: null,
+  sshUseSudo: false, sshKeyEnc: null, sshPassEnc: null, createdAt: new Date(), updatedAt: new Date(),
+  hosts: [],
+})
 
 vi.mock("@/lib/tenant", () => ({
   getSessionPrisma: async () => ({ connection: { findMany: findManySessionMock } }),
@@ -24,6 +34,7 @@ vi.mock("@/lib/rbac", () => ({
   PERMISSIONS: { CONNECTION_VIEW: "connection.view", CONNECTION_MANAGE: "connection.manage" },
   getRBACContext: () => getRBACContextMock(),
   getRbacInfraScope: (...a: any[]) => getRbacInfraScopeMock(...a),
+  getGuestVisibleConnectionIds: (...a: any[]) => getGuestVisibleConnectionIdsMock(...a),
   filterVisibleConnections: (list: Array<{ id: string }>, scope: any) => {
     if (scope === null) return list
     return list.filter((item: { id: string }) => {
@@ -48,6 +59,7 @@ beforeEach(() => {
   // Default: no RBAC context (unauthenticated / unrestricted path)
   getRBACContextMock.mockReset().mockResolvedValue(null)
   getRbacInfraScopeMock.mockReset().mockResolvedValue(null)
+  getGuestVisibleConnectionIdsMock.mockReset().mockResolvedValue(new Set<string>())
 })
 
 describe("GET /api/v1/connections scope", () => {
@@ -100,6 +112,50 @@ describe("GET /api/v1/connections scope", () => {
     expect(body.data[0].id).toBe("connA")
     // provider where clause must not have an id filter (prisma query is untouched)
     expect(findManyGlobalMock.mock.calls[0][0].where?.id).toBeUndefined()
+  })
+
+  // Issue #262: the wizards ask for the guest-derived perimeter on top of the
+  // strict one, otherwise a pool-scoped user gets no cluster to create on.
+  it("guest-derived scope: hidden by default, added back with includeGuestScoped", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "user-pool", isAdmin: false, tenantId: "tenant-x" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map(),
+      guestDerived: true,
+    })
+    getGuestVisibleConnectionIdsMock.mockResolvedValue(new Set(["connB"]))
+    findManyGlobalMock.mockResolvedValue([connRow("connA"), connRow("connB")])
+
+    const { GET } = await import("./route")
+
+    const strict = await callRoute(GET, { method: "GET" })
+    expect((await strict.json()).data).toHaveLength(0)
+    expect(getGuestVisibleConnectionIdsMock).not.toHaveBeenCalled()
+
+    const widened = await callRoute(GET, { method: "GET", searchParams: { includeGuestScoped: "1" } })
+    const body = await widened.json()
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].id).toBe("connB")
+  })
+
+  it("includeGuestScoped is inert for an infra-scoped user", async () => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getRBACContextMock.mockResolvedValue({ userId: "user-node", isAdmin: false, tenantId: "tenant-x" })
+    getRbacInfraScopeMock.mockResolvedValue({
+      fullConnections: new Set(["connA"]),
+      nodesByConnection: new Map(),
+      guestDerived: false,
+    })
+    findManyGlobalMock.mockResolvedValue([connRow("connA"), connRow("connB")])
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { includeGuestScoped: "1" } })
+    const body = await res.json()
+
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0].id).toBe("connA")
+    expect(getGuestVisibleConnectionIdsMock).not.toHaveBeenCalled()
   })
 
   it("provider + admin: full list returned, getRbacInfraScope not consulted", async () => {

--- a/frontend/src/app/api/v1/connections/route.ts
+++ b/frontend/src/app/api/v1/connections/route.ts
@@ -6,7 +6,7 @@ import { getSessionPrisma, getCurrentTenantId, DEFAULT_TENANT_ID } from "@/lib/t
 import { prisma as globalPrisma } from "@/lib/db/prisma"
 import { getTenantInfrastructureScope } from "@/lib/tenant/infraScope"
 import { encryptSecret } from "@/lib/crypto/secret"
-import { checkPermission, PERMISSIONS, getRBACContext, getRbacInfraScope, filterVisibleConnections } from "@/lib/rbac"
+import { checkPermission, PERMISSIONS, getRBACContext, getRbacInfraScope, filterVisibleConnections, getGuestVisibleConnectionIds } from "@/lib/rbac"
 import { createConnectionSchema } from "@/lib/schemas"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -28,6 +28,9 @@ export async function GET(req: Request) {
 
     const url = new URL(req.url)
     const typeFilter = url.searchParams.get('type') // 'pve' | 'pbs' | null
+    // Provisioning wizards ask for the guest-derived perimeter on top of the
+    // strict one (see the widening below).
+    const guestScoped = url.searchParams.get('includeGuestScoped') === '1'
     const hasCephFilter = url.searchParams.get('hasCeph') // 'true' | null
 
     const where: any = {}
@@ -134,7 +137,20 @@ export async function GET(req: Request) {
     // provider branch where clause is not touched (preserves existing behaviour
     // for admin/null scope). filterVisibleConnections is a no-op when rbacScope
     // is null (admin or unrestricted user).
-    const visibleConnections = filterVisibleConnections(connections, rbacScope)
+    const visibleIds = new Set(filterVisibleConnections(connections, rbacScope).map(c => c.id))
+
+    // Opt-in widening for the provisioning wizards (issue #262). A flat-scoped
+    // caller (vm/tag/pool) is deliberately absent from this list: they get no
+    // topology (issue #633). But Create VM / Create LXC cannot offer a
+    // placement target without a cluster, so when the caller asks for it we add
+    // back the connections that already host one of their guests. The inventory
+    // stream reveals exactly that much to them, so nothing new leaks here.
+    if (guestScoped && rbacScope?.guestDerived && rbacCtx?.userId) {
+      const guestConnIds = await getGuestVisibleConnectionIds(rbacCtx.userId, rbacCtx.tenantId)
+      for (const connId of guestConnIds) visibleIds.add(connId)
+    }
+
+    const visibleConnections = connections.filter(c => visibleIds.has(c.id))
 
     // Calculer sshConfigured en mémoire sans N+1 queries
     const connectionsWithSSHStatus = visibleConnections.map((conn) => {

--- a/frontend/src/lib/rbac/guestScopePerimeter.test.ts
+++ b/frontend/src/lib/rbac/guestScopePerimeter.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const { headersMock, getServerSessionMock } = vi.hoisted(() => ({
+  headersMock: vi.fn<() => Promise<Headers>>(),
+  getServerSessionMock: vi.fn<() => Promise<any>>(),
+}))
+
+vi.mock('next/headers', () => ({ headers: headersMock }))
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+
+import { prismaTest, truncate } from '@/__tests__/setup/prisma-test'
+import { seedDefaultTenant } from '@/__tests__/setup/apiTokens'
+import { setCachedInventory, invalidateInventoryCache } from '@/lib/cache/inventoryCache'
+import {
+  getAccessiblePools,
+  getGuestScopePerimeter,
+  getGuestVisibleConnectionIds,
+  PERMISSIONS,
+} from './index'
+
+// Issue #262: a caller holding only flat scopes (vm/tag/pool) can never match a
+// connection-scoped permission check, which used to 403 them out of the routes
+// the Create VM wizard needs. The perimeter below is the fallback those routes
+// use, so it must be exact in both directions: wide enough to unblock the
+// wizard, narrow enough never to hand over a cluster the caller cannot see.
+
+const USER = 'user-perimeter'
+
+/** Two clusters: the caller's guest sits on conn-1/node1, conn-2 is foreign. */
+const primeInventory = () =>
+  setCachedInventory(
+    {
+      storages: [],
+      clusters: [
+        {
+          id: 'conn-1',
+          nodes: [
+            { node: 'node1', guests: [{ type: 'qemu', vmid: 100, pool: 'district-a', tags: 'prod' }] },
+            { node: 'node2', guests: [{ type: 'qemu', vmid: 101, pool: 'district-b' }] },
+          ],
+        },
+        {
+          id: 'conn-2',
+          nodes: [{ node: 'other1', guests: [{ type: 'qemu', vmid: 200, pool: 'district-b' }] }],
+        },
+      ],
+    } as any,
+    'default',
+  )
+
+async function seedGrants(
+  scopes: Array<{ scopeType: string; scopeTarget: string | null; permissions: string[] }>,
+) {
+  const now = new Date()
+  await prismaTest.user.create({
+    data: { id: USER, email: 'perimeter@test.local', createdAt: now, updatedAt: now },
+  })
+
+  const permissionIds = new Map<string, string>()
+  let seq = 0
+
+  for (const scope of scopes) {
+    for (const permission of scope.permissions) {
+      if (!permissionIds.has(permission)) {
+        const id = `perm_${permissionIds.size}`
+        permissionIds.set(permission, id)
+        await prismaTest.rbacPermission.create({
+          data: { id, name: permission, category: permission.split('.')[0] },
+        })
+      }
+      await prismaTest.rbacUserPermission.create({
+        data: {
+          id: `grant-${seq++}`,
+          userId: USER,
+          permissionId: permissionIds.get(permission) as string,
+          scopeType: scope.scopeType,
+          scopeTarget: scope.scopeTarget,
+          tenantId: 'default',
+          grantedAt: now,
+        },
+      })
+    }
+  }
+}
+
+const poolScoped = () =>
+  seedGrants([
+    {
+      scopeType: 'pool',
+      scopeTarget: 'district-a',
+      permissions: [PERMISSIONS.VM_VIEW, PERMISSIONS.VM_CREATE, PERMISSIONS.CONNECTION_VIEW],
+    },
+  ])
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  headersMock.mockResolvedValue(new Headers())
+  getServerSessionMock.mockResolvedValue(null)
+  invalidateInventoryCache()
+  await truncate(['api_tokens', 'tenants', 'users', 'rbac_permissions'])
+  await seedDefaultTenant()
+})
+
+describe('getGuestScopePerimeter, flat-scoped caller', () => {
+  it('opens the connection hosting their guest and reports its pool and node', async () => {
+    await poolScoped()
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.restricted).toBe(true)
+    expect(perimeter.holdsPermission).toBe(true)
+    expect(perimeter.hasVisibleGuests).toBe(true)
+    expect([...perimeter.pools]).toEqual(['district-a'])
+    expect([...perimeter.nodes]).toEqual(['node1'])
+  })
+
+  it('stays shut on a connection where they own nothing', async () => {
+    await poolScoped()
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-2', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.restricted).toBe(true)
+    expect(perimeter.hasVisibleGuests).toBe(false)
+    expect([...perimeter.nodes]).toEqual([])
+  })
+
+  it('fails closed on an inventory cache miss', async () => {
+    await poolScoped()
+    // no primeInventory() on purpose
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.restricted).toBe(true)
+    expect(perimeter.hasVisibleGuests).toBe(false)
+    // The pool grant is still reported: the gate is what refuses, not the list.
+    expect([...perimeter.pools]).toEqual(['district-a'])
+  })
+
+  it('reports holdsPermission false when no grant carries the permission', async () => {
+    await seedGrants([
+      { scopeType: 'pool', scopeTarget: 'district-a', permissions: [PERMISSIONS.VM_VIEW] },
+    ])
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.holdsPermission).toBe(false)
+    // Guests are still visible; the route is what turns this into a 403.
+    expect(perimeter.hasVisibleGuests).toBe(true)
+  })
+
+  it('derives the pools from the guests for a tag scope, which has no pool grant', async () => {
+    await seedGrants([
+      {
+        scopeType: 'tag',
+        scopeTarget: 'prod',
+        permissions: [PERMISSIONS.VM_VIEW, PERMISSIONS.CONNECTION_VIEW],
+      },
+    ])
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.hasVisibleGuests).toBe(true)
+    // Only the tagged guest counts, so district-b never shows up.
+    expect([...perimeter.pools]).toEqual(['district-a'])
+    expect([...perimeter.nodes]).toEqual(['node1'])
+  })
+})
+
+describe('getGuestScopePerimeter, callers that must not be narrowed', () => {
+  it('an infra grant outranks a pool grant held at the same time', async () => {
+    await seedGrants([
+      { scopeType: 'connection', scopeTarget: 'conn-1', permissions: [PERMISSIONS.CONNECTION_VIEW] },
+      { scopeType: 'pool', scopeTarget: 'district-a', permissions: [PERMISSIONS.CONNECTION_VIEW] },
+    ])
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.restricted).toBe(false)
+    expect(perimeter.holdsPermission).toBe(true)
+  })
+
+  it('a global grant is never narrowed', async () => {
+    await seedGrants([
+      { scopeType: 'global', scopeTarget: null, permissions: [PERMISSIONS.CONNECTION_VIEW] },
+    ])
+    primeInventory()
+
+    const perimeter = await getGuestScopePerimeter(USER, 'conn-1', PERMISSIONS.CONNECTION_VIEW, 'default')
+
+    expect(perimeter.restricted).toBe(false)
+  })
+})
+
+describe('getAccessiblePools', () => {
+  it('returns the caller own pools on that connection', async () => {
+    await poolScoped()
+    primeInventory()
+
+    const accessible = await getAccessiblePools(USER, 'conn-1', 'default')
+
+    expect(accessible.restricted).toBe(true)
+    expect([...accessible.pools]).toEqual(['district-a'])
+  })
+
+  it('reports no narrowing for a connection-scoped caller', async () => {
+    await seedGrants([
+      { scopeType: 'connection', scopeTarget: 'conn-1', permissions: [PERMISSIONS.CONNECTION_VIEW] },
+    ])
+    primeInventory()
+
+    const accessible = await getAccessiblePools(USER, 'conn-1', 'default')
+
+    expect(accessible.restricted).toBe(false)
+    expect([...accessible.pools]).toEqual([])
+  })
+})
+
+describe('getGuestVisibleConnectionIds', () => {
+  it('keeps only the connections hosting a visible guest', async () => {
+    await poolScoped()
+    primeInventory()
+
+    expect([...(await getGuestVisibleConnectionIds(USER, 'default'))]).toEqual(['conn-1'])
+  })
+
+  it('returns nothing on a cache miss', async () => {
+    await poolScoped()
+
+    expect([...(await getGuestVisibleConnectionIds(USER, 'default'))]).toEqual([])
+  })
+})

--- a/frontend/src/lib/rbac/index.ts
+++ b/frontend/src/lib/rbac/index.ts
@@ -12,6 +12,7 @@ import { NextResponse } from "next/server"
 import { prisma } from "@/lib/db/prisma"
 import { getPrincipal, rejectionToResponse, type Principal } from "@/lib/auth/principal"
 import { resolveVmMeta } from "@/lib/cache/vmMetaCache"
+import { getTenantInventoriesFromCache } from "@/lib/cache/inventoryCache"
 import { DEFAULT_TENANT_ID } from "@/lib/tenant"
 import {
   deriveRbacInfraScope,
@@ -849,4 +850,219 @@ export async function loadGuestVisibilityCheck(
       pool: guest.pool || undefined,
     })
   }
+}
+
+/**
+ * Scope kinds that carry an infrastructure perimeter. Holding one of them
+ * outranks any flat (vm/tag/pool) narrowing: an operator scoped to a whole
+ * cluster keeps seeing every pool of that cluster, even when they also hold a
+ * pool grant elsewhere (issue #262 acceptance criteria: no regression for
+ * Global and Cluster/Connection scopes).
+ */
+const INFRA_GRANT_SCOPES = new Set(["global", "connection", "node"])
+
+export type GuestScopePerimeter = {
+  /**
+   * True when the caller only holds flat scopes (vm/tag/pool), so everything a
+   * connection-level route returns must be narrowed to what their guests
+   * justify. False for admins, tokens and any infra-level grant: no narrowing.
+   */
+  restricted: boolean
+  /** The caller holds `permission` on at least one grant, whatever its scope. */
+  holdsPermission: boolean
+  /** At least one guest currently hosted on this connection is visible. */
+  hasVisibleGuests: boolean
+  /** Pools the caller may see on this connection. Only set when `restricted`. */
+  pools: Set<string>
+  /** Nodes hosting at least one visible guest. Only set when `restricted`. */
+  nodes: Set<string>
+}
+
+/**
+ * Resolve what a flat-scoped caller (vm/tag/pool) may legitimately see on ONE
+ * connection, derived from the guests they can already see there.
+ *
+ * `scopeMatches` can never satisfy a `"connection"` resource check for such a
+ * caller (a connection carries no tag and no pool), so every connection-scoped
+ * read route 403s on them, including the two the Create VM wizard needs
+ * (issue #262). The perimeter below is what those routes use instead: let the
+ * caller through when they hold the permission AND own a guest on the cluster,
+ * then narrow the payload to `pools` / `nodes`.
+ *
+ * Nothing here widens what the user already knows: the inventory stream
+ * already sends them their guests along with the cluster and node hosting them
+ * (issue #633, guest-derived perimeter). It only stops the same routes from
+ * answering with the whole cluster.
+ *
+ * Fails closed: an inventory cache miss yields `hasVisibleGuests: false`, so
+ * the caller keeps the 403 rather than receiving an unnarrowed payload.
+ */
+export async function getGuestScopePerimeter(
+  principalOrUserId: string | Principal,
+  connId: string,
+  permission: string = PERMISSIONS.CONNECTION_VIEW,
+  tenantId?: string,
+): Promise<GuestScopePerimeter> {
+  const unrestricted: GuestScopePerimeter = {
+    restricted: false,
+    holdsPermission: true,
+    hasVisibleGuests: false,
+    pools: new Set<string>(),
+    nodes: new Set<string>(),
+  }
+
+  // A token carries flat scope permissions plus a connection perimeter, never
+  // a pool grant. checkTokenPermission already decided; nothing to widen.
+  if (asTokenPrincipal(principalOrUserId)) return unrestricted
+
+  const userId = toUserId(principalOrUserId)
+  const tid = resolveGrantTenantId(principalOrUserId, tenantId)
+  const grants = await loadUserGrants(userId, tid)
+  if (grants.superAdmin) return unrestricted
+
+  let holdsPermission = false
+  const grantedPools = new Set<string>()
+  for (const g of grants.byScope) {
+    const carries = g.permissions.has(permission)
+    if (carries) holdsPermission = true
+    if (carries && INFRA_GRANT_SCOPES.has(g.scopeType)) {
+      return { ...unrestricted, holdsPermission: true }
+    }
+    if (g.scopeType === "pool" && g.scopeTarget) grantedPools.add(g.scopeTarget)
+  }
+
+  // Guest-derived half: the pools and nodes the caller's own guests sit in.
+  // Covers tag scopes too, which have no pool grant to read from.
+  const isVisible = await loadGuestVisibilityCheck(principalOrUserId, PERMISSIONS.VM_VIEW, tid)
+  const found = scanVisibleGuests(tid, isVisible, connId).get(connId)
+  const pools = new Set<string>(grantedPools)
+
+  for (const pool of found?.pools ?? []) pools.add(pool)
+
+  return {
+    restricted: true,
+    holdsPermission,
+    hasVisibleGuests: !!found,
+    pools,
+    nodes: found?.nodes ?? new Set<string>(),
+  }
+}
+
+/**
+ * Walk the cached inventory and collect, per connection, the nodes and pools
+ * holding a guest the caller can see. Connections without a single visible
+ * guest are absent from the map, which is what makes it usable as a gate.
+ *
+ * Reads the cache only: on a miss the caller is treated as seeing nothing,
+ * which keeps every consumer fail-closed.
+ */
+function scanVisibleGuests(
+  tenantId: string,
+  isVisible: GuestVisibilityCheck,
+  onlyConnId?: string,
+): Map<string, { nodes: Set<string>; pools: Set<string> }> {
+  const byConnection = new Map<string, { nodes: Set<string>; pools: Set<string> }>()
+
+  for (const inventory of getTenantInventoriesFromCache(tenantId)) {
+    for (const cluster of (inventory.clusters ?? []) as any[]) {
+      const connId = cluster?.id
+      if (!connId) continue
+      if (onlyConnId !== undefined && connId !== onlyConnId) continue
+      for (const node of (cluster.nodes ?? []) as any[]) {
+        for (const guest of (node?.guests ?? []) as any[]) {
+          if (
+            !isVisible({
+              connId,
+              node: node.node,
+              type: guest.type,
+              vmid: guest.vmid,
+              tags: guest.tags,
+              pool: guest.pool,
+            })
+          ) {
+            continue
+          }
+          let entry = byConnection.get(connId)
+          if (!entry) {
+            entry = { nodes: new Set<string>(), pools: new Set<string>() }
+            byConnection.set(connId, entry)
+          }
+          if (node.node) entry.nodes.add(node.node)
+          if (guest.pool) entry.pools.add(guest.pool)
+        }
+      }
+    }
+  }
+
+  return byConnection
+}
+
+/**
+ * Connections currently hosting at least one guest the caller can see.
+ *
+ * Companion of `filterVisibleConnections`, which stays strict on purpose: a
+ * flat-scoped user has no business enumerating connections in the inventory.
+ * Provisioning is the exception, since a VM cannot be created without naming a
+ * cluster and a node, hence a separate opt-in helper rather than a relaxation
+ * of the default perimeter.
+ */
+export async function getGuestVisibleConnectionIds(
+  principalOrUserId: string | Principal,
+  tenantId?: string,
+): Promise<Set<string>> {
+  if (asTokenPrincipal(principalOrUserId)) return new Set<string>()
+  const tid = resolveGrantTenantId(principalOrUserId, tenantId)
+  const isVisible = await loadGuestVisibilityCheck(principalOrUserId, PERMISSIONS.VM_VIEW, tid)
+  return new Set(scanVisibleGuests(tid, isVisible).keys())
+}
+
+/**
+ * Pools a caller may see on one connection. `restricted: false` means no
+ * narrowing at all (admin, token, or an infra-level grant), so the caller
+ * keeps the full list the connection exposes.
+ *
+ * Thin read of {@link getGuestScopePerimeter}; use that one directly when the
+ * node perimeter or the gate decision is needed too.
+ */
+export async function getAccessiblePools(
+  principalOrUserId: string | Principal,
+  connId: string,
+  tenantId?: string,
+): Promise<{ restricted: boolean; pools: Set<string> }> {
+  const perimeter = await getGuestScopePerimeter(
+    principalOrUserId,
+    connId,
+    PERMISSIONS.CONNECTION_VIEW,
+    tenantId,
+  )
+  return { restricted: perimeter.restricted, pools: perimeter.pools }
+}
+
+/**
+ * Request-scoped wrapper over {@link getGuestScopePerimeter}: resolves the
+ * caller from the session first. Returns null when there is no session user
+ * (unauthenticated, or a token principal, which never holds a pool grant), so
+ * a route can simply keep its 403 in that case.
+ */
+export async function getRequestGuestScopePerimeter(
+  connId: string,
+  permission: string = PERMISSIONS.CONNECTION_VIEW,
+): Promise<GuestScopePerimeter | null> {
+  const ctx = await getRBACContext()
+  if (!ctx?.userId) return null
+  return getGuestScopePerimeter(ctx.userId, connId, permission, ctx.tenantId)
+}
+
+/**
+ * Boolean form of {@link getRequestGuestScopePerimeter} for the routes that
+ * only need the gate, not the perimeter: connection-level facts (bridges, CPU
+ * models, storage contents) a flat-scoped caller must be able to read to fill
+ * in the creation wizard. Placement is cluster-wide by design, so the node in
+ * the URL is not required to already host one of their guests.
+ *
+ * Use as `if (denied && !(await guestPerimeterAllows(id, PERMISSIONS.X))) return denied`.
+ */
+export async function guestPerimeterAllows(connId: string, permission: string): Promise<boolean> {
+  const perimeter = await getRequestGuestScopePerimeter(connId, permission)
+  return !!(perimeter?.holdsPermission && perimeter.hasVisibleGuests)
 }


### PR DESCRIPTION
## The problem

A grant whose only scope is flat (vm, tag or pool) can never satisfy a connection-scoped permission check. A connection carries no tag and no pool, so `scopeMatches` returns false for it, and the second pass of `checkPermission`, the one that resolves guest metadata, only runs for a `"vm"` resource.

Six of the endpoints the Create VM wizard calls are gated exactly that way, so the wizard was unusable from end to end for a pool-scoped user:

- Resource Pool dropdown empty (`/connections/{id}/pools` returned 403)
- Storage dropdown empty (`/connections/{id}/storage` returned 403)
- Node picker empty, so the wizard could not even leave its first tab: the connection list is deliberately closed to flat scopes, and the wizard derives its nodes from it
- ISO picker, bridge list and CPU model list all refused for the same reason
- and the submit itself refused, so fixing only the dropdowns would have moved the wall rather than removed it

Reported against 1.3.3 by an operator giving district users access to create VMs inside their own resource pool, and still reproducible on main.

## The approach

Resolve, once, what such a caller may legitimately see on a single connection, derived from the guests they can already see there, and let those endpoints fall back to it instead of hard-refusing.

`getGuestScopePerimeter(principal, connId, permission)` reports whether the caller holds the permission at all, whether they own a guest on that cluster, and which pools and nodes those guests sit in. It reuses the guest-derived perimeter introduced for the tag/pool inventory fix, so nothing is widened beyond what the inventory stream already sends these users. The endpoints simply stop answering with the whole cluster.

The gate becomes, everywhere:

```ts
const denied = await checkPermission(PERMISSIONS.X, "connection", id)
const perimeter = denied ? await getRequestGuestScopePerimeter(id) : null
if (denied && !(perimeter?.holdsPermission && perimeter.hasVisibleGuests)) return denied
```

## Decisions worth reviewing

**An infra grant outranks a pool grant held at the same time.** A global, connection or node scope keeps seeing every pool of the cluster, which is what the no-regression acceptance criteria of the issue ask for. Narrowing only applies to a caller who has nothing but flat scopes.

**Fail closed on an inventory cache miss.** No cached inventory means no proven guest, so the caller keeps the 403 rather than receiving an unnarrowed payload. In practice the cache is warm, since the wizard is opened from the inventory.

**Storage is not filtered by pool.** A PVE storage belongs to no pool, so a pool filter would return an empty list and reproduce the original symptom. The caller gets the shared storages, usable anywhere on the cluster, plus the local ones of the nodes already hosting their guests.

**Placement stays cluster-wide.** The wizard keeps offering every node of the cluster rather than only the nodes hosting the caller's guests: a pool is not bound to a node, and restricting it would make the first VM of an empty pool impossible to place.

**Creation is contained.** A restricted caller has their pool applied when a single one is accessible, and is refused with 403 when they ask for one outside their scope. This mirrors the existing vDC pool forcing and stops a user from creating a guest that is invisible to them the moment it exists.

**The connection list stays strict by default.** Flat scopes still get no topology anywhere in the product; the wizards opt in explicitly with `?includeGuestScoped=1`, which adds back only the connections hosting one of their guests.

## Verification

Verified end to end against a live cluster with a Tenant Admin account scoped to a single pool.

- the six endpoints answer 200 on the cluster hosting the caller's guest, and all six still answer 403 on a cluster where the caller owns nothing
- storage narrowing measured against the raw PVE payload: 13 storage rows exposed by the cluster, 4 returned (2 shared, plus local and local-lvm of the single node hosting their guest)
- connection list empty without the opt-in, one entry with it, out of three PVE connections
- creation refused with `Resource pool outside your scope` for a pool outside the perimeter, without ever reaching PVE
- pool list narrowing itself is covered by tests rather than the live check: the lab cluster only exposes one pool, so the filtered and unfiltered lists are identical there

Tests: 20 new cases across the touched routes plus 11 on the perimeter helper. New-code coverage measured locally at 87.4 percent (lines and branches), above the 80 percent gate. Full suite green, typecheck and lint at the same baseline as main, production build passes.

Closes #262
