### PR TITLE
Guard the alert write, and scope upload progress to its owner

### DIFF
--- a/frontend/src/app/api/v1/alerts/route.test.ts
+++ b/frontend/src/app/api/v1/alerts/route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/tenant', () => ({
+  getSessionPrisma: vi.fn<() => Promise<any>>(),
+  getCurrentTenantId: vi.fn<() => Promise<string>>(),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null>>(),
+  PERMISSIONS: {
+    ALERTS_VIEW: 'alerts.view',
+    ALERTS_MANAGE: 'alerts.manage',
+  },
+}))
+
+import { POST } from './route'
+import { getSessionPrisma, getCurrentTenantId } from '@/lib/tenant'
+import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+
+const upsert = vi.fn<(...args: any[]) => Promise<any>>()
+
+const body = {
+  severity: 'crit',
+  message: 'Node pve1 is down',
+  source: 'pve1',
+  entityType: 'node',
+  entityId: 'conn1:pve1',
+  metric: 'status',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  upsert.mockResolvedValue({ id: 'alert-1' })
+  // Structural cast: a hand-rolled stub never satisfies the generated Prisma
+  // client type (the delegate methods are generic over their args).
+  vi.mocked(getSessionPrisma).mockResolvedValue({ alert: { upsert } } as any)
+  vi.mocked(getCurrentTenantId).mockResolvedValue('tenant-1')
+  vi.mocked(checkPermission).mockResolvedValue(null)
+})
+
+describe('POST /api/v1/alerts', () => {
+  it('requires alerts.manage, like the other writes on the resource', async () => {
+    await callRoute(POST, { body })
+
+    expect(checkPermission).toHaveBeenCalledWith(PERMISSIONS.ALERTS_MANAGE)
+  })
+
+  it('upserts the alert when the permission is granted', async () => {
+    const res = await callRoute(POST, { body })
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ data: { id: 'alert-1' } })
+    expect(upsert).toHaveBeenCalledTimes(1)
+    expect(upsert.mock.calls[0][0].where.tenantId_fingerprint.tenantId).toBe('tenant-1')
+  })
+
+  it('refuses the write and touches nothing when the permission is denied', async () => {
+    vi.mocked(checkPermission).mockResolvedValue(
+      NextResponse.json({ error: 'Permission denied: alerts.manage' }, { status: 403 }),
+    )
+
+    const res = await callRoute(POST, { body })
+
+    expect(res.status).toBe(403)
+    expect(upsert).not.toHaveBeenCalled()
+  })
+
+  it('checks the permission before reading the body, so an invalid payload still gets a 403', async () => {
+    vi.mocked(checkPermission).mockResolvedValue(
+      NextResponse.json({ error: 'Permission denied: alerts.manage' }, { status: 403 }),
+    )
+
+    const res = await callRoute(POST, { body: { severity: '' } })
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/frontend/src/app/api/v1/alerts/route.ts
+++ b/frontend/src/app/api/v1/alerts/route.ts
@@ -111,6 +111,12 @@ return NextResponse.json({ error: error?.message || 'Server error' }, { status: 
 export async function POST(req: Request) {
   try {
     const prisma = await getSessionPrisma()
+    // Same permission as PATCH, DELETE and /alerts/sync: writing an alert is a
+    // management action, and this handler was the only one on the resource
+    // without a check of its own (#699).
+    const permError = await checkPermission(PERMISSIONS.ALERTS_MANAGE)
+    if (permError) return permError
+
     const rawBody = await req.json()
     const parseResult = createAlertSchema.safeParse(rawBody)
 

--- a/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/upload/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/nodes/[node]/storage/[storage]/upload/route.ts
@@ -4,6 +4,7 @@ import http from "node:http"
 import { randomUUID } from "node:crypto"
 
 import { getConnectionById } from "@/lib/connections/getConnection"
+import { getPrincipal } from "@/lib/auth/principal"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { guardTenantStorageWrite } from "@/lib/vdc/scope"
 import { setProgress, clearProgress } from "@/lib/upload-progress"
@@ -105,7 +106,13 @@ async function handleChunk(
         ? new https.Agent({ rejectUnauthorized: false })
         : undefined
 
-      setProgress(uploadId, { bytesSent: 0, totalBytes: totalSize, status: "transferring" })
+      // Stamp the owner on the entry the first chunk creates: the progress
+      // route hands the counters back to that user and to nobody else (#699).
+      // Resolved here only, the per-chunk updates below inherit it.
+      const principalResult = await getPrincipal()
+      const ownerId = principalResult.ok ? principalResult.principal?.userId || null : null
+
+      setProgress(uploadId, { bytesSent: 0, totalBytes: totalSize, status: "transferring" }, ownerId)
 
       let resolveResult: any
       let rejectResult: any

--- a/frontend/src/app/api/v1/upload-progress/[uploadId]/route.test.ts
+++ b/frontend/src/app/api/v1/upload-progress/[uploadId]/route.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextResponse } from 'next/server'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/auth/principal', () => ({
+  getPrincipal: vi.fn<() => Promise<any>>(),
+  rejectionToResponse: (rejection: any) =>
+    NextResponse.json(rejection?.body || { error: 'Invalid or expired API token' }, {
+      status: rejection?.status || 401,
+    }),
+}))
+
+import { GET } from './route'
+import { getPrincipal } from '@/lib/auth/principal'
+import { setProgress, clearProgress } from '@/lib/upload-progress'
+
+const session = (userId: string) => ({
+  ok: true,
+  principal: { kind: 'session', userId, tenantId: 'tenant-1', connectionIds: null },
+})
+
+const transferring = { bytesSent: 512, totalBytes: 2048, status: 'transferring' as const }
+
+const get = (uploadId: string) => callRoute(GET, { params: { uploadId } })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearProgress('up-1')
+  vi.mocked(getPrincipal).mockResolvedValue(session('user-1') as any)
+})
+
+describe('GET /api/v1/upload-progress/[uploadId]', () => {
+  it('returns the progress of the user who started the upload', async () => {
+    setProgress('up-1', transferring, 'user-1')
+
+    const res = await get('up-1')
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual(transferring)
+  })
+
+  it('tells another user the id is unknown rather than serving it', async () => {
+    setProgress('up-1', transferring, 'user-1')
+    vi.mocked(getPrincipal).mockResolvedValue(session('user-2') as any)
+
+    const res = await get('up-1')
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ bytesSent: 0, totalBytes: 0, status: 'unknown' })
+  })
+
+  it('answers an id that never existed the same way', async () => {
+    const res = await get('never-existed')
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ bytesSent: 0, totalBytes: 0, status: 'unknown' })
+  })
+
+  it('refuses a caller without a session', async () => {
+    setProgress('up-1', transferring, 'user-1')
+    vi.mocked(getPrincipal).mockResolvedValue({ ok: true } as any)
+
+    const res = await get('up-1')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('passes a principal rejection through untouched', async () => {
+    vi.mocked(getPrincipal).mockResolvedValue({
+      ok: false,
+      rejection: { status: 405, body: { error: 'API tokens are read-only' } },
+    } as any)
+
+    const res = await get('up-1')
+
+    expect(res.status).toBe(405)
+    expect(await readJson<any>(res)).toEqual({ error: 'API tokens are read-only' })
+  })
+})

--- a/frontend/src/app/api/v1/upload-progress/[uploadId]/route.ts
+++ b/frontend/src/app/api/v1/upload-progress/[uploadId]/route.ts
@@ -1,13 +1,33 @@
 export const dynamic = "force-dynamic"
 import { NextResponse } from "next/server"
+import { getPrincipal, rejectionToResponse } from "@/lib/auth/principal"
 import { getProgress } from "@/lib/upload-progress"
 
+/**
+ * GET /api/v1/upload-progress/{uploadId}
+ *
+ * Scoped to the caller who opened the upload rather than to a permission
+ * (#699): the counters belong to one transfer of one user, and no role in the
+ * model says "may watch someone else's upload". An id that is not the caller's
+ * gets the same answer as an id that never existed.
+ */
 export async function GET(
   _req: Request,
   ctx: { params: Promise<{ uploadId: string }> }
 ) {
   const { uploadId } = await ctx.params
-  const progress = getProgress(uploadId)
+
+  const result = await getPrincipal()
+
+  if (!result.ok) return rejectionToResponse(result.rejection)
+
+  const userId = result.principal?.userId
+
+  if (!userId) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 })
+  }
+
+  const progress = getProgress(uploadId, userId)
 
   if (!progress) {
     return NextResponse.json({ bytesSent: 0, totalBytes: 0, status: "unknown" })

--- a/frontend/src/lib/upload-progress.test.ts
+++ b/frontend/src/lib/upload-progress.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { setProgress, getProgress, clearProgress } from './upload-progress'
+
+const transferring = { bytesSent: 10, totalBytes: 100, status: 'transferring' as const }
+
+beforeEach(() => {
+  clearProgress('up-1')
+})
+
+describe('upload progress ownership', () => {
+  it('serves an entry back to the user who opened the transfer', () => {
+    setProgress('up-1', transferring, 'user-1')
+
+    expect(getProgress('up-1', 'user-1')).toEqual(transferring)
+  })
+
+  it('hides an entry from another user', () => {
+    setProgress('up-1', transferring, 'user-1')
+
+    expect(getProgress('up-1', 'user-2')).toBeNull()
+  })
+
+  it('answers an unknown id exactly like a foreign one', () => {
+    setProgress('up-1', transferring, 'user-1')
+
+    expect(getProgress('up-1', 'user-2')).toBe(getProgress('never-existed', 'user-2'))
+  })
+
+  it('keeps the owner across the updates of the same upload', () => {
+    setProgress('up-1', transferring, 'user-1')
+    setProgress('up-1', { bytesSent: 100, totalBytes: 100, status: 'done' })
+
+    expect(getProgress('up-1', 'user-1')).toEqual({ bytesSent: 100, totalBytes: 100, status: 'done' })
+    expect(getProgress('up-1', 'user-2')).toBeNull()
+  })
+
+  it('leaves an ownerless entry readable by nobody', () => {
+    setProgress('up-1', transferring)
+
+    expect(getProgress('up-1', 'user-1')).toBeNull()
+  })
+
+  it('forgets an entry once cleared', () => {
+    setProgress('up-1', transferring, 'user-1')
+    clearProgress('up-1')
+
+    expect(getProgress('up-1', 'user-1')).toBeNull()
+  })
+})

--- a/frontend/src/lib/upload-progress.ts
+++ b/frontend/src/lib/upload-progress.ts
@@ -1,4 +1,10 @@
-// In-memory upload progress tracking (server-side only)
+// In-memory upload progress tracking (server-side only).
+//
+// Entries are owner-scoped: the upload id is a client-generated UUID and was
+// the only thing standing between a signed-in user and someone else's upload
+// counters (#699). The owner is the user who opened the transfer, stamped on
+// the first chunk and kept for the later updates, so a reader who is not that
+// user is told the id is unknown rather than being handed the entry.
 
 export type UploadProgress = {
   bytesSent: number
@@ -7,14 +13,41 @@ export type UploadProgress = {
   error?: string
 }
 
-const uploads = new Map<string, UploadProgress>()
-
-export function setProgress(uploadId: string, progress: UploadProgress) {
-  uploads.set(uploadId, progress)
+type UploadEntry = {
+  progress: UploadProgress
+  /** User id that opened the transfer. Null = nobody can read it back. */
+  ownerId: string | null
 }
 
-export function getProgress(uploadId: string): UploadProgress | null {
-  return uploads.get(uploadId) || null
+const uploads = new Map<string, UploadEntry>()
+
+/**
+ * Record progress for an upload.
+ *
+ * `ownerId` is resolved once, when the entry is created; the later calls of the
+ * same transfer omit it and inherit the stamped owner, so a chunk loop never
+ * pays for a second session lookup.
+ */
+export function setProgress(uploadId: string, progress: UploadProgress, ownerId?: string | null) {
+  const existing = uploads.get(uploadId)
+
+  uploads.set(uploadId, {
+    progress,
+    ownerId: ownerId ?? existing?.ownerId ?? null,
+  })
+}
+
+/**
+ * Read progress back for `ownerId`. Returns null for an unknown id AND for an
+ * id owned by someone else: the caller answers both the same way, so the route
+ * cannot be used to tell a live upload id from a made-up one.
+ */
+export function getProgress(uploadId: string, ownerId: string): UploadProgress | null {
+  const entry = uploads.get(uploadId)
+
+  if (!entry || !entry.ownerId || entry.ownerId !== ownerId) return null
+
+  return entry.progress
 }
 
 export function clearProgress(uploadId: string) {


### PR DESCRIPTION
Closes #699.

Both routes were deliberately left out of the middleware authentication fix: neither path can contain a dot, so neither was reachable through that bypass, and keeping them out kept that change auditable against the reported surface. They remain the two API routes with no permission check of their own, so this closes the inconsistency on its own terms.

## POST /api/v1/alerts

Now requires `alerts.manage`, checked before the body is read, in the same place `PATCH` and `DELETE` check it. That is also what `/api/v1/alerts/sync` requires for the same kind of write. Nothing in the product reaches this handler today: the UI writes alerts through `/alerts/sync` and `/alerts/silence`, and no other component calls it.

## GET /api/v1/upload-progress/{uploadId}

Scoped to the caller who opened the upload rather than to a permission. No role in the model says "may watch someone else's upload", and the upload id was the only thing protecting the counters.

The progress entry now carries the id of the user who opened the transfer, resolved once on the first chunk and inherited by the later updates, so a chunk loop pays for no extra session lookup. An id owned by someone else gets the same answer as an id that never existed, so the route cannot be used to tell a live upload id from a made-up one. A caller without a session gets a 401, and a principal rejection is passed through untouched.

One failure mode is worth naming, because it is the one that would show up as a progress bar stuck at zero: an entry with no owner. It cannot happen here. `setProgress` is only reached after `checkPermission` returned null, and for a session caller `checkPermission` returns null only when the principal carries a user id. The stamping happens in the same request, from the same headers, so it resolves the same principal.

## Tests

Three files, 15 tests: permission granted and denied on the alert write, including that nothing is written on denial and that the check runs before the payload is parsed; owner scoping in the progress store, including that the owner survives the later updates and that an ownerless entry is readable by nobody; and the route itself, where the owner reads its progress, another user gets `unknown`, an unknown id gets the same answer, a caller without a session gets a 401 and a principal rejection passes through.

Full suite green on the branch: 524 files, 5363 tests, no failure. `tsc` sits at the repository baseline, 68 errors before and after, none in the touched files.
