### PR TITLE
fix(api-tokens): close the offboarding and scope gaps, delete tokens outright

### DIFF
--- a/frontend/prisma/migrations/20260817000000_api_token_creator_provenance/migration.sql
+++ b/frontend/prisma/migrations/20260817000000_api_token_creator_provenance/migration.sql
@@ -1,0 +1,24 @@
+-- API token creator provenance and offboarding lookup (issue #632).
+--
+-- `created_by_user_id` is ON DELETE SET NULL: a token deliberately outlives
+-- its creator (spec 2026-07-28, decision D3) so that deleting an employee
+-- account does not kill the Prometheus integration they set up. The cost was
+-- that the row lost all trace of who minted the credential the moment the
+-- account went away. `created_by_email` freezes that answer at creation time
+-- so provenance survives the delete.
+--
+-- The index backs the new "tokens created by this user" lookup shown when an
+-- admin disables or deletes an account.
+
+ALTER TABLE "api_tokens" ADD COLUMN IF NOT EXISTS "created_by_email" TEXT;
+
+-- Backfill every token whose creator still exists. Rows whose creator was
+-- already deleted keep a NULL email: that history is gone and inventing a
+-- value would be worse than admitting the gap.
+UPDATE "api_tokens" AS t
+SET "created_by_email" = u."email"
+FROM "users" AS u
+WHERE u."id" = t."created_by_user_id"
+  AND t."created_by_email" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "api_tokens_created_by_user_id_idx" ON "api_tokens"("created_by_user_id");

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -416,6 +416,12 @@ model ApiToken {
   lastUsedIp      String?   @map("last_used_ip")
   rateLimitPerMin Int       @default(600) @map("rate_limit_per_min")
   createdByUserId String?   @map("created_by_user_id")
+  // Denormalised on purpose (#632): createdByUserId is SetNull, so deleting
+  // the account erases "who minted this credential" from the row while the
+  // token itself keeps working. The email is a frozen copy of the creator at
+  // creation time, never refreshed — it answers a provenance question about
+  // the past, not "who is this account today".
+  createdByEmail  String?   @map("created_by_email")
   createdAt       DateTime  @default(now()) @map("created_at")
   updatedAt       DateTime  @updatedAt @map("updated_at")
 
@@ -423,6 +429,8 @@ model ApiToken {
   creator User?  @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
 
   @@index([tenantId])
+  // Offboarding lists "tokens created by this user" (#632).
+  @@index([createdByUserId])
   @@map("api_tokens")
 }
 

--- a/frontend/public/openapi/proxcenter-public-api.json
+++ b/frontend/public/openapi/proxcenter-public-api.json
@@ -368,9 +368,6 @@
       ],
       "reports:read": [
         "reports.view"
-      ],
-      "compliance:read": [
-        "admin.compliance"
       ]
     }
   },

--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -8,11 +8,13 @@ import { useTranslations } from 'next-intl'
 
 import {
   Alert,
+  AlertTitle,
   Autocomplete,
   Box,
   Button,
   Card,
   CardContent,
+  Checkbox,
   Chip,
   CircularProgress,
   Dialog,
@@ -122,6 +124,138 @@ return <Chip size='small' label={t('usersPage.localAuth')} variant='outlined' ic
 }
 
 /* --------------------------------
+   API tokens outliving their creator (issue #632)
+
+   A pxc_ token authenticates on its own: it keeps working after the
+   account that created it is disabled or deleted. That is deliberate — a
+   token driving Prometheus must not die with the admin who created it —
+   but nothing in the UI used to connect the two facts, so an operator
+   disabled an account and believed the access was cut.
+
+   These two helpers surface the surviving tokens at the exact two moments
+   it matters (disable, delete) and offer deletion as an explicit opt-in.
+   Never delete implicitly: the checkbox is unchecked by default and the
+   `deleteApiTokens` flag is only ever sent when the operator ticked it.
+
+   Deletion, not revocation: "delete a token" removes the row here exactly
+   as it does from the tokens table, so the product has one verb and one
+   outcome. The journal entry is what survives.
+-------------------------------- */
+
+// Live tokens created by `userId`. GET /users/[id]/api-tokens is guarded by
+// admin.users — the same permission as this page — so no extra gating here.
+// Fails soft: a load error never blocks the dialog, it only raises
+// `loadFailed` so the caller can mention it discreetly. Warning the operator
+// is best-effort; it must never stand between them and disabling an account.
+function useCreatorApiTokens(userId, active) {
+  const [tokens, setTokens] = useState([])
+  const [loadFailed, setLoadFailed] = useState(false)
+
+  useEffect(() => {
+    if (!active || !userId) {
+      // Dialogs stay mounted between opens — clear the previous target's
+      // tokens so they can never be attributed to the next one.
+      setTokens([])
+      setLoadFailed(false)
+
+      return
+    }
+
+    let cancelled = false
+
+    setLoadFailed(false)
+
+    fetch(`/api/v1/users/${userId}/api-tokens`)
+      .then(async res => {
+        if (!res.ok) throw new Error('load failed')
+
+        return res.json()
+      })
+      .then(body => {
+        if (cancelled) return
+        setTokens(Array.isArray(body?.data) ? body.data : [])
+      })
+      .catch(() => {
+        if (cancelled) return
+        setTokens([])
+        setLoadFailed(true)
+      })
+
+    return () => { cancelled = true }
+  }, [userId, active])
+
+  return { tokens, loadFailed }
+}
+
+// The warning block shared by the disable (UserDialog) and delete paths.
+// `warningKey` swaps the sentence; everything else — the token listing and
+// the opt-in checkbox — is identical on both sides.
+function ApiTokenOffboardingWarning({ tokens, warningKey, fallbackWarning, deleteTokens, onDeleteTokensChange, t }) {
+  const count = tokens.length
+
+  return (
+    <Alert severity='warning' icon={<i className='ri-key-2-line' />} sx={{ mt: 2, mb: 1 }}>
+      <AlertTitle sx={{ mb: 0.5 }}>{t ? t('usersPage.apiTokens.title') : 'API tokens'}</AlertTitle>
+      {/* Typography never inherits its container's colour — spell out
+          `inherit` so the text follows the Alert's warning palette. */}
+      <Typography variant='body2' sx={{ color: 'inherit' }}>
+        {t ? t(warningKey, { count }) : fallbackWarning}
+      </Typography>
+      <Box component='ul' sx={{ m: 0, mt: 1, pl: 2.5 }}>
+        {tokens.map(token => (
+          <Box component='li' key={token.id} sx={{ mb: 0.25 }}>
+            {/* No monospace on the prefix — project-wide convention. */}
+            <Typography variant='caption' component='div' sx={{ color: 'inherit' }}>
+              <strong>{token.name}</strong>
+              {' · '}
+              {token.token_prefix}
+              {' · '}
+              {token.last_used_at
+                ? `${t ? t('settings.apiTokens.columns.lastUsed') : 'Last used'}: ${timeAgo(token.last_used_at, t)}`
+                : (t ? t('usersPage.apiTokens.neverUsed') : 'Never used')}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+      <FormControlLabel
+        sx={{ mt: 0.5, alignItems: 'flex-start' }}
+        control={
+          <Checkbox
+            size='small'
+            color='warning'
+            checked={deleteTokens}
+            onChange={e => onDeleteTokensChange(e.target.checked)}
+            sx={{ pt: 0.25 }}
+          />
+        }
+        label={
+          <Box component='span' sx={{ display: 'block' }}>
+            <Typography variant='body2' component='span' sx={{ color: 'inherit', display: 'block' }}>
+              {t ? t('usersPage.apiTokens.deleteCheckbox') : 'Delete these tokens as well'}
+            </Typography>
+            <Typography variant='caption' component='span' sx={{ color: 'inherit', opacity: 0.85, display: 'block' }}>
+              {t
+                ? t('usersPage.apiTokens.deleteHint')
+                : 'Any integration using them stops working immediately. This cannot be undone.'}
+            </Typography>
+          </Box>
+        }
+      />
+    </Alert>
+  )
+}
+
+// Load failures are reported inline and unobtrusively — see the fail-soft
+// note on useCreatorApiTokens.
+function ApiTokenLoadError({ t }) {
+  return (
+    <Typography variant='caption' sx={{ display: 'block', mt: 1, color: 'warning.main' }}>
+      {t ? t('usersPage.apiTokens.loadError') : 'Failed to load the API tokens of this user'}
+    </Typography>
+  )
+}
+
+/* --------------------------------
    User Dialog - Création/Modification
 -------------------------------- */
 
@@ -159,6 +293,9 @@ function UserDialog({ open, onClose, user, onSave, rbacRoles, t, showRbac = true
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [showPassword, setShowPassword] = useState(false)
+  // Opt-in deletion of the tokens this account created (issue #632).
+  // Unchecked by default, and only honoured while the warning is on screen.
+  const [deleteApiTokens, setDeleteApiTokens] = useState(false)
 
   const isEdit = !!user
   // Password is owned by the external IdP for SSO/LDAP accounts — never let the
@@ -175,6 +312,18 @@ function UserDialog({ open, onClose, user, onSave, rbacRoles, t, showRbac = true
   const rolesAreDivergent = isEdit && Array.isArray(user?.roles)
     ? new Set(user.roles.map(r => r.id).filter(Boolean)).size > 1
     : false
+
+  // Tokens the target created, loaded whenever the dialog edits somebody
+  // else. Self-edits cannot reach the Enabled switch at all (see isSelf).
+  const { tokens: creatorTokens, loadFailed: tokensLoadFailed } = useCreatorApiTokens(
+    user?.id,
+    open && isEdit && !isSelf
+  )
+
+  // Only warn on the transition active → inactive. An account that was
+  // already disabled when the dialog opened teaches the operator nothing
+  // new here, and a dialog opened to rename somebody must stay quiet.
+  const showTokenWarning = isEdit && !isSelf && creatorTokens.length > 0 && !enabled && !!user?.enabled
 
   useEffect(() => {
     if (user) {
@@ -202,6 +351,7 @@ function UserDialog({ open, onClose, user, onSave, rbacRoles, t, showRbac = true
     }
 
     setError('')
+    setDeleteApiTokens(false)
   }, [user, open])
 
   // Clear the role state when the selected tenants make the current role
@@ -281,6 +431,10 @@ return
             ...(enableTenantMgmt && showRbac && !isSelf && (selectedRole?.id ?? null) !== initialRoleId
               ? { roleId: selectedRole?.id ?? null }
               : {}),
+            // Gated on showTokenWarning, not on the checkbox alone: ticking
+            // the box then switching the account back on must not smuggle a
+            // deletion through with a save that no longer disables anyone.
+            ...(showTokenWarning && deleteApiTokens ? { deleteApiTokens: true } : {}),
           }
         : {
             email,
@@ -517,6 +671,19 @@ return
           />
         )}
 
+        {isEdit && !isSelf && tokensLoadFailed && <ApiTokenLoadError t={t} />}
+
+        {showTokenWarning && (
+          <ApiTokenOffboardingWarning
+            tokens={creatorTokens}
+            warningKey='usersPage.apiTokens.disableWarning'
+            fallbackWarning={`This account created ${creatorTokens.length} active API token(s). Disabling the account does not stop them: a token authenticates on its own.`}
+            deleteTokens={deleteApiTokens}
+            onDeleteTokensChange={setDeleteApiTokens}
+            t={t}
+          />
+        )}
+
         {enableTenantMgmt && (
           <Autocomplete
             multiple
@@ -568,15 +735,36 @@ return
 function DeleteDialog({ open, onClose, user, onConfirm, currentUserId, t }) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  // Opt-in deletion of the tokens this account created (issue #632).
+  const [deleteApiTokens, setDeleteApiTokens] = useState(false)
 
   const isSelf = user?.id === currentUserId
+
+  const { tokens: creatorTokens, loadFailed: tokensLoadFailed } = useCreatorApiTokens(
+    user?.id,
+    open && !isSelf
+  )
+
+  const showTokenWarning = !isSelf && creatorTokens.length > 0
+
+  // The dialog is never unmounted between two targets — start every delete
+  // from an unticked box so a previous decision cannot ride along.
+  useEffect(() => {
+    setDeleteApiTokens(false)
+  }, [user, open])
 
   const handleDelete = async () => {
     setLoading(true)
     setError('')
 
     try {
-      const res = await fetch(`/api/v1/users/${user.id}`, { method: 'DELETE' })
+      // The query flag is opt-in: without it the backend deletes the account
+      // and leaves the tokens live, which is the historical behaviour.
+      const url = showTokenWarning && deleteApiTokens
+        ? `/api/v1/users/${user.id}?deleteApiTokens=true`
+        : `/api/v1/users/${user.id}`
+
+      const res = await fetch(url, { method: 'DELETE' })
       const data = await res.json()
 
       if (!res.ok) {
@@ -615,6 +803,17 @@ return
             <Typography variant='body2' sx={{ mt: 1, color: 'warning.main' }}>
               {t ? t('usersPage.deleteWarning') : 'This action is irreversible. All role assignments will also be deleted.'}
             </Typography>
+            {tokensLoadFailed && <ApiTokenLoadError t={t} />}
+            {showTokenWarning && (
+              <ApiTokenOffboardingWarning
+                tokens={creatorTokens}
+                warningKey='usersPage.apiTokens.deleteWarning'
+                fallbackWarning={`This account created ${creatorTokens.length} active API token(s). They survive the deletion: a token authenticates on its own.`}
+                deleteTokens={deleteApiTokens}
+                onDeleteTokensChange={setDeleteApiTokens}
+                t={t}
+              />
+            )}
           </>
         )}
       </DialogContent>

--- a/frontend/src/app/api/v1/settings/api-tokens/[id]/route.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/[id]/route.ts
@@ -7,9 +7,22 @@ import { requireApiTokenAdmin, tenantVisibleToCaller } from "../_shared"
 
 export const runtime = "nodejs"
 
-// Soft revocation: revoked_at is set, the row is KEPT for the audit trail
-// (spec section 5). Idempotent. NOT license-gated (D6): an administrator
-// can still revoke a token after the option lapses.
+// Hard delete: the row is REMOVED. This replaced the original soft revocation
+// (spec section 5, revoked_at kept for the audit trail) on owner feedback --
+// "supprimer" has to mean the token is gone, not greyed out in the table.
+//
+// The audit trail does not depend on the row surviving: audit_logs.api_token_id
+// was created deliberately WITHOUT a foreign key precisely so journal entries
+// outlive the token they describe (see the 20260728000000_api_tokens
+// migration). What is genuinely lost is the token's own history, last_used_at
+// above all -- that is the accepted cost of the row disappearing.
+//
+// NOT idempotent, unlike the revocation it replaces: a second DELETE on the
+// same id answers 404. That is the honest answer once the row is gone, and the
+// only caller reloads the list rather than reading this response.
+//
+// NOT license-gated (D6): an administrator can still delete a token after the
+// option lapses.
 export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string }> | { id: string } }) {
   const guard = await requireApiTokenAdmin()
   if (!guard.ok) return guard.response!
@@ -22,34 +35,35 @@ export async function DELETE(_req: Request, ctx: { params: Promise<{ id: string 
 
   const token = await prisma.apiToken.findUnique({
     where: { id },
-    select: { id: true, name: true, tenantId: true, revokedAt: true },
+    select: { id: true, name: true, tenantId: true, tokenPrefix: true },
   })
   const visible = token && (await tenantVisibleToCaller(rbac, token.tenantId))
   if (!visible) return NextResponse.json({ error: "API token not found" }, { status: 404 })
 
-  const revokedAt = token.revokedAt ?? new Date()
-  if (!token.revokedAt) {
-    // Atomic with the audit row (fix round 1, finding 1): if the audit
-    // insert fails, the revocation must roll back too, so revoked_at never
-    // ends up set with no journal entry to show for it.
-    try {
-      await prisma.$transaction(async tx => {
-        await tx.apiToken.update({ where: { id }, data: { revokedAt } })
-        await audit(
-          {
-            action: "apitoken.revoke",
-            category: "api_tokens",
-            resourceType: "api_token",
-            resourceId: id,
-            resourceName: token.name,
-          },
-          tx,
-        )
-      })
-    } catch (e: any) {
-      return NextResponse.json({ error: e?.message || "Internal server error" }, { status: 500 })
-    }
+  // Atomic with the audit row (fix round 1, finding 1): if the audit insert
+  // fails, the delete must roll back too. A credential vanishing with no
+  // journal entry to show for it is worse here than it was for revocation --
+  // there would be nothing left anywhere to say the token ever existed.
+  try {
+    await prisma.$transaction(async tx => {
+      await tx.apiToken.delete({ where: { id } })
+      await audit(
+        {
+          action: "apitoken.delete",
+          category: "api_tokens",
+          resourceType: "api_token",
+          resourceId: id,
+          resourceName: token.name,
+          // The prefix is the only identifier that survives the row, and it
+          // is what an operator reads to recognise which integration this was.
+          details: { tokenPrefix: token.tokenPrefix },
+        },
+        tx,
+      )
+    })
+  } catch (e: any) {
+    return NextResponse.json({ error: e?.message || "Internal server error" }, { status: 500 })
   }
 
-  return NextResponse.json({ data: { id, revokedAt: revokedAt.toISOString() } })
+  return NextResponse.json({ data: { id, deleted: true } })
 }

--- a/frontend/src/app/api/v1/settings/api-tokens/_shared.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/_shared.ts
@@ -29,6 +29,11 @@ export const TOKEN_VIEW_SELECT = {
   lastUsedIp: true,
   rateLimitPerMin: true,
   createdByUserId: true,
+  // Frozen copy of the creator's email (#632). createdByUserId goes NULL when
+  // the account is deleted while the token stays valid, so it cannot answer
+  // "who minted this credential" on its own -- and the audit row only
+  // answers it for as long as audit retention keeps it.
+  createdByEmail: true,
   createdAt: true,
 } as const
 

--- a/frontend/src/app/api/v1/settings/api-tokens/apiTokensAuditAtomicity.test.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/apiTokensAuditAtomicity.test.ts
@@ -1,5 +1,5 @@
-// Fix round 1, findings 1 and 2: the token/revocation state change and its
-// audit row must be one transaction. Proven here with a REAL forced audit
+// Fix round 1, findings 1 and 2: the token row change (its creation, and now
+// its removal) and its audit row must be one transaction. Proven here with a REAL forced audit
 // insert failure (a primary-key collision on audit_logs.id, a real Postgres
 // constraint), not a mocked throw — @/lib/audit itself is NOT mocked in
 // this file, only the admin-side guard (@/lib/rbac, @/lib/tenant) and the
@@ -98,8 +98,12 @@ describe('POST create: token row and audit row are one transaction', () => {
   })
 })
 
-describe('DELETE revoke: revoked_at and audit row are one transaction', () => {
-  it('leaves revoked_at unset when the audit insert fails', async () => {
+// Now that the DELETE removes the row instead of stamping it, the stake of
+// this atomicity is higher than it was for revocation: a credential vanishing
+// with no journal entry to show for it leaves nothing, anywhere, to say the
+// token ever existed. So the rollback assertion is "the row is STILL THERE".
+describe('DELETE: the row removal and the audit row are one transaction', () => {
+  it('leaves the token row in place when the audit insert fails', async () => {
     const { id } = await seedApiToken()
     // The only nanoid() call on this path is audit()'s own row id.
     nanoidMock.mockReturnValueOnce('colliding-audit-id-2')
@@ -110,10 +114,11 @@ describe('DELETE revoke: revoked_at and audit row are one transaction', () => {
 
     expect(res.status).toBe(500)
     const row = await prismaTest.apiToken.findUnique({ where: { id } })
-    expect(row?.revokedAt).toBeNull()
+    expect(row).not.toBeNull()
+    expect(row?.id).toBe(id)
   })
 
-  it('sets revoked_at when the audit insert succeeds (control case)', async () => {
+  it('removes the row when the audit insert succeeds (control case)', async () => {
     const { id } = await seedApiToken()
     nanoidMock.mockReturnValueOnce('audit-id-ok-2')
 
@@ -122,8 +127,8 @@ describe('DELETE revoke: revoked_at and audit row are one transaction', () => {
 
     expect(res.status).toBe(200)
     const row = await prismaTest.apiToken.findUnique({ where: { id } })
-    expect(row?.revokedAt).not.toBeNull()
+    expect(row).toBeNull()
     const auditRow = await prismaTest.auditLog.findUnique({ where: { id: 'audit-id-ok-2' } })
-    expect(auditRow?.action).toBe('apitoken.revoke')
+    expect(auditRow?.action).toBe('apitoken.delete')
   })
 })

--- a/frontend/src/app/api/v1/settings/api-tokens/apiTokensRoutes.test.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/apiTokensRoutes.test.ts
@@ -287,16 +287,19 @@ describe('POST /api/v1/settings/api-tokens', () => {
 })
 
 describe('DELETE /api/v1/settings/api-tokens/{id}', () => {
-  it('soft-revokes and keeps the row', async () => {
-    const { id } = await seedApiToken()
+  // Owner arbitration: the row is REMOVED, it is no longer stamped with
+  // revoked_at. The audit entry is what remains, carrying the prefix -- the
+  // only identifier that survives the row.
+  it('deletes the row outright and journals apitoken.delete with the prefix', async () => {
+    const { id, prefix } = await seedApiToken()
     const { DELETE } = await import('./[id]/route')
     const res = await callRoute(DELETE, { method: 'DELETE', params: { id } })
     expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ data: { id, deleted: true } })
     const row = await prismaTest.apiToken.findUnique({ where: { id } })
-    expect(row).not.toBeNull()
-    expect(row?.revokedAt).not.toBeNull()
+    expect(row).toBeNull()
     expect(auditMock).toHaveBeenCalledWith(
-      expect.objectContaining({ action: 'apitoken.revoke' }),
+      expect.objectContaining({ action: 'apitoken.delete', details: { tokenPrefix: prefix } }),
       expect.anything(),
     )
   })
@@ -310,14 +313,15 @@ describe('DELETE /api/v1/settings/api-tokens/{id}', () => {
     expect((await callRoute(DELETE, { method: 'DELETE', params: { id } })).status).toBe(404)
   })
 
-  it('denies revocation when admin.apitokens is missing', async () => {
+  it('denies deletion when admin.apitokens is missing', async () => {
     checkPermissionMock.mockResolvedValue(new Response(JSON.stringify({ error: 'nope' }), { status: 403 }))
     const { id } = await seedApiToken()
     const { DELETE } = await import('./[id]/route')
     const res = await callRoute(DELETE, { method: 'DELETE', params: { id } })
     expect(res.status).toBe(403)
-    const row = await prismaTest.apiToken.findUnique({ where: { id } })
-    expect(row?.revokedAt).toBeNull()
+    // On a hard delete the survival of the row is the whole assertion: reading
+    // `row?.revokedAt` would pass just as happily on a row that was removed.
+    expect(await prismaTest.apiToken.findUnique({ where: { id } })).not.toBeNull()
   })
 
   it('400s when params.id is missing entirely', async () => {
@@ -327,26 +331,44 @@ describe('DELETE /api/v1/settings/api-tokens/{id}', () => {
     expect(await readJson<any>(res)).toEqual({ error: 'Missing params.id' })
   })
 
-  it('is idempotent: revoking an already-revoked token keeps the original revokedAt and never re-enters the transaction', async () => {
+  // The route is deliberately NOT idempotent any more, unlike the revocation
+  // it replaces (which answered 200 forever). Once the row is gone 404 is the
+  // honest answer, and the only caller reloads the list rather than reading
+  // this response.
+  it('answers 404 on a second DELETE of the same id, and journals nothing the second time', async () => {
+    const { id } = await seedApiToken()
+    const { DELETE } = await import('./[id]/route')
+
+    const first = await callRoute(DELETE, { method: 'DELETE', params: { id } })
+    expect(first.status).toBe(200)
+    expect(auditMock).toHaveBeenCalledTimes(1)
+
+    const second = await callRoute(DELETE, { method: 'DELETE', params: { id } })
+    expect(second.status).toBe(404)
+    expect(await readJson<any>(second)).toEqual({ error: 'API token not found' })
+    // The lookup fails before the transaction, so no second journal entry.
+    expect(auditMock).toHaveBeenCalledTimes(1)
+  })
+
+  // A legacy row still carrying revoked_at from the soft-revocation era is
+  // deletable like any other: the route keys on the row, not on its state.
+  it('deletes a legacy already-revoked row instead of refusing it', async () => {
     const { id } = await seedApiToken({ revokedAt: new Date('2026-01-01T00:00:00.000Z') })
     const { DELETE } = await import('./[id]/route')
     const res = await callRoute(DELETE, { method: 'DELETE', params: { id } })
     expect(res.status).toBe(200)
-    const body = await readJson<any>(res)
-    expect(body.data.revokedAt).toBe('2026-01-01T00:00:00.000Z')
-    // No second audit row: the transaction (and its audit() call) never runs
-    // again for a token that is already revoked.
-    expect(auditMock).not.toHaveBeenCalled()
+    expect(await readJson<any>(res)).toEqual({ data: { id, deleted: true } })
+    expect(await prismaTest.apiToken.findUnique({ where: { id } })).toBeNull()
   })
 
-  it('falls back to a generic 500 message when the revoke transaction failure carries no message', async () => {
+  it('falls back to a generic 500 message when the delete transaction failure carries no message', async () => {
     auditMock.mockRejectedValueOnce({})
     const { id } = await seedApiToken()
     const { DELETE } = await import('./[id]/route')
     const res = await callRoute(DELETE, { method: 'DELETE', params: { id } })
     expect(res.status).toBe(500)
     expect(await readJson<any>(res)).toEqual({ error: 'Internal server error' })
-    const row = await prismaTest.apiToken.findUnique({ where: { id } })
-    expect(row?.revokedAt).toBeNull()
+    // Rolled back with the audit insert: the credential is still there.
+    expect(await prismaTest.apiToken.findUnique({ where: { id } })).not.toBeNull()
   })
 })

--- a/frontend/src/app/api/v1/settings/api-tokens/apiTokensSelfReview.test.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/apiTokensSelfReview.test.ts
@@ -4,8 +4,9 @@
 //      other response (GET list, DELETE);
 //   B. a created token actually authenticates through the REAL getPrincipal
 //      (Task 9), proving the stored hash matches the returned secret;
-//   C. revoking a token makes that same, previously-working token fail the
-//      REAL getPrincipal check;
+//   C. deleting a token makes that same, previously-working token fail the
+//      REAL getPrincipal check (the legacy soft-revoked row is the other half
+//      of that guarantee and is covered in src/lib/auth/principal.test.ts);
 //   D. POST is refused without api_access while GET and DELETE still work
 //      (D6 asymmetric gating).
 //
@@ -110,8 +111,8 @@ describe('self-review A: secret is revealed once, nowhere else', () => {
   })
 })
 
-describe('self-review B/C: the returned secret really authenticates, and revocation really breaks it', () => {
-  it('authenticates via the real getPrincipal, then stops authenticating once revoked', async () => {
+describe('self-review B/C: the returned secret really authenticates, and deletion really breaks it', () => {
+  it('authenticates via the real getPrincipal, then stops authenticating once deleted', async () => {
     const { POST } = await import('./route')
     const { DELETE } = await import('./[id]/route')
 
@@ -129,10 +130,13 @@ describe('self-review B/C: the returned secret really authenticates, and revocat
     expect(before.principal?.kind).toBe('token')
     expect(before.principal?.tokenId).toBe(tokenId)
 
-    // C: revoke through the route under test, then replay the identical
-    // request — the same secret must now be rejected.
-    const revokeRes = await callRoute(DELETE, { method: 'DELETE', params: { id: tokenId } })
-    expect(revokeRes.status).toBe(200)
+    // C: delete through the route under test, then replay the identical
+    // request — the same secret must now be rejected. The row is gone, so the
+    // rejection comes from the prefix lookup finding nothing, and it must be
+    // the same undifferentiated 401 as a wrong hash (no oracle).
+    const deleteRes = await callRoute(DELETE, { method: 'DELETE', params: { id: tokenId } })
+    expect(deleteRes.status).toBe(200)
+    expect(await prismaTest.apiToken.findUnique({ where: { id: tokenId } })).toBeNull()
 
     headersMock.mockResolvedValue(tokenHeaders(secret, 'vms-list', '/api/v1/vms'))
     const after = await getPrincipal()
@@ -161,7 +165,8 @@ describe('self-review D: asymmetric licence gating (D6)', () => {
 
     const deleteRes = await callRoute(DELETE, { method: 'DELETE', params: { id: seeded.id } })
     expect(deleteRes.status).toBe(200)
-    const row = await prismaTest.apiToken.findUnique({ where: { id: seeded.id } })
-    expect(row?.revokedAt).not.toBeNull()
+    // `row?.revokedAt` would have gone on passing here for the wrong reason
+    // once the route started removing the row -- assert the removal itself.
+    expect(await prismaTest.apiToken.findUnique({ where: { id: seeded.id } })).toBeNull()
   })
 })

--- a/frontend/src/app/api/v1/settings/api-tokens/route.ts
+++ b/frontend/src/app/api/v1/settings/api-tokens/route.ts
@@ -111,6 +111,14 @@ export async function POST(req: Request) {
 
   const generated = generateApiToken()
 
+  // Denormalised provenance (#632): read the creator's email once, here, and
+  // freeze it on the row. Resolving it at display time through the FK would
+  // return nothing precisely in the case that matters, after the account has
+  // been deleted.
+  const creator = ctx.userId
+    ? await prisma.user.findUnique({ where: { id: ctx.userId }, select: { email: true } })
+    : null
+
   // Atomic with the audit row (fix round 1, finding 1): if the audit insert
   // fails, the token creation must roll back too. Otherwise a caller could
   // get an error response while an active, unlogged credential (with its
@@ -131,6 +139,7 @@ export async function POST(req: Request) {
           expiresAt,
           rateLimitPerMin,
           createdByUserId: ctx.userId ?? null,
+          createdByEmail: creator?.email ?? null,
         },
         select: TOKEN_VIEW_SELECT,
       })

--- a/frontend/src/app/api/v1/users/[id]/__tests__/api-tokens-route.test.ts
+++ b/frontend/src/app/api/v1/users/[id]/__tests__/api-tokens-route.test.ts
@@ -1,0 +1,204 @@
+/**
+ * GET /users/[id]/api-tokens — the offboarding read (#632).
+ *
+ * This route exists so the user-admin dialogs can show, before disabling or
+ * deleting an account, the credentials that will keep authenticating without
+ * it. Three things must hold: it is gated by admin.users (not
+ * admin.apitokens — the admin managing people may not hold the token right),
+ * it resolves its target exactly like GET /users/[id] so a tenant-scoped
+ * caller cannot probe ids from another tenant, and its projection carries
+ * identifying fields ONLY — never a secret, never a hash.
+ *
+ * Runs against the real schema: the tenant name comes from a relation and the
+ * live/dead split is a SQL predicate, so a mocked Prisma would assert nothing.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  checkPermissionMock,
+  isUserProtectedMock,
+  isUserSuperAdminMock,
+  getCurrentTenantIdMock,
+  getServerSessionMock,
+} = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn<() => Promise<Response | null>>(),
+  isUserProtectedMock: vi.fn<() => Promise<boolean>>(),
+  isUserSuperAdminMock: vi.fn<() => Promise<boolean>>(),
+  getCurrentTenantIdMock: vi.fn<() => Promise<string>>(),
+  getServerSessionMock: vi.fn<() => Promise<any>>(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_USERS: 'admin.users' },
+  isUserProtected: isUserProtectedMock,
+  isUserSuperAdmin: isUserSuperAdminMock,
+}))
+vi.mock('@/lib/tenant', () => ({
+  DEFAULT_TENANT_ID: 'default',
+  getCurrentTenantId: getCurrentTenantIdMock,
+}))
+
+import { prismaTest, truncate } from '@/__tests__/setup/prisma-test'
+import { seedDefaultTenant } from '@/__tests__/setup/apiTokens'
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const HASH = 'deadbeef'.repeat(8)
+const FAR_FUTURE = new Date('2099-01-01T00:00:00.000Z')
+const LONG_PAST = new Date('2020-01-01T00:00:00.000Z')
+
+async function seedUser(id: string, tenantIds: string[]): Promise<void> {
+  const now = new Date()
+  await prismaTest.user.create({
+    data: { id, email: `${id}@test.local`, createdAt: now, updatedAt: now },
+  })
+  for (const tenantId of tenantIds) {
+    await prismaTest.userTenant.create({ data: { userId: id, tenantId, joinedAt: now } })
+  }
+}
+
+async function seedToken(opts: {
+  id: string
+  createdByUserId: string | null
+  tenantId?: string
+  createdAt?: Date
+  revokedAt?: Date | null
+  expiresAt?: Date | null
+  lastUsedAt?: Date | null
+}): Promise<void> {
+  await prismaTest.apiToken.create({
+    data: {
+      id: opts.id,
+      tenantId: opts.tenantId ?? 'default',
+      name: `name-of-${opts.id}`,
+      tokenPrefix: `pxc_${opts.id}`,
+      tokenHash: `${HASH}-${opts.id}`,
+      scopes: ['vms:read', 'backups:read'],
+      connectionIds: null,
+      createdByUserId: opts.createdByUserId,
+      createdAt: opts.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+      revokedAt: opts.revokedAt ?? null,
+      expiresAt: opts.expiresAt ?? null,
+      lastUsedAt: opts.lastUsedAt ?? null,
+    },
+  })
+}
+
+async function importGET() {
+  const mod = await import('../api-tokens/route')
+  return mod.GET
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  isUserProtectedMock.mockResolvedValue(false)
+  isUserSuperAdminMock.mockResolvedValue(false)
+  getCurrentTenantIdMock.mockResolvedValue('default')
+  getServerSessionMock.mockResolvedValue({ user: { id: 'u-admin', email: 'admin@test.local' } })
+
+  await truncate(['api_tokens', 'user_tenants', 'users', 'tenants'])
+  await seedDefaultTenant()
+  const now = new Date()
+  await prismaTest.tenant.create({
+    data: { id: 't2', slug: 't2', name: 'Tenant Two', operatingModel: 'msp', createdAt: now, updatedAt: now },
+  })
+  await seedUser('u-leaver', ['default', 't2'])
+})
+
+describe('GET /users/[id]/api-tokens', () => {
+  it('denies the read without admin.users', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    await seedToken({ id: 'live', createdByUserId: 'u-leaver' })
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-leaver' } })
+    expect(res.status).toBe(403)
+    expect(await readJson<any>(res)).not.toHaveProperty('data')
+  })
+
+  it('404s on a user id that does not exist', async () => {
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-ghost' } })
+    expect(res.status).toBe(404)
+    expect(await readJson<any>(res)).toEqual({ error: 'Utilisateur non trouvé' })
+  })
+
+  it('404s (never 403) when the target is a protected account and the caller is not a super admin', async () => {
+    isUserProtectedMock.mockResolvedValue(true)
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-leaver' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('projects the live tokens in snake_case with the tenant name, and no secret or hash', async () => {
+    await seedToken({
+      id: 'live',
+      createdByUserId: 'u-leaver',
+      lastUsedAt: new Date('2026-03-04T05:06:07.000Z'),
+      expiresAt: FAR_FUTURE,
+    })
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-leaver' } })
+
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.data).toHaveLength(1)
+    expect(body.data[0]).toEqual({
+      id: 'live',
+      name: 'name-of-live',
+      token_prefix: 'pxc_live',
+      tenant_id: 'default',
+      tenant_name: 'Provider',
+      scopes: ['vms:read', 'backups:read'],
+      last_used_at: '2026-03-04T05:06:07.000Z',
+      expires_at: '2099-01-01T00:00:00.000Z',
+      created_at: '2026-01-01T00:00:00.000Z',
+    })
+    // Explicit: neither casing of the hash column, under any name, and not
+    // as a raw substring anywhere in the payload either.
+    expect(body.data[0].tokenHash).toBeUndefined()
+    expect(body.data[0].token_hash).toBeUndefined()
+    expect(body.data[0].secret).toBeUndefined()
+    expect(JSON.stringify(body)).not.toContain(HASH)
+  })
+
+  it('omits the revoked and the expired tokens, keeps the ones that still authenticate', async () => {
+    await seedToken({ id: 'live', createdByUserId: 'u-leaver' })
+    await seedToken({ id: 'revoked', createdByUserId: 'u-leaver', revokedAt: new Date('2026-02-01T00:00:00.000Z') })
+    await seedToken({ id: 'expired', createdByUserId: 'u-leaver', expiresAt: LONG_PAST })
+    const GET = await importGET()
+    const body = await readJson<any>(await callRoute(GET as any, { params: { id: 'u-leaver' } }))
+    expect(body.data.map((t: any) => t.id)).toEqual(['live'])
+  })
+
+  it('shows every tenant to the provider view but only its own to a tenant-scoped admin', async () => {
+    await seedToken({ id: 'live-default', createdByUserId: 'u-leaver', createdAt: new Date('2026-01-01T00:00:00.000Z') })
+    await seedToken({ id: 'live-t2', createdByUserId: 'u-leaver', tenantId: 't2', createdAt: new Date('2026-01-02T00:00:00.000Z') })
+    const GET = await importGET()
+
+    const provider = await readJson<any>(await callRoute(GET as any, { params: { id: 'u-leaver' } }))
+    expect(provider.data.map((t: any) => t.id)).toEqual(['live-t2', 'live-default'])
+
+    getCurrentTenantIdMock.mockResolvedValue('t2')
+    const scoped = await readJson<any>(await callRoute(GET as any, { params: { id: 'u-leaver' } }))
+    expect(scoped.data.map((t: any) => t.id)).toEqual(['live-t2'])
+  })
+
+  it('404s for a tenant-scoped caller whose tenant the target does not belong to', async () => {
+    getCurrentTenantIdMock.mockResolvedValue('t2')
+    await seedUser('u-elsewhere', ['default'])
+    await seedToken({ id: 'live-elsewhere', createdByUserId: 'u-elsewhere' })
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-elsewhere' } })
+    expect(res.status).toBe(404)
+  })
+
+  it('returns an empty list, not a 404, for a user who never created a token', async () => {
+    const GET = await importGET()
+    const res = await callRoute(GET as any, { params: { id: 'u-leaver' } })
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ data: [] })
+  })
+})

--- a/frontend/src/app/api/v1/users/[id]/__tests__/offboarding-token-deletion.test.ts
+++ b/frontend/src/app/api/v1/users/[id]/__tests__/offboarding-token-deletion.test.ts
@@ -1,0 +1,333 @@
+/**
+ * PATCH / DELETE /users/[id] — opt-in API token deletion on offboarding (#632).
+ *
+ * A pxc_ token authenticates on its own row: it survives the disabling or the
+ * deletion of the account that minted it, by design (spec D3 — a departure
+ * must not take Prometheus down). The product arbitration is therefore that
+ * the admin decides, explicitly, in the same gesture:
+ *
+ *   - PATCH { deleteApiTokens: true } and DELETE ?deleteApiTokens=true remove
+ *     the token rows outright. On owner arbitration this is a hard delete, not
+ *     the revocation stamp it started as: "supprimer" has to mean the token is
+ *     gone. What survives is the audit entry, which names the prefixes
+ *     (audit_logs.api_token_id carries no foreign key precisely so a journal
+ *     line can outlive the row it describes).
+ *   - The same requests WITHOUT the flag must delete nothing. That negative is
+ *     the feature, not an oversight: an implicit deletion would silently
+ *     break integrations during an offboarding, which is the failure mode the
+ *     spec chose to avoid.
+ *
+ * Two orderings also matter, and both are asserted below:
+ *   - PATCH deletes BEFORE prisma.user.update, so a deletion failure aborts
+ *     the request with the account still enabled rather than leaving an admin
+ *     believing the tokens died with the account.
+ *   - DELETE deletes the tokens BEFORE the account, because
+ *     created_by_user_id is ON DELETE SET NULL: after the delete the tokens
+ *     can no longer be found by creator and the chance is lost for good. The
+ *     evidence for that ordering is the NON-ZERO count in the response — had
+ *     the sweep run after the account delete, the creator link would already
+ *     be NULL and it would have found, and reported, nothing.
+ *
+ * Real Postgres: the SET NULL behaviour, the disappearance of a row and the
+ * survival of created_by_email are database facts, unobservable through a
+ * mocked Prisma.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  checkPermissionMock,
+  isUserProtectedMock,
+  isUserSuperAdminMock,
+  getCurrentTenantIdMock,
+  getServerSessionMock,
+  hashPasswordMock,
+  auditMock,
+  revokeAllSessionsMock,
+} = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn<() => Promise<Response | null>>(),
+  isUserProtectedMock: vi.fn<() => Promise<boolean>>(),
+  isUserSuperAdminMock: vi.fn<() => Promise<boolean>>(),
+  getCurrentTenantIdMock: vi.fn<() => Promise<string>>(),
+  getServerSessionMock: vi.fn<() => Promise<any>>(),
+  hashPasswordMock: vi.fn<() => Promise<string>>(),
+  auditMock: vi.fn<() => Promise<string>>(),
+  revokeAllSessionsMock: vi.fn<() => Promise<number>>(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: getServerSessionMock }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/auth/password', () => ({ hashPassword: hashPasswordMock }))
+vi.mock('@/lib/auth/sessions', () => ({ revokeAllSessions: revokeAllSessionsMock }))
+vi.mock('@/lib/audit', () => ({ audit: auditMock }))
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: checkPermissionMock,
+  PERMISSIONS: { ADMIN_USERS: 'admin.users' },
+  isUserProtected: isUserProtectedMock,
+  isUserSuperAdmin: isUserSuperAdminMock,
+  PROTECTED_ROLE_IDS: ['role_super_admin', 'role_provider_admin'],
+  PROVIDER_ONLY_ROLE_IDS: ['role_operator', 'role_vm_admin', 'role_viewer', 'role_vm_user'],
+}))
+vi.mock('@/lib/tenant', () => ({
+  DEFAULT_TENANT_ID: 'default',
+  getCurrentTenantId: getCurrentTenantIdMock,
+  addUserToTenant: vi.fn(),
+  removeUserFromTenant: vi.fn(),
+  TenantMembershipError: class extends Error {},
+}))
+
+import { prismaTest, truncate } from '@/__tests__/setup/prisma-test'
+import { seedDefaultTenant } from '@/__tests__/setup/apiTokens'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { prisma } from '@/lib/db/prisma'
+
+const FAR_FUTURE = new Date('2099-01-01T00:00:00.000Z')
+const LONG_PAST = new Date('2020-01-01T00:00:00.000Z')
+const ALREADY_REVOKED_AT = new Date('2026-02-01T00:00:00.000Z')
+
+async function seedUser(id: string, tenantIds: string[]): Promise<void> {
+  const now = new Date()
+  await prismaTest.user.create({
+    data: { id, email: `${id}@test.local`, name: id, createdAt: now, updatedAt: now },
+  })
+  for (const tenantId of tenantIds) {
+    await prismaTest.userTenant.create({ data: { userId: id, tenantId, joinedAt: now } })
+  }
+}
+
+async function seedToken(opts: {
+  id: string
+  createdByUserId: string | null
+  tenantId?: string
+  revokedAt?: Date | null
+  expiresAt?: Date | null
+}): Promise<void> {
+  await prismaTest.apiToken.create({
+    data: {
+      id: opts.id,
+      tenantId: opts.tenantId ?? 'default',
+      name: `name-of-${opts.id}`,
+      tokenPrefix: `pxc_${opts.id}`,
+      tokenHash: `hash-of-${opts.id}`,
+      scopes: ['vms:read'],
+      connectionIds: null,
+      createdByUserId: opts.createdByUserId,
+      createdByEmail: opts.createdByUserId ? `${opts.createdByUserId}@test.local` : null,
+      revokedAt: opts.revokedAt ?? null,
+      expiresAt: opts.expiresAt ?? null,
+    },
+  })
+}
+
+function tokenRow(id: string) {
+  return prismaTest.apiToken.findUnique({ where: { id } })
+}
+
+// Deliberately not `(await tokenRow(id))?.someColumn`: on a missing row that
+// reads back as `undefined`, which quietly satisfies most negative matchers.
+// Row disappearance is the assertion here, so it is checked on the row itself.
+async function exists(id: string): Promise<boolean> {
+  return (await tokenRow(id)) !== null
+}
+
+async function importRoute() {
+  return await import('../route')
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  isUserProtectedMock.mockResolvedValue(false)
+  isUserSuperAdminMock.mockResolvedValue(false)
+  getCurrentTenantIdMock.mockResolvedValue('default')
+  getServerSessionMock.mockResolvedValue({ user: { id: 'u-admin', email: 'admin@test.local' } })
+  hashPasswordMock.mockResolvedValue('hashed')
+  auditMock.mockResolvedValue('audit-id')
+  revokeAllSessionsMock.mockResolvedValue(0)
+
+  await truncate(['api_tokens', 'audit_logs', 'sessions', 'rbac_user_roles', 'rbac_user_permissions', 'user_tenants', 'users', 'tenants'])
+  await seedDefaultTenant()
+  const now = new Date()
+  await prismaTest.tenant.create({
+    data: { id: 't2', slug: 't2', name: 'Tenant Two', operatingModel: 'msp', createdAt: now, updatedAt: now },
+  })
+  await seedUser('u-leaver', ['default', 't2'])
+  await seedUser('u-stays', ['default'])
+
+  await seedToken({ id: 'live-default', createdByUserId: 'u-leaver' })
+  await seedToken({ id: 'live-t2', createdByUserId: 'u-leaver', tenantId: 't2' })
+  await seedToken({ id: 'revoked', createdByUserId: 'u-leaver', revokedAt: ALREADY_REVOKED_AT })
+  await seedToken({ id: 'expired', createdByUserId: 'u-leaver', expiresAt: LONG_PAST })
+  await seedToken({ id: 'live-of-u-stays', createdByUserId: 'u-stays', expiresAt: FAR_FUTURE })
+})
+
+describe('PATCH /users/[id] — deleteApiTokens', () => {
+  it('deletes the live tokens when the admin ticks the box while disabling the account', async () => {
+    const { PATCH } = await importRoute()
+    const res = await callRoute(PATCH as any, {
+      method: 'PATCH',
+      params: { id: 'u-leaver' },
+      body: { enabled: false, deleteApiTokens: true },
+    })
+
+    expect(res.status).toBe(200)
+    const json = await readJson<any>(res)
+    expect(json.data.enabled).toBe(false)
+    expect(json.data.api_tokens_deleted).toBe(2)
+
+    // Gone from the database, not stamped.
+    expect(await exists('live-default')).toBe(false)
+    expect(await exists('live-t2')).toBe(false)
+    // A dead token is not offered to the admin, so it is not swept either; and
+    // another creator's token is never in scope.
+    expect(await exists('revoked')).toBe(true)
+    expect((await tokenRow('revoked'))?.revokedAt).toEqual(ALREADY_REVOKED_AT)
+    expect(await exists('expired')).toBe(true)
+    expect(await exists('live-of-u-stays')).toBe(true)
+
+    const details = auditMock.mock.calls[0]![0] as any
+    expect(details.details.apiTokensDeleted.count).toBe(2)
+    expect([...details.details.apiTokensDeleted.prefixes].sort()).toEqual(['pxc_live-default', 'pxc_live-t2'])
+  })
+
+  it('deletes NOTHING when the same disable comes without the flag', async () => {
+    const { PATCH } = await importRoute()
+    const res = await callRoute(PATCH as any, {
+      method: 'PATCH',
+      params: { id: 'u-leaver' },
+      body: { enabled: false },
+    })
+
+    expect(res.status).toBe(200)
+    const json = await readJson<any>(res)
+    expect(json.data.enabled).toBe(false)
+    expect(json.data.api_tokens_deleted).toBe(0)
+
+    expect(await exists('live-default')).toBe(true)
+    expect(await exists('live-t2')).toBe(true)
+    expect(await prismaTest.apiToken.count()).toBe(5)
+
+    const audited = auditMock.mock.calls[0]![0] as any
+    expect(audited.details).not.toHaveProperty('apiTokensDeleted')
+  })
+
+  it('accepts a PATCH that carries only deleteApiTokens, instead of 400 "Aucune modification fournie"', async () => {
+    const { PATCH } = await importRoute()
+    const res = await callRoute(PATCH as any, {
+      method: 'PATCH',
+      params: { id: 'u-leaver' },
+      body: { deleteApiTokens: true },
+    })
+
+    expect(res.status).toBe(200)
+    const json = await readJson<any>(res)
+    expect(json.error).toBeUndefined()
+    expect(json.data.api_tokens_deleted).toBe(2)
+    // No account field was submitted, so the account itself is untouched.
+    expect(json.data.enabled).toBe(true)
+    expect(await exists('live-default')).toBe(false)
+  })
+
+  it('confines a tenant-scoped admin to the tokens of the tenant they act from', async () => {
+    getCurrentTenantIdMock.mockResolvedValue('t2')
+    const { PATCH } = await importRoute()
+    const res = await callRoute(PATCH as any, {
+      method: 'PATCH',
+      params: { id: 'u-leaver' },
+      body: { enabled: false, deleteApiTokens: true },
+    })
+
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res)).data.api_tokens_deleted).toBe(1)
+    expect(await exists('live-t2')).toBe(false)
+    expect(await exists('live-default')).toBe(true)
+  })
+
+  it('aborts with the account still enabled when the deletion fails (deletion runs first)', async () => {
+    const deleteMany = vi.spyOn(prisma.apiToken, 'deleteMany').mockRejectedValueOnce(new Error('token store unreachable'))
+    try {
+      const { PATCH } = await importRoute()
+      const res = await callRoute(PATCH as any, {
+        method: 'PATCH',
+        params: { id: 'u-leaver' },
+        body: { enabled: false, deleteApiTokens: true },
+      })
+
+      expect(res.status).toBe(500)
+      expect(await readJson<any>(res)).toEqual({ error: 'token store unreachable' })
+    } finally {
+      deleteMany.mockRestore()
+    }
+
+    // The whole point of the ordering: nobody was left believing the tokens
+    // died with an account that is, in fact, still enabled.
+    expect((await prismaTest.user.findUnique({ where: { id: 'u-leaver' } }))?.enabled).toBe(true)
+    expect(auditMock).not.toHaveBeenCalled()
+    expect(await exists('live-default')).toBe(true)
+  })
+})
+
+describe('DELETE /users/[id] — ?deleteApiTokens=true', () => {
+  it('deletes the tokens before the account, which is why the reported count is not zero', async () => {
+    const { DELETE } = await importRoute()
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'u-leaver' },
+      searchParams: { deleteApiTokens: 'true' },
+    })
+
+    expect(res.status).toBe(200)
+    // 2, not 0: had the deletion run after the account delete,
+    // created_by_user_id would already be NULL and nothing would have been
+    // found by creator. The count IS the proof of the ordering.
+    expect(await readJson<any>(res)).toEqual({ success: true, api_tokens_deleted: 2 })
+
+    expect(await prismaTest.user.findUnique({ where: { id: 'u-leaver' } })).toBeNull()
+
+    expect(await exists('live-default')).toBe(false)
+    expect(await exists('live-t2')).toBe(false)
+    expect(await exists('live-of-u-stays')).toBe(true)
+
+    // The audit entry is what outlives the rows, and the prefixes are the only
+    // identifier left to say which integrations just lost their credential.
+    const audited = auditMock.mock.calls[0]![0] as any
+    expect(audited.action).toBe('delete')
+    expect(audited.details.apiTokensDeleted.count).toBe(2)
+    expect([...audited.details.apiTokensDeleted.prefixes].sort()).toEqual(['pxc_live-default', 'pxc_live-t2'])
+  })
+
+  it('leaves the tokens alive, orphaned on created_by_user_id, when the parameter is absent', async () => {
+    const { DELETE } = await importRoute()
+    const res = await callRoute(DELETE as any, { method: 'DELETE', params: { id: 'u-leaver' } })
+
+    expect(res.status).toBe(200)
+    expect(await readJson<any>(res)).toEqual({ success: true, api_tokens_deleted: 0 })
+    expect(await prismaTest.user.findUnique({ where: { id: 'u-leaver' } })).toBeNull()
+
+    for (const id of ['live-default', 'live-t2']) {
+      const row = await tokenRow(id)
+      expect(row).not.toBeNull()
+      // ON DELETE SET NULL: this is exactly why the deletion cannot be
+      // deferred to a later request — the creator link is gone.
+      expect(row?.createdByUserId).toBeNull()
+      // ...and exactly why created_by_email is frozen on the row: provenance
+      // has to outlive the account for every token the operator chose to keep.
+      expect(row?.createdByEmail).toBe('u-leaver@test.local')
+    }
+
+    const audited = auditMock.mock.calls[0]![0] as any
+    expect(audited.details).toEqual({})
+  })
+
+  it('treats ?deleteApiTokens=false as no deletion at all', async () => {
+    const { DELETE } = await importRoute()
+    const res = await callRoute(DELETE as any, {
+      method: 'DELETE',
+      params: { id: 'u-leaver' },
+      searchParams: { deleteApiTokens: 'false' },
+    })
+
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res)).api_tokens_deleted).toBe(0)
+    expect(await exists('live-default')).toBe(true)
+  })
+})

--- a/frontend/src/app/api/v1/users/[id]/api-tokens/route.ts
+++ b/frontend/src/app/api/v1/users/[id]/api-tokens/route.ts
@@ -1,0 +1,70 @@
+// GET /api/v1/users/[id]/api-tokens — the API tokens a user created that are
+// still live (issue #632).
+//
+// Deliberately hung off /users rather than /settings/api-tokens: this is the
+// offboarding view, read by the user-admin dialogs before disabling or
+// deleting an account, so it is guarded by admin.users like the rest of that
+// screen. Routing it through the token-management API instead would have
+// demanded admin.apitokens from an admin who only manages people.
+//
+// It never exposes a secret or a hash — the projection is the same handful of
+// identifying fields the offboarding warning displays.
+import { NextResponse } from "next/server"
+
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "@/lib/auth/config"
+import { prisma } from "@/lib/db/prisma"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { denyIfTargetIsProtectedAndCallerIsNot, findUserInTenant } from "@/lib/rbac/userTargetGuards"
+import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
+import { listActiveTokensCreatedBy } from "@/lib/api-tokens/creatorTokens"
+
+export const runtime = "nodejs"
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const denied = await checkPermission(PERMISSIONS.ADMIN_USERS)
+    if (denied) return denied
+
+    const { id } = await params
+    const session = await getServerSession(authOptions)
+    const superAdminBlock = await denyIfTargetIsProtectedAndCallerIsNot(id, session?.user?.id)
+    if (superAdminBlock) return superAdminBlock
+
+    const tenantId = await getCurrentTenantId()
+    const isProviderView = tenantId === DEFAULT_TENANT_ID
+
+    // Same target resolution as GET /api/v1/users/[id]: the provider view
+    // reaches any account, a tenant-scoped caller only reaches its own
+    // members, so ids from another tenant cannot be probed.
+    const user = isProviderView
+      ? await prisma.user.findUnique({ where: { id }, select: { id: true } })
+      : await findUserInTenant(id, tenantId)
+
+    if (!user) {
+      return NextResponse.json({ error: "Utilisateur non trouvé" }, { status: 404 })
+    }
+
+    // A tenant-scoped admin only sees, and later only revokes, the tokens
+    // living in the tenant they are acting from.
+    const tokens = await listActiveTokensCreatedBy(id, isProviderView ? undefined : tenantId)
+
+    return NextResponse.json({
+      data: tokens.map(t => ({
+        id: t.id,
+        name: t.name,
+        token_prefix: t.tokenPrefix,
+        tenant_id: t.tenantId,
+        tenant_name: t.tenantName,
+        scopes: t.scopes,
+        last_used_at: t.lastUsedAt?.toISOString() ?? null,
+        expires_at: t.expiresAt?.toISOString() ?? null,
+        created_at: t.createdAt.toISOString(),
+      })),
+    })
+  } catch (error: any) {
+    console.error("Erreur GET user api-tokens:", error)
+    return NextResponse.json({ error: error?.message || "Erreur serveur" }, { status: 500 })
+  }
+}

--- a/frontend/src/app/api/v1/users/[id]/route.ts
+++ b/frontend/src/app/api/v1/users/[id]/route.ts
@@ -67,7 +67,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     const session = await getServerSession(authOptions)
     const { id } = await params
     const body = await req.json()
-    const { name, enabled, password, tenantIds, roleId } = body
+    const { name, enabled, password, tenantIds, roleId, deleteApiTokens } = body
 
     const isSelf = session?.user?.id === id
     const selfServiceFields = new Set(["name", "password"])
@@ -300,11 +300,47 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
       }
     }
 
-    if (Object.keys(data).length === 0 && !tenantsChanged && !rolesChanged) {
+    const wantsTokenDeletion = deleteApiTokens === true
+
+    if (Object.keys(data).length === 0 && !tenantsChanged && !rolesChanged && !wantsTokenDeletion) {
       return NextResponse.json({ error: "Aucune modification fournie" }, { status: 400 })
     }
 
     if (Object.keys(data).length > 0) data.updatedAt = new Date()
+
+    // Offboarding (#632). A pxc_ token created by this user keeps
+    // authenticating after the account is disabled — that is decision D3 of
+    // the token spec, so that a departure never silently takes monitoring
+    // down. The admin who disables the account is the one who gets to
+    // decide, and the disable dialog now shows them the live tokens and
+    // asks. When they say yes, we act here.
+    //
+    // Ordered BEFORE prisma.user.update on purpose. The invariant that
+    // matters is: this request never disables the account while leaving the
+    // tokens live. A failing deletion therefore has to abort before the
+    // `enabled` write, not after it — the reverse order would answer 500 to
+    // an admin whose account edit went through, and they would reasonably
+    // read the disabled account as proof the tokens died with it.
+    //
+    // Scope of that guarantee, precisely: only the `data` update below. The
+    // tenantIds reconciliation and the roleId propagation above have already
+    // committed by the time we get here, so a PATCH combining those with
+    // deleteApiTokens can still fail with memberships and RBAC grants
+    // changed. Widening the guarantee would mean wrapping the whole handler
+    // in one transaction, which is a bigger change than this issue calls
+    // for; the security-relevant pairing (disable + delete) is the one that
+    // is held.
+    let tokensDeleted: { count: number; tokens: { id: string; name: string; tokenPrefix: string }[] } | null = null
+    if (wantsTokenDeletion) {
+      const { deleteTokensCreatedBy } = await import("@/lib/api-tokens/creatorTokens")
+
+      // A tenant-scoped admin only reaches the tokens of the tenant they
+      // are acting from; the provider view reaches every one of them.
+      tokensDeleted = await deleteTokensCreatedBy(id, isProviderView ? undefined : tenantId)
+      if (tokensDeleted.count > 0) {
+        console.log(`[api-tokens] deleted ${tokensDeleted.count} token(s) created by ${safeLog(id)}`)
+      }
+    }
 
     const updated = Object.keys(data).length > 0
       ? await prisma.user.update({ where: { id }, data })
@@ -340,6 +376,15 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     if (rolesChanged) {
       changes.role = rolesChanged
     }
+    if (tokensDeleted) {
+      // Prefixes, never secrets: the prefix is the public half already shown
+      // in the tokens table, and it is what an operator reads to recognise
+      // which integration just lost its credential.
+      changes.apiTokensDeleted = {
+        count: tokensDeleted.count,
+        prefixes: tokensDeleted.tokens.map(t => t.tokenPrefix),
+      }
+    }
 
     await audit({
       action: "update",
@@ -363,6 +408,7 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
         last_login_at: updated.lastLoginAt?.toISOString() ?? null,
         created_at: updated.createdAt.toISOString(),
         updated_at: updated.updatedAt.toISOString(),
+        api_tokens_deleted: tokensDeleted?.count ?? 0,
       },
     })
   } catch (error: any) {
@@ -403,6 +449,24 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
         { error: "Vous ne pouvez pas supprimer votre propre compte" },
         { status: 400 }
       )
+    }
+
+    // Offboarding (#632), opt-in through ?deleteApiTokens=true. This MUST run
+    // before the account delete: `created_by_user_id` is ON DELETE SET NULL,
+    // so once the account is gone the tokens it created can no longer be
+    // found by creator and the chance to act on them is lost for good.
+    //
+    // Without the flag the tokens are LEFT ALIVE, which is the documented
+    // behaviour (spec D3) and is why `created_by_email` exists — provenance
+    // has to outlive the account for every token the operator chose to keep.
+    let tokensDeleted: { count: number; tokens: { id: string; name: string; tokenPrefix: string }[] } | null = null
+    if (new URL(req.url).searchParams.get("deleteApiTokens") === "true") {
+      const { deleteTokensCreatedBy } = await import("@/lib/api-tokens/creatorTokens")
+
+      tokensDeleted = await deleteTokensCreatedBy(id, isProviderView ? undefined : tenantId)
+      if (tokensDeleted.count > 0) {
+        console.log(`[api-tokens] deleted ${tokensDeleted.count} token(s) created by ${safeLog(id)}`)
+      }
     }
 
     if (isProviderView) {
@@ -452,11 +516,13 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
       resourceType: "user",
       resourceId: id,
       resourceName: user.email,
-      details: {},
+      details: tokensDeleted
+        ? { apiTokensDeleted: { count: tokensDeleted.count, prefixes: tokensDeleted.tokens.map(t => t.tokenPrefix) } }
+        : {},
       status: "success",
     })
 
-    return NextResponse.json({ success: true })
+    return NextResponse.json({ success: true, api_tokens_deleted: tokensDeleted?.count ?? 0 })
   } catch (error: any) {
     console.error("Erreur DELETE user:", error)
     return NextResponse.json({ error: error?.message || "Erreur serveur" }, { status: 500 })

--- a/frontend/src/components/settings/api-tokens/ApiTokensTab.test.tsx
+++ b/frontend/src/components/settings/api-tokens/ApiTokensTab.test.tsx
@@ -25,6 +25,11 @@ import en from '@/messages/en.json'
 // ever equal CONFIRM_SENTINEL.
 const CONFIRM_SENTINEL = '__CONFIRM_SENTINEL__'
 
+// renderWithProviders always renders the English bundle, so the labels the
+// component emits are exactly these -- sourcing them from the bundle keeps the
+// selectors honest through the revoke -> delete key rename.
+const enTokens = (en as any).settings.apiTokens
+
 function messagesWithSentinelConfirm() {
   const base = en as any
   return {
@@ -57,7 +62,35 @@ const TOKEN_ROW = {
   lastUsedIp: '203.0.113.9',
   rateLimitPerMin: 600,
   createdByUserId: 'admin-1',
+  createdByEmail: 'admin@example.com',
   createdAt: '2026-07-01T10:00:00.000Z',
+}
+
+// #632: a token minted before the frozen-email column existed, whose creator
+// account has since been deleted -- both provenance fields are null. Kept out
+// of the default fixture on purpose: a permanent second row would make the
+// single-row queries the other tests rely on (tenant name, delete button)
+// ambiguous, so only the creator-column test opts into it.
+const ORPHANED_TOKEN_ROW = {
+  ...TOKEN_ROW,
+  id: 'tok-orphan',
+  name: 'legacy-exporter',
+  tokenPrefix: 'pxc_Zz99Yy88',
+  createdByUserId: null,
+  createdByEmail: null,
+}
+
+// A row soft-revoked back when the delete button wrote revoked_at instead of
+// removing the row. Nothing produces these any more, but existing databases
+// hold them, so the grid still has to handle them -- see the dedicated test at
+// the bottom of this file. Also kept out of the default fixture to preserve
+// the single-row queries above.
+const LEGACY_REVOKED_TOKEN_ROW = {
+  ...TOKEN_ROW,
+  id: 'tok-legacy-revoked',
+  name: 'retired-exporter',
+  tokenPrefix: 'pxc_Rr77Vv66',
+  revokedAt: '2026-03-01T09:00:00.000Z',
 }
 
 // Fix round 1, finding 1: tenant + connection plumbing fixtures. Mutable so
@@ -65,6 +98,7 @@ const TOKEN_ROW = {
 // in beforeEach).
 let tenantsFetchOk = true
 let connectionsFetchOk = true
+let tokensFixture: any[] = []
 let tenantsFixture: any[] = []
 let vdcsFixture: any[] = []
 let connectionsFixture: any[] = []
@@ -72,6 +106,7 @@ let connectionsFixture: any[] = []
 function resetFixtures() {
   tenantsFetchOk = true
   connectionsFetchOk = true
+  tokensFixture = [TOKEN_ROW]
   tenantsFixture = [
     { id: 'default', name: 'Provider', enabled: true },
     { id: 'tenant-a', name: 'Tenant A', enabled: true },
@@ -91,7 +126,7 @@ beforeEach(() => {
   resetFixtures()
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
     if (url === '/api/v1/settings/api-tokens' && (!init || init.method === undefined)) {
-      return new Response(JSON.stringify({ data: [TOKEN_ROW] }), { status: 200 })
+      return new Response(JSON.stringify({ data: tokensFixture }), { status: 200 })
     }
     if (url === '/api/v1/settings/api-tokens' && init?.method === 'POST') {
       return new Response(
@@ -100,7 +135,12 @@ beforeEach(() => {
       )
     }
     if (url.startsWith('/api/v1/settings/api-tokens/') && init?.method === 'DELETE') {
-      return new Response(JSON.stringify({ data: { id: 'tok-1', revokedAt: '2026-07-28T11:00:00.000Z' } }), { status: 200 })
+      // The route no longer answers with a revocation stamp: the row is gone.
+      // Echo back the id from the path so a test can delete any row it likes.
+      return new Response(
+        JSON.stringify({ data: { id: url.slice('/api/v1/settings/api-tokens/'.length), deleted: true } }),
+        { status: 200 },
+      )
     }
     if (url === '/api/v1/tenants') {
       return tenantsFetchOk
@@ -166,6 +206,26 @@ describe('ApiTokensTab', () => {
     expect(row.querySelector('i.ri-key-2-line')).not.toBeNull()
   })
 
+  // #632 (offboarding): the grid used to show no provenance at all, so an
+  // admin processing a departure could not tie a live credential to a person.
+  // Both halves of the new column are covered here: the frozen creator email,
+  // and the fallback for rows that never captured one (pre-fix tokens whose
+  // creator account is gone, or tokens minted without a user session).
+  it('shows the creator email, falling back to the unknown label when it is null', async () => {
+    tokensFixture = [TOKEN_ROW, ORPHANED_TOKEN_ROW]
+    renderWithProviders(<ApiTokensTab />)
+
+    const namedRow = (await screen.findByText('pxc_Ab12Cd34')).closest('.MuiDataGrid-row') as HTMLElement
+    expect(screen.getByText(enTokens.columns.createdBy)).toBeInTheDocument()
+    expect(within(namedRow).getByText('admin@example.com')).toBeInTheDocument()
+
+    // Empty cell would be the regression: the row must carry the explicit
+    // "unknown" label, and must not borrow the other row's email.
+    const orphanedRow = screen.getByText('pxc_Zz99Yy88').closest('.MuiDataGrid-row') as HTMLElement
+    expect(within(orphanedRow).getByText(enTokens.unknownCreator)).toBeInTheDocument()
+    expect(within(orphanedRow).queryByText('admin@example.com')).not.toBeInTheDocument()
+  })
+
   it('shows the add-on upsell instead of the list when the option is missing', async () => {
     useLicenseMock.mockReturnValue({ hasFeature: () => false, loading: false })
     renderWithProviders(<ApiTokensTab />)
@@ -179,10 +239,10 @@ describe('ApiTokensTab', () => {
     expect(screen.queryByText('pxc_Ab12Cd34')).not.toBeInTheDocument()
   })
 
-  it('revokes a token after confirmation', async () => {
+  it('deletes a token after confirmation', async () => {
     renderWithProviders(<ApiTokensTab />, { messages: messagesWithSentinelConfirm() })
     await screen.findByText('pxc_Ab12Cd34')
-    await userEvent.click(screen.getByRole('button', { name: /revoke/i }))
+    await userEvent.click(screen.getByRole('button', { name: enTokens.delete }))
     await userEvent.click(screen.getByRole('button', { name: CONFIRM_SENTINEL }))
     await waitFor(() => {
       expect(vi.mocked(fetch)).toHaveBeenCalledWith(
@@ -337,7 +397,6 @@ describe('ApiTokensTab', () => {
       'automation:read': 'ri-robot-line',
       'alerts:read': 'ri-alarm-warning-line',
       'reports:read': 'ri-file-list-3-line',
-      'compliance:read': 'ri-shield-check-line',
     }
 
     const rows = Object.entries(scopeIcons).map(([scope, iconClass]) => {
@@ -382,6 +441,41 @@ describe('ApiTokensTab', () => {
 
     await waitFor(() => {
       expect(lastPostBody().connectionIds).toEqual(['conn-x', 'conn-y'])
+    })
+  })
+
+  // Owner-reported regression: the actions cell rendered the "Revoked" chip
+  // INSTEAD of the delete button, so a legacy soft-revoked row was stuck in the
+  // grid with no way to remove it -- while the backend deletes such a row
+  // happily. Both halves are asserted: the chip stays (the row really is dead
+  // and the grid must keep saying so) and the button is there TOO.
+  //
+  // Two rows on purpose, one revoked and one live: every delete button is
+  // reached through its own row (found by prefix) the way the tests above do,
+  // so an ambiguous screen-wide selector cannot pass this by accident.
+  it('offers the delete button on a legacy revoked row, alongside the Revoked chip', async () => {
+    tokensFixture = [TOKEN_ROW, LEGACY_REVOKED_TOKEN_ROW]
+    renderWithProviders(<ApiTokensTab />, { messages: messagesWithSentinelConfirm() })
+
+    const revokedRow = (await screen.findByText('pxc_Rr77Vv66')).closest('.MuiDataGrid-row') as HTMLElement
+    const liveRow = screen.getByText('pxc_Ab12Cd34').closest('.MuiDataGrid-row') as HTMLElement
+
+    // The chip belongs to the revoked row and to it alone.
+    expect(within(revokedRow).getByText(enTokens.revoked)).toBeInTheDocument()
+    expect(within(liveRow).queryByText(enTokens.revoked)).not.toBeInTheDocument()
+
+    // ...and the action is offered on BOTH rows.
+    const revokedRowButton = within(revokedRow).getByRole('button', { name: enTokens.delete })
+    expect(within(liveRow).getByRole('button', { name: enTokens.delete })).toBeInTheDocument()
+
+    // And it actually works: the DELETE goes to the revoked row's own id.
+    await userEvent.click(revokedRowButton)
+    await userEvent.click(screen.getByRole('button', { name: CONFIRM_SENTINEL }))
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        '/api/v1/settings/api-tokens/tok-legacy-revoked',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
     })
   })
 })

--- a/frontend/src/components/settings/api-tokens/ApiTokensTab.tsx
+++ b/frontend/src/components/settings/api-tokens/ApiTokensTab.tsx
@@ -28,6 +28,10 @@ type ApiTokenView = {
   lastUsedAt: string | null
   lastUsedIp: string | null
   rateLimitPerMin: number
+  // Frozen copy of the creator's email (TOKEN_VIEW_SELECT). Null on tokens
+  // minted before the column existed, and on tokens created without a user
+  // session -- the grid falls back to the "unknown" label for those.
+  createdByEmail?: string | null
   createdAt: string
 }
 
@@ -38,7 +42,7 @@ function ApiTokensPanel() {
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
   const [createOpen, setCreateOpen] = useState(false)
-  const [revoking, setRevoking] = useState<ApiTokenView | null>(null)
+  const [deletingToken, setDeletingToken] = useState<ApiTokenView | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -58,17 +62,17 @@ function ApiTokensPanel() {
     load()
   }, [load])
 
-  async function confirmRevoke() {
-    if (!revoking) return
+  async function confirmDelete() {
+    if (!deletingToken) return
     try {
-      const res = await fetch(`/api/v1/settings/api-tokens/${revoking.id}`, { method: 'DELETE' })
+      const res = await fetch(`/api/v1/settings/api-tokens/${deletingToken.id}`, { method: 'DELETE' })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      setSuccess(t('revokeSuccess'))
+      setSuccess(t('deleteSuccess'))
       await load()
     } catch {
       setError(t('loadError'))
     } finally {
-      setRevoking(null)
+      setDeletingToken(null)
     }
   }
 
@@ -127,19 +131,43 @@ function ApiTokensPanel() {
       },
     },
     {
+      field: 'createdByEmail',
+      headerName: t('columns.createdBy'),
+      flex: 1,
+      minWidth: 200,
+      // Offboarding (#632): without this the grid never says who minted a
+      // credential, so an admin cannot tie a live token to a departing
+      // person. Plain text like the tenant column -- an email is a name,
+      // not an identifier, so no monospace.
+      renderCell: params => (params.value ? (params.value as string) : t('unknownCreator')),
+    },
+    {
       field: 'actions',
       headerName: '',
-      width: 120,
+      width: 170,
       sortable: false,
       renderCell: params => {
         const row = params.row as ApiTokenView
-        if (row.revokedAt) return <Chip label={t('revoked')} size='small' color='warning' variant='outlined' />
+
+        // The action deletes the row outright, so nothing writes revokedAt any
+        // more. The chip is kept for LEGACY rows: databases created before the
+        // change still hold tokens that were soft-revoked, they are still
+        // refused at authentication, and the grid has to keep saying so.
+        //
+        // The delete button shows for those rows TOO, and that is the point.
+        // Rendering the chip *instead of* the button left a legacy revoked
+        // token permanently stuck in the table with no way to remove it -- the
+        // backend deletes it happily, only the UI refused to ask. A row the
+        // operator cannot act on is worse than one that is merely dead.
         return (
-          <Tooltip title={t('revoke')} slotProps={tooltipSlotProps}>
-            <IconButton size='small' aria-label={t('revoke')} onClick={() => setRevoking(row)}>
-              <i className='ri-delete-bin-line' />
-            </IconButton>
-          </Tooltip>
+          <Stack direction='row' spacing={1} sx={{ alignItems: 'center' }}>
+            {row.revokedAt && <Chip label={t('revoked')} size='small' color='warning' variant='outlined' />}
+            <Tooltip title={t('delete')} slotProps={tooltipSlotProps}>
+              <IconButton size='small' aria-label={t('delete')} onClick={() => setDeletingToken(row)}>
+                <i className='ri-delete-bin-line' />
+              </IconButton>
+            </Tooltip>
+          </Stack>
         )
       },
     },
@@ -181,14 +209,14 @@ function ApiTokensPanel() {
 
       <CreateTokenDialog open={createOpen} onClose={() => setCreateOpen(false)} onCreated={load} />
 
-      <Dialog open={!!revoking} onClose={() => setRevoking(null)}>
-        <DialogTitle>{t('revoke')}</DialogTitle>
+      <Dialog open={!!deletingToken} onClose={() => setDeletingToken(null)}>
+        <DialogTitle>{t('delete')}</DialogTitle>
         <DialogContent>
-          <Typography variant='body2'>{t('revokeConfirm')}</Typography>
+          <Typography variant='body2'>{t('deleteConfirm')}</Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setRevoking(null)}>{t('dialog.cancel')}</Button>
-          <Button color='error' variant='contained' onClick={confirmRevoke}>{t('dialog.confirm')}</Button>
+          <Button onClick={() => setDeletingToken(null)}>{t('dialog.cancel')}</Button>
+          <Button color='error' variant='contained' onClick={confirmDelete}>{t('dialog.confirm')}</Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/frontend/src/components/settings/api-tokens/CreateTokenDialog.tsx
+++ b/frontend/src/components/settings/api-tokens/CreateTokenDialog.tsx
@@ -51,7 +51,6 @@ const SCOPE_ICONS: Record<string, string> = {
   'automation:read': 'ri-robot-line',
   'alerts:read': 'ri-alarm-warning-line',
   'reports:read': 'ri-file-list-3-line',
-  'compliance:read': 'ri-shield-check-line',
 }
 const DEFAULT_SCOPE_ICON = 'ri-key-line'
 

--- a/frontend/src/lib/api-tokens/creatorTokens.test.ts
+++ b/frontend/src/lib/api-tokens/creatorTokens.test.ts
@@ -1,0 +1,241 @@
+/**
+ * listActiveTokensCreatedBy / deleteTokensCreatedBy — offboarding helpers (#632).
+ *
+ * The whole point of these two functions is the definition of "would still
+ * authenticate": not revoked AND not past its expiry. Everything else in the
+ * offboarding UX (the warning, the checkbox, the audit line) is derived from
+ * that set, so a token wrongly included pads the warning with credentials
+ * nobody has to decide about, and a token wrongly excluded is exactly the
+ * silent survivor the issue is about.
+ *
+ * On owner arbitration, "delete a token" means the ROW IS GONE — there is no
+ * soft revocation on the write path any more. `revokedAt` survives as a READ
+ * filter only: existing databases still hold rows stamped back when the delete
+ * button was a revocation, and those must keep being excluded from the
+ * offboarding list. Both halves are asserted below.
+ *
+ * Backed by the real Postgres schema rather than a mocked Prisma: the where
+ * clause (a null-or-future OR, plus an optional tenant narrowing) is the unit
+ * under test, and a mock would only ever assert the shape of an object we
+ * wrote ourselves. Row disappearance is likewise a database fact.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { prismaTest, truncate } from '@/__tests__/setup/prisma-test'
+import { seedDefaultTenant } from '@/__tests__/setup/apiTokens'
+import { prisma } from '@/lib/db/prisma'
+import { deleteTokensCreatedBy, listActiveTokensCreatedBy } from './creatorTokens'
+
+const FAR_FUTURE = new Date('2099-01-01T00:00:00.000Z')
+const LONG_PAST = new Date('2020-01-01T00:00:00.000Z')
+const ALREADY_REVOKED_AT = new Date('2026-02-01T00:00:00.000Z')
+
+// A hash that no projection has any business carrying around, distinctive
+// enough to be searched for as a plain substring.
+const HASH = 'deadbeef'.repeat(8)
+
+async function seedUser(id: string): Promise<void> {
+  const now = new Date()
+  await prismaTest.user.create({
+    data: { id, email: `${id}@test.local`, createdAt: now, updatedAt: now },
+  })
+}
+
+async function seedToken(opts: {
+  id: string
+  createdByUserId: string | null
+  tenantId?: string
+  createdAt?: Date
+  revokedAt?: Date | null
+  expiresAt?: Date | null
+  lastUsedAt?: Date | null
+  scopes?: string[]
+}): Promise<void> {
+  await prismaTest.apiToken.create({
+    data: {
+      id: opts.id,
+      tenantId: opts.tenantId ?? 'default',
+      name: `name-of-${opts.id}`,
+      tokenPrefix: `pxc_${opts.id}`,
+      tokenHash: `${HASH}-${opts.id}`,
+      scopes: opts.scopes ?? ['vms:read'],
+      connectionIds: null,
+      createdByUserId: opts.createdByUserId,
+      createdAt: opts.createdAt ?? new Date('2026-01-01T00:00:00.000Z'),
+      revokedAt: opts.revokedAt ?? null,
+      expiresAt: opts.expiresAt ?? null,
+      lastUsedAt: opts.lastUsedAt ?? null,
+    },
+  })
+}
+
+function rowOf(id: string) {
+  return prismaTest.apiToken.findUnique({ where: { id }, select: { id: true, revokedAt: true } })
+}
+
+// `rowOf(...)?.revokedAt` would silently pass on a missing row (undefined is
+// not null), which is precisely the confusion this suite has to rule out — so
+// existence is asserted through the row itself, never through one of its
+// columns.
+async function exists(id: string): Promise<boolean> {
+  return (await rowOf(id)) !== null
+}
+
+beforeEach(async () => {
+  await truncate(['api_tokens', 'user_tenants', 'users', 'tenants'])
+  await seedDefaultTenant()
+  const now = new Date()
+  await prismaTest.tenant.create({
+    data: { id: 't2', slug: 't2', name: 'Tenant Two', operatingModel: 'msp', createdAt: now, updatedAt: now },
+  })
+  await seedUser('u-leaver')
+  await seedUser('u-stays')
+
+  // Everything below is created by the departing user unless stated.
+  await seedToken({ id: 'live-no-expiry', createdByUserId: 'u-leaver', createdAt: new Date('2026-01-01T00:00:00.000Z') })
+  await seedToken({ id: 'live-future-expiry', createdByUserId: 'u-leaver', createdAt: new Date('2026-01-02T00:00:00.000Z'), expiresAt: FAR_FUTURE })
+  await seedToken({ id: 'live-other-tenant', createdByUserId: 'u-leaver', createdAt: new Date('2026-01-03T00:00:00.000Z'), tenantId: 't2' })
+  await seedToken({ id: 'already-revoked', createdByUserId: 'u-leaver', revokedAt: ALREADY_REVOKED_AT })
+  await seedToken({ id: 'expired', createdByUserId: 'u-leaver', expiresAt: LONG_PAST })
+  await seedToken({ id: 'other-creator', createdByUserId: 'u-stays' })
+  // created_by_user_id is SetNull: a token whose creator was already deleted
+  // must never be swept up by a query keyed on a creator id.
+  await seedToken({ id: 'orphan', createdByUserId: null })
+})
+
+describe('listActiveTokensCreatedBy', () => {
+  it('lists every live token of that creator across tenants, newest first', async () => {
+    const rows = await listActiveTokensCreatedBy('u-leaver')
+    expect(rows.map(r => r.id)).toEqual(['live-other-tenant', 'live-future-expiry', 'live-no-expiry'])
+  })
+
+  it('keeps a token whose expiry is in the future but drops the revoked and the expired one', async () => {
+    const ids = (await listActiveTokensCreatedBy('u-leaver')).map(r => r.id)
+    expect(ids).toContain('live-future-expiry')
+    expect(ids).not.toContain('already-revoked')
+    expect(ids).not.toContain('expired')
+  })
+
+  it('never lists a token created by somebody else, nor one with no creator at all', async () => {
+    const ids = (await listActiveTokensCreatedBy('u-leaver')).map(r => r.id)
+    expect(ids).not.toContain('other-creator')
+    expect(ids).not.toContain('orphan')
+    expect((await listActiveTokensCreatedBy('u-stays')).map(r => r.id)).toEqual(['other-creator'])
+  })
+
+  it('narrows to a single tenant when tenantId is given, and includes foreign tenants when it is not', async () => {
+    const scoped = await listActiveTokensCreatedBy('u-leaver', 'default')
+    expect(scoped.map(r => r.id)).toEqual(['live-future-expiry', 'live-no-expiry'])
+    expect(scoped.map(r => r.id)).not.toContain('live-other-tenant')
+
+    const scopedToT2 = await listActiveTokensCreatedBy('u-leaver', 't2')
+    expect(scopedToT2.map(r => r.id)).toEqual(['live-other-tenant'])
+
+    const unscoped = await listActiveTokensCreatedBy('u-leaver')
+    expect(unscoped.map(r => r.id)).toContain('live-other-tenant')
+  })
+
+  it('flattens the row and resolves the tenant name from the relation, without the hash', async () => {
+    const rows = await listActiveTokensCreatedBy('u-leaver', 't2')
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual({
+      id: 'live-other-tenant',
+      name: 'name-of-live-other-tenant',
+      tokenPrefix: 'pxc_live-other-tenant',
+      tenantId: 't2',
+      tenantName: 'Tenant Two',
+      scopes: ['vms:read'],
+      lastUsedAt: null,
+      expiresAt: null,
+      createdAt: new Date('2026-01-03T00:00:00.000Z'),
+    })
+    expect(JSON.stringify(rows)).not.toContain(HASH)
+  })
+
+  it('returns an empty array for a creator with nothing live', async () => {
+    expect(await listActiveTokensCreatedBy('u-nobody')).toEqual([])
+  })
+})
+
+describe('deleteTokensCreatedBy', () => {
+  it('removes only the live tokens and reports what it deleted', async () => {
+    const deleteMany = vi.spyOn(prisma.apiToken, 'deleteMany')
+    try {
+      const result = await deleteTokensCreatedBy('u-leaver')
+
+      expect(result.count).toBe(3)
+      expect(result.tokens.map(t => t.id).sort()).toEqual(['live-future-expiry', 'live-no-expiry', 'live-other-tenant'])
+      expect(result.tokens.map(t => t.tokenPrefix).sort()).toEqual([
+        'pxc_live-future-expiry',
+        'pxc_live-no-expiry',
+        'pxc_live-other-tenant',
+      ])
+      // Proves the spy below (and the "never issues a DELETE" test) is wired
+      // to the call the function actually makes.
+      expect(deleteMany).toHaveBeenCalledTimes(1)
+    } finally {
+      deleteMany.mockRestore()
+    }
+
+    // The rows are GONE, not stamped: this is the whole behaviour change.
+    expect(await exists('live-no-expiry')).toBe(false)
+    expect(await exists('live-future-expiry')).toBe(false)
+    expect(await exists('live-other-tenant')).toBe(false)
+  })
+
+  it('leaves the expired token and the already-revoked one in place, untouched', async () => {
+    await deleteTokensCreatedBy('u-leaver')
+    // Neither is offered to the admin, so neither is deleted either: the two
+    // filters that exclude them from the LIST also exclude them from the sweep.
+    expect(await exists('expired')).toBe(true)
+    expect((await rowOf('expired'))?.revokedAt).toBeNull()
+    expect(await exists('already-revoked')).toBe(true)
+    expect((await rowOf('already-revoked'))?.revokedAt).toEqual(ALREADY_REVOKED_AT)
+  })
+
+  it('never touches a token created by somebody else: those rows still exist afterwards', async () => {
+    const result = await deleteTokensCreatedBy('u-leaver')
+    expect(result.tokens.map(t => t.id)).not.toContain('other-creator')
+    expect(await exists('other-creator')).toBe(true)
+    expect(await exists('orphan')).toBe(true)
+  })
+
+  it('confines the deletion to the given tenant', async () => {
+    const result = await deleteTokensCreatedBy('u-leaver', 'default')
+    expect(result.count).toBe(2)
+    expect(result.tokens.map(t => t.id).sort()).toEqual(['live-future-expiry', 'live-no-expiry'])
+    expect(await exists('live-other-tenant')).toBe(true)
+  })
+
+  it('is a hard delete: the table shrinks by exactly the tokens it reported', async () => {
+    const before = await prismaTest.apiToken.count()
+    const result = await deleteTokensCreatedBy('u-leaver')
+    expect(await prismaTest.apiToken.count()).toBe(before - result.count)
+    // Belt and braces on the count arithmetic: 3 of the 7 seeded rows go, and
+    // the survivors are named rather than merely counted.
+    expect(result.count).toBe(3)
+    expect((await prismaTest.apiToken.findMany({ select: { id: true } })).map(r => r.id).sort()).toEqual([
+      'already-revoked',
+      'expired',
+      'orphan',
+      'other-creator',
+    ])
+  })
+
+  it('returns a zero count and never issues a DELETE when there is nothing live to remove', async () => {
+    const deleteMany = vi.spyOn(prisma.apiToken, 'deleteMany')
+    try {
+      // u-stays' only token is live, so use a creator whose whole set is dead.
+      await prismaTest.apiToken.updateMany({ where: { createdByUserId: 'u-leaver' }, data: { revokedAt: ALREADY_REVOKED_AT } })
+      deleteMany.mockClear()
+
+      expect(await deleteTokensCreatedBy('u-leaver')).toEqual({ count: 0, tokens: [] })
+      expect(deleteMany).not.toHaveBeenCalled()
+    } finally {
+      deleteMany.mockRestore()
+    }
+
+    // Nothing was swept, so nothing was lost either.
+    expect(await prismaTest.apiToken.count()).toBe(7)
+  })
+})

--- a/frontend/src/lib/api-tokens/creatorTokens.ts
+++ b/frontend/src/lib/api-tokens/creatorTokens.ts
@@ -1,0 +1,115 @@
+// Offboarding support for API tokens (issue #632).
+//
+// A `pxc_` token is an autonomous row: validation checks the hash, the
+// revocation and expiry stamps and the tenant, never the account that
+// created it (spec 2026-07-28, decision D3). That is deliberate — a token
+// driving Prometheus must not die because the admin who minted it left the
+// company, and taking monitoring down in the middle of an offboarding would
+// be the worse failure.
+//
+// The gap it left is one of visibility, not of authorisation: an admin
+// disables a departing colleague, reasonably believes access is cut, and
+// nothing anywhere connects the two facts. These helpers let the user
+// admin SEE the credentials that will keep working and delete them in the
+// same gesture, without ever making that deletion automatic.
+import { prisma } from "@/lib/db/prisma"
+
+export type CreatorTokenSummary = {
+  id: string
+  name: string
+  tokenPrefix: string
+  tenantId: string
+  tenantName: string | null
+  scopes: unknown
+  lastUsedAt: Date | null
+  expiresAt: Date | null
+  createdAt: Date
+}
+
+/**
+ * Tokens created by `userId` that would still authenticate right now:
+ * neither revoked nor past their expiry. An expired token needs no
+ * offboarding decision, and listing it would only pad the warning. The
+ * `revokedAt` half of that filter still matters even though nothing writes
+ * the column any more: existing databases hold rows revoked back when the
+ * delete button was a soft revocation, and those must not be re-offered.
+ *
+ * `tenantId` narrows the search to a single tenant, for callers acting from
+ * a tenant-scoped view rather than the provider view.
+ */
+export async function listActiveTokensCreatedBy(
+  userId: string,
+  tenantId?: string,
+): Promise<CreatorTokenSummary[]> {
+  const rows = await prisma.apiToken.findMany({
+    where: activeCreatedByWhere(userId, tenantId),
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      name: true,
+      tokenPrefix: true,
+      tenantId: true,
+      tenant: { select: { name: true } },
+      scopes: true,
+      lastUsedAt: true,
+      expiresAt: true,
+      createdAt: true,
+    },
+  })
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    tokenPrefix: row.tokenPrefix,
+    tenantId: row.tenantId,
+    tenantName: row.tenant?.name ?? null,
+    scopes: row.scopes,
+    lastUsedAt: row.lastUsedAt,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+  }))
+}
+
+/**
+ * Delete every still-active token created by `userId`, returning what was
+ * deleted so the caller can put it in the audit trail.
+ *
+ * Deletion, not a revocation stamp: "delete a token" means the row is gone,
+ * the same semantics as the delete button in the tokens table. The journal
+ * entry is what survives — audit_logs.api_token_id has no foreign key exactly
+ * so it can outlive the row — which is why the caller records the prefixes.
+ *
+ * Call this BEFORE deleting the user: `created_by_user_id` is ON DELETE SET
+ * NULL, so once the account is gone these tokens can no longer be found by
+ * creator and the chance to act on them is lost for good.
+ */
+export async function deleteTokensCreatedBy(
+  userId: string,
+  tenantId?: string,
+): Promise<{ count: number; tokens: { id: string; name: string; tokenPrefix: string }[] }> {
+  const doomed = await prisma.apiToken.findMany({
+    where: activeCreatedByWhere(userId, tenantId),
+    select: { id: true, name: true, tokenPrefix: true },
+  })
+  if (doomed.length === 0) return { count: 0, tokens: [] }
+
+  // `count` is what was actually removed, `tokens` is what was targeted. They
+  // diverge only if someone deletes one of these tokens between the two
+  // queries, in which case the audit entry names a prefix this call did not
+  // remove itself. Reporting the delete count honestly beats using
+  // tokens.length, which would claim removals that may not have happened.
+  const deleted = await prisma.apiToken.deleteMany({
+    where: { id: { in: doomed.map(t => t.id) } },
+  })
+
+  return { count: deleted.count, tokens: doomed }
+}
+
+function activeCreatedByWhere(userId: string, tenantId?: string) {
+  return {
+    createdByUserId: userId,
+    revokedAt: null,
+    OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
+    ...(tenantId ? { tenantId } : {}),
+  }
+}

--- a/frontend/src/lib/api-tokens/scopes.test.ts
+++ b/frontend/src/lib/api-tokens/scopes.test.ts
@@ -12,14 +12,51 @@ describe('scope to permission resolver (spec section 7)', () => {
     expect(SCOPE_DEFINITIONS['automation:read']).toEqual(['automation.view'])
     expect(SCOPE_DEFINITIONS['alerts:read']).toEqual(['alerts.view', 'events.view'])
     expect(SCOPE_DEFINITIONS['reports:read']).toEqual(['reports.view'])
-    expect(SCOPE_DEFINITIONS['compliance:read']).toEqual(['admin.compliance'])
-    expect(ALL_SCOPE_IDS).toHaveLength(8)
+    expect(ALL_SCOPE_IDS).toHaveLength(7)
+  })
+
+  it('does not offer compliance:read (#632)', () => {
+    // It mapped to admin.compliance, which also authorises the five
+    // compliance mutations. Nothing in the allowlist ever required it, so
+    // the scope granted exactly nothing while promising a read — and it
+    // would have turned into a live write grant the day any compliance
+    // route joined the allowlist.
+    expect(SCOPE_DEFINITIONS['compliance:read']).toBeUndefined()
+    expect(ALL_SCOPE_IDS).not.toContain('compliance:read')
+    expect(expandScopes(['compliance:read'])).toEqual(new Set())
   })
 
   it('every resolved key already exists in ALL_PERMISSIONS (seeded catalogue)', () => {
     const known = new Set(ALL_PERMISSIONS.map(p => p.id))
     for (const keys of Object.values(SCOPE_DEFINITIONS)) {
       for (const key of keys) expect(known.has(key)).toBe(true)
+    }
+  })
+
+  // The guard that closes the whole class, not just the compliance:read
+  // instance (#632). A token is read-only by construction (405 on any
+  // non-GET, allowlist entries are all GET), so a scope carrying a
+  // write-capable permission is always a naming lie — and one that goes
+  // live silently as soon as an unrelated change allowlists a route that
+  // checks it. Fail here instead, at the moment the scope is written.
+  it('never bundles a dangerous or write-capable permission', () => {
+    const catalogue = new Map(ALL_PERMISSIONS.map(p => [p.id, p]))
+    const READ_SUFFIXES = ['.view', '.content']
+
+    for (const [scope, keys] of Object.entries(SCOPE_DEFINITIONS)) {
+      for (const key of keys) {
+        const entry = catalogue.get(key)
+
+        expect(entry, `scope ${scope} maps to unknown permission ${key}`).toBeDefined()
+        expect(
+          Boolean(entry && (entry as { isDangerous?: boolean }).isDangerous),
+          `scope ${scope} maps to ${key}, which is flagged isDangerous in the catalogue`,
+        ).toBe(false)
+        expect(
+          READ_SUFFIXES.some(suffix => key.endsWith(suffix)),
+          `scope ${scope} maps to ${key}, which is not a read permission (expected a ${READ_SUFFIXES.join(' or ')} suffix)`,
+        ).toBe(true)
+      }
     }
   })
 

--- a/frontend/src/lib/api-tokens/scopes.ts
+++ b/frontend/src/lib/api-tokens/scopes.ts
@@ -1,6 +1,17 @@
 // PURE module. A scope is a named bundle of EXISTING RBAC permission keys
 // (spec section 7). The RBAC assignment scope vocabulary
 // (global/connection/node/vm/tag/pool) is orthogonal and untouched.
+//
+// INVARIANT (#632): a scope may only bundle read permissions. Every key
+// here must be non-dangerous in the seeded catalogue AND end in .view or
+// .content — scopes.test.ts enforces both, so a future scope cannot quietly
+// hand a token something write-capable. `compliance:read` used to violate
+// this: it mapped to `admin.compliance`, the single permission guarding both
+// the compliance reads and its five mutations. It was inert (no compliance
+// path is in the allowlist, so the scope opened nothing at all) but it would
+// have become a real escalation the day a compliance route was allowlisted.
+// Removed rather than papered over; exposing compliance over the API needs a
+// read-only permission to map to first.
 export const SCOPE_DEFINITIONS: Record<string, readonly string[]> = {
   "vms:read": ["vm.view"],
   "nodes:read": ["node.view", "connection.view"],
@@ -9,7 +20,6 @@ export const SCOPE_DEFINITIONS: Record<string, readonly string[]> = {
   "automation:read": ["automation.view"],
   "alerts:read": ["alerts.view", "events.view"],
   "reports:read": ["reports.view"],
-  "compliance:read": ["admin.compliance"],
 }
 
 export const ALL_SCOPE_IDS = Object.keys(SCOPE_DEFINITIONS)

--- a/frontend/src/lib/audit/apiTokenAudit.test.ts
+++ b/frontend/src/lib/audit/apiTokenAudit.test.ts
@@ -56,7 +56,7 @@ describe('audit, token attribution (D13)', () => {
   })
 
   it('accepts an explicit entry.apiTokenId without any header lookup', async () => {
-    const auditId = await audit({ action: 'apitoken.revoke', category: 'api_tokens', apiTokenId: 'tok_explicit' })
+    const auditId = await audit({ action: 'apitoken.delete', category: 'api_tokens', apiTokenId: 'tok_explicit' })
     const row = await prismaTest.auditLog.findUnique({ where: { id: auditId } })
     expect(row?.apiTokenId).toBe('tok_explicit')
   })

--- a/frontend/src/lib/audit/index.ts
+++ b/frontend/src/lib/audit/index.ts
@@ -83,6 +83,10 @@ export type AuditAction =
 
   // API tokens
   | "apitoken.create"
+  // Deleting a token removes the row outright; "apitoken.revoke" is KEPT
+  // because journal entries written before that change still carry it, and an
+  // audit vocabulary may never lose a term it has already published.
+  | "apitoken.delete"
   | "apitoken.revoke"
   | "apitoken.denied"
 

--- a/frontend/src/lib/inventory/fetchRawInventory.test.ts
+++ b/frontend/src/lib/inventory/fetchRawInventory.test.ts
@@ -116,3 +116,68 @@ describe('getInventorySWR', () => {
     expect(setCachedInventoryMock).toHaveBeenCalled()
   })
 })
+
+/** Returns the promise the code under test parked in the shared in-flight slot. */
+function storedInflightPromise() {
+  const call = setInflightFetchMock.mock.calls.find(([p]: any[]) => p !== null && p !== undefined)
+  expect(call, 'expected a promise to be stored in the in-flight slot').toBeDefined()
+
+  return (call as any[])[0] as Promise<any>
+}
+
+// Regression suite for the intermittent 500 on GET /api/v1/inventory
+// ("TypeError: Cannot read properties of undefined (reading 'clusters')"),
+// observed in the field on the first inventory call after a server start.
+//
+// blockingFetch hands the shared in-flight promise straight back to its
+// callers, so whatever triggerBackgroundRevalidation parks there IS what a
+// concurrent blocking caller receives. It used to park a Promise<void> (the
+// .then returned nothing, the .catch swallowed), through an `as any` that
+// defeated the slot's own Promise<CachedInventory> type. The piggybacking
+// caller got `undefined` and died dereferencing it.
+//
+// The window is NOT limited to startup: the stale branch triggers a
+// revalidation on every TTL expiry, so a polling monitor could hit this at
+// any time.
+describe('background revalidation shares a usable promise (inventory 500 regression)', () => {
+  it('parks a promise that resolves to the inventory, not to undefined', async () => {
+    getInventoryFromCacheMock.mockReturnValue({ status: 'stale', data: RAW })
+
+    await getInventorySWR('default', { kind: 'provider' } as any)
+
+    // THE load-bearing assertion: this awaited to `undefined` before the fix.
+    await expect(storedInflightPromise()).resolves.toEqual(RAW)
+  })
+
+  it('a blocking caller piggybacking on a running revalidation receives the inventory', async () => {
+    // 1) A stale read triggers the revalidation and parks its promise.
+    getInventoryFromCacheMock.mockReturnValue({ status: 'stale', data: RAW })
+    await getInventorySWR('default', { kind: 'provider' } as any)
+    const parked = storedInflightPromise()
+
+    // 2) A second caller finds a cold cache while that revalidation is still
+    //    in flight — the exact production sequence, where /api/v1/vms warmed
+    //    the cache non-blockingly and /api/v1/inventory arrived right behind.
+    getInventoryFromCacheMock.mockReturnValue({ status: 'miss' })
+    getInflightFetchMock.mockReturnValue(parked)
+
+    const out = await getInventorySWR('default', { kind: 'provider' } as any)
+
+    expect(out.raw, 'the piggybacking caller must never receive undefined').toBeDefined()
+    // The dereference that produced the 500 in the route handler.
+    expect(out.raw.clusters).toEqual([])
+  })
+
+  it('a FAILING revalidation rejects for the piggybacking caller instead of resolving undefined', async () => {
+    getSessionPrismaMock.mockRejectedValue(new Error('proxmox unreachable'))
+    getInventoryFromCacheMock.mockReturnValue({ status: 'stale', data: RAW })
+
+    await getInventorySWR('default', { kind: 'provider' } as any)
+
+    // Rejecting is the honest answer: it surfaces the real cause instead of a
+    // bogus TypeError further down. The detached handler in
+    // triggerBackgroundRevalidation is what keeps this from also becoming an
+    // unhandled rejection for the fire-and-forget caller.
+    await expect(storedInflightPromise()).rejects.toThrow('proxmox unreachable')
+  })
+})

--- a/frontend/src/lib/inventory/fetchRawInventory.ts
+++ b/frontend/src/lib/inventory/fetchRawInventory.ts
@@ -555,17 +555,44 @@ export function triggerBackgroundRevalidation(tenantId: string, infra: InfraScop
   if (getInflightFetch(tenantId, vdcContext) !== null) return
 
   const startTime = Date.now()
+
+  // This promise goes into the SHARED in-flight slot, which blockingFetch
+  // hands straight back to its callers. So it must resolve to the inventory
+  // and reject on failure, exactly like blockingFetch's own promise does.
+  //
+  // It used to do neither. The `.then` returned nothing and the `.catch`
+  // swallowed the error, making this a Promise<void> stored through an
+  // `as any` — the slot is typed Promise<CachedInventory>, so the cast was
+  // the only reason it compiled. Any request that reached the blocking path
+  // while a background revalidation was running got that promise, awaited it,
+  // and received `undefined`, which then died on `raw.clusters` as a 500.
+  // Reproduced on the first inventory call after a server start, but the same
+  // window opens on EVERY stale revalidation, so under a polling monitor it
+  // was an intermittent 500 with no explanation.
   const revalidation = fetchRawInventory(infra)
     .then(result => {
       console.log(`[inventory] Background revalidation completed in ${Date.now() - startTime}ms`)
       setCachedInventory(result, tenantId, vdcContext)
       setInflightFetch(null, tenantId, vdcContext)
+
+      return result
     })
     .catch(err => {
       console.error('[inventory] Background revalidation failed:', err?.message)
       setInflightFetch(null, tenantId, vdcContext)
+      // Rethrow so a piggybacking blockingFetch caller learns the fetch
+      // failed. Answering it with `undefined` is what produced the bogus
+      // TypeError instead of the real cause.
+      throw err
     })
-  setInflightFetch(revalidation as any, tenantId, vdcContext)
+
+  setInflightFetch(revalidation, tenantId, vdcContext)
+
+  // Fire-and-forget for THIS caller: the rethrow above is for whoever awaits
+  // the shared slot, and without a detached handler it would surface as an
+  // unhandled rejection. Attached after the slot is set, and deliberately on
+  // a separate handler chain so the promise stored above still rejects.
+  revalidation.catch(() => {})
 }
 
 /** All-empty shape, same fields as a real RawInventory, served on a cold

--- a/frontend/src/messages/apiTokensMessages.test.ts
+++ b/frontend/src/messages/apiTokensMessages.test.ts
@@ -23,8 +23,10 @@ describe('settings.apiTokens i18n parity across the 6 served locales', () => {
   it('declares the required keys in en.json', () => {
     for (const key of [
       'tabLabel', 'title', 'subtitle', 'newToken', 'columns.prefix', 'columns.name',
-      'columns.tenant', 'columns.scopes', 'columns.expires', 'columns.lastUsed', 'never', 'revoke',
-      'revoked', 'revokeConfirm', 'revokeSuccess', 'loadError', 'createError',
+      'columns.tenant', 'columns.scopes', 'columns.expires', 'columns.lastUsed', 'never', 'delete',
+      // `revoked` stays: nothing writes revoked_at any more, but the grid still
+      // has to chip the legacy rows that existing databases carry.
+      'revoked', 'deleteConfirm', 'deleteSuccess', 'loadError', 'createError',
       'dialog.title', 'dialog.name', 'dialog.description', 'dialog.expiration',
       'dialog.expirationNone', 'dialog.expiration30', 'dialog.expiration90',
       'dialog.expiration365', 'dialog.expirationCustom', 'dialog.customDays',

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2619,13 +2619,15 @@
         "tenant": "Mandant",
         "scopes": "Berechtigungen",
         "expires": "Ablauf",
-        "lastUsed": "Zuletzt verwendet"
+        "lastUsed": "Zuletzt verwendet",
+        "createdBy": "Erstellt von"
       },
       "never": "Nie",
-      "revoke": "Widerrufen",
+      "unknownCreator": "Unbekannt",
+      "delete": "Löschen",
       "revoked": "Widerrufen",
-      "revokeConfirm": "Diesen Token widerrufen? Integrationen, die ihn verwenden, funktionieren sofort nicht mehr.",
-      "revokeSuccess": "Token widerrufen",
+      "deleteConfirm": "Dieses Token löschen? Integrationen, die es verwenden, funktionieren sofort nicht mehr, und der Vorgang ist unwiderruflich.",
+      "deleteSuccess": "Token gelöscht",
       "loadError": "API-Token konnten nicht geladen werden",
       "createError": "API-Token konnte nicht erstellt werden",
       "dialog": {
@@ -5628,7 +5630,17 @@
     "passwordManagedByIdp": "Das Passwort wird vom Identitätsanbieter verwaltet (OIDC / LDAP).",
     "emailLabel": "E-Mail",
     "emailHeader": "E-Mail",
-    "authHeader": "Auth"
+    "authHeader": "Auth",
+    "apiTokens": {
+      "title": "API-Token",
+      "disableWarning": "Dieses Konto hat {count} aktive(s) API-Token erstellt. Das Deaktivieren des Kontos stoppt sie nicht: Ein Token authentifiziert sich eigenständig.",
+      "deleteWarning": "Dieses Konto hat {count} aktive(s) API-Token erstellt. Sie überleben die Löschung: Ein Token authentifiziert sich eigenständig.",
+      "deleteCheckbox": "Diese Token ebenfalls löschen",
+      "deleteHint": "Jede Integration, die sie verwendet, funktioniert sofort nicht mehr. Der Vorgang ist unwiderruflich.",
+      "loadError": "Die API-Token dieses Benutzers konnten nicht geladen werden",
+      "neverUsed": "Nie verwendet",
+      "deleted": "{count} API-Token gelöscht"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "Feature under aktiv development",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2649,13 +2649,15 @@
         "tenant": "Tenant",
         "scopes": "Scopes",
         "expires": "Expires",
-        "lastUsed": "Last used"
+        "lastUsed": "Last used",
+        "createdBy": "Created by"
       },
       "never": "Never",
-      "revoke": "Revoke",
+      "unknownCreator": "Unknown",
+      "delete": "Delete",
       "revoked": "Revoked",
-      "revokeConfirm": "Revoke this token? Integrations using it stop working immediately.",
-      "revokeSuccess": "Token revoked",
+      "deleteConfirm": "Delete this token? Integrations using it stop working immediately, and this cannot be undone.",
+      "deleteSuccess": "Token deleted",
       "loadError": "Failed to load API tokens",
       "createError": "Failed to create the API token",
       "dialog": {
@@ -5698,7 +5700,17 @@
     "tenantsHelper": "The user will be a member of every selected tenant",
     "tenantsRequired": "Select at least one tenant",
     "rolesMixed": "{count} roles",
-    "rolesDivergentWarning": "Roles differ across this user's tenants. Saving a role here will overwrite every per-tenant assignment."
+    "rolesDivergentWarning": "Roles differ across this user's tenants. Saving a role here will overwrite every per-tenant assignment.",
+    "apiTokens": {
+      "title": "API tokens",
+      "disableWarning": "This account created {count} active API token(s). Disabling the account does not stop them: a token authenticates on its own.",
+      "deleteWarning": "This account created {count} active API token(s). They survive the deletion: a token authenticates on its own.",
+      "deleteCheckbox": "Delete these tokens as well",
+      "deleteHint": "Any integration using them stops working immediately. This cannot be undone.",
+      "loadError": "Failed to load the API tokens of this user",
+      "neverUsed": "Never used",
+      "deleted": "{count} API token(s) deleted"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "Feature under active development",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2649,13 +2649,15 @@
         "tenant": "Tenant",
         "scopes": "Ámbitos",
         "expires": "Caduca",
-        "lastUsed": "Último uso"
+        "lastUsed": "Último uso",
+        "createdBy": "Creado por"
       },
       "never": "Nunca",
-      "revoke": "Revocar",
+      "unknownCreator": "Desconocido",
+      "delete": "Eliminar",
       "revoked": "Revocado",
-      "revokeConfirm": "¿Revocar este token? Las integraciones que lo usan dejan de funcionar de inmediato.",
-      "revokeSuccess": "Token revocado",
+      "deleteConfirm": "¿Eliminar este token? Las integraciones que lo usan dejan de funcionar de inmediato y la operación es irreversible.",
+      "deleteSuccess": "Token eliminado",
       "loadError": "No se pudieron cargar los tokens de API",
       "createError": "No se pudo crear el token de API",
       "dialog": {
@@ -5698,7 +5700,17 @@
     "tenantsHelper": "El usuario será miembro de cada tenant seleccionado",
     "tenantsRequired": "Seleccione al menos un tenant",
     "rolesMixed": "{count} roles",
-    "rolesDivergentWarning": "Los roles difieren entre los tenants de este usuario. Guardar un rol aquí sobrescribirá cada asignación por tenant."
+    "rolesDivergentWarning": "Los roles difieren entre los tenants de este usuario. Guardar un rol aquí sobrescribirá cada asignación por tenant.",
+    "apiTokens": {
+      "title": "Tokens de API",
+      "disableWarning": "Esta cuenta creó {count} token(s) de API activo(s). Desactivar la cuenta no los detiene: un token se autentica por sí mismo.",
+      "deleteWarning": "Esta cuenta creó {count} token(s) de API activo(s). Sobreviven a la eliminación: un token se autentica por sí mismo.",
+      "deleteCheckbox": "Eliminar también estos tokens",
+      "deleteHint": "Cualquier integración que los use deja de funcionar de inmediato. La operación es irreversible.",
+      "loadError": "No se pudieron cargar los tokens de API de este usuario",
+      "neverUsed": "Nunca usado",
+      "deleted": "{count} token(s) de API eliminado(s)"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "Función en desarrollo activo",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2649,13 +2649,15 @@
         "tenant": "Tenant",
         "scopes": "Périmètres",
         "expires": "Expiration",
-        "lastUsed": "Dernière utilisation"
+        "lastUsed": "Dernière utilisation",
+        "createdBy": "Créé par"
       },
       "never": "Jamais",
-      "revoke": "Révoquer",
+      "unknownCreator": "Inconnu",
+      "delete": "Supprimer",
       "revoked": "Révoqué",
-      "revokeConfirm": "Révoquer ce jeton ? Les intégrations qui l'utilisent s'arrêtent immédiatement.",
-      "revokeSuccess": "Jeton révoqué",
+      "deleteConfirm": "Supprimer ce jeton ? Les intégrations qui l'utilisent s'arrêtent immédiatement, et l'opération est irréversible.",
+      "deleteSuccess": "Jeton supprimé",
       "loadError": "Échec du chargement des jetons API",
       "createError": "Échec de la création du jeton API",
       "dialog": {
@@ -5698,7 +5700,17 @@
     "tenantsHelper": "L'utilisateur sera membre de chaque tenant sélectionné",
     "tenantsRequired": "Sélectionner au moins un tenant",
     "rolesMixed": "{count} rôles",
-    "rolesDivergentWarning": "Les rôles diffèrent entre les tenants de cet utilisateur. Enregistrer un rôle ici écrasera chaque affectation per-tenant."
+    "rolesDivergentWarning": "Les rôles diffèrent entre les tenants de cet utilisateur. Enregistrer un rôle ici écrasera chaque affectation per-tenant.",
+    "apiTokens": {
+      "title": "Jetons d'API",
+      "disableWarning": "Ce compte a créé {count} jeton(s) d'API actif(s). Désactiver le compte ne les arrête pas : un jeton s'authentifie tout seul.",
+      "deleteWarning": "Ce compte a créé {count} jeton(s) d'API actif(s). Ils survivent à la suppression : un jeton s'authentifie tout seul.",
+      "deleteCheckbox": "Supprimer aussi ces jetons",
+      "deleteHint": "Toute intégration qui les utilise cesse de fonctionner immédiatement. L'opération est irréversible.",
+      "loadError": "Impossible de charger les jetons d'API de cet utilisateur",
+      "neverUsed": "Jamais utilisé",
+      "deleted": "{count} jeton(s) d'API supprimé(s)"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "Fonctionnalité en cours de développement",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2649,13 +2649,15 @@
         "tenant": "테넌트",
         "scopes": "범위",
         "expires": "만료",
-        "lastUsed": "마지막 사용"
+        "lastUsed": "마지막 사용",
+        "createdBy": "생성자"
       },
       "never": "없음",
-      "revoke": "취소",
+      "unknownCreator": "알 수 없음",
+      "delete": "삭제",
       "revoked": "취소됨",
-      "revokeConfirm": "이 토큰을 취소하시겠습니까? 이를 사용하는 통합은 즉시 작동을 멈춥니다.",
-      "revokeSuccess": "토큰이 취소되었습니다",
+      "deleteConfirm": "이 토큰을 삭제하시겠습니까? 이 토큰을 사용하는 연동이 즉시 중단되며 되돌릴 수 없습니다.",
+      "deleteSuccess": "토큰이 삭제되었습니다",
       "loadError": "API 토큰을 불러오지 못했습니다",
       "createError": "API 토큰을 생성하지 못했습니다",
       "dialog": {
@@ -5698,7 +5700,17 @@
     "tenantsHelper": "사용자는 선택한 모든 테넌트의 구성원이 됩니다",
     "tenantsRequired": "테넌트를 하나 이상 선택하세요",
     "rolesMixed": "역할 {count}개",
-    "rolesDivergentWarning": "이 사용자의 테넌트별 역할이 서로 다릅니다. 여기서 역할을 저장하면 모든 테넌트별 할당을 덮어씁니다."
+    "rolesDivergentWarning": "이 사용자의 테넌트별 역할이 서로 다릅니다. 여기서 역할을 저장하면 모든 테넌트별 할당을 덮어씁니다.",
+    "apiTokens": {
+      "title": "API 토큰",
+      "disableWarning": "이 계정이 활성 API 토큰 {count}개를 생성했습니다. 계정을 비활성화해도 토큰은 중지되지 않습니다. 토큰은 스스로 인증합니다.",
+      "deleteWarning": "이 계정이 활성 API 토큰 {count}개를 생성했습니다. 계정을 삭제해도 토큰은 남습니다. 토큰은 스스로 인증합니다.",
+      "deleteCheckbox": "이 토큰도 함께 삭제",
+      "deleteHint": "이 토큰을 사용하는 모든 연동이 즉시 중단됩니다. 되돌릴 수 없습니다.",
+      "loadError": "이 사용자의 API 토큰을 불러오지 못했습니다",
+      "neverUsed": "사용된 적 없음",
+      "deleted": "API 토큰 {count}개가 삭제되었습니다"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "활발히 개발 중인 기능",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2618,13 +2618,15 @@
         "tenant": "租户",
         "scopes": "权限范围",
         "expires": "到期时间",
-        "lastUsed": "最近使用"
+        "lastUsed": "最近使用",
+        "createdBy": "创建者"
       },
       "never": "从未",
-      "revoke": "撤销",
+      "unknownCreator": "未知",
+      "delete": "删除",
       "revoked": "已撤销",
-      "revokeConfirm": "撤销此令牌?使用它的集成将立即停止工作。",
-      "revokeSuccess": "令牌已撤销",
+      "deleteConfirm": "删除此令牌？使用它的集成会立即停止工作，且该操作不可撤销。",
+      "deleteSuccess": "令牌已删除",
       "loadError": "加载 API 令牌失败",
       "createError": "创建 API 令牌失败",
       "dialog": {
@@ -5630,7 +5632,17 @@
     "passwordManagedByIdp": "密码由身份提供商管理 (OIDC / LDAP)。",
     "emailLabel": "电子邮件",
     "emailHeader": "电子邮件",
-    "authHeader": "认证"
+    "authHeader": "认证",
+    "apiTokens": {
+      "title": "API 令牌",
+      "disableWarning": "该账户创建了 {count} 个有效的 API 令牌。停用账户不会使其失效：令牌独立完成认证。",
+      "deleteWarning": "该账户创建了 {count} 个有效的 API 令牌。删除账户后它们依然有效：令牌独立完成认证。",
+      "deleteCheckbox": "同时删除这些令牌",
+      "deleteHint": "使用它们的所有集成会立即停止工作。该操作不可撤销。",
+      "loadError": "无法加载该用户的 API 令牌",
+      "neverUsed": "从未使用",
+      "deleted": "已删除 {count} 个 API 令牌"
+    }
   },
   "networkPage": {
     "devNoticeTitle": "功能正在开发中",


### PR DESCRIPTION
Closes #632.

Both follow-ups from the issue, plus the delete semantics the owner asked for during review and a cache race the recette surfaced.

## 1. `compliance:read` carried a write-capable permission

The scope mapped to `admin.compliance`, the single permission guarding both the compliance reads and its five mutations (`PUT /policies`, `POST /profiles`, `PUT` and `DELETE /profiles/{id}`, `POST /profiles/{id}/activate`). Nothing was exploitable: no compliance path is on the Bearer allowlist, so a token holding the scope could do nothing at all with it. It would have become a real escalation the day any compliance route joined the allowlist, and whoever made that unrelated change had no reason to look at the scope table.

The scope is removed. More importantly, `scopes.test.ts` now fails if any scope maps a permission flagged `isDangerous` in the seeded catalogue, or one whose name is not a read. That closes the class rather than the instance, so the trap cannot be recreated by accident.

Splitting `admin.compliance` into a view half and a manage half was the other option on the table. It was rejected for now: it needs an RBAC migration to expand every existing grant, and the scope would still be inert until a compliance route is actually exposed to tokens. Exposing read-only compliance over the API is a product decision that deserves its own issue, and the split belongs with it.

## 2. Disabling or deleting a user left the tokens they created behind

Token validation deliberately ignores the creating account: a token driving Prometheus must not die because the admin who set it up left the company, and taking monitoring down in the middle of an offboarding would be the worse failure. The gap was one of visibility, not of authorisation, so nothing here changes that decision.

What changes is that the operator can now see it and act on it. The disable and delete dialogs list the live tokens the account created, with name, prefix and last use, and offer to delete them in the same gesture. The checkbox is unchecked by default: showing the count is what fixes the false belief that access was cut, while deleting by default would manufacture the outage the original design avoided. The flag is only honoured while that warning is on screen, so ticking the box and then switching the account back on cannot smuggle a deletion through.

Ordering matters twice. On the disable path the deletion runs before the account write, so a failure can never answer 500 on a request that already disabled the account, which an admin would reasonably read as proof the tokens died with it. On the delete path it must run before the account is removed at all: `created_by_user_id` is `ON DELETE SET NULL`, so once the account is gone the tokens can no longer be found by creator and the chance to act on them is lost for good.

Provenance is fixed separately. `created_by_email` freezes the creator on the row, because `SET NULL` erased the answer to "who minted this credential" exactly when it mattered, and the audit entry was the only remaining record for as long as retention kept it. The tokens table also shows the creator now, which it never did despite the column existing since day one.

New endpoint: `GET /api/v1/users/{id}/api-tokens`, guarded by `admin.users` rather than `admin.apitokens` so an admin who manages people does not need the token permission to see this. It returns only live tokens, never a secret or a hash, and it is not on the Bearer allowlist.

## 3. Deleting a token now removes the row

Raised during review: the action stamped `revoked_at` and kept the row, so a revoked token stayed in the table for good. Worse, the grid rendered a "Revoked" chip *instead of* the button, so a legacy revoked row was a dead end even though the route would have deleted it happily. A row the operator cannot act on is worse than one that is merely dead.

Delete now means gone, in the tokens table and in the offboarding flow alike, and the chip and the button coexist on a revoked row. `audit_logs.api_token_id` was already created without a foreign key so journal entries outlive the token they describe, and the entry now carries the prefix, the only identifier that survives the row. The trade accepted here is the token's own history, `last_used_at` above all.

`revoked_at`, its check in `getPrincipal` and its chip all stay: existing databases hold rows revoked under the old behaviour, they must keep being refused at authentication, and the grid has to keep labelling them. The action i18n keys were renamed from `revoke*` to `delete*` so the vocabulary matches what the button does, and `apitoken.revoke` stays in the audit action union because entries already carry it.

## 4. Inventory answered 500 while a background revalidation ran

Found while testing the token surface, in a file this branch did not otherwise touch. `triggerBackgroundRevalidation` parked a `Promise<void>` in the shared in-flight slot behind an `as any`, which was the only reason it compiled against that slot's `Promise<CachedInventory>` type: its `.then` returned nothing and its `.catch` swallowed the error. `blockingFetch` hands the in-flight promise straight back to its callers, so any request reaching the blocking path while a revalidation ran awaited that promise and received `undefined`, which then died on `raw.clusters` and surfaced as `TypeError: Cannot read properties of undefined (reading 'clusters')`.

First seen on the first inventory call after a server start, but the window opens on every stale revalidation, so a polling monitor could hit it at any time and the previous 500 would have looked inexplicable. The revalidation now resolves to the inventory and rethrows on failure, so a piggybacking caller gets either real data or the real cause; a detached handler keeps the fire-and-forget path from becoming an unhandled rejection.

## Verification

Full suite green: 527 test files, 5401 tests. Production build green. Typecheck reports no error in production code.

The three regression tests for the cache race were checked by mutation: removing the `return result` turns them red with `expected undefined to deeply equal { clusters: [], ... }` and `the piggybacking caller must never receive undefined`. The offboarding and delete tests were checked the same way, including the one that proves a `PATCH` without the flag deletes nothing, since "never implicit" is the whole point of that design.

Exercised against a real Proxmox estate with a live token: the seven allowlisted routes answer 200 with real data, compliance paths answer 401 even with forged `x-pxc-*` headers, non-GET answers 405, `OPTIONS` answers 405 with `Allow: GET, HEAD`, and a token created with every scope now holds seven, with no compliance entry offered in the dialog. A legacy revoked token was deleted from the UI. The cache race was reproduced on a cold cache after a restart and now answers 200; the absence of the `Fetched from Proxmox` log line proves the request went through the shared promise rather than starting its own fetch.

## Migration

`20260817000000_api_token_creator_provenance` adds a nullable `created_by_email`, backfills it by joining `users` for every token whose creator still exists, and indexes `created_by_user_id` for the offboarding lookup. Additive and safe to apply ahead of the deploy. Rows whose creator was already deleted keep a null email: that history is gone, and inventing a value would be worse than admitting the gap.
