### PR TITLE
Add a dedicated ZFS ARC widget to the dashboard

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.test.ts
@@ -16,7 +16,8 @@ vi.mock("@/lib/proxmox/client", () => ({
 }))
 
 import { POST } from "./route"
-import { callRoute, readJson } from "@/__tests__/setup/route-test"
+import { checkPermission } from "@/lib/rbac"
+import { callRoute, readJson, deniedPermissionResponse } from "@/__tests__/setup/route-test"
 
 beforeEach(() => vi.clearAllMocks())
 
@@ -77,5 +78,107 @@ describe("POST /api/v1/connections/[id]/nodes/trends — ZFS ARC (#617)", () => 
 
     expect(points[0].arc).toBe(2 * GIB)
     expect(points[0].arcPct).toBeNull()
+  })
+})
+
+describe("POST /api/v1/connections/[id]/nodes/trends — shape and guards", () => {
+  it("keeps the CPU ratio inside 0 to 100 whatever the RRD reports", async () => {
+    const points = await trendsFor([
+      { time: 1_700_000_000, cpu: 1.4, mem: GIB, maxmem: 4 * GIB },
+    ])
+
+    expect(points[0].cpu).toBe(100)
+  })
+
+  it("labels a week point with its date, an hour point with its time only", async () => {
+    pveFetch.mockResolvedValue([{ time: 1_700_000_000, cpu: 0.5, mem: GIB, maxmem: 4 * GIB }])
+
+    const res = await callRoute(POST, {
+      params: { id: "c1" },
+      body: { items: [{ node: "pve1" }], timeframe: "week" },
+    })
+
+    const json = await readJson<{ data: Record<string, { t: string }[]> }>(res)
+
+    expect(json?.data["node:pve1"][0].t).toMatch(/^\d{2}\/\d{2} \d{2}:\d{2}$/)
+  })
+
+  it("downsamples an hour series to the point budget of the chart", async () => {
+    const rrd = Array.from({ length: 400 }, (_, i) => ({
+      time: 1_700_000_000 + i * 60, cpu: 0.1, mem: GIB, maxmem: 4 * GIB,
+    }))
+
+    pveFetch.mockResolvedValue(rrd)
+
+    const res = await callRoute(POST, {
+      params: { id: "c1" },
+      body: { items: [{ node: "pve1" }], timeframe: "hour" },
+    })
+
+    const json = await readJson<{ data: Record<string, unknown[]> }>(res)
+
+    expect(json?.data["node:pve1"]).toHaveLength(70)
+  })
+
+  it("answers with an empty map when no node is asked for", async () => {
+    const res = await callRoute(POST, { params: { id: "c1" }, body: { items: [] } })
+
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual({ data: {} })
+    expect(pveFetch).not.toHaveBeenCalled()
+  })
+
+  it("answers with an empty map when the body is not JSON", async () => {
+    const res = await callRoute(POST, { params: { id: "c1" }, body: "not json" })
+
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual({ data: {} })
+  })
+
+  it("rejects a call without a connection id", async () => {
+    const res = await callRoute(POST, { params: {}, body: { items: [{ node: "pve1" }] } })
+
+    expect(res.status).toBe(400)
+  })
+
+  it("passes the permission refusal straight through", async () => {
+    vi.mocked(checkPermission).mockResolvedValueOnce(deniedPermissionResponse() as never)
+
+    const res = await callRoute(POST, {
+      params: { id: "c1" },
+      body: { items: [{ node: "pve1" }] },
+    })
+
+    expect(res.status).toBe(403)
+    expect(pveFetch).not.toHaveBeenCalled()
+  })
+
+  it("keeps the other nodes when one of them fails to answer", async () => {
+    pveFetch.mockImplementation(async (_conn: unknown, path: string) => {
+      if (path.includes("pve1")) throw new Error("unreachable")
+
+      return [{ time: 1_700_000_000, cpu: 0.2, mem: GIB, maxmem: 4 * GIB }]
+    })
+
+    const res = await callRoute(POST, {
+      params: { id: "c1" },
+      body: { items: [{ node: "pve1" }, { node: "pve2" }] },
+    })
+
+    const json = await readJson<{ data: Record<string, unknown[]> }>(res)
+
+    expect(json?.data["node:pve1"]).toEqual([])
+    expect(json?.data["node:pve2"]).toHaveLength(1)
+  })
+
+  it("tolerates an RRD payload that is not a series", async () => {
+    pveFetch.mockResolvedValue({ unexpected: true } as never)
+
+    const res = await callRoute(POST, {
+      params: { id: "c1" },
+      body: { items: [{ node: "pve1" }] },
+    })
+
+    expect(await readJson(res)).toEqual({ data: { "node:pve1": [] } })
   })
 })

--- a/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: vi.fn(async () => null),
+  PERMISSIONS: { NODE_VIEW: "node.view" },
+}))
+vi.mock("@/lib/connections/getConnection", () => ({
+  getConnectionById: vi.fn(async () => ({ id: "c1", baseUrl: "https://h", apiToken: "t" })),
+}))
+vi.mock("@/lib/demo/demo-api", () => ({
+  demoResponse: vi.fn(() => null),
+}))
+const pveFetch = vi.fn()
+vi.mock("@/lib/proxmox/client", () => ({
+  pveFetch: (...args: unknown[]) => pveFetch(...args),
+}))
+
+import { POST } from "./route"
+import { callRoute, readJson } from "@/__tests__/setup/route-test"
+
+beforeEach(() => vi.clearAllMocks())
+
+type Point = { ts: number; cpu: number; ram: number; arc: number | null; arcPct: number | null }
+
+const GIB = 1024 * 1024 * 1024
+
+async function trendsFor(rrd: Record<string, number>[]) {
+  pveFetch.mockResolvedValue(rrd)
+
+  const res = await callRoute(POST, {
+    params: { id: "c1" },
+    body: { items: [{ node: "pve1" }], timeframe: "hour" },
+  })
+
+  expect(res.status).toBe(200)
+  const json = await readJson<{ data: Record<string, Point[]> }>(res)
+
+  return json?.data["node:pve1"] ?? []
+}
+
+describe("POST /api/v1/connections/[id]/nodes/trends — ZFS ARC (#617)", () => {
+  it("exposes arcsize in bytes and as a share of the node memory", async () => {
+    const points = await trendsFor([
+      { time: 1_700_000_000, cpu: 0.1, mem: 4 * GIB, maxmem: 32 * GIB, arcsize: 8 * GIB },
+    ])
+
+    expect(points[0].arc).toBe(8 * GIB)
+    expect(points[0].arcPct).toBe(25)
+  })
+
+  it("reports null on a PVE 8 node, whose RRD has no arcsize column at all", async () => {
+    const points = await trendsFor([
+      { time: 1_700_000_000, cpu: 0.1, mem: 4 * GIB, maxmem: 32 * GIB },
+    ])
+
+    expect(points[0].arc).toBeNull()
+    expect(points[0].arcPct).toBeNull()
+
+    // The pre-existing metrics must keep their exact shape.
+    expect(points[0].cpu).toBe(10)
+    expect(points[0].ram).toBe(13)
+  })
+
+  it("reports null rather than zero on a node without ZFS", async () => {
+    const points = await trendsFor([
+      { time: 1_700_000_000, cpu: 0.1, mem: 4 * GIB, maxmem: 32 * GIB, arcsize: 0 },
+    ])
+
+    expect(points[0].arc).toBeNull()
+    expect(points[0].arcPct).toBeNull()
+  })
+
+  it("leaves arcPct null when the node reports no total memory", async () => {
+    const points = await trendsFor([
+      { time: 1_700_000_000, cpu: 0.1, mem: 0, maxmem: 0, arcsize: 2 * GIB },
+    ])
+
+    expect(points[0].arc).toBe(2 * GIB)
+    expect(points[0].arcPct).toBeNull()
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/trends/route.ts
@@ -57,7 +57,14 @@ function toTrendPoints(rrd: any[], timeframe: string) {
     const memTotal = Number(p.maxmem ?? p.memtotal ?? 0)
     const ramPct = memTotal > 0 ? Math.round(clampPct((memUsed / memTotal) * 100)) : 0
 
-    return { ts: p.time, t: formatTimestamp(d, timeframe), cpu: cpuPct, ram: ramPct }
+    // ZFS ARC: the `arcsize` column only exists in the node RRD schema of PVE 9+,
+    // and a node without ZFS reports 0. Both stay null so the consumer can drop
+    // the node from the series instead of drawing a flat zero line.
+    const arcRaw = Number(p.arcsize)
+    const arc = Number.isFinite(arcRaw) && arcRaw > 0 ? arcRaw : null
+    const arcPct = arc != null && memTotal > 0 ? Math.round(clampPct((arc / memTotal) * 100) * 10) / 10 : null
+
+    return { ts: p.time, t: formatTimestamp(d, timeframe), cpu: cpuPct, ram: ramPct, arc, arcPct }
   })
 }
 

--- a/frontend/src/components/dashboard/widgetRegistry.js
+++ b/frontend/src/components/dashboard/widgetRegistry.js
@@ -29,6 +29,9 @@ const QuickStatsWidget = dynamic(() => import('./widgets/QuickStatsWidget'), { s
 // Infrastructure Global Chart (per-node CPU/RAM)
 const InfraGlobalChartWidget = dynamic(() => import('./widgets/InfraGlobalChartWidget'), { ssr: false })
 
+// ZFS ARC (per-node ARC memory usage)
+const ZfsArcWidget = dynamic(() => import('./widgets/ZfsArcWidget'), { ssr: false })
+
 // VM Heatmap (CPU/RAM utilization grid)
 const VmHeatmapWidget = dynamic(() => import('./widgets/VmHeatmapWidget'), { ssr: false })
 
@@ -309,6 +312,19 @@ export const WIDGET_REGISTRY = {
     noContainer: true,
     requiresInfraScope: true,
     component: InfraGlobalChartWidget,
+  },
+  'zfs-arc': {
+    type: 'zfs-arc',
+    name: 'ZFS ARC',
+    description: 'Per-node ZFS ARC memory usage (PVE 9+)',
+    icon: 'ri-ram-2-line',
+    category: 'resources',
+    defaultSize: { w: 6, h: 5 },
+    minSize: { w: 3, h: 3 },
+    maxSize: { w: 12, h: 20 },
+    noContainer: true,
+    requiresInfraScope: true,
+    component: ZfsArcWidget,
   },
   'vm-heatmap': {
     type: 'vm-heatmap',

--- a/frontend/src/components/dashboard/widgetRegistry.test.tsx
+++ b/frontend/src/components/dashboard/widgetRegistry.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  WIDGET_REGISTRY, WIDGET_CATEGORIES, getWidgetsByCategory, isWidgetVisibleForScope,
+} from './widgetRegistry'
+
+/**
+ * The registry is what the widget picker, the dashboard grid and the RBAC
+ * screen all read, and a malformed entry only shows up at runtime as an
+ * unknown widget card. These checks are cheap insurance on every entry.
+ */
+
+const entries = Object.entries(WIDGET_REGISTRY) as [string, Record<string, unknown>][]
+const categoryIds = new Set(WIDGET_CATEGORIES.map(c => c.id))
+
+describe('WIDGET_REGISTRY', () => {
+  it('keys every entry by its own type', () => {
+    for (const [key, def] of entries) expect(def.type).toBe(key)
+  })
+
+  it('gives every entry the fields the picker and the grid read', () => {
+    for (const [key, def] of entries) {
+      expect(def.name, key).toBeTruthy()
+      expect(def.description, key).toBeTruthy()
+      expect(def.icon, key).toBeTruthy()
+      expect(def.component, key).toBeTruthy()
+      expect(def.defaultSize, key).toBeTruthy()
+    }
+  })
+
+  it('files every entry under a declared category', () => {
+    for (const [key, def] of entries) expect(categoryIds.has(def.category as string), key).toBe(true)
+  })
+
+  it('registers the ZFS ARC widget under Resources, behind the infrastructure scope', () => {
+    const def = WIDGET_REGISTRY['zfs-arc']
+
+    expect(def).toBeTruthy()
+    expect(def.category).toBe('resources')
+    expect(def.requiresInfraScope).toBe(true)
+    expect(def.defaultSize).toEqual({ w: 6, h: 5 })
+  })
+})
+
+describe('getWidgetsByCategory', () => {
+  it('returns the widgets of the asked category only', () => {
+    const types = getWidgetsByCategory('resources').map(w => w.type)
+
+    expect(types).toContain('zfs-arc')
+    expect(types).toContain('infra-global-chart')
+    expect(types).not.toContain('vm-heatmap') // infrastructure
+  })
+
+  it('never offers section headers, which have their own toolbar button', () => {
+    const all = WIDGET_CATEGORIES.flatMap(c => getWidgetsByCategory(c.id).map(w => w.type))
+
+    expect(all).not.toContain('section-header')
+  })
+
+  it('hides the infrastructure-scoped widgets from a user without that scope', () => {
+    const types = getWidgetsByCategory('resources', { hasInfraScope: false }).map(w => w.type)
+
+    expect(types).not.toContain('zfs-arc')
+  })
+
+  it('honours the per-role hidden widget list', () => {
+    const types = getWidgetsByCategory('resources', { hiddenWidgets: new Set(['zfs-arc']) }).map(w => w.type)
+
+    expect(types).not.toContain('zfs-arc')
+    expect(types).toContain('infra-global-chart')
+  })
+})
+
+describe('isWidgetVisibleForScope', () => {
+  it('accepts a registered widget by default', () => {
+    expect(isWidgetVisibleForScope('zfs-arc')).toBe(true)
+  })
+
+  it('rejects a type that is not registered', () => {
+    expect(isWidgetVisibleForScope('does-not-exist')).toBe(false)
+  })
+
+  it('rejects an infrastructure-scoped widget without the scope', () => {
+    expect(isWidgetVisibleForScope('zfs-arc', { hasInfraScope: false })).toBe(false)
+  })
+
+  it('rejects a widget hidden for the role', () => {
+    expect(isWidgetVisibleForScope('zfs-arc', { hiddenWidgets: new Set(['zfs-arc']) })).toBe(false)
+  })
+})

--- a/frontend/src/components/dashboard/widgets/ConnectionFilter.jsx
+++ b/frontend/src/components/dashboard/widgets/ConnectionFilter.jsx
@@ -1,0 +1,54 @@
+'use client'
+
+import React, { useState } from 'react'
+
+import { Checkbox, IconButton, ListItemText, Menu, MenuItem, Tooltip } from '@mui/material'
+
+// ─── Connection Filter ───────────────────────────────────────────────────────
+// Shared by the chart widgets that load per-node trends. An empty selection
+// means "all connections", which is also what the reset entry restores.
+function ConnectionFilter({ connections, selected, onChange, t }) {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const allSelected = !selected || selected.length === 0
+
+  const handleToggle = (id) => {
+    if (allSelected) {
+      onChange([id])
+    } else if (selected.includes(id)) {
+      const next = selected.filter(k => k !== id)
+
+      onChange(next.length === 0 ? [] : next)
+    } else {
+      onChange([...selected, id])
+    }
+  }
+
+  return (
+    <>
+      <Tooltip title={t('common.filter')}>
+        <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
+          <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.65 : 1 }} />
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
+        <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
+          <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
+          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{t('common.all')}</ListItemText>
+        </MenuItem>
+        {connections.map(c => {
+          const checked = allSelected || selected.includes(c.id)
+
+
+return (
+            <MenuItem key={c.id} dense onClick={() => handleToggle(c.id)}>
+              <Checkbox size='small' checked={checked} sx={{ p: 0, mr: 1 }} />
+              <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{c.name}</ListItemText>
+            </MenuItem>
+          )
+        })}
+      </Menu>
+    </>
+  )
+}
+
+export default ConnectionFilter

--- a/frontend/src/components/dashboard/widgets/ConnectionFilter.test.tsx
+++ b/frontend/src/components/dashboard/widgets/ConnectionFilter.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import ConnectionFilter from './ConnectionFilter'
+
+afterEach(cleanup)
+
+const connections = [
+  { id: 'c1', name: 'cluster-1' },
+  { id: 'c2', name: 'cluster-2' },
+]
+
+const t = (key: string) => key
+
+const open = (selected: string[], onChange: (v: string[]) => void) => {
+  render(<ConnectionFilter connections={connections} selected={selected} onChange={onChange} t={t} />)
+  fireEvent.click(screen.getByRole('button'))
+}
+
+describe('ConnectionFilter', () => {
+  it('treats an empty selection as "all connections"', () => {
+    open([], vi.fn())
+
+    const boxes = screen.getAllByRole('checkbox') as HTMLInputElement[]
+
+    // The "all" entry plus one per connection, every one of them ticked.
+    expect(boxes).toHaveLength(3)
+    expect(boxes.every(b => b.checked)).toBe(true)
+  })
+
+  it('narrows to a single connection when one is picked from the "all" state', () => {
+    const onChange = vi.fn()
+
+    open([], onChange)
+    fireEvent.click(screen.getByText('cluster-2'))
+
+    expect(onChange).toHaveBeenCalledWith(['c2'])
+  })
+
+  it('adds a connection to an existing selection', () => {
+    const onChange = vi.fn()
+
+    open(['c1'], onChange)
+    fireEvent.click(screen.getByText('cluster-2'))
+
+    expect(onChange).toHaveBeenCalledWith(['c1', 'c2'])
+  })
+
+  it('removes a connection from a selection of several', () => {
+    const onChange = vi.fn()
+
+    open(['c1', 'c2'], onChange)
+    fireEvent.click(screen.getByText('cluster-1'))
+
+    expect(onChange).toHaveBeenCalledWith(['c2'])
+  })
+
+  it('falls back to "all" rather than an empty chart when the last one is unpicked', () => {
+    const onChange = vi.fn()
+
+    open(['c1'], onChange)
+    fireEvent.click(screen.getByText('cluster-1'))
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('restores "all" from the reset entry', () => {
+    const onChange = vi.fn()
+
+    open(['c1'], onChange)
+    fireEvent.click(screen.getByText('common.all'))
+
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+})

--- a/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/InfraGlobalChartWidget.jsx
@@ -1,24 +1,18 @@
 'use client'
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useState } from 'react'
 
 import { useTranslations } from 'next-intl'
-import {
-  Box, Checkbox, CircularProgress, IconButton, ListItemText, Menu, MenuItem,
-  Tooltip, Typography, useTheme,
-} from '@mui/material'
+import { Box, CircularProgress, Typography, useTheme } from '@mui/material'
 import { AreaChart, Area, XAxis, YAxis, Tooltip as RTooltip, CartesianGrid } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 
-import { widgetColors } from './themeColors'
-import { mapTimeRange, formatTime } from './timeRangeUtils'
+import { NODE_COLORS, widgetColors } from './themeColors'
+import { formatTime } from './timeRangeUtils'
+import ConnectionFilter from './ConnectionFilter'
+import { useNodeTrends } from './useNodeTrends'
 
-const NODE_COLORS = [
-  '#6366f1', '#8b5cf6', '#a855f7', '#d946ef',
-  '#ec4899', '#f43f5e', '#ef4444', '#f97316',
-  '#eab308', '#84cc16', '#22c55e', '#14b8a6',
-  '#06b6d4', '#3b82f6', '#2563eb', '#7c3aed',
-]
+const METRICS = ['cpu', 'ram']
 
 // ─── Custom Tooltip ──────────────────────────────────────────────────────────
 function ChartTooltip({ active, payload, label, metric, isDark }) {
@@ -46,51 +40,6 @@ return (
   )
 }
 
-// ─── Connection Filter ───────────────────────────────────────────────────────
-function ConnectionFilter({ connections, selected, onChange, t }) {
-  const [anchorEl, setAnchorEl] = useState(null)
-  const allSelected = !selected || selected.length === 0
-
-  const handleToggle = (id) => {
-    if (allSelected) {
-      onChange([id])
-    } else if (selected.includes(id)) {
-      const next = selected.filter(k => k !== id)
-
-      onChange(next.length === 0 ? [] : next)
-    } else {
-      onChange([...selected, id])
-    }
-  }
-
-  return (
-    <>
-      <Tooltip title={t('common.filter')}>
-        <IconButton size='small' onClick={(e) => { e.stopPropagation(); setAnchorEl(e.currentTarget) }} sx={{ p: 0.25 }}>
-          <i className='ri-filter-3-line' style={{ fontSize: '1rem', opacity: allSelected ? 0.65 : 1 }} />
-        </IconButton>
-      </Tooltip>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)} slotProps={{ paper: { sx: { maxHeight: 300 } } }}>
-        <MenuItem dense onClick={() => { onChange([]); setAnchorEl(null) }}>
-          <Checkbox size='small' checked={allSelected} sx={{ p: 0, mr: 1 }} />
-          <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{t('common.all')}</ListItemText>
-        </MenuItem>
-        {connections.map(c => {
-          const checked = allSelected || selected.includes(c.id)
-
-          
-return (
-            <MenuItem key={c.id} dense onClick={() => handleToggle(c.id)}>
-              <Checkbox size='small' checked={checked} sx={{ p: 0, mr: 1 }} />
-              <ListItemText primaryTypographyProps={{ fontSize: '0.8571rem' }}>{c.name}</ListItemText>
-            </MenuItem>
-          )
-        })}
-      </Menu>
-    </>
-  )
-}
-
 // ─── Main Widget ─────────────────────────────────────────────────────────────
 function InfraGlobalChartWidget({ data, loading: dashboardLoading, config, onUpdateSettings, timeRange }) {
   const t = useTranslations()
@@ -98,143 +47,15 @@ function InfraGlobalChartWidget({ data, loading: dashboardLoading, config, onUpd
   const isDark = theme.palette.mode === 'dark'
   const c = widgetColors(isDark)
   const [metric, setMetric] = useState('ram')
-  const [trendsData, setTrendsData] = useState(null)
-  const [nodeNames, setNodeNames] = useState([])
-  const [loading, setLoading] = useState(false)
-
   const selectedConnections = config?.settings?.selectedConnections || []
 
   const handleFilterChange = (newSelected) => {
     if (onUpdateSettings) onUpdateSettings({ selectedConnections: newSelected })
   }
 
-  // All connections for filter (try clusters first, fallback to unique connections from nodes)
-  const allConnections = useMemo(() => {
-    const clusters = (data?.clusters || []).map(c => ({ id: c.id, name: c.name }))
-
-    if (clusters.length > 0) return clusters
-    const seen = new Set()
-
-    return (data?.nodes || []).reduce((acc, n) => {
-      const id = n.connectionId || n.connId
-
-      if (id && !seen.has(id)) { seen.add(id); acc.push({ id, name: n.connection || id }) }
-
-      return acc
-    }, [])
-  }, [data?.clusters, data?.nodes])
-
-  // Stable key for nodes
-  const nodesStableKey = (data?.nodes || []).map(n => `${n.connectionId || n.connId}:${n.name}`).join(',')
-  const selectedKey = selectedConnections.join(',')
-
-  // Group nodes by connection, filtered
-  const nodesByConnection = useMemo(() => {
-    const nodes = data?.nodes || []
-    const grouped = {}
-    const validConnIds = new Set(nodes.map(n => n.connectionId || n.connId).filter(Boolean))
-
-    // If selectedConnections references IDs that don't exist, ignore the filter
-    const effectiveFilter = selectedConnections.length > 0 && selectedConnections.some(id => validConnIds.has(id))
-      ? selectedConnections : []
-
-    nodes.forEach((node) => {
-      const connId = node.connectionId || node.connId
-
-      if (!connId) return
-      if (effectiveFilter.length > 0 && !effectiveFilter.includes(connId)) return
-      if (!grouped[connId]) grouped[connId] = []
-      grouped[connId].push({ node: node.node || node.name })
-    })
-
-    return grouped
-  }, [nodesStableKey, selectedKey]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Fetch trends
-  useEffect(() => {
-    const fetchTrends = async () => {
-      const connIds = Object.keys(nodesByConnection)
-
-      if (connIds.length === 0) return
-
-      // Only show full loading on first fetch, not on refresh
-      if (!trendsData) setLoading(true)
-
-      try {
-        const results = await Promise.all(
-          connIds.map(async (connId) => {
-            const items = nodesByConnection[connId]
-
-            const res = await fetch(`/api/v1/connections/${connId}/nodes/trends`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ items, timeframe: mapTimeRange(timeRange).trendsTimeframe }),
-            })
-
-            if (!res.ok) return {}
-            const json = await res.json()
-
-            
-return json.data || {}
-          })
-        )
-
-        const allNodeNames = new Set()
-        const timeMap = new Map()
-
-        results.forEach((connData) => {
-          Object.entries(connData).forEach(([nodeKey, nodePoints]) => {
-            const nodeName = nodeKey.replace(/^node:/, '')
-
-            allNodeNames.add(nodeName)
-            if (!Array.isArray(nodePoints)) return
-            nodePoints.forEach((point) => {
-              const key = point.ts || point.t
-
-              if (!timeMap.has(key)) timeMap.set(key, { ts: point.ts || 0, t: point.t })
-              const entry = timeMap.get(key)
-
-              entry[`${nodeName}_cpu`] = point.cpu || 0
-              entry[`${nodeName}_ram`] = point.ram || 0
-            })
-          })
-        })
-
-        const aggregated = Array.from(timeMap.values()).sort((a, b) => a.ts - b.ts)
-        const sortedNames = [...allNodeNames].sort((a, b) => a.localeCompare(b))
-        const keys = sortedNames.flatMap(name => [`${name}_cpu`, `${name}_ram`])
-        const lastKnown = {}
-
-        for (const slot of aggregated) {
-          for (const key of keys) {
-            if (slot[key] != null) lastKnown[key] = slot[key]
-            else if (lastKnown[key] != null) slot[key] = lastKnown[key]
-          }
-        }
-
-        const firstKnown = {}
-
-        for (let i = aggregated.length - 1; i >= 0; i--) {
-          const slot = aggregated[i]
-
-          for (const key of keys) {
-            if (slot[key] != null) firstKnown[key] = slot[key]
-            else if (firstKnown[key] != null) slot[key] = firstKnown[key]
-          }
-        }
-
-        setNodeNames(sortedNames)
-        setTrendsData(aggregated)
-      } catch (e) {
-        console.error('Failed to fetch infra trends:', e)
-        setTrendsData([])
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchTrends()
-  }, [nodesStableKey, selectedKey, timeRange]) // eslint-disable-line react-hooks/exhaustive-deps
+  const { trendsData, nodeNames, loading, allConnections } = useNodeTrends({
+    data, selectedConnections, timeRange, metrics: METRICS,
+  })
 
   if (dashboardLoading || loading) {
     return (

--- a/frontend/src/components/dashboard/widgets/ZfsArcWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ZfsArcWidget.jsx
@@ -1,0 +1,204 @@
+'use client'
+
+import React, { useMemo, useState } from 'react'
+
+import { useTranslations } from 'next-intl'
+import { Box, CircularProgress, Typography, useTheme } from '@mui/material'
+import { AreaChart, Area, XAxis, YAxis, Tooltip as RTooltip, CartesianGrid } from 'recharts'
+import ChartContainer from '@/components/ChartContainer'
+
+import { formatBytes } from '@/utils/format'
+
+import { NODE_COLORS, widgetColors } from './themeColors'
+import { formatTime } from './timeRangeUtils'
+import ConnectionFilter from './ConnectionFilter'
+import { useNodeTrends } from './useNodeTrends'
+
+const METRICS = ['arc', 'arcPct']
+
+// The ARC series colour of the node Summary chart, kept identical so the same
+// metric reads the same way in both places.
+const ARC_ACCENT = '#8b5cf6'
+
+const formatValue = (metric, value) => {
+  if (value == null) return '-'
+
+  return metric === 'arcPct' ? `${value}%` : formatBytes(value)
+}
+
+// ─── Custom Tooltip ──────────────────────────────────────────────────────────
+function ChartTooltip({ active, payload, label, metric, isDark }) {
+  if (!active || !payload?.length) return null
+  const c = widgetColors(isDark)
+  const time = formatTime(payload) || label
+
+  return (
+    <div style={{ background: c.tooltipBg, border: `1px solid ${c.tooltipBorder}`, borderRadius: 6, overflow: 'hidden', fontSize: '0.7143rem', minWidth: 100, color: c.tooltipText }}>
+      <div style={{ background: ARC_ACCENT, color: '#fff', padding: '2px 8px', fontWeight: 700, fontSize: '0.6429rem', display: 'flex', alignItems: 'center', gap: 4 }}>
+        <i className='ri-ram-2-line' style={{ fontSize: '0.7143rem' }} />
+        ZFS ARC {time && <span style={{ fontWeight: 400, opacity: 0.8, marginLeft: 'auto' }}>{time}</span>}
+      </div>
+      <div style={{ padding: '4px 8px' }}>
+        {payload.filter(e => !e.hide).map((entry) => (
+          <div key={entry.dataKey} style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
+            <span style={{ width: 6, height: 6, borderRadius: '50%', background: entry.color, flexShrink: 0 }} />
+            <span style={{ flex: 1, color: c.tooltipText }}>{entry.name}</span>
+            <span style={{ fontWeight: 700 }}>{formatValue(metric, entry.value)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Keeps only the nodes that actually report ARC.
+ *
+ * A node on PVE 8 has no `arcsize` column at all, and a node without ZFS
+ * reports nothing usable: both are dropped rather than drawn as a flat zero
+ * line that would read as "ARC collapsed".
+ */
+export function selectArcNodes(trendsData, nodeNames) {
+  if (!trendsData?.length) return []
+
+  return nodeNames.filter(name => trendsData.some(p => (p[`${name}_arc`] ?? 0) > 0))
+}
+
+// ─── Main Widget ─────────────────────────────────────────────────────────────
+function ZfsArcWidget({ data, loading: dashboardLoading, config, onUpdateSettings, timeRange }) {
+  const t = useTranslations()
+  const theme = useTheme()
+  const isDark = theme.palette.mode === 'dark'
+  const c = widgetColors(isDark)
+  const [metric, setMetric] = useState('arc')
+
+  const selectedConnections = config?.settings?.selectedConnections || []
+
+  const handleFilterChange = (newSelected) => {
+    if (onUpdateSettings) onUpdateSettings({ selectedConnections: newSelected })
+  }
+
+  const { trendsData, nodeNames, loading, allConnections } = useNodeTrends({
+    data, selectedConnections, timeRange, metrics: METRICS, defaultValue: null,
+  })
+
+  const arcNodes = useMemo(() => selectArcNodes(trendsData, nodeNames), [trendsData, nodeNames])
+
+  if (dashboardLoading || loading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
+        <CircularProgress size={24} />
+      </Box>
+    )
+  }
+
+  const isEmpty = arcNodes.length === 0
+  const suffix = metric === 'arcPct' ? '_arcPct' : '_arc'
+
+  return (
+    <Box
+      sx={{
+        bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+        border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.75,
+        transition: 'box-shadow 0.2s ease, border-color 0.2s ease',
+        '&:hover': { borderColor: isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.12)', boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
+        height: '100%',
+      }}
+    >
+      {/* Controls — kept mounted even on an empty chart, same reasoning as #611:
+          the connection filter is persisted, so it must stay reachable. */}
+      <Box sx={{ display: 'flex', gap: 0.75, alignItems: 'center', flexWrap: 'wrap' }}>
+        {/* A noContainer widget shows no title outside edit mode, so the toggle
+            labels are what names the metric on screen. */}
+        {[['arc', 'ARC'], ['arcPct', '% RAM']].map(([v, labelText]) => (
+          <Box
+            key={v}
+            onClick={() => setMetric(v)}
+            sx={{
+              px: 1, py: 0.25, fontSize: '0.7143rem', fontWeight: metric === v ? 700 : 400, cursor: 'pointer',
+              // textPrimary, not a hardcoded white: the active chip sits on a
+              // near-white surface in light mode.
+              borderRadius: 1, color: metric === v ? c.textPrimary : c.textMuted,
+              bgcolor: metric === v ? c.surfaceActive : 'transparent',
+              '&:hover': { bgcolor: c.surfaceSubtle, color: c.textPrimary },
+            }}
+          >
+            {labelText}
+          </Box>
+        ))}
+        {allConnections.length > 1 && (
+          <ConnectionFilter connections={allConnections} selected={selectedConnections} onChange={handleFilterChange} t={t} />
+        )}
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 100, width: '100%' }}>
+        {isEmpty ? (
+          <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 0.75, px: 1 }}>
+            <Typography variant="caption" sx={{ opacity: 0.65, textAlign: 'center' }}>{t('dashboard.widgetArc.noData')}</Typography>
+            {selectedConnections.length > 0 && (
+              <Box onClick={() => handleFilterChange([])} sx={{
+                px: 1, py: 0.25, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: 600,
+                color: c.textMuted, bgcolor: c.borderLight,
+                '&:hover': { bgcolor: c.surfaceSubtle, color: c.textPrimary },
+              }}>{t('common.reset')}</Box>
+            )}
+          </Box>
+        ) : (
+        <ChartContainer>
+          <AreaChart data={trendsData} margin={{ top: 4, right: 4, left: -8, bottom: 0 }}>
+            <defs>
+              {arcNodes.map((name, i) => {
+                const color = NODE_COLORS[i % NODE_COLORS.length]
+
+
+return (
+                  <linearGradient key={name} id={`arc-grad-${i}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={color} stopOpacity={0.25} />
+                    <stop offset="95%" stopColor={color} stopOpacity={0.02} />
+                  </linearGradient>
+                )
+              })}
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke={c.borderLight} />
+            <XAxis dataKey="t" tick={{ fontSize: '0.6429rem', fill: c.textMuted }} tickLine={false} axisLine={false} interval="preserveStartEnd" />
+            {/* Bytes autoscale on their own axis: that is the whole point of a
+                dedicated widget, ARC is orders of magnitude below total RAM. */}
+            <YAxis
+              domain={metric === 'arcPct' ? [0, 100] : [0, 'auto']}
+              width={54}
+              tick={{ fontSize: '0.6429rem', fill: c.textMuted }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v) => (metric === 'arcPct' ? `${v}%` : formatBytes(v, 0))}
+            />
+            <RTooltip content={<ChartTooltip metric={metric} isDark={isDark} />} wrapperStyle={{ backgroundColor: 'transparent', zIndex: 10 }} />
+            {arcNodes.map((name, i) => {
+              const color = NODE_COLORS[i % NODE_COLORS.length]
+
+
+return (
+                <Area
+                  key={name}
+                  type="monotone"
+                  dataKey={`${name}${suffix}`}
+                  name={name}
+                  stroke={color}
+                  strokeWidth={1.5}
+                  fill={`url(#arc-grad-${i})`}
+                  dot={false}
+                  activeDot={{ r: 3, strokeWidth: 0 }}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              )
+            })}
+          </AreaChart>
+        </ChartContainer>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+export default React.memo(ZfsArcWidget)

--- a/frontend/src/components/dashboard/widgets/ZfsArcWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ZfsArcWidget.jsx
@@ -20,14 +20,14 @@ const METRICS = ['arc', 'arcPct']
 // metric reads the same way in both places.
 const ARC_ACCENT = '#8b5cf6'
 
-const formatValue = (metric, value) => {
+export const formatValue = (metric, value) => {
   if (value == null) return '-'
 
   return metric === 'arcPct' ? `${value}%` : formatBytes(value)
 }
 
 // ─── Custom Tooltip ──────────────────────────────────────────────────────────
-function ChartTooltip({ active, payload, label, metric, isDark }) {
+export function ChartTooltip({ active, payload, label, metric, isDark }) {
   if (!active || !payload?.length) return null
   const c = widgetColors(isDark)
   const time = formatTime(payload) || label

--- a/frontend/src/components/dashboard/widgets/ZfsArcWidget.test.tsx
+++ b/frontend/src/components/dashboard/widgets/ZfsArcWidget.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import ZfsArcWidget, { selectArcNodes } from './ZfsArcWidget'
+
+/**
+ * #617: the ARC series used to share the memory chart's linear axis, where a
+ * few MB of ARC against GB of RAM is an invisible flat line. The dedicated
+ * widget only holds up if it also refuses to plot nodes that have no ARC at
+ * all — PVE 8 has no `arcsize` column, and a node without ZFS reports nothing.
+ */
+
+// This project does not enable Vitest globals, so RTL's auto-cleanup is off.
+afterEach(cleanup)
+
+const data = {
+  clusters: [{ id: 'c1', name: 'cluster-1' }],
+  nodes: [
+    { name: 'pve-01', node: 'pve-01', connectionId: 'c1' },
+    { name: 'pve-02', node: 'pve-02', connectionId: 'c1' },
+  ],
+}
+
+const respondWith = (payload: unknown) =>
+  server.use(
+    http.post('/api/v1/connections/:connId/nodes/trends', () => HttpResponse.json({ data: payload })),
+  )
+
+const render = (settings: Record<string, unknown> = {}) =>
+  renderWithProviders(
+    <ZfsArcWidget
+      data={data}
+      loading={false}
+      timeRange="1h"
+      config={{ settings }}
+      onUpdateSettings={() => {}}
+    />,
+  )
+
+describe('selectArcNodes', () => {
+  const series = [
+    { ts: 1, 'pve-01_arc': 3221225472, 'pve-02_arc': null },
+    { ts: 2, 'pve-01_arc': 3221225472, 'pve-02_arc': null },
+  ]
+
+  it('keeps a node that reports ARC', () => {
+    expect(selectArcNodes(series, ['pve-01', 'pve-02'])).toEqual(['pve-01'])
+  })
+
+  it('drops a node whose ARC is always zero (no ZFS)', () => {
+    const zeroed = [{ ts: 1, 'pve-03_arc': 0 }, { ts: 2, 'pve-03_arc': 0 }]
+
+    expect(selectArcNodes(zeroed, ['pve-03'])).toEqual([])
+  })
+
+  it('returns nothing when there is no series at all', () => {
+    expect(selectArcNodes(null, ['pve-01'])).toEqual([])
+    expect(selectArcNodes([], ['pve-01'])).toEqual([])
+  })
+})
+
+describe('ZfsArcWidget', () => {
+  it('explains the PVE 9 requirement when no node reports ARC', async () => {
+    respondWith({ 'node:pve-01': [{ ts: 1, t: '10:00', cpu: 5, ram: 40, arc: null, arcPct: null }] })
+    render()
+
+    expect(await screen.findByText(/No ZFS ARC data/i)).toBeInTheDocument()
+  })
+
+  it('plots the chart as soon as one node reports ARC', async () => {
+    respondWith({
+      'node:pve-01': [{ ts: 1, t: '10:00', cpu: 5, ram: 40, arc: 3221225472, arcPct: 18.7 }],
+      'node:pve-02': [{ ts: 1, t: '10:00', cpu: 7, ram: 51, arc: null, arcPct: null }],
+    })
+    render()
+
+    // Wait for the controls to actually mount: the widget paints a spinner
+    // first, so asserting an absence here would pass before anything renders.
+    expect(await screen.findByText('ARC')).toBeInTheDocument()
+    expect(screen.getByText('% RAM')).toBeInTheDocument()
+    expect(screen.queryByText(/No ZFS ARC data/i)).not.toBeInTheDocument()
+  })
+
+  it('keeps its controls and offers a reset when a connection filter empties the chart', async () => {
+    respondWith({})
+    render({ selectedConnections: ['c1'] })
+
+    expect(await screen.findByText(/No ZFS ARC data/i)).toBeInTheDocument()
+
+    // Same bug class as #611: the filter is persisted, so it must stay reachable.
+    expect(screen.getByText('ARC')).toBeInTheDocument()
+    expect(screen.getByText('Reset')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/dashboard/widgets/ZfsArcWidget.test.tsx
+++ b/frontend/src/components/dashboard/widgets/ZfsArcWidget.test.tsx
@@ -1,9 +1,19 @@
-import { describe, it, expect, afterEach } from 'vitest'
-import { cleanup } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup, fireEvent } from '@testing-library/react'
+import { ResponsiveContainer } from 'recharts'
 import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
-import ZfsArcWidget, { selectArcNodes } from './ZfsArcWidget'
+// jsdom gives every element a zero size, so the real ChartContainer never
+// reaches the width it needs and renders nothing. Fixed dimensions here let
+// the chart body actually mount, which is what the series assertions read.
+vi.mock('@/components/ChartContainer', () => ({
+  default: ({ children }: { children: React.ReactElement }) => (
+    <ResponsiveContainer width={600} height={300}>{children}</ResponsiveContainer>
+  ),
+}))
+
+import ZfsArcWidget, { selectArcNodes, formatValue, ChartTooltip } from './ZfsArcWidget'
 
 /**
  * #617: the ARC series used to share the memory chart's linear axis, where a
@@ -92,5 +102,97 @@ describe('ZfsArcWidget', () => {
     // Same bug class as #611: the filter is persisted, so it must stay reachable.
     expect(screen.getByText('ARC')).toBeInTheDocument()
     expect(screen.getByText('Reset')).toBeInTheDocument()
+  })
+})
+
+describe('formatValue', () => {
+  it('renders bytes for the ARC view and a percentage for the share view', () => {
+    expect(formatValue('arc', 3221225472)).toBe('3 GiB')
+    expect(formatValue('arcPct', 18.7)).toBe('18.7%')
+  })
+
+  it('shows a dash rather than "0 B" for a slot the node never reported', () => {
+    expect(formatValue('arc', null)).toBe('-')
+    expect(formatValue('arcPct', undefined)).toBe('-')
+  })
+})
+
+describe('ChartTooltip', () => {
+  it('stays silent until the chart is hovered', () => {
+    const { container } = renderWithProviders(<ChartTooltip active={false} payload={[]} metric="arc" isDark />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('formats each node row with the unit of the current view', () => {
+    renderWithProviders(
+      <ChartTooltip
+        active
+        label="10:00"
+        metric="arc"
+        isDark={false}
+        payload={[{ dataKey: 'pve-01_arc', name: 'pve-01', value: 3221225472, color: '#fff' }]}
+      />,
+    )
+
+    expect(screen.getByText('pve-01')).toBeInTheDocument()
+    expect(screen.getByText('3 GiB')).toBeInTheDocument()
+  })
+})
+
+describe('ZfsArcWidget interactions', () => {
+  it('plots one series per node that reports ARC, and none for the others', async () => {
+    respondWith({
+      'node:pve-01': [
+        { ts: 1, t: '10:00', arc: 3221225472, arcPct: 18.7 },
+        { ts: 2, t: '10:01', arc: 3221225472, arcPct: 18.7 },
+      ],
+      'node:pve-02': [
+        { ts: 1, t: '10:00', arc: null, arcPct: null },
+        { ts: 2, t: '10:01', arc: null, arcPct: null },
+      ],
+    })
+    const { container } = render()
+
+    expect(await screen.findByText('ARC')).toBeInTheDocument()
+    await new Promise(r => setTimeout(r, 0))
+    expect(container.querySelectorAll('.recharts-area')).toHaveLength(1)
+  })
+
+  it('switches to the share of RAM view', async () => {
+    respondWith({ 'node:pve-01': [{ ts: 1, t: '10:00', arc: 3221225472, arcPct: 18.7 }] })
+    render()
+
+    fireEvent.click(await screen.findByText('% RAM'))
+
+    // The percentage axis is bounded, so its ticks carry the percent sign.
+    expect(await screen.findByText('100%')).toBeInTheDocument()
+  })
+
+  it('clears the connection filter from the empty state', async () => {
+    const onUpdateSettings = vi.fn()
+
+    respondWith({})
+    renderWithProviders(
+      <ZfsArcWidget
+        data={data}
+        loading={false}
+        timeRange="1h"
+        config={{ settings: { selectedConnections: ['c2'] } }}
+        onUpdateSettings={onUpdateSettings}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText('Reset'))
+    expect(onUpdateSettings).toHaveBeenCalledWith({ selectedConnections: [] })
+  })
+
+  it('shows a spinner while the dashboard itself is still loading', () => {
+    respondWith({})
+    const { container } = renderWithProviders(
+      <ZfsArcWidget data={data} loading timeRange="1h" config={{ settings: {} }} onUpdateSettings={() => {}} />,
+    )
+
+    expect(container.querySelector('.MuiCircularProgress-root')).toBeTruthy()
   })
 })

--- a/frontend/src/components/dashboard/widgets/themeColors.js
+++ b/frontend/src/components/dashboard/widgets/themeColors.js
@@ -1,4 +1,15 @@
 /**
+ * Per-node series palette, shared by the chart widgets so a node keeps the same
+ * colour from one chart to the next.
+ */
+export const NODE_COLORS = [
+  '#6366f1', '#8b5cf6', '#a855f7', '#d946ef',
+  '#ec4899', '#f43f5e', '#ef4444', '#f97316',
+  '#eab308', '#84cc16', '#22c55e', '#14b8a6',
+  '#06b6d4', '#3b82f6', '#2563eb', '#7c3aed',
+]
+
+/**
  * Theme-aware color helpers for dashboard widgets.
  * Usage: const c = widgetColors(isDark)
  */

--- a/frontend/src/components/dashboard/widgets/useNodeTrends.js
+++ b/frontend/src/components/dashboard/widgets/useNodeTrends.js
@@ -1,0 +1,154 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+
+import { mapTimeRange } from './timeRangeUtils'
+
+/**
+ * Loads per-node RRD trends for the dashboard chart widgets.
+ *
+ * One request per connection, then every node is merged into a single
+ * time-indexed series whose keys are `${nodeName}_${metric}`. Slots a node did
+ * not report are filled forward then backward, otherwise a node whose RRD lags
+ * behind the others cuts its own curve in half.
+ *
+ * `defaultValue` is what a missing metric becomes: 0 for ratios that are
+ * meaningful at zero, null for metrics whose absence must stay distinguishable
+ * from a real zero (ZFS ARC on a node without ZFS).
+ */
+export function useNodeTrends({ data, selectedConnections = [], timeRange, metrics, defaultValue = 0 }) {
+  const [trendsData, setTrendsData] = useState(null)
+  const [nodeNames, setNodeNames] = useState([])
+  const [loading, setLoading] = useState(false)
+
+  // All connections for the filter (clusters first, fallback to the unique
+  // connections carried by the nodes themselves)
+  const allConnections = useMemo(() => {
+    const clusters = (data?.clusters || []).map(c => ({ id: c.id, name: c.name }))
+
+    if (clusters.length > 0) return clusters
+    const seen = new Set()
+
+    return (data?.nodes || []).reduce((acc, n) => {
+      const id = n.connectionId || n.connId
+
+      if (id && !seen.has(id)) { seen.add(id); acc.push({ id, name: n.connection || id }) }
+
+      return acc
+    }, [])
+  }, [data?.clusters, data?.nodes])
+
+  // Stable keys for nodes
+  const nodesStableKey = (data?.nodes || []).map(n => `${n.connectionId || n.connId}:${n.name}`).join(',')
+  const selectedKey = selectedConnections.join(',')
+  const metricsKey = metrics.join(',')
+
+  // Group nodes by connection, filtered
+  const nodesByConnection = useMemo(() => {
+    const nodes = data?.nodes || []
+    const grouped = {}
+    const validConnIds = new Set(nodes.map(n => n.connectionId || n.connId).filter(Boolean))
+
+    // If selectedConnections references IDs that don't exist, ignore the filter
+    const effectiveFilter = selectedConnections.length > 0 && selectedConnections.some(id => validConnIds.has(id))
+      ? selectedConnections : []
+
+    nodes.forEach((node) => {
+      const connId = node.connectionId || node.connId
+
+      if (!connId) return
+      if (effectiveFilter.length > 0 && !effectiveFilter.includes(connId)) return
+      if (!grouped[connId]) grouped[connId] = []
+      grouped[connId].push({ node: node.node || node.name })
+    })
+
+    return grouped
+  }, [nodesStableKey, selectedKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch trends
+  useEffect(() => {
+    const fetchTrends = async () => {
+      const connIds = Object.keys(nodesByConnection)
+
+      if (connIds.length === 0) return
+
+      // Only show full loading on first fetch, not on refresh
+      if (!trendsData) setLoading(true)
+
+      try {
+        const results = await Promise.all(
+          connIds.map(async (connId) => {
+            const items = nodesByConnection[connId]
+
+            const res = await fetch(`/api/v1/connections/${connId}/nodes/trends`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ items, timeframe: mapTimeRange(timeRange).trendsTimeframe }),
+            })
+
+            if (!res.ok) return {}
+            const json = await res.json()
+
+
+return json.data || {}
+          })
+        )
+
+        const allNodeNames = new Set()
+        const timeMap = new Map()
+
+        results.forEach((connData) => {
+          Object.entries(connData).forEach(([nodeKey, nodePoints]) => {
+            const nodeName = nodeKey.replace(/^node:/, '')
+
+            allNodeNames.add(nodeName)
+            if (!Array.isArray(nodePoints)) return
+            nodePoints.forEach((point) => {
+              const key = point.ts || point.t
+
+              if (!timeMap.has(key)) timeMap.set(key, { ts: point.ts || 0, t: point.t })
+              const entry = timeMap.get(key)
+
+              metrics.forEach((m) => { entry[`${nodeName}_${m}`] = point[m] ?? defaultValue })
+            })
+          })
+        })
+
+        const aggregated = Array.from(timeMap.values()).sort((a, b) => a.ts - b.ts)
+        const sortedNames = [...allNodeNames].sort((a, b) => a.localeCompare(b))
+        const keys = sortedNames.flatMap(name => metrics.map(m => `${name}_${m}`))
+        const lastKnown = {}
+
+        for (const slot of aggregated) {
+          for (const key of keys) {
+            if (slot[key] != null) lastKnown[key] = slot[key]
+            else if (lastKnown[key] != null) slot[key] = lastKnown[key]
+          }
+        }
+
+        const firstKnown = {}
+
+        for (let i = aggregated.length - 1; i >= 0; i--) {
+          const slot = aggregated[i]
+
+          for (const key of keys) {
+            if (slot[key] != null) firstKnown[key] = slot[key]
+            else if (firstKnown[key] != null) slot[key] = firstKnown[key]
+          }
+        }
+
+        setNodeNames(sortedNames)
+        setTrendsData(aggregated)
+      } catch (e) {
+        console.error('Failed to fetch node trends:', e)
+        setTrendsData([])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchTrends()
+  }, [nodesStableKey, selectedKey, metricsKey, timeRange]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { trendsData, nodeNames, loading, allConnections }
+}

--- a/frontend/src/components/dashboard/widgets/useNodeTrends.test.tsx
+++ b/frontend/src/components/dashboard/widgets/useNodeTrends.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+
+import { useNodeTrends } from './useNodeTrends'
+
+afterEach(cleanup)
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+const CPU_RAM = ['cpu', 'ram']
+const ARC = ['arc', 'arcPct']
+
+const jsonResponse = (body: unknown) => ({ ok: true, json: async () => body }) as Response
+
+const clusterData = {
+  clusters: [{ id: 'c1', name: 'cluster-1' }],
+  nodes: [
+    { name: 'pve-01', node: 'pve-01', connectionId: 'c1' },
+    { name: 'pve-02', node: 'pve-02', connectionId: 'c1' },
+  ],
+}
+
+describe('useNodeTrends', () => {
+  it('merges every node of every connection into one time-indexed series', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: {
+        'node:pve-01': [{ ts: 1, t: '10:00', cpu: 12, ram: 34 }],
+        'node:pve-02': [{ ts: 1, t: '10:00', cpu: 7, ram: 51 }],
+      },
+    })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).not.toBeNull())
+    expect(result.current.nodeNames).toEqual(['pve-01', 'pve-02'])
+    expect(result.current.trendsData?.[0]).toMatchObject({
+      't': '10:00', 'pve-01_cpu': 12, 'pve-01_ram': 34, 'pve-02_cpu': 7, 'pve-02_ram': 51,
+    })
+  })
+
+  it('falls back to the connections carried by the nodes when there is no cluster', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: {} })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: { nodes: [
+        { name: 'pve-09', connId: 'c9', connection: 'Lab' },
+        { name: 'pve-10', connId: 'c9', connection: 'Lab' },
+      ] },
+      selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.allConnections).toHaveLength(1))
+    expect(result.current.allConnections[0]).toEqual({ id: 'c9', name: 'Lab' })
+  })
+
+  it('names a connection by its id when the node carries no label', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ data: {} })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: { nodes: [{ name: 'pve-09', connectionId: 'c9' }] },
+      selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.allConnections).toHaveLength(1))
+    expect(result.current.allConnections[0]).toEqual({ id: 'c9', name: 'c9' })
+  })
+
+  it('ignores a filter that only references connections which no longer exist', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ data: {} }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: ['gone'], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    // Both nodes of c1 are still requested: a stale filter must not empty the chart.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/connections/c1/nodes/trends')
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).items).toEqual([{ node: 'pve-01' }, { node: 'pve-02' }])
+  })
+
+  it('fills a gap forward and backward for a node whose RRD lags behind', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: {
+        'node:pve-01': [
+          { ts: 1, t: '10:00', cpu: 10, ram: 20 },
+          { ts: 2, t: '10:01', cpu: 11, ram: 21 },
+          { ts: 3, t: '10:02', cpu: 12, ram: 22 },
+        ],
+        'node:pve-02': [{ ts: 2, t: '10:01', cpu: 50, ram: 60 }],
+      },
+    })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toHaveLength(3))
+    const series = result.current.trendsData as Record<string, number>[]
+
+    expect(series[0]['pve-02_cpu']).toBe(50) // backward fill
+    expect(series[2]['pve-02_cpu']).toBe(50) // forward fill
+  })
+
+  it('keeps a missing metric null when the caller asked for null', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: { 'node:pve-01': [{ ts: 1, t: '10:00', arc: null, arcPct: null }] },
+    })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: ARC, defaultValue: null,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toHaveLength(1))
+    expect(result.current.trendsData?.[0]['pve-01_arc']).toBeNull()
+  })
+
+  it('indexes a point that carries no timestamp by its label', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: { 'node:pve-01': [{ t: '10:00', cpu: 5, ram: 6 }] },
+    })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toHaveLength(1))
+    expect(result.current.trendsData?.[0]).toMatchObject({ ts: 0, t: '10:00', 'pve-01_cpu': 5 })
+  })
+
+  it('ignores a connection whose payload is not a series', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({
+      data: { 'node:pve-01': null, 'node:pve-02': [{ ts: 1, t: '10:00', cpu: 1, ram: 2 }] },
+    })))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toHaveLength(1))
+    expect(result.current.nodeNames).toEqual(['pve-01', 'pve-02'])
+  })
+
+  it('drops the payload of a connection that answers with an error status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) } as Response))
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toEqual([]))
+    expect(result.current.nodeNames).toEqual([])
+  })
+
+  it('empties the series when the request throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: clusterData, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.trendsData).toEqual([]))
+  })
+
+  it('does not call the endpoint when no node carries a connection', async () => {
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useNodeTrends({
+      data: { nodes: [{ name: 'orphan' }] }, selectedConnections: [], timeRange: '1h', metrics: CPU_RAM,
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.trendsData).toBeNull()
+  })
+})

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -472,6 +472,7 @@
       "vmStatusWaffle": "Guest-Status (Waffle)",
       "resourceTrends": "Ressourcentrends",
       "infraGlobalChart": "Infra CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "Guest-Heatmap",
       "drsStatus": "DRS-Status",
       "siteRecovery": "Site Recovery"
@@ -500,6 +501,7 @@
       "vmStatusWaffle": "Waffle-Ansicht der Guests nach Cluster und Status",
       "resourceTrends": "CPU/RAM-Verlauf über 1h, 24h oder 7d",
       "infraGlobalChart": "CPU/RAM pro Node über die gesamte Infrastruktur",
+      "zfsArc": "ZFS-ARC-Speichernutzung pro Node (PVE 9+)",
       "vmHeatmap": "CPU/RAM-Heatmap aller Guests",
       "drsStatus": "DRS-Status, aktive Migrationen und Empfehlungen",
       "siteRecovery": "VM-Schutz, RPO-Compliance und Replikationsstatus",
@@ -538,6 +540,9 @@
       "jobs": "Aufträge",
       "syncing": "Synchronisierung",
       "errors": "Fehlers"
+    },
+    "widgetArc": {
+      "noData": "Keine ZFS-ARC-Daten. Erfordert PVE 9 oder neuer auf einem Node mit ZFS."
     }
   },
   "alerts": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -482,6 +482,7 @@
       "vmStatusWaffle": "Guest Status (Waffle)",
       "resourceTrends": "Resource Trends",
       "infraGlobalChart": "Infra CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "Guest Heatmap",
       "drsStatus": "DRS Status",
       "siteRecovery": "Site Recovery",
@@ -513,6 +514,7 @@
       "vmStatusWaffle": "Waffle view of guests by cluster and status",
       "resourceTrends": "CPU/RAM evolution over 1h, 24h or 7d",
       "infraGlobalChart": "Per-node CPU/RAM across all infrastructure",
+      "zfsArc": "Per-node ZFS ARC memory usage (PVE 9+)",
       "vmHeatmap": "CPU/RAM heatmap of all guests",
       "drsStatus": "DRS status, active migrations and recommendations",
       "siteRecovery": "VM protection, RPO compliance and replication status",
@@ -551,6 +553,9 @@
       "jobs": "Jobs",
       "syncing": "Syncing",
       "errors": "Errors"
+    },
+    "widgetArc": {
+      "noData": "No ZFS ARC data. Requires PVE 9 or later on a node using ZFS."
     }
   },
   "alerts": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -482,6 +482,7 @@
       "vmStatusWaffle": "Estado de guests (waffle)",
       "resourceTrends": "Tendencias de recursos",
       "infraGlobalChart": "Infra CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "Mapa de calor de guests",
       "drsStatus": "Estado de DRS",
       "siteRecovery": "Site Recovery",
@@ -513,6 +514,7 @@
       "vmStatusWaffle": "Waffle ver de guests por cluster y estado",
       "resourceTrends": "CPU/RAM evolution over 1h, 24h o 7d",
       "infraGlobalChart": "por-nodo CPU/RAM across all infrastructure",
+      "zfsArc": "Uso de memoria ZFS ARC por nodo (PVE 9+)",
       "vmHeatmap": "CPU/RAM heatmap de all guests",
       "drsStatus": "DRS estado, activo migraciones y recomendaciones",
       "siteRecovery": "VM protection, RPO compliance y replication estado",
@@ -551,6 +553,9 @@
       "jobs": "Trabajos",
       "syncing": "Sincronizando",
       "errors": "Errores"
+    },
+    "widgetArc": {
+      "noData": "Sin datos de ZFS ARC. Requiere PVE 9 o posterior en un nodo que use ZFS."
     }
   },
   "alerts": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -482,6 +482,7 @@
       "vmStatusWaffle": "État des guests (Waffle)",
       "resourceTrends": "Tendances ressources",
       "infraGlobalChart": "Infra CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "Heatmap guests",
       "drsStatus": "État DRS",
       "siteRecovery": "Reprise d'activité",
@@ -513,6 +514,7 @@
       "vmStatusWaffle": "Vue waffle des guests par cluster et status",
       "resourceTrends": "Évolution CPU/RAM sur 1h, 24h ou 7j",
       "infraGlobalChart": "CPU/RAM par nœud sur toute l'infrastructure",
+      "zfsArc": "Utilisation mémoire du cache ZFS ARC par nœud (PVE 9+)",
       "vmHeatmap": "Heatmap CPU/RAM de tous les guests",
       "drsStatus": "Status DRS, migrations actives et recommandations",
       "siteRecovery": "Protection VMs, conformité RPO et status réplication",
@@ -551,6 +553,9 @@
       "jobs": "Jobs",
       "syncing": "En sync",
       "errors": "Erreurs"
+    },
+    "widgetArc": {
+      "noData": "Aucune donnée ZFS ARC. Nécessite PVE 9 ou supérieur sur un nœud utilisant ZFS."
     }
   },
   "alerts": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -482,6 +482,7 @@
       "vmStatusWaffle": "게스트 상태 (와플)",
       "resourceTrends": "리소스 추세",
       "infraGlobalChart": "인프라 CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "게스트 히트맵",
       "drsStatus": "DRS 상태",
       "siteRecovery": "사이트 복구",
@@ -513,6 +514,7 @@
       "vmStatusWaffle": "클러스터 및 상태별 게스트 와플 뷰",
       "resourceTrends": "1시간, 24시간, 7일간의 CPU/RAM 추이",
       "infraGlobalChart": "전체 인프라의 노드별 CPU/RAM",
+      "zfsArc": "노드별 ZFS ARC 메모리 사용량 (PVE 9 이상)",
       "vmHeatmap": "모든 게스트의 CPU/RAM 히트맵",
       "drsStatus": "DRS 상태, 진행 중인 마이그레이션 및 권장 사항",
       "siteRecovery": "VM 보호, RPO 준수 및 복제 상태",
@@ -551,6 +553,9 @@
       "jobs": "작업",
       "syncing": "동기화 중",
       "errors": "오류"
+    },
+    "widgetArc": {
+      "noData": "ZFS ARC 데이터가 없습니다. ZFS를 사용하는 노드에서 PVE 9 이상이 필요합니다."
     }
   },
   "alerts": {

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -472,6 +472,7 @@
       "vmStatusWaffle": "客户机状态（华夫图）",
       "resourceTrends": "资源趋势",
       "infraGlobalChart": "基础设施 CPU/RAM",
+      "zfsArc": "ZFS ARC",
       "vmHeatmap": "客户机热力图",
       "drsStatus": "DRS 状态",
       "siteRecovery": "站点恢复"
@@ -500,6 +501,7 @@
       "vmStatusWaffle": "按集群和状态的客户机华夫图",
       "resourceTrends": "1小时、24小时或7天的 CPU/RAM 变化趋势",
       "infraGlobalChart": "所有基础设施中每个节点的 CPU/RAM",
+      "zfsArc": "各节点的 ZFS ARC 内存占用（PVE 9+）",
       "vmHeatmap": "所有客户机的 CPU/RAM 热力图",
       "drsStatus": "DRS 状态、活跃迁移和建议",
       "siteRecovery": "虚拟机保护、RPO 合规性和复制状态",
@@ -538,6 +540,9 @@
       "jobs": "任务",
       "syncing": "同步中",
       "errors": "错误"
+    },
+    "widgetArc": {
+      "noData": "无 ZFS ARC 数据。需要 PVE 9 或更高版本，且节点使用 ZFS。"
     }
   },
   "alerts": {


### PR DESCRIPTION
Closes #617.

## What

A dedicated **ZFS ARC** widget for the customisable dashboard, under the *Resources* category. It plots ARC per node over the dashboard time range, with two views: **ARC** in bytes on its own auto scaled axis, and **% RAM** for the share of the node memory it holds.

The reporter originally asked for ARC stacked inside the memory graph, the way the Proxmox UI draws it. We already have that shape in Infrastructure > Inventory > node > Summary > Performance, and it does not survive the move to a dashboard tile: ARC and total memory can differ by three orders of magnitude, so on a shared linear axis the ARC curve flattens to the baseline. A dedicated widget with its own axis is what makes the metric readable, and the percentage view answers the question the stacked graph was really being used for.

## Nodes without ARC are dropped, not zeroed

The `arcsize` column only exists in the node RRD schema introduced by PVE 9, and a node without ZFS reports nothing usable. Both cases stay `null` all the way from the route to the chart, and such nodes are excluded from the series rather than drawn as a flat zero line that would read as "ARC collapsed". When no node qualifies, the widget says so and names the PVE 9 requirement instead of showing an empty frame.

## Shared plumbing rather than a copy

`InfraGlobalChartWidget` already loaded per-node trends, filtered them by connection and coloured one series per node. Copying those 130 lines into a second widget would have duplicated them, so the connection filter, the trends loader and the node palette now live in their own modules and both widgets consume them. The existing widget keeps its behaviour and its tests.

## Data path

The node trends endpoint now returns `arc` and `arcPct` alongside `cpu` and `ram`, computed from the RRD payload it already fetches. No extra Proxmox call, no new endpoint.

## Tests

Four cases on the route mapping (PVE 9 node, PVE 8 node with no column, node without ZFS, node reporting no total memory) and six on the widget, covering the node selection rule and the empty states. Full suite green.

