### PR TITLE
feat(alerts): configure replication RPO and Ceph OSD latency alerts (#721)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/helpers.ts
@@ -531,7 +531,13 @@ export function getMetricIcon(label: string): string {
   if (l.includes('storage') || l.includes('stockage') || l.includes('hd') || l.includes('disk')) return 'ri-hard-drive-2-line'
   if (l.includes('swap')) return 'ri-swap-line'
   if (l.includes('load')) return 'ri-dashboard-3-line'
+  // Before the `io` test on purpose: "replication" itself contains "io", so
+  // the generic I/O branch would swallow every replication metric.
+  if (l.includes('rpo') || l.includes('replic')) return 'ri-timer-flash-line'
   if (l.includes('io')) return 'ri-time-line'
+  // After the `io` test on purpose: an "IO latency" label keeps the historical
+  // I/O icon, while a Ceph "OSD latency" (no "io" substring) lands here.
+  if (l.includes('osd') || l.includes('latency')) return 'ri-speed-line'
 
 return 'ri-bar-chart-line'
 }

--- a/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
@@ -133,6 +133,52 @@ describe('GET /api/v1/internal/alert-config', () => {
     expect(body.thresholds.recovery_confirmations).toBe(3)
   })
 
+  it('ships the OSD latency and replication RPO grace to the orchestrator, unrounded', async () => {
+    // #721: the Ceph OSD latency and replication RPO checks live in the Go
+    // worker, which reads all three as float64. Dropping them here would pin
+    // the worker to its own defaults, and truncating them would quietly coarsen
+    // a sub-millisecond latency budget into a no-op.
+    getSettingMock.mockResolvedValueOnce({
+      osd_latency_warning: 12.5,
+      osd_latency_critical: 300.5,
+      replication_rpo_grace_percent: 12.5,
+    })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.thresholds.osd_latency_warning).toBe(12.5)
+    expect(body.thresholds.osd_latency_critical).toBe(300.5)
+    expect(body.thresholds.replication_rpo_grace_percent).toBe(12.5)
+  })
+
+  it('falls back to the default OSD latency and RPO grace when the setting predates them', async () => {
+    getSettingMock.mockResolvedValueOnce({ memory_warning: 90 })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    const body = await res.json()
+    expect(body.thresholds.osd_latency_warning).toBe(0)
+    expect(body.thresholds.osd_latency_critical).toBe(250)
+    expect(body.thresholds.replication_rpo_grace_percent).toBe(25)
+  })
+
+  it('preserves an explicit 0 for the disable-the-check convention', async () => {
+    // 0 means "check disabled" for both families, exactly like
+    // snapshot_max_age_days. A falsy-guarded merge would silently re-enable them.
+    getSettingMock.mockResolvedValueOnce({
+      osd_latency_warning: 0,
+      replication_rpo_grace_percent: 0,
+    })
+    findManyMock.mockResolvedValueOnce([])
+
+    const res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    const body = await res.json()
+    expect(body.thresholds.osd_latency_warning).toBe(0)
+    expect(body.thresholds.replication_rpo_grace_percent).toBe(0)
+  })
+
   it('honors X-Tenant-ID by scoping the query', async () => {
     getSettingMock.mockResolvedValueOnce({})
     findManyMock.mockResolvedValueOnce([])

--- a/frontend/src/app/api/internal/alert-config/route.ts
+++ b/frontend/src/app/api/internal/alert-config/route.ts
@@ -18,6 +18,12 @@ const DEFAULT_THRESHOLDS = {
   // Recovery hysteresis (#551) — see the settings route for the rationale.
   recovery_margin: 5,
   recovery_confirmations: 3,
+  // Ceph OSD latency and replication RPO grace (#721), see the settings route.
+  // All three are float64 on the Go side, so they must NOT be truncated below.
+  osd_latency_warning: 0,
+  osd_latency_critical: 250,
+  replication_rpo_grace_percent: 25,
+  replication_failure_alerts: 1,
 }
 
 type Thresholds = typeof DEFAULT_THRESHOLDS

--- a/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
+++ b/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
@@ -23,6 +23,18 @@ const DEFAULT_THRESHOLDS = {
   // firing and a recovery notification every minute.
   recovery_margin: 5,
   recovery_confirmations: 3,
+  // Ceph OSD commit/apply latency in milliseconds (#721). 0 disables the whole
+  // OSD latency check, mirroring the snapshot_max_age_days convention.
+  osd_latency_warning: 0,
+  osd_latency_critical: 250,
+  // Tolerance above a replication job's own RPO target before its last
+  // successful sync is considered late, as a percentage of that target (#721).
+  // 0 disables the replication alerts.
+  replication_rpo_grace_percent: 25,
+  // Alert when a replication job errors out (#721). 0 disables, 1 enables.
+  // Independent from the RPO grace above: an operator can want to hear about a
+  // job that failed outright without hearing about one that merely drifted.
+  replication_failure_alerts: 1,
 }
 
 type Thresholds = typeof DEFAULT_THRESHOLDS

--- a/frontend/src/components/settings/AlertThresholdsTab.jsx
+++ b/frontend/src/components/settings/AlertThresholdsTab.jsx
@@ -28,6 +28,10 @@ const DEFAULTS = {
   snapshot_max_age_days: 7,
   recovery_margin: 5,
   recovery_confirmations: 3,
+  osd_latency_warning: 0,
+  osd_latency_critical: 250,
+  replication_rpo_grace_percent: 25,
+  replication_failure_alerts: 1,
 }
 
 export default function AlertThresholdsTab() {
@@ -139,48 +143,80 @@ export default function AlertThresholdsTab() {
       </Box>
 
       <Typography variant='overline' color='text.secondary' fontWeight={700} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+        <i className='ri-timer-flash-line' style={{ fontSize: 16 }} />
+        {t('alerts.performanceReplication')}
+      </Typography>
+
+      <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' }, gap: 2, mb: 4 }}>
+        <ThresholdCard
+          icon='ri-speed-line'
+          label={t('alerts.osdLatency')}
+          warning={thresholds.osd_latency_warning || 100}
+          critical={thresholds.osd_latency_critical}
+          onChange={(w, c) => setThresholds(th => ({ ...th, osd_latency_warning: w, osd_latency_critical: c }))}
+          tWarning={t('alerts.warning')}
+          tCritical={t('alerts.critical')}
+          min={10}
+          max={Math.max(500, thresholds.osd_latency_critical || 0)}
+          step={5}
+          unit=' ms'
+          enabled={thresholds.osd_latency_warning > 0}
+          onToggle={(checked) => setThresholds(th => (checked
+            ? { ...th, osd_latency_warning: 100, osd_latency_critical: Math.max(100, th.osd_latency_critical) }
+            : { ...th, osd_latency_warning: 0 }
+          ))}
+          tDisabled={t('alerts.snapshotDisabled')}
+        />
+
+        <SingleThresholdCard
+          icon='ri-timer-flash-line'
+          label={t('alerts.replicationRpo')}
+          description={t('alerts.replicationRpoDesc')}
+          value={thresholds.replication_rpo_grace_percent || 25}
+          onChange={(pct) => setThresholds(th => ({ ...th, replication_rpo_grace_percent: pct }))}
+          min={5}
+          max={Math.max(200, thresholds.replication_rpo_grace_percent || 0)}
+          step={5}
+          enabled={thresholds.replication_rpo_grace_percent > 0}
+          onToggle={(checked) => setThresholds(th => ({ ...th, replication_rpo_grace_percent: checked ? 25 : 0 }))}
+          tDisabled={t('alerts.snapshotDisabled')}
+        />
+
+        <ToggleCard
+          icon='ri-file-copy-2-line'
+          label={t('alerts.replicationFailures')}
+          description={t('alerts.replicationFailuresDesc')}
+          detail={t('alerts.replicationFailuresEscalation')}
+          enabled={thresholds.replication_failure_alerts > 0}
+          onToggle={(checked) => setThresholds(th => ({ ...th, replication_failure_alerts: checked ? 1 : 0 }))}
+          tDisabled={t('alerts.snapshotDisabled')}
+        />
+      </Box>
+
+      <Typography variant='overline' color='text.secondary' fontWeight={700} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
         <i className='ri-tools-line' style={{ fontSize: 16 }} />
         {t('alerts.maintenance')}
       </Typography>
 
       <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', lg: '1fr 1fr 1fr' }, gap: 2 }}>
-        <Card variant='outlined' sx={{ borderRadius: 2 }}>
-          <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <i className='ri-camera-line' style={{ fontSize: 18, opacity: 0.6 }} />
-                <Typography variant='subtitle2' fontWeight={700}>{t('alerts.snapshotAge')}</Typography>
-              </Box>
-              <Switch
-                size='small'
-                checked={thresholds.snapshot_max_age_days > 0}
-                onChange={(_, checked) => setThresholds(th => ({ ...th, snapshot_max_age_days: checked ? 7 : 0 }))}
-              />
-            </Box>
-            <Typography variant='caption' color='text.secondary'>{t('alerts.snapshotAgeDesc')}</Typography>
-            {thresholds.snapshot_max_age_days > 0 ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 2 }}>
-                {/* The Math.max stays on the commit: this whole field is only
-                    rendered while snapshot_max_age_days > 0, so writing a 0
-                    mid-keystroke would unmount the input under the cursor and
-                    flip the Switch off. min={1} still clamps on blur. */}
-                <NumericTextField
-                  type='number'
-                  size='small'
-                  value={thresholds.snapshot_max_age_days}
-                  onChange={(days) => setThresholds(th => ({ ...th, snapshot_max_age_days: Math.max(1, days) }))}
-                  fallback={1}
-                  min={1}
-                  slotProps={{ htmlInput: { min: 1, max: 365 } }}
-                  sx={{ width: 80 }}
-                />
-                <Typography variant='body2' color='text.secondary'>{t('alerts.snapshotDays')}</Typography>
-              </Box>
-            ) : (
-              <Typography variant='body2' color='text.disabled' sx={{ mt: 2 }}>{t('alerts.snapshotDisabled')}</Typography>
-            )}
-          </CardContent>
-        </Card>
+        <SingleThresholdCard
+          icon='ri-camera-line'
+          label={t('alerts.snapshotAge')}
+          description={t('alerts.snapshotAgeDesc')}
+          value={thresholds.snapshot_max_age_days || 7}
+          onChange={(days) => setThresholds(th => ({ ...th, snapshot_max_age_days: days }))}
+          min={1}
+          step={1}
+          /* The ceiling follows any value already stored above it: the field
+             used to accept up to 365 days, and a fixed max would let MUI clamp
+             such a setting down the first time the card rendered. */
+          max={Math.max(90, thresholds.snapshot_max_age_days || 0)}
+          formatValue={(v) => `${v} ${t('alerts.snapshotDays')}`}
+          markFormat={(v) => `${v}`}
+          enabled={thresholds.snapshot_max_age_days > 0}
+          onToggle={(checked) => setThresholds(th => ({ ...th, snapshot_max_age_days: checked ? 7 : 0 }))}
+          tDisabled={t('alerts.snapshotDisabled')}
+        />
 
         <Card variant='outlined' sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
@@ -233,32 +269,132 @@ export default function AlertThresholdsTab() {
   )
 }
 
-function ThresholdCard({ icon, label, warning, critical, onChange, tWarning, tCritical }) {
+// Edge marks would otherwise be centred on the thumb and clipped by the card.
+const edgeMarkSx = {
+  mt: 2,
+  '& .MuiSlider-markLabel[data-index="0"]': { left: '6% !important' },
+  '& .MuiSlider-markLabel[data-index="2"]': { left: '94% !important' },
+}
+
+function CardShell({ icon, label, enabled, onToggle, children }) {
   return (
     <Card variant='outlined' sx={{ borderRadius: 2 }}>
       <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-          <i className={icon} style={{ fontSize: 18, opacity: 0.6 }} />
-          <Typography variant='subtitle2' fontWeight={700}>{label}</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <i className={icon} style={{ fontSize: 18, opacity: 0.6 }} />
+            <Typography variant='subtitle2' fontWeight={700}>{label}</Typography>
+          </Box>
+          {onToggle ? <Switch size='small' checked={enabled} onChange={(_, checked) => onToggle(checked)} /> : null}
         </Box>
-        <Typography variant='caption' color='text.secondary' sx={{ fontFamily: 'JetBrains Mono, monospace' }}>
-          {tWarning}: {warning}% · {tCritical}: {critical}%
-        </Typography>
-        <Slider
-          value={[warning, critical]}
-          onChange={(_, v) => { const [w, c] = v; onChange(w, c) }}
-          valueLabelDisplay='auto'
-          valueLabelFormat={(v) => `${v}%`}
-          min={50}
-          max={100}
-          marks={[
-            { value: 50, label: '50%' },
-            { value: 75, label: '75%' },
-            { value: 100, label: '100%' },
-          ]}
-          sx={{ mt: 2, '& .MuiSlider-markLabel[data-index="0"]': { left: '6% !important' }, '& .MuiSlider-markLabel[data-index="2"]': { left: '94% !important' } }}
-        />
+        {children}
       </CardContent>
     </Card>
+  )
+}
+
+/**
+ * Two-thumb warning/critical card. Defaults to the percentage scale the
+ * resource cards have always used; the Ceph latency card passes a millisecond
+ * scale so every threshold on the tab is set the same way, by dragging.
+ *
+ * `onToggle` is optional: a card that can be switched off renders the disabled
+ * caption in place of its slider, exactly like the stale-snapshot card.
+ */
+function ThresholdCard({
+  icon, label, warning, critical, onChange, tWarning, tCritical,
+  min = 50, max = 100, step = 1, unit = '%', marks,
+  enabled = true, onToggle, tDisabled,
+}) {
+  const format = (v) => `${v}${unit}`
+  const scale = marks || [
+    { value: min, label: format(min) },
+    { value: Math.round((min + max) / 2), label: format(Math.round((min + max) / 2)) },
+    { value: max, label: format(max) },
+  ]
+
+  return (
+    <CardShell icon={icon} label={label} enabled={enabled} onToggle={onToggle}>
+      {enabled ? (
+        <>
+          <Typography variant='caption' color='text.secondary'>
+            {tWarning}: {format(warning)} · {tCritical}: {format(critical)}
+          </Typography>
+          <Slider
+            value={[warning, critical]}
+            onChange={(_, v) => { const [w, c] = v; onChange(w, c) }}
+            valueLabelDisplay='auto'
+            valueLabelFormat={format}
+            min={min}
+            max={max}
+            step={step}
+            marks={scale}
+            disableSwap
+            sx={edgeMarkSx}
+          />
+        </>
+      ) : (
+        <Typography variant='body2' color='text.disabled' sx={{ mt: 2 }}>{tDisabled}</Typography>
+      )}
+    </CardShell>
+  )
+}
+
+/**
+ * Single-thumb variant, for a setting that has no critical tier of its own.
+ *
+ * `markFormat` exists because a long unit reads well on the value line but
+ * overflows the three mark labels under the track: "7 days" above, bare
+ * numbers below.
+ */
+function SingleThresholdCard({
+  icon, label, description, value, onChange,
+  min, max, step = 1, unit = '%', formatValue, markFormat,
+  enabled, onToggle, tDisabled,
+}) {
+  const format = formatValue || ((v) => `${v}${unit}`)
+  const mark = markFormat || format
+  const mid = Math.round((min + max) / 2)
+
+  return (
+    <CardShell icon={icon} label={label} enabled={enabled} onToggle={onToggle}>
+      {enabled ? (
+        <>
+          <Typography variant='caption' color='text.secondary' display='block'>{description}</Typography>
+          <Typography variant='caption' color='text.secondary' display='block' sx={{ mt: 0.5 }}>
+            {format(value)}
+          </Typography>
+          <Slider
+            value={value}
+            onChange={(_, v) => onChange(v)}
+            valueLabelDisplay='auto'
+            valueLabelFormat={format}
+            min={min}
+            max={max}
+            step={step}
+            marks={[
+              { value: min, label: mark(min) },
+              { value: mid, label: mark(mid) },
+              { value: max, label: mark(max) },
+            ]}
+            sx={edgeMarkSx}
+          />
+        </>
+      ) : (
+        <Typography variant='body2' color='text.disabled' sx={{ mt: 2 }}>{tDisabled}</Typography>
+      )}
+    </CardShell>
+  )
+}
+
+/** On/off only, for a condition that is binary and has nothing to tune. */
+function ToggleCard({ icon, label, description, detail, enabled, onToggle, tDisabled }) {
+  return (
+    <CardShell icon={icon} label={label} enabled={enabled} onToggle={onToggle}>
+      <Typography variant='caption' color='text.secondary'>{description}</Typography>
+      <Typography variant='body2' color={enabled ? 'text.secondary' : 'text.disabled'} sx={{ mt: 2 }}>
+        {enabled ? detail : tDisabled}
+      </Typography>
+    </CardShell>
   )
 }

--- a/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
+++ b/frontend/src/lib/alerts/__tests__/orchestratorFingerprint.test.ts
@@ -15,6 +15,14 @@ describe('buildOrchestratorFingerprint (canonical contract)', () => {
     { name: 'vector4 storage on node',           input: { connection_id: 'conn-abc123', type: 'storage', severity: 'warning',  resource_type: 'node',  resource: 'pve-node-1' }, expected: 'a5a9f0d7ba8311b6dfbb879d0c3b50c3' },
     { name: 'vector5 event with rule',           input: { connection_id: 'conn-abc123', type: 'event',   severity: 'warning',  resource_type: 'event', resource: '100', rule_id: 'rule-uuid-xyz' },   expected: '381423f2e2a93b55a890900ea01503c4' },
     { name: 'vector6 event with different rule', input: { connection_id: 'conn-abc123', type: 'event',   severity: 'warning',  resource_type: 'event', resource: '100', rule_id: 'rule-uuid-OTHER' }, expected: '619999b15c20bc06ce993bf9042de5f3' },
+    // Ceph OSD latency + DR replication (issue #721). `resource` is the OSD /
+    // replication job name; the carrying host or target cluster travels in
+    // `resource_name`, which is NOT part of the fingerprint.
+    { name: 'vector7 osd latency warning',       input: { connection_id: 'conn-abc123', type: 'osd_latency',        severity: 'warning',  resource_type: 'osd',         resource: 'osd.2' },     expected: 'ede9a1e69ce7d4f48ec92a8d85296c73' },
+    { name: 'vector8 osd latency critical',      input: { connection_id: 'conn-abc123', type: 'osd_latency',        severity: 'critical', resource_type: 'osd',         resource: 'osd.2' },     expected: '28be3689a7f61ff9f462e72b983acb6c' },
+    { name: 'vector9 replication rpo warning',   input: { connection_id: 'conn-abc123', type: 'replication_rpo',    severity: 'warning',  resource_type: 'replication', resource: 'job-100-0' }, expected: '698910286e988fd1d9017dc6ad3e18ac' },
+    { name: 'vector10 replication failed',       input: { connection_id: 'conn-abc123', type: 'replication_failed', severity: 'critical', resource_type: 'replication', resource: 'job-100-0' }, expected: '1d3239c572b2a2a698973e189033ded7' },
+    { name: 'vector11 replication rpo with rule',input: { connection_id: 'conn-abc123', type: 'replication_rpo',    severity: 'warning',  resource_type: 'replication', resource: 'job-100-0', rule_id: 'rule-uuid-xyz' }, expected: '833b8ed1117866c1a3667724e3024194' },
   ] as const
 
   for (const v of vectors) {

--- a/frontend/src/lib/alerts/visibility.test.ts
+++ b/frontend/src/lib/alerts/visibility.test.ts
@@ -13,7 +13,7 @@
  * instead of in production.
  */
 
-import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { isAlertVisibleToTenant, type AlertVisibilityCtx } from './visibility'
 import { prismaTest, truncate } from '@/__tests__/setup/prisma-test'
@@ -168,6 +168,72 @@ describe('isAlertVisibleToTenant — tenant isolation contract', () => {
       ctx(PROVIDER, { vdcScope: null, infraKind: 'provider' as const }),
     )
     expect(typeof result).toBe('boolean')
+  })
+
+  describe('cluster-wide infrastructure alerts (osd / replication)', () => {
+    // The orchestrator emits `osd_latency` on `resource_type='osd'` and
+    // `replication_rpo` / `replication_failed` on `resource_type='replication'`.
+    // Both describe shared cluster hardware / a cluster-wide DR job, so they
+    // are SYSTEM alerts: a vDC tenant must never see them, and the denial must
+    // come from the system-resource gate, not from the VM-identification gate,
+    // whose `cannot_identify_vm` reason would be misleading here.
+    const CASES = [
+      { name: 'osd_latency',          type: 'osd_latency',          resource_type: 'osd',         resource: 'osd.2' },
+      { name: 'replication_rpo',      type: 'replication_rpo',      resource_type: 'replication', resource: 'job-100-0' },
+      { name: 'replication_failed',   type: 'replication_failed',   resource_type: 'replication', resource: 'job-100-0' },
+    ] as const
+
+    // resource_id 100 is INSIDE the tenant's vDC vmid set and node pve1 is in
+    // scope: every later gate would pass, so a denial can only be the system
+    // gate firing.
+    const alertFor = (c: (typeof CASES)[number], extra: Record<string, unknown> = {}) => ({
+      type: c.type,
+      connection_id: CONN_SHARED,
+      resource_type: c.resource_type,
+      resource: c.resource,
+      resource_id: 100,
+      node: 'pve1',
+      ...extra,
+    })
+
+    for (const c of CASES) {
+      it(`${c.name} is denied to a vDC tenant even when it owns the rule`, async () => {
+        expect(await isAlertVisibleToTenant(alertFor(c, { rule_id: 'rule-a' }), ctx(TENANT_A))).toBe(false)
+      })
+
+      it(`${c.name} is visible to the provider`, async () => {
+        expect(
+          await isAlertVisibleToTenant(alertFor(c), ctx(PROVIDER, { vdcScope: null, infraKind: 'provider' as const })),
+        ).toBe(true)
+      })
+    }
+
+    it('denies with the system-alert reason, never cannot_identify_vm', async () => {
+      // The denial reason is only observable through the DEBUG_ALERTS_VISIBILITY
+      // logger, and the module reads that flag once at load time, hence the
+      // reset + dynamic re-import (same pattern as requireEnterprise.test.ts).
+      vi.resetModules()
+      vi.stubEnv('DEBUG_ALERTS_VISIBILITY', '1')
+      const reasons: string[] = []
+      const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        const payload = args[1] as { reason?: string } | undefined
+        if (payload?.reason) reasons.push(payload.reason)
+      })
+
+      try {
+        const { isAlertVisibleToTenant: freshIsAlertVisibleToTenant } = await import('./visibility')
+        for (const c of CASES) {
+          expect(await freshIsAlertVisibleToTenant(alertFor(c, { rule_id: 'rule-a' }), ctx(TENANT_A))).toBe(false)
+        }
+      } finally {
+        spy.mockRestore()
+        vi.unstubAllEnvs()
+        vi.resetModules()
+      }
+
+      expect(reasons).toEqual(CASES.map(() => 'system_resource_type'))
+      expect(reasons).not.toContain('cannot_identify_vm')
+    })
   })
 
   describe('MSP tenant visibility', () => {

--- a/frontend/src/lib/alerts/visibility.ts
+++ b/frontend/src/lib/alerts/visibility.ts
@@ -60,7 +60,19 @@ interface OrchestratorAlertLike {
   event_id?: string
 }
 
-const SYSTEM_RESOURCE_TYPES = new Set(['node', 'storage', 'license', 'cluster', 'system'])
+/**
+ * Resource types that describe cluster-wide infrastructure and must never
+ * reach a vDC-scoped tenant, whoever owns the rule.
+ *
+ * `osd` (Ceph OSD latency) and `replication` (DR replication job RPO /
+ * failure) belong here for the same reason as `node` and `storage`: an OSD
+ * is shared Ceph hardware and a replication job spans a whole cluster, so
+ * neither maps to a single tenant's VM. Listing them here also fixes the
+ * denial reason: without it they fall through to the VM-identification
+ * gate and get denied as `cannot_identify_vm`, which is misleading when
+ * debugging visibility.
+ */
+const SYSTEM_RESOURCE_TYPES = new Set(['node', 'storage', 'license', 'cluster', 'system', 'osd', 'replication'])
 
 const DEBUG = process.env.DEBUG_ALERTS_VISIBILITY === '1'
 

--- a/frontend/src/lib/demo/demo-api.ts
+++ b/frontend/src/lib/demo/demo-api.ts
@@ -501,7 +501,11 @@ export const EXTRA_MOCKS: MockDataMap = {
   // --- Orchestrator Alerts (for /operations/alerts page) ---
   get 'GET:/api/v1/orchestrator/alerts'() {
     const now = Date.now()
-    const severities = ['critical', 'warning', 'warning', 'info', 'critical', 'warning', 'info', 'warning']
+    // Parallel arrays rather than index ternaries: the tail entries (#721 added
+    // the Ceph OSD latency and replication families) need their own entity type,
+    // metric and status, which the previous `i < 5 ? ... : ...` chains could not
+    // express without silently mislabelling every new row as a resolved VM alert.
+    const severities = ['critical', 'warning', 'warning', 'info', 'critical', 'warning', 'info', 'warning', 'critical', 'warning', 'critical']
     const messages = [
       'Node pve-node-03: RAM usage critical (94%)',
       'Node pve-node-07: CPU usage high (82%)',
@@ -511,34 +515,45 @@ export const EXTRA_MOCKS: MockDataMap = {
       'Node pve-node-11: Storage pool local-zfs usage 87%',
       'PBS datastore backup-main: GC completed',
       'VM web-prod-01: High network packet loss detected',
+      'Ceph osd.3 on pve-node-02: apply latency 412ms (critical above 250ms)',
+      'Replication job 102-0 (db-master to pve-dr-02): last sync 41min ago, past its 30min RPO target',
+      'Replication job 118-0 (mail-relay to pve-dr-02) failed: connection reset by peer',
     ]
-    const sources = ['pve-node-03','pve-node-07','pve-node-01','pve-node-05','pve-dr-02','pve-node-11','PBS-MASTER','pve-node-01']
+    const sources = ['pve-node-03','pve-node-07','pve-node-01','pve-node-05','pve-dr-02','pve-node-11','PBS-MASTER','pve-node-01','pve-node-02','pve-node-01','pve-node-05']
+    const types = ['memory','cpu','custom','event','node_down','storage','event','custom','osd_latency','replication_rpo','replication_failed']
+    const entityTypes = ['node','node','vm','vm','osd','vm','vm','vm','osd','replication','replication']
+    const entityNames = [...sources.slice(0, 8), 'osd.3', '102-0', '118-0']
+    const metrics = ['ram','cpu','disk_io',null,null,null,null,null,'osd_apply_latency','replication_lag',null]
+    const currentValues = [94, 82, null, null, null, 87, null, null, 412, 41, null]
+    const alertThresholds = [90, 80, null, null, null, 85, null, null, 250, 30, null]
+    const statuses = ['active','active','active','active','active','resolved','resolved','resolved','active','active','active']
     return {
       data: messages.map((msg, i) => ({
         id: `alert-demo-${i}`,
         fingerprint: `fp-${i}`,
+        type: types[i],
         severity: severities[i],
         message: msg,
         source: sources[i],
         sourceType: 'pve',
-        entityType: i < 2 ? 'node' : i === 4 ? 'osd' : 'vm',
-        entityName: sources[i],
-        metric: i === 0 ? 'ram' : i === 1 ? 'cpu' : i === 2 ? 'disk_io' : null,
-        currentValue: i === 0 ? 94 : i === 1 ? 82 : i === 5 ? 87 : null,
-        threshold: i === 0 ? 90 : i === 1 ? 80 : i === 5 ? 85 : null,
-        status: i < 5 ? 'active' : 'resolved',
+        entityType: entityTypes[i],
+        entityName: entityNames[i],
+        metric: metrics[i],
+        currentValue: currentValues[i],
+        threshold: alertThresholds[i],
+        status: statuses[i],
         occurrences: 1 + Math.floor(Math.random() * 10),
         firstSeenAt: new Date(now - (i + 1) * 3600000).toISOString(),
         lastSeenAt: new Date(now - i * 600000).toISOString(),
         acknowledgedAt: i === 2 ? new Date(now - 1800000).toISOString() : null,
         acknowledgedBy: i === 2 ? 'admin' : null,
-        resolvedAt: i >= 5 ? new Date(now - i * 300000).toISOString() : null,
+        resolvedAt: statuses[i] === 'resolved' ? new Date(now - i * 300000).toISOString() : null,
       })),
       total: messages.length,
     }
   },
   'GET:/api/v1/orchestrator/alerts/summary': {
-    data: { total: 8, active: 5, acknowledged: 1, resolved: 3, critical: 2, warning: 4, info: 2 },
+    data: { total: 11, active: 8, acknowledged: 1, resolved: 3, critical: 4, warning: 5, info: 2 },
   },
   get 'GET:/api/v1/orchestrator/alerts/rules'() {
     return {
@@ -551,11 +566,25 @@ export const EXTRA_MOCKS: MockDataMap = {
       ],
     }
   },
+  // Every key of DEFAULT_THRESHOLDS must appear here: a missing one renders its
+  // card at the component default in demo mode, which reads as a feature that
+  // silently forgot its own setting.
+  //
+  // The values are a demo tenant's choices, not the shipped defaults. The Ceph
+  // latency check ships at 0, i.e. disabled, because no latency threshold suits
+  // every disk; the demo turns it on so its card shows a configured state and
+  // matches the osd_latency alert listed above.
   'GET:/api/v1/settings/alerts/thresholds': {
     cpu_warning: 80, cpu_critical: 90,
     memory_warning: 80, memory_critical: 90,
     storage_warning: 80, storage_critical: 90,
     snapshot_max_age_days: 7,
+    recovery_margin: 5,
+    recovery_confirmations: 3,
+    osd_latency_warning: 100,
+    osd_latency_critical: 250,
+    replication_rpo_grace_percent: 25,
+    replication_failure_alerts: 1,
   },
   get 'GET:/api/v1/audit'() {
     const actions = [

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -644,7 +644,18 @@ export default orchestratorClient
 export interface Alert {
   id: string
   connection_id: string
-  type: 'cpu' | 'memory' | 'storage' | 'node_down' | 'vm_down' | 'custom'
+  type:
+    | 'cpu'
+    | 'memory'
+    | 'storage'
+    | 'node_down'
+    | 'vm_down'
+    | 'event'
+    | 'snapshot_stale'
+    | 'osd_latency'
+    | 'replication_rpo'
+    | 'replication_failed'
+    | 'custom'
   severity: 'info' | 'warning' | 'critical'
   status: 'active' | 'acknowledged' | 'resolved' | 'silenced'
   resource: string
@@ -690,6 +701,17 @@ export interface AlertThresholds {
   recovery_margin: number
   /** Consecutive collections below the margin before the alert resolves. */
   recovery_confirmations: number
+  /** Ceph OSD latency in ms that raises a warning (#721). 0 disables the check. */
+  osd_latency_warning: number
+  /** Ceph OSD latency in ms that raises a critical alert (#721). */
+  osd_latency_critical: number
+  /**
+   * Tolerance above a replication job's own RPO target, in percent, before its
+   * last successful sync counts as late (#721). 0 disables replication alerts.
+   */
+  replication_rpo_grace_percent: number
+  /** Alert on a failed replication job (#721). 0 disables, 1 enables. */
+  replication_failure_alerts: number
 }
 
 export interface AlertsResponse {

--- a/frontend/src/messages/alertsMessages.test.ts
+++ b/frontend/src/messages/alertsMessages.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+
+import en from './en.json'
+import fr from './fr.json'
+import de from './de.json'
+import zhCN from './zh-CN.json'
+import ko from './ko.json'
+import es from './es.json'
+
+type Messages = Record<string, unknown>
+
+function keyPaths(obj: Messages, prefix = ''): string[] {
+  const out: string[] = []
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key
+    if (value && typeof value === 'object') {
+      out.push(...keyPaths(value as Messages, path))
+    } else {
+      out.push(path)
+    }
+  }
+  return out.sort()
+}
+
+const locales: Array<[string, Messages]> = [
+  ['fr', fr as Messages],
+  ['de', de as Messages],
+  ['zh-CN', zhCN as Messages],
+  ['ko', ko as Messages],
+  ['es', es as Messages],
+]
+
+describe('alerts message namespace', () => {
+  const reference = keyPaths((en as Messages).alerts as Messages)
+
+  it('en defines the full alerts key inventory', () => {
+    for (const required of [
+      'title',
+      'thresholdsConfig',
+      'resourceUsage',
+      'maintenance',
+      'detail.title',
+      'detail.currentValue',
+      'messages.nodeOffline',
+      'snapshotAge',
+      'snapshotDisabled',
+      'recoveryTitle',
+      'recoveryMargin',
+      'recoveryConfirmations',
+      // #721: Ceph OSD latency and replication RPO thresholds.
+      'performanceReplication',
+      'osdLatency',
+      'osdLatencyDesc',
+      'osdLatencyWarning',
+      'osdLatencyCritical',
+      'replicationRpo',
+      'replicationRpoDesc',
+      'replicationRpoGrace',
+    ]) {
+      expect(reference).toContain(required)
+    }
+  })
+
+  for (const [name, messages] of locales) {
+    it(`${name} has exactly the same alerts keys as en`, () => {
+      expect(messages.alerts, `${name}.json is missing the top-level "alerts" section`).toBeDefined()
+      expect(keyPaths(messages.alerts as Messages)).toEqual(reference)
+    })
+  }
+})

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -558,6 +558,21 @@
     "resolve": "Beheben",
     "resolveAll": "Alle beheben",
     "viewAll": "View all Warnmeldungen",
+    "detail": {
+      "title": "Warnungsdetails",
+      "severity": "Schweregrad",
+      "message": "Nachricht",
+      "source": "Quelle",
+      "sourceType": "Quellentyp",
+      "entity": "Objekt",
+      "entityType": "Objekttyp",
+      "metric": "Metrik",
+      "currentValue": "Aktueller Wert",
+      "threshold": "Schwellenwert",
+      "time": "Erkannt am",
+      "goToEntity": "Zum Objekt",
+      "close": "Schließen"
+    },
     "messages": {
       "nodeOffline": "Node {node}: OFFLINE",
       "ramCritical": "Node {node}: RAM kritisch ({value}%)",
@@ -656,7 +671,18 @@
     "recoveryTitle": "Alarm-Entwarnung",
     "recoveryDesc": "Wie weit eine Metrik zurückgehen muss, bevor ihr Alarm als behoben gilt, damit ein schwankender Wert nicht jede Minute eine Auslösung und eine Entwarnung verschickt",
     "recoveryMargin": "Punkte unter dem Warnschwellenwert",
-    "recoveryConfirmations": "aufeinanderfolgende Prüfungen unter dem Abstand"
+    "recoveryConfirmations": "aufeinanderfolgende Prüfungen unter dem Abstand",
+    "performanceReplication": "Leistung und Replikation",
+    "osdLatency": "Ceph-OSD-Latenz",
+    "osdLatencyDesc": "Warnen, wenn ein Ceph-OSD dauerhaft langsamer als diese Werte bleibt, was Benutzer als träge Datenträger wahrnehmen",
+    "osdLatencyWarning": "ms (Warnung)",
+    "osdLatencyCritical": "ms (kritisch)",
+    "replicationRpo": "Replikations-RPO",
+    "replicationRpoDesc": "Warnen, wenn die letzte erfolgreiche Synchronisierung eines Replikationsauftrags weiter zurückliegt als dessen eigenes RPO-Ziel zuzüglich dieser Marge",
+    "replicationRpoGrace": "% Toleranz über dem RPO-Ziel des Auftrags",
+    "replicationFailures": "Replikationsfehler",
+    "replicationFailuresDesc": "Warnen, wenn eine Replikationsaufgabe fehlschlägt, unabhängig von ihrem RPO",
+    "replicationFailuresEscalation": "Warnung, dann kritisch, sobald die Versuche aufgebraucht sind"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -684,7 +684,18 @@
     "recoveryTitle": "Alert recovery",
     "recoveryDesc": "How far a metric must settle back down before its alert is declared resolved, so an unstable value does not email a firing and a recovery every minute",
     "recoveryMargin": "points below the warning threshold",
-    "recoveryConfirmations": "consecutive checks below the margin"
+    "recoveryConfirmations": "consecutive checks below the margin",
+    "performanceReplication": "Performance & replication",
+    "osdLatency": "Ceph OSD latency",
+    "osdLatencyDesc": "Alert when a Ceph OSD stays slower than these values, which users feel as sluggish disks",
+    "osdLatencyWarning": "ms (warning)",
+    "osdLatencyCritical": "ms (critical)",
+    "replicationRpo": "Replication RPO",
+    "replicationRpoDesc": "Alert when a replication job's last successful sync falls further behind than its own RPO target, plus this margin",
+    "replicationRpoGrace": "% tolerated above the job's RPO target",
+    "replicationFailures": "Replication failures",
+    "replicationFailuresDesc": "Alert when a replication job errors out, independently of its RPO",
+    "replicationFailuresEscalation": "Warning, then critical once the retries are spent"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -684,7 +684,18 @@
     "recoveryTitle": "Recuperación de alertas",
     "recoveryDesc": "Cuánto debe bajar una métrica antes de declarar resuelta su alerta, para evitar que un valor inestable envíe un aviso y una recuperación cada minuto",
     "recoveryMargin": "puntos por debajo del umbral de advertencia",
-    "recoveryConfirmations": "comprobaciones consecutivas por debajo del margen"
+    "recoveryConfirmations": "comprobaciones consecutivas por debajo del margen",
+    "performanceReplication": "Rendimiento y replicación",
+    "osdLatency": "Latencia de los OSD de Ceph",
+    "osdLatencyDesc": "Alertar cuando un OSD de Ceph se mantiene más lento que estos valores, algo que los usuarios perciben como discos lentos",
+    "osdLatencyWarning": "ms (advertencia)",
+    "osdLatencyCritical": "ms (crítico)",
+    "replicationRpo": "RPO de replicación",
+    "replicationRpoDesc": "Alertar cuando la última sincronización correcta de un trabajo de replicación se retrasa más que su propio objetivo de RPO, más este margen",
+    "replicationRpoGrace": "% tolerado por encima del objetivo de RPO del trabajo",
+    "replicationFailures": "Fallos de replicación",
+    "replicationFailuresDesc": "Alertar cuando una tarea de replicación falla, con independencia de su RPO",
+    "replicationFailuresEscalation": "Advertencia y luego crítico cuando se agotan los reintentos"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -684,7 +684,18 @@
     "recoveryTitle": "Retour à la normale",
     "recoveryDesc": "Jusqu'où une métrique doit redescendre avant que son alerte soit déclarée résolue, pour éviter qu'une valeur instable envoie un mail de déclenchement et de résolution chaque minute",
     "recoveryMargin": "points sous le seuil d'avertissement",
-    "recoveryConfirmations": "relevés consécutifs sous la marge"
+    "recoveryConfirmations": "relevés consécutifs sous la marge",
+    "performanceReplication": "Performances et réplication",
+    "osdLatency": "Latence des OSD Ceph",
+    "osdLatencyDesc": "Alerter quand un OSD Ceph reste plus lent que ces valeurs, ce que les utilisateurs ressentent comme des disques poussifs",
+    "osdLatencyWarning": "ms (avertissement)",
+    "osdLatencyCritical": "ms (critique)",
+    "replicationRpo": "RPO de réplication",
+    "replicationRpoDesc": "Alerter quand la dernière synchronisation réussie d'une tâche de réplication accuse un retard supérieur à son propre objectif RPO, majoré de cette marge",
+    "replicationRpoGrace": "% toléré au-delà de l'objectif RPO de la tâche",
+    "replicationFailures": "Échecs de réplication",
+    "replicationFailuresDesc": "Alerter quand une tâche de réplication tombe en erreur, indépendamment de son RPO",
+    "replicationFailuresEscalation": "Avertissement, puis critique une fois les tentatives épuisées"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -684,7 +684,18 @@
     "recoveryTitle": "알림 해제",
     "recoveryDesc": "불안정한 값이 매분 발생 및 해제 메일을 보내지 않도록, 알림을 해제로 선언하기 전에 지표가 얼마나 안정되어야 하는지 정합니다",
     "recoveryMargin": "경고 임계값보다 낮은 포인트",
-    "recoveryConfirmations": "여유 값 미만인 연속 확인 횟수"
+    "recoveryConfirmations": "여유 값 미만인 연속 확인 횟수",
+    "performanceReplication": "성능 및 복제",
+    "osdLatency": "Ceph OSD 지연 시간",
+    "osdLatencyDesc": "Ceph OSD가 이 값보다 계속 느릴 때 알림을 보냅니다. 사용자는 디스크가 느려진 것으로 체감합니다",
+    "osdLatencyWarning": "ms (경고)",
+    "osdLatencyCritical": "ms (심각)",
+    "replicationRpo": "복제 RPO",
+    "replicationRpoDesc": "복제 작업의 마지막 성공 동기화가 해당 작업의 RPO 목표에 이 여유를 더한 값보다 더 뒤처질 때 알림을 보냅니다",
+    "replicationRpoGrace": "작업의 RPO 목표를 초과해 허용하는 비율(%)",
+    "replicationFailures": "복제 실패",
+    "replicationFailuresDesc": "RPO와 무관하게 복제 작업이 오류로 끝나면 알립니다",
+    "replicationFailuresEscalation": "경고로 시작하여 재시도가 모두 소진되면 심각으로 올립니다"
   },
   "inventory": {
     "alertsDialog": {

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -558,6 +558,21 @@
     "resolve": "解决",
     "resolveAll": "全部解决",
     "viewAll": "查看所有告警",
+    "detail": {
+      "title": "告警详情",
+      "severity": "严重级别",
+      "message": "消息",
+      "source": "来源",
+      "sourceType": "来源类型",
+      "entity": "实体",
+      "entityType": "实体类型",
+      "metric": "指标",
+      "currentValue": "当前值",
+      "threshold": "阈值",
+      "time": "检测时间",
+      "goToEntity": "前往实体",
+      "close": "关闭"
+    },
     "messages": {
       "nodeOffline": "节点 {node}: 离线",
       "ramCritical": "节点 {node}: 内存严重 ({value}%)",
@@ -656,7 +671,18 @@
     "recoveryTitle": "告警恢复",
     "recoveryDesc": "指标需要回落到什么程度才宣告告警已解决，避免波动的数值每分钟发送一次触发和恢复邮件",
     "recoveryMargin": "低于警告阈值的百分点",
-    "recoveryConfirmations": "低于该余量的连续检测次数"
+    "recoveryConfirmations": "低于该余量的连续检测次数",
+    "performanceReplication": "性能与复制",
+    "osdLatency": "Ceph OSD 延迟",
+    "osdLatencyDesc": "当 Ceph OSD 持续慢于这些数值时告警，用户会感觉磁盘变慢",
+    "osdLatencyWarning": "ms (警告)",
+    "osdLatencyCritical": "ms (严重)",
+    "replicationRpo": "复制 RPO",
+    "replicationRpoDesc": "当复制任务上次成功同步的滞后超过其自身的 RPO 目标加上此余量时告警",
+    "replicationRpoGrace": "% 相对任务 RPO 目标的容忍上限",
+    "replicationFailures": "复制失败",
+    "replicationFailuresDesc": "当复制任务出错时告警，与其 RPO 无关",
+    "replicationFailuresEscalation": "先为警告，重试次数用尽后升为严重"
   },
   "inventory": {
     "alertsDialog": {


### PR DESCRIPTION
Closes #721 on the UI side. The alert engine itself lives in the orchestrator and ships as a separate PR there.

## What it adds

A "Performance and replication" section in the alert thresholds tab, three cards, each set the way the resource cards have always been set, by dragging a slider:

- **Ceph OSD latency**, warning and critical in milliseconds, off by default
- **Replication RPO**, the tolerated grace as a percentage of each job's own target
- **Replication failures**, a switch

The failure alerts get their own setting rather than riding on the RPO one, since an operator can want to hear about a job that failed outright without hearing about one that merely drifted.

**Stale Snapshots moves to a slider too**, so every threshold on the tab is now set the same way instead of two of them being free text fields.

**Slider ceilings follow any value already stored above them.** The snapshot field used to accept up to 365 days; a fixed maximum would let the slider clamp such a setting down the first time the card rendered, silently changing a configuration nobody touched.

**The value line no longer uses a monospace face**, which was the only font on the tab that differed from the rest of the page.

## Two defects found along the way

**Cluster-wide alerts were denied for the wrong reason.** Alerts carrying the resource types `osd` and `replication` now join the system set in the visibility gate. They describe shared infrastructure that no vDC tenant should see, an OSD being shared Ceph hardware and a replication job spanning a whole cluster. Without this they fell through to the VM identification gate and were denied as `cannot_identify_vm`, which is misleading when debugging visibility.

**The metric icon lookup matches on substrings, and "replication" itself contains "io".** The pre-existing I/O branch therefore swallowed every replication metric. The RPO branch now sits before it, while the latency branch sits after it so that an "IO latency" label keeps its historical icon.

The demo threshold stub had also drifted: it still stopped at `snapshot_max_age_days` and never received the recovery hysteresis keys added in the previous release. It now mirrors the full set, and demo mode shows one alert of each new type.

## Locale parity

`de.json` and `zh-CN.json` were both missing the entire `alerts.detail` block, thirteen keys each, 109 against the 122 the other four carried. They are translated and restored in place so the key order matches, and a new parity test locks the whole `alerts` namespace across the six locales, which is what caught the gap.

## Where the settings go

Unchanged path: the tab writes to the local database, and the orchestrator receives the values through the existing best effort push. All three new keys are floats on the engine side, so none of them belongs in the integer coercion set. A test covers that an explicit 0 survives the round trip, since 0 means "check disabled" for both families and a falsy guarded merge would silently switch them back on.

## Verification

Full suite green, 528 files and 5422 tests, production build green, ESLint clean with no new warning. Verified against a real orchestrator: enabling a threshold in this tab reached the engine and produced the expected alerts, and clearing the condition resolved them.
