### PR TITLE
Expose the alert recovery hysteresis in the settings

### DIFF
--- a/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
@@ -104,6 +104,35 @@ describe('GET /api/v1/internal/alert-config', () => {
     expect(body.thresholds.memory_warning).toBe(90)
   })
 
+  it('ships the recovery hysteresis to the orchestrator, confirmations as int', async () => {
+    // #551: the orchestrator only sends a "resolved" email once the metric has
+    // stayed below the margin for N consecutive collections. Dropping these two
+    // keys here would silently pin the worker to its own defaults, and a
+    // fractional confirmation count would break the whole payload decode.
+    getSettingMock.mockResolvedValueOnce({
+      recovery_margin: 7.5,
+      recovery_confirmations: 4.6,
+    })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.thresholds.recovery_margin).toBe(7.5)
+    expect(body.thresholds.recovery_confirmations).toBe(4)
+    expect(Number.isInteger(body.thresholds.recovery_confirmations)).toBe(true)
+  })
+
+  it('falls back to the default hysteresis when the setting predates it', async () => {
+    getSettingMock.mockResolvedValueOnce({ memory_warning: 90 })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    const body = await res.json()
+    expect(body.thresholds.recovery_margin).toBe(5)
+    expect(body.thresholds.recovery_confirmations).toBe(3)
+  })
+
   it('honors X-Tenant-ID by scoping the query', async () => {
     getSettingMock.mockResolvedValueOnce({})
     findManyMock.mockResolvedValueOnce([])

--- a/frontend/src/app/api/internal/alert-config/route.ts
+++ b/frontend/src/app/api/internal/alert-config/route.ts
@@ -15,6 +15,9 @@ const DEFAULT_THRESHOLDS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  // Recovery hysteresis (#551) — see the settings route for the rationale.
+  recovery_margin: 5,
+  recovery_confirmations: 3,
 }
 
 type Thresholds = typeof DEFAULT_THRESHOLDS
@@ -22,7 +25,10 @@ type Thresholds = typeof DEFAULT_THRESHOLDS
 // Fields the Go orchestrator decodes as int (see backend AlertThresholds).
 // A fractional value here makes the configsync JSON decode fail and the worker
 // rejects the entire payload, leaving thresholds and silences silently stale.
-const INT_THRESHOLD_KEYS: ReadonlySet<keyof Thresholds> = new Set(['snapshot_max_age_days'])
+const INT_THRESHOLD_KEYS: ReadonlySet<keyof Thresholds> = new Set([
+  'snapshot_max_age_days',
+  'recovery_confirmations',
+])
 
 function coerceThresholds(raw: unknown): Thresholds {
   const t = { ...DEFAULT_THRESHOLDS }

--- a/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
+++ b/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
@@ -17,6 +17,12 @@ const DEFAULT_THRESHOLDS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  // Hysteresis before an alert is declared resolved (#551): how far below the
+  // warning threshold the metric must fall, and for how many consecutive
+  // collections. Without it, a value oscillating around the threshold emits a
+  // firing and a recovery notification every minute.
+  recovery_margin: 5,
+  recovery_confirmations: 3,
 }
 
 type Thresholds = typeof DEFAULT_THRESHOLDS

--- a/frontend/src/components/settings/AlertThresholdsTab.jsx
+++ b/frontend/src/components/settings/AlertThresholdsTab.jsx
@@ -26,6 +26,8 @@ const DEFAULTS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  recovery_margin: 5,
+  recovery_confirmations: 3,
 }
 
 export default function AlertThresholdsTab() {
@@ -177,6 +179,42 @@ export default function AlertThresholdsTab() {
             ) : (
               <Typography variant='body2' color='text.disabled' sx={{ mt: 2 }}>{t('alerts.snapshotDisabled')}</Typography>
             )}
+          </CardContent>
+        </Card>
+
+        <Card variant='outlined' sx={{ borderRadius: 2 }}>
+          <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+              <i className='ri-heart-pulse-line' style={{ fontSize: 18, opacity: 0.6 }} />
+              <Typography variant='subtitle2' fontWeight={700}>{t('alerts.recoveryTitle')}</Typography>
+            </Box>
+            <Typography variant='caption' color='text.secondary'>{t('alerts.recoveryDesc')}</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 2 }}>
+              <NumericTextField
+                type='number'
+                size='small'
+                value={thresholds.recovery_margin}
+                onChange={(points) => setThresholds(th => ({ ...th, recovery_margin: Math.min(50, Math.max(0, points)) }))}
+                fallback={0}
+                min={0}
+                slotProps={{ htmlInput: { min: 0, max: 50 } }}
+                sx={{ width: 80 }}
+              />
+              <Typography variant='body2' color='text.secondary'>{t('alerts.recoveryMargin')}</Typography>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1.5 }}>
+              <NumericTextField
+                type='number'
+                size='small'
+                value={thresholds.recovery_confirmations}
+                onChange={(checks) => setThresholds(th => ({ ...th, recovery_confirmations: Math.min(10, Math.max(1, Math.trunc(checks))) }))}
+                fallback={1}
+                min={1}
+                slotProps={{ htmlInput: { min: 1, max: 10 } }}
+                sx={{ width: 80 }}
+              />
+              <Typography variant='body2' color='text.secondary'>{t('alerts.recoveryConfirmations')}</Typography>
+            </Box>
           </CardContent>
         </Card>
       </Box>

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -686,6 +686,10 @@ export interface AlertThresholds {
   storage_warning: number
   storage_critical: number
   snapshot_max_age_days: number
+  /** Points below the warning threshold before a recovery is counted (#551). */
+  recovery_margin: number
+  /** Consecutive collections below the margin before the alert resolves. */
+  recovery_confirmations: number
 }
 
 export interface AlertsResponse {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -652,7 +652,11 @@
     "snapshotAge": "Veraltete Snapshots",
     "snapshotAgeDesc": "Warnung wenn Snapshots dieses Alter überschreiten",
     "snapshotDays": "Tage",
-    "snapshotDisabled": "Deaktiviert"
+    "snapshotDisabled": "Deaktiviert",
+    "recoveryTitle": "Alarm-Entwarnung",
+    "recoveryDesc": "Wie weit eine Metrik zurückgehen muss, bevor ihr Alarm als behoben gilt, damit ein schwankender Wert nicht jede Minute eine Auslösung und eine Entwarnung verschickt",
+    "recoveryMargin": "Punkte unter dem Warnschwellenwert",
+    "recoveryConfirmations": "aufeinanderfolgende Prüfungen unter dem Abstand"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -680,7 +680,11 @@
     "snapshotAge": "Stale Snapshots",
     "snapshotAgeDesc": "Alert when VM snapshots exceed this age",
     "snapshotDays": "days",
-    "snapshotDisabled": "Disabled"
+    "snapshotDisabled": "Disabled",
+    "recoveryTitle": "Alert recovery",
+    "recoveryDesc": "How far a metric must settle back down before its alert is declared resolved, so an unstable value does not email a firing and a recovery every minute",
+    "recoveryMargin": "points below the warning threshold",
+    "recoveryConfirmations": "consecutive checks below the margin"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -680,7 +680,11 @@
     "snapshotAge": "Snapshots obsoletos",
     "snapshotAgeDesc": "Alertar cuando los snapshots de VM superen esta antigüedad",
     "snapshotDays": "días",
-    "snapshotDisabled": "Deshabilitado"
+    "snapshotDisabled": "Deshabilitado",
+    "recoveryTitle": "Recuperación de alertas",
+    "recoveryDesc": "Cuánto debe bajar una métrica antes de declarar resuelta su alerta, para evitar que un valor inestable envíe un aviso y una recuperación cada minuto",
+    "recoveryMargin": "puntos por debajo del umbral de advertencia",
+    "recoveryConfirmations": "comprobaciones consecutivas por debajo del margen"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -680,7 +680,11 @@
     "snapshotAge": "Snapshots obsolètes",
     "snapshotAgeDesc": "Alerter quand les snapshots dépassent cet âge",
     "snapshotDays": "jours",
-    "snapshotDisabled": "Désactivé"
+    "snapshotDisabled": "Désactivé",
+    "recoveryTitle": "Retour à la normale",
+    "recoveryDesc": "Jusqu'où une métrique doit redescendre avant que son alerte soit déclarée résolue, pour éviter qu'une valeur instable envoie un mail de déclenchement et de résolution chaque minute",
+    "recoveryMargin": "points sous le seuil d'avertissement",
+    "recoveryConfirmations": "relevés consécutifs sous la marge"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -680,7 +680,11 @@
     "snapshotAge": "오래된 스냅샷",
     "snapshotAgeDesc": "VM 스냅샷이 이 기간을 초과하면 알림",
     "snapshotDays": "일",
-    "snapshotDisabled": "비활성화됨"
+    "snapshotDisabled": "비활성화됨",
+    "recoveryTitle": "알림 해제",
+    "recoveryDesc": "불안정한 값이 매분 발생 및 해제 메일을 보내지 않도록, 알림을 해제로 선언하기 전에 지표가 얼마나 안정되어야 하는지 정합니다",
+    "recoveryMargin": "경고 임계값보다 낮은 포인트",
+    "recoveryConfirmations": "여유 값 미만인 연속 확인 횟수"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -652,7 +652,11 @@
     "snapshotAge": "过期快照",
     "snapshotAgeDesc": "当快照超过此天数时发出警报",
     "snapshotDays": "天",
-    "snapshotDisabled": "已禁用"
+    "snapshotDisabled": "已禁用",
+    "recoveryTitle": "告警恢复",
+    "recoveryDesc": "指标需要回落到什么程度才宣告告警已解决，避免波动的数值每分钟发送一次触发和恢复邮件",
+    "recoveryMargin": "低于警告阈值的百分点",
+    "recoveryConfirmations": "低于该余量的连续检测次数"
   },
   "inventory": {
     "alertsDialog": {


### PR DESCRIPTION
Closes #551

## What

From discussion #549: when an alert fires, nothing tells you it is over. The monitoring service now sends a recovery notification once the condition clears, and this PR is the settings surface for it.

The alert history already showed resolved alerts, and recovery emails reuse the channel of the original alert, so the only frontend work is exposing the hysteresis that decides when an alert counts as recovered.

## Why there is a hysteresis at all

Metrics are collected every minute, and the firing condition was the exact complement of the clearing one, with no margin. A value oscillating around its threshold flapped between the two states on every collection. An alert now clears only once the value has stayed a configurable margin below the warning threshold for a configurable number of consecutive collections, which is what the two new fields set.

## Changes

The alert thresholds screen gets a `Recovery` card with the clearance margin in points and the number of consecutive checks, alongside the existing stale snapshot card. Labels are translated in the six locales.

Both values travel to the monitoring service through the settings endpoint and through the config sync payload. `recovery_confirmations` is decoded as an integer downstream, so it joins the integer coercion set in the config sync route: a fractional value would fail the decode of the entire payload and silently freeze the worker, which is precisely the silent-stale failure that endpoint was built to avoid.

## Tests

Two new cases on the config sync route: the hysteresis reaches the payload with the confirmation count truncated to an integer, and a settings record written before these keys existed falls back to the defaults instead of shipping zeros. Vitest on the alerting perimeter: 18 files, 117 tests green. ESLint clean on the changed files, and the six locale files parse with the four new keys present.

## Note

The behaviour itself lives in the monitoring service and ships in a separate change to that component, which is already open for review.
