### PR TITLE
fix(inventory): scope VMID availability to the target connection (#724)

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,3 +1,0 @@
-auto-install-peers=true
-shamefully-hoist=true
-node-linker=hoisted

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.test.tsx
@@ -312,6 +312,19 @@ describe('CreateLxcDialog - form inputs', () => {
     expect(screen.getByText(/CT ID 101 is already in use/i)).toBeInTheDocument()
   })
 
+  it('CT ID used on ANOTHER connection does not block the create (#724)', async () => {
+    renderWithProviders(
+      <CreateLxcDialog
+        {...makeProps({ allVms: [{ vmid: '101', connId: 'conn-2', node: 'other-node' } as any] })}
+      />,
+    )
+    await waitForDataLoad()
+
+    const ctidInput = screen.getByLabelText('CT ID') as HTMLInputElement
+    fireEvent.change(ctidInput, { target: { value: '101' } })
+    expect(screen.queryByText(/CT ID 101 is already in use/i)).not.toBeInTheDocument()
+  })
+
   it('Unprivileged toggle is checked by default after data loads', async () => {
     renderWithProviders(<CreateLxcDialog {...makeProps()} />)
     await waitForDataLoad()

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateLxcDialog.tsx
@@ -38,6 +38,7 @@ import { alpha } from '@mui/material/styles'
 import AppDialogTitle from '@/components/ui/AppDialogTitle'
 import { onPrimaryTextColor } from '@/lib/theme/onPrimary'
 import NumericTextField from '@/components/ui/NumericTextField'
+import { usedVmidsOnConnection } from '@/components/hardware/utils'
 import { AllVmItem } from './InventoryTree'
 
 function CreateLxcDialog({
@@ -145,9 +146,10 @@ function CreateLxcDialog({
   const [cpuAdvancedExpanded, setCpuAdvancedExpanded] = useState(false)
   const [netAdvancedExpanded, setNetAdvancedExpanded] = useState(false)
 
-  // Client-side fallback — range-aware (see CreateVmDialog.fallbackNextVmid)
-  const fallbackNextCtid = (scopedVms: typeof allVms) => {
-    const usedIds = new Set(scopedVms.map(vm => Number.parseInt(String(vm.vmid), 10)))
+  // Client-side fallback, range-aware (see CreateVmDialog.fallbackNextVmid) and
+  // scoped to the target connection (#724).
+  const fallbackNextCtid = (connId?: string) => {
+    const usedIds = new Set(usedVmidsOnConnection(allVms, connId))
     const startId = tenantVmidRange ? tenantVmidRange.start : 100
     const maxId = tenantVmidRange ? tenantVmidRange.end : 999999999
     let nextId = startId
@@ -180,13 +182,13 @@ function CreateLxcDialog({
     } catch (e) {
       console.error('Error loading next CT ID from API:', e)
     }
-    fallbackNextCtid(allVms.filter(vm => vm.connId === connId))
+    fallbackNextCtid(connId)
   }
 
-  // Calculer le prochain CTID disponible (global sur toutes les VMs)
+  // Pré-remplissage du CTID, sur la connexion sélectionnée quand il y en a une
   useEffect(() => {
     if (allVms.length > 0) {
-      fallbackNextCtid(allVms)
+      fallbackNextCtid(selectedConnection)
     }
   }, [allVms])
 
@@ -221,7 +223,9 @@ return
       return
     }
 
-    const isUsed = allVms.some(vm => Number.parseInt(String(vm.vmid), 10) === ctidNum)
+    // Sur la connexion cible uniquement: le même id sur un autre cluster ne
+    // gêne pas cette création (#724).
+    const isUsed = usedVmidsOnConnection(allVms, selectedConnection).includes(ctidNum)
 
     if (isUsed) {
       setCtidError(t('inventory.createLxc.ctIdInUse', { id: ctidNum }))
@@ -238,7 +242,7 @@ return
       void loadNextCtid(selectedConnection)
       return
     }
-    fallbackNextCtid(allVms)
+    fallbackNextCtid()
   }
 
   // Charger toutes les connexions et tous leurs nodes

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.test.tsx
@@ -344,6 +344,21 @@ describe('CreateVmDialog - form inputs', () => {
     expect(screen.getByText(/VM ID 200 is already in use/i)).toBeInTheDocument()
   })
 
+  it('VM ID used on ANOTHER connection does not block the create (#724)', async () => {
+    // Same id, but the guest lives on a second cluster. Proxmox only requires
+    // uniqueness inside a cluster, so the target connection is free to use 200.
+    renderWithProviders(
+      <CreateVmDialog
+        {...makeProps({ allVms: [{ vmid: '200', connId: 'conn-2', node: 'other-node' } as any] })}
+      />,
+    )
+    await waitForDataLoad()
+
+    const vmidInput = screen.getByLabelText('VM ID') as HTMLInputElement
+    fireEvent.change(vmidInput, { target: { value: '200' } })
+    expect(screen.queryByText(/VM ID 200 is already in use/i)).not.toBeInTheDocument()
+  })
+
   it('expanding Boot and Shutdown section shows the Start at boot toggle', async () => {
     renderWithProviders(<CreateVmDialog {...makeProps()} />)
     await waitForDataLoad()

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/CreateVmDialog.tsx
@@ -46,6 +46,7 @@ import AppDialogTitle from '@/components/ui/AppDialogTitle'
 import { onPrimaryTextColor } from '@/lib/theme/onPrimary'
 import NumericTextField from '@/components/ui/NumericTextField'
 import QuotaDonut from '@/components/mydc/QuotaDonut'
+import { usedVmidsOnConnection } from '@/components/hardware/utils'
 import { formatBytes } from '@/utils/format'
 import { AllVmItem } from './InventoryTree'
 
@@ -224,7 +225,7 @@ function CreateVmDialog({
   // Client-side fallback when the nextid API is unreachable — range-aware so
   // it never proposes an out-of-range VMID for MSP tenants.
   const fallbackNextVmid = () => {
-    const usedVmids = new Set(allVms.map(vm => Number.parseInt(String(vm.vmid), 10)))
+    const usedVmids = new Set(usedVmidsOnConnection(allVms, selectedConnection))
     const startId = tenantVmidRange ? tenantVmidRange.start : 100
     const maxId = tenantVmidRange ? tenantVmidRange.end : 999999999
     let nextId = startId
@@ -525,8 +526,9 @@ return
       return
     }
 
-    // Vérifier si le VMID est déjà utilisé
-    const isUsed = allVms.some(vm => Number.parseInt(String(vm.vmid), 10) === vmidNum)
+    // Vérifier si le VMID est déjà utilisé, sur la connexion cible uniquement:
+    // le même id sur un autre cluster ne gêne pas cette création (#724).
+    const isUsed = usedVmidsOnConnection(allVms, selectedConnection).includes(vmidNum)
 
     if (isUsed) {
       setVmidError(t('inventory.createVm.vmIdInUse', { id: vmidNum }))

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -40,6 +40,7 @@ import {
 
 import { NodeRow, BulkAction } from '@/components/NodesTable'
 import NumericTextField from '@/components/ui/NumericTextField'
+import { usedVmidsOnConnection, nextVmidOnConnection } from '@/components/hardware/utils'
 import { tooltipSlotProps } from '@/components/settings/ha/tooltipSlotProps'
 // Dependency-free eligibility check (NOT ./cbt, which pulls the server-only SOAP client).
 import { cbtEligibility } from '@/lib/vmware/cbt-eligibility'
@@ -1366,8 +1367,8 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
               vmName={data?.name || `VM ${vmid}`}
               vmid={vmid}
               vmType={type}
-              nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
-              existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
+              nextVmid={nextVmidOnConnection(allVms, connId)}
+              existingVmids={usedVmidsOnConnection(allVms, connId)}
               pools={[]}
             />
           </>
@@ -1402,8 +1403,8 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
           vmName={tableCloneVm.name}
           vmid={tableCloneVm.vmid}
           vmType={tableCloneVm.type}
-          nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
-          existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
+          nextVmid={nextVmidOnConnection(allVms, tableCloneVm.connId)}
+          existingVmids={usedVmidsOnConnection(allVms, tableCloneVm.connId)}
           pools={[]}
         />
       )}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
@@ -32,6 +32,7 @@ import {
 import EntityTagManager from './EntityTagManager'
 import { MigrateVmDialog, CrossClusterMigrateParams } from '@/components/MigrateVmDialog'
 import { CloneVmDialog } from '@/components/hardware/CloneVmDialog'
+import { usedVmidsOnConnection, nextVmidOnConnection } from '@/components/hardware/utils'
 import { crossClusterMigrate } from '@/lib/migration/crossClusterMigrate'
 import { NodeIcon, ClusterIcon, getVmIcon } from './TreeIcons'
 import { useTenant } from '@/contexts/TenantContext'
@@ -794,8 +795,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
           vmName={cloneTarget.name || `VM ${cloneTarget.vmid}`}
           vmid={cloneTarget.vmid}
           vmType={cloneTarget.type}
-          nextVmid={Math.max(100, ...allVms.map(v => Number(v.vmid) || 0)) + 1}
-          existingVmids={allVms.map(v => Number(v.vmid) || 0).filter(id => id > 0)}
+          nextVmid={nextVmidOnConnection(allVms, cloneTarget.connId)}
+          existingVmids={usedVmidsOnConnection(allVms, cloneTarget.connId)}
           pools={[]}
         />
       )}

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/TreeDialogs.tsx
@@ -28,24 +28,92 @@ import {
   TextField,
   Typography,
 } from '@mui/material'
+import { alpha } from '@mui/material/styles'
 
 import EntityTagManager from './EntityTagManager'
 import { MigrateVmDialog, CrossClusterMigrateParams } from '@/components/MigrateVmDialog'
 import { CloneVmDialog } from '@/components/hardware/CloneVmDialog'
 import { usedVmidsOnConnection, nextVmidOnConnection } from '@/components/hardware/utils'
 import { crossClusterMigrate } from '@/lib/migration/crossClusterMigrate'
-import { NodeIcon, ClusterIcon, getVmIcon } from './TreeIcons'
+import { NodeIcon, ClusterIcon, StatusIcon } from './TreeIcons'
 import { useTenant } from '@/contexts/TenantContext'
 
-// RemixIcon replacements used in context menus / dialogs
-const PlayArrowIcon = (props: any) => <i className="ri-play-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const StopIcon = (props: any) => <i className="ri-stop-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const PowerSettingsNewIcon = (props: any) => <i className="ri-shut-down-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const PauseIcon = (props: any) => <i className="ri-pause-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const TerminalIcon = (props: any) => <i className="ri-terminal-box-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const MoveUpIcon = (props: any) => <i className="ri-upload-2-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const ContentCopyIcon = (props: any) => <i className="ri-file-copy-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const DescriptionIcon = (props: any) => <i className="ri-file-text-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
+// RemixIcon replacements used in context menus / dialogs.
+// Rendered through Box so `sx={{ color: 'warning.main' }}` resolves against the
+// theme. A bare <i style={{ color: 'warning.main' }}> is an invalid CSS value
+// that browsers drop in silence, which is how several of these icons ended up
+// uncoloured while others carried a raw hex.
+const RemixIcon = ({ name, fontSize, sx, style }: { name: string; fontSize?: string; sx?: any; style?: React.CSSProperties }) => (
+  <Box component="i" className={name} style={style} sx={{ fontSize: fontSize === 'small' ? 18 : 20, lineHeight: 1, ...sx }} />
+)
+
+const PlayArrowIcon = (props: any) => <RemixIcon name="ri-play-fill" {...props} />
+const StopIcon = (props: any) => <RemixIcon name="ri-stop-fill" {...props} />
+const PowerSettingsNewIcon = (props: any) => <RemixIcon name="ri-shut-down-line" {...props} />
+const PauseIcon = (props: any) => <RemixIcon name="ri-pause-fill" {...props} />
+
+// One icon column for every context-menu row: a single size for all of them, and
+// a tone taken from the theme palette rather than the brighter MUI defaults the
+// menu used to mix in.
+const MenuIcon = ({ name, tone = 'text.secondary' }: { name: string; tone?: string }) => (
+  <Box
+    component="i"
+    className={name}
+    sx={{ fontSize: 16, lineHeight: 1, color: tone, width: 16, display: 'inline-flex', justifyContent: 'center', flexShrink: 0 }}
+  />
+)
+
+// Shared shell for the three context menus: inset rows with a rounded hover, one
+// exact icon gutter, and dividers that separate without cutting the card in two.
+const contextMenuPaperSx = {
+  minWidth: 232,
+  maxWidth: 320,
+  borderRadius: 2,
+  py: 0.5,
+  '& .MuiMenuItem-root': {
+    mx: 0.75,
+    px: 1,
+    py: 0.5,
+    gap: 1.25,
+    minHeight: 34,
+    borderRadius: 1,
+  },
+  '& .MuiListItemIcon-root': { minWidth: 0 },
+  '& .MuiListItemText-primary': { fontSize: '0.8125rem' },
+  '& .MuiDivider-root': { mx: 1, my: 0.5 },
+} as const
+
+// Menu title: the subject of the actions below, not another row to click. Wears
+// the theme accent so the card reads as titled, and sits on the same left edge
+// and icon gutter as the rows underneath. It carries the tint, so no divider.
+const ContextMenuHeader = ({ icon, label, hint }: { icon: React.ReactNode; label?: string; hint?: string }) => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1.25,
+      mx: 0.75,
+      mb: 0.5,
+      px: 1,
+      py: 0.75,
+      borderRadius: 1,
+      bgcolor: theme => alpha(theme.palette.primary.main, 0.08),
+    }}
+  >
+    {icon}
+    <Typography
+      noWrap
+      sx={{ minWidth: 0, fontSize: '0.8125rem', fontWeight: 600, color: 'primary.main', letterSpacing: '0.01em' }}
+    >
+      {label}
+    </Typography>
+    {hint && (
+      <Typography sx={{ fontSize: '0.6875rem', color: 'primary.main', opacity: 0.65, ml: 'auto', pl: 1 }}>
+        {hint}
+      </Typography>
+    )}
+  </Box>
+)
 
 // ----- Types used by context menus / dialogs -----
 
@@ -266,22 +334,23 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
             : undefined
         }
-        slotProps={{ paper: { sx: { minWidth: 200, '& .MuiListItemIcon-root': { minWidth: 32 } } } }}
+        slotProps={{ paper: { sx: contextMenuPaperSx } }}
       >
-        {/* Header du menu */}
-        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            {contextMenu && (
-              <i
-                className={getVmIcon(contextMenu.type, contextMenu.template)}
-                style={{ fontSize: 14, opacity: 0.5 }}
-              />
-            )}
-            <Typography variant="body2" sx={{ opacity: 0.7 }}>
-              {contextMenu?.name}
-            </Typography>
-          </Box>
-        </Box>
+        {/* Header du menu: le VMID à droite, l'identifiant que porte l'arbre */}
+        <ContextMenuHeader
+          // Same status-dotted icon as the tree row the menu was opened from.
+          icon={contextMenu ? (
+            <StatusIcon
+              type="vm"
+              vmType={contextMenu.type}
+              template={contextMenu.template}
+              status={contextMenu.status}
+              size={16}
+            />
+          ) : null}
+          label={contextMenu?.name}
+          hint={contextMenu?.vmid}
+        />
 
         {/* Menu pour TEMPLATE */}
         {contextMenu?.template && (
@@ -294,7 +363,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy}
           >
             <ListItemIcon>
-              <ContentCopyIcon fontSize="small" sx={{ color: 'primary.main' }} />
+              <MenuIcon name="ri-file-copy-line" tone="primary.main" />
             </ListItemIcon>
             <ListItemText>{t('audit.actions.clone')}</ListItemText>
           </MenuItem>
@@ -309,7 +378,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status === 'running'}
           >
             <ListItemIcon>
-              <i className="ri-play-fill" style={{ fontSize: 18, color: '#4caf50' }} />
+              <MenuIcon name="ri-play-fill" tone="success.main" />
             </ListItemIcon>
             <ListItemText>{contextMenu?.status === 'paused' ? t('vmActions.resume') : t('audit.actions.start')}</ListItemText>
           </MenuItem>,
@@ -320,7 +389,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-pause-fill" style={{ fontSize: 18, color: '#2196f3' }} />
+              <MenuIcon name="ri-pause-fill" tone="info.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.pause')}</ListItemText>
           </MenuItem>,
@@ -331,7 +400,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-zzz-line" style={{ fontSize: 18, color: '#2196f3' }} />
+              <MenuIcon name="ri-zzz-line" tone="info.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.hibernate')}</ListItemText>
           </MenuItem>,
@@ -342,7 +411,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-shut-down-line" style={{ fontSize: 18, color: '#ff9800' }} />
+              <MenuIcon name="ri-shut-down-line" tone="warning.main" />
             </ListItemIcon>
             <ListItemText>{t('inventoryPage.shutdownClean')}</ListItemText>
           </MenuItem>,
@@ -353,7 +422,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-stop-fill" style={{ fontSize: 18, color: '#f44336' }} />
+              <MenuIcon name="ri-stop-fill" tone="error.main" />
             </ListItemIcon>
             <ListItemText>{t('audit.actions.stop')}</ListItemText>
           </MenuItem>,
@@ -364,7 +433,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-restart-line" style={{ fontSize: 18, color: '#ff9800' }} />
+              <MenuIcon name="ri-restart-line" tone="warning.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.reboot')}</ListItemText>
           </MenuItem>,
@@ -375,7 +444,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy || contextMenu?.status !== 'running'}
           >
             <ListItemIcon>
-              <i className="ri-loop-left-line" style={{ fontSize: 18, color: '#f44336' }} />
+              <MenuIcon name="ri-loop-left-line" tone="error.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.reset')}</ListItemText>
           </MenuItem>,
@@ -393,7 +462,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             disabled={actionBusy}
           >
             <ListItemIcon>
-              <ContentCopyIcon fontSize="small" />
+              <MenuIcon name="ri-file-copy-line" />
             </ListItemIcon>
             <ListItemText>{t('audit.actions.clone')}</ListItemText>
           </MenuItem>,
@@ -404,7 +473,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             handleCloseContextMenu()
           }} disabled={actionBusy || contextMenu?.status === 'running'}>
             <ListItemIcon>
-              <DescriptionIcon fontSize="small" />
+              <MenuIcon name="ri-file-copy-fill" />
             </ListItemIcon>
             <ListItemText>{t('templates.convertToTemplate')}</ListItemText>
           </MenuItem>,
@@ -414,14 +483,14 @@ export default function TreeDialogs(props: TreeDialogsProps) {
           /* --- Snapshot / Backup --- */
           <MenuItem key="snapshot" onClick={handleTakeSnapshot} disabled={actionBusy}>
             <ListItemIcon>
-              <i className="ri-camera-line" style={{ fontSize: 20 }} />
+              <MenuIcon name="ri-camera-line" />
             </ListItemIcon>
             <ListItemText>{t('inventory.takeSnapshot')}</ListItemText>
           </MenuItem>,
 
           <MenuItem key="backup" onClick={handleBackupNow} disabled={actionBusy}>
             <ListItemIcon>
-              <i className="ri-save-line" style={{ fontSize: 20 }} />
+              <MenuIcon name="ri-save-line" />
             </ListItemIcon>
             <ListItemText>{t('inventory.backupNow')}</ListItemText>
           </MenuItem>,
@@ -440,7 +509,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
               disabled={actionBusy}
             >
               <ListItemIcon>
-                <MoveUpIcon fontSize="small" />
+                <MenuIcon name="ri-exchange-line" />
               </ListItemIcon>
               <ListItemText>{t('audit.actions.migrate')}</ListItemText>
             </MenuItem>
@@ -448,7 +517,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
 
           <MenuItem key="console" onClick={handleOpenConsole} disabled={actionBusy}>
             <ListItemIcon>
-              <TerminalIcon fontSize="small" />
+              <MenuIcon name="ri-terminal-box-line" />
             </ListItemIcon>
             <ListItemText>{t('inventory.console')}</ListItemText>
           </MenuItem>,
@@ -456,7 +525,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
           contextMenu?.sshEnabled ? (
             <MenuItem key="unlock" onClick={handleUnlock} disabled={actionBusy || unlocking}>
               <ListItemIcon>
-                <i className="ri-lock-unlock-line" style={{ fontSize: 20, color: '#f59e0b' }} />
+                <MenuIcon name="ri-lock-unlock-line" tone="warning.main" />
               </ListItemIcon>
               <ListItemText>{t('inventory.unlock')}</ListItemText>
             </MenuItem>
@@ -474,22 +543,18 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             ? { top: clusterContextMenu.mouseY, left: clusterContextMenu.mouseX }
             : undefined
         }
-        slotProps={{ paper: { sx: { minWidth: 200, '& .MuiListItemIcon-root': { minWidth: 32 } } } }}
+        slotProps={{ paper: { sx: contextMenuPaperSx } }}
       >
-        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <ClusterIcon nodes={clusterContextMenu?.nodes || []} size={14} />
-            <Typography variant="body2" sx={{ opacity: 0.7 }}>
-              {clusterContextMenu?.name}
-            </Typography>
-          </Box>
-        </Box>
+        <ContextMenuHeader
+          icon={<ClusterIcon nodes={clusterContextMenu?.nodes || []} size={16} />}
+          label={clusterContextMenu?.name}
+        />
         <MenuItem onClick={() => {
           if (clusterContextMenu) openTagDialog('connection', clusterContextMenu.connId, clusterContextMenu.name, undefined, undefined, { clusterNodes: clusterContextMenu.nodes })
           setClusterContextMenu(null)
         }}>
-          <ListItemIcon sx={{ minWidth: 36 }}>
-            <i className="ri-price-tag-3-line" style={{ fontSize: 18 }} />
+          <ListItemIcon>
+            <MenuIcon name="ri-price-tag-3-line" />
           </ListItemIcon>
           <ListItemText>{t('inventory.manageTags', { defaultMessage: 'Manage Tags' })}</ListItemText>
         </MenuItem>
@@ -505,28 +570,24 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             ? { top: nodeContextMenu.mouseY, left: nodeContextMenu.mouseX }
             : undefined
         }
-        slotProps={{ paper: { sx: { minWidth: 200, '& .MuiListItemIcon-root': { minWidth: 32 } } } }}
+        slotProps={{ paper: { sx: contextMenuPaperSx } }}
       >
-        <Box sx={{ px: 2, py: 1, borderBottom: '1px solid', borderColor: 'divider' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-            <NodeIcon status={(() => {
-              if (!nodeContextMenu) return 'online'
-              const clu = clusters.find(c => c.connId === nodeContextMenu.connId)
-              const n = clu?.nodes.find(n => n.node === nodeContextMenu.node)
-              return n?.status || 'online'
-            })()} maintenance={nodeContextMenu?.maintenance} size={14} />
-            <Typography variant="body2" sx={{ opacity: 0.7 }}>
-              {nodeContextMenu?.node}
-            </Typography>
-          </Box>
-        </Box>
+        <ContextMenuHeader
+          icon={<NodeIcon status={(() => {
+            if (!nodeContextMenu) return 'online'
+            const clu = clusters.find(c => c.connId === nodeContextMenu.connId)
+            const n = clu?.nodes.find(n => n.node === nodeContextMenu.node)
+            return n?.status || 'online'
+          })()} maintenance={nodeContextMenu?.maintenance} size={16} />}
+          label={nodeContextMenu?.node}
+        />
         {onCreateVm && (
           <MenuItem onClick={() => {
             if (nodeContextMenu) onCreateVm(nodeContextMenu.connId, nodeContextMenu.node)
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-computer-line" style={{ fontSize: 18, color: '#3b82f6' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-computer-line" tone="info.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.createVm.title')}</ListItemText>
           </MenuItem>
@@ -536,8 +597,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             if (nodeContextMenu) onCreateLxc(nodeContextMenu.connId, nodeContextMenu.node)
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-instance-line" style={{ fontSize: 18, color: '#a855f7' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-instance-line" tone="primary.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.createLxc.title')}</ListItemText>
           </MenuItem>
@@ -547,28 +608,28 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             if (nodeContextMenu) handleOpenShell(nodeContextMenu.connId, nodeContextMenu.node)
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-terminal-box-line" style={{ fontSize: 18 }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-terminal-box-line" />
             </ListItemIcon>
             <ListItemText>{t('inventory.tabShell')}</ListItemText>
           </MenuItem>,
           <Divider key="d-bulk" />,
           <MenuItem key="bulk-start" onClick={() => handleBulkActionClick('start-all')}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <PlayArrowIcon fontSize="small" sx={{ color: 'success.main' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-play-fill" tone="success.main" />
             </ListItemIcon>
             <ListItemText>{t('bulkActions.startAllVms')}</ListItemText>
           </MenuItem>,
           <MenuItem key="bulk-shutdown" onClick={() => handleBulkActionClick('shutdown-all')}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <PowerSettingsNewIcon fontSize="small" sx={{ color: 'warning.main' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-shut-down-line" tone="warning.main" />
             </ListItemIcon>
             <ListItemText>{t('bulkActions.shutdownAllVms')}</ListItemText>
           </MenuItem>,
           !tenantLoading && isFullClusterView ? (
             <MenuItem key="bulk-migrate" onClick={() => handleBulkActionClick('migrate-all')}>
-              <ListItemIcon sx={{ minWidth: 36 }}>
-                <MoveUpIcon fontSize="small" />
+              <ListItemIcon>
+                <MenuIcon name="ri-exchange-line" />
               </ListItemIcon>
               <ListItemText>{t('bulkActions.migrateAllVms')}</ListItemText>
             </MenuItem>
@@ -578,8 +639,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             if (nodeContextMenu) onNodeAction?.(nodeContextMenu.connId, nodeContextMenu.node, 'reboot')
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-restart-line" style={{ fontSize: 18, color: '#f59e0b' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-restart-line" tone="warning.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.nodeReboot')}</ListItemText>
           </MenuItem>,
@@ -587,8 +648,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             if (nodeContextMenu) onNodeAction?.(nodeContextMenu.connId, nodeContextMenu.node, 'shutdown')
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-shut-down-line" style={{ fontSize: 18, color: '#c62828' }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-shut-down-line" tone="error.main" />
             </ListItemIcon>
             <ListItemText>{t('inventory.nodeShutdown')}</ListItemText>
           </MenuItem>,
@@ -597,20 +658,24 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             key="maintenance"
             onClick={nodeContextMenu?.sshEnabled ? handleMaintenanceClick : undefined}
             disabled={maintenanceBusy || !nodeContextMenu?.sshEnabled}
-            sx={!nodeContextMenu?.sshEnabled ? { opacity: 0.5 } : undefined}
           >
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className={nodeContextMenu?.maintenance ? 'ri-play-circle-line' : 'ri-tools-fill'} style={{ fontSize: 20, color: !nodeContextMenu?.sshEnabled ? undefined : nodeContextMenu?.maintenance ? '#4caf50' : '#ff9800' }} />
+            <ListItemIcon>
+              <MenuIcon
+                name={nodeContextMenu?.maintenance ? 'ri-play-circle-line' : 'ri-tools-fill'}
+                tone={nodeContextMenu?.maintenance ? 'success.main' : 'warning.main'}
+              />
             </ListItemIcon>
             <ListItemText>
               {nodeContextMenu?.maintenance ? t('inventory.exitMaintenance') : t('inventory.enterMaintenance')}
             </ListItemText>
           </MenuItem>,
           !nodeContextMenu?.sshEnabled ? (
-            <Typography key="ssh-hint" variant="caption" sx={{ px: 2, pb: 1, display: 'block', opacity: 0.5 }}>
-              <i className="ri-ssh-line" style={{ fontSize: 12, marginRight: 4, verticalAlign: 'middle' }} />
-              {t('inventory.maintenanceRequiresSsh')}
-            </Typography>
+            <Box key="ssh-hint" sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1.75, pt: 0.25, pb: 1 }}>
+              <Box component="i" className="ri-ssh-line" sx={{ fontSize: 13, color: 'text.disabled' }} />
+              <Typography sx={{ fontSize: '0.6875rem', color: 'text.disabled' }}>
+                {t('inventory.maintenanceRequiresSsh')}
+              </Typography>
+            </Box>
           ) : null,
           <Divider key="d-tags" />,
           <MenuItem key="tags" onClick={() => {
@@ -621,8 +686,8 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             }
             handleCloseNodeContextMenu()
           }}>
-            <ListItemIcon sx={{ minWidth: 36 }}>
-              <i className="ri-price-tag-3-line" style={{ fontSize: 18 }} />
+            <ListItemIcon>
+              <MenuIcon name="ri-price-tag-3-line" />
             </ListItemIcon>
             <ListItemText>{t('inventory.manageTags', { defaultMessage: 'Manage Tags' })}</ListItemText>
           </MenuItem>,
@@ -714,9 +779,9 @@ export default function TreeDialogs(props: TreeDialogsProps) {
             bgcolor: bulkActionDialog.action === 'start-all' ? 'rgba(76,175,80,0.12)' : bulkActionDialog.action === 'migrate-all' ? 'rgba(33,150,243,0.12)' : 'rgba(255,152,0,0.12)',
             display: 'flex', alignItems: 'center', justifyContent: 'center'
           }}>
-            {bulkActionDialog.action === 'start-all' && <PlayArrowIcon fontSize="small" sx={{ color: '#4caf50' }} />}
-            {bulkActionDialog.action === 'shutdown-all' && <PowerSettingsNewIcon fontSize="small" sx={{ color: '#ff9800' }} />}
-            {bulkActionDialog.action === 'migrate-all' && <MoveUpIcon fontSize="small" sx={{ color: '#2196f3' }} />}
+            {bulkActionDialog.action === 'start-all' && <PlayArrowIcon fontSize="small" sx={{ color: 'success.main' }} />}
+            {bulkActionDialog.action === 'shutdown-all' && <PowerSettingsNewIcon fontSize="small" sx={{ color: 'warning.main' }} />}
+            {bulkActionDialog.action === 'migrate-all' && <RemixIcon name="ri-exchange-line" fontSize="small" sx={{ color: 'info.main' }} />}
           </Box>
           {bulkActionDialog.action === 'start-all' && t('bulkActions.startAllVms')}
           {bulkActionDialog.action === 'shutdown-all' && t('bulkActions.shutdownAllVms')}
@@ -809,7 +874,7 @@ export default function TreeDialogs(props: TreeDialogsProps) {
         fullWidth
       >
         <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <DescriptionIcon sx={{ fontSize: 24 }} />
+          <RemixIcon name="ri-file-copy-fill" sx={{ fontSize: 24, color: 'text.secondary' }} />
           {t('templates.convertToTemplate')}
         </DialogTitle>
         <DialogContent>

--- a/frontend/src/components/hardware/CloneVmDialog.test.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.test.tsx
@@ -239,6 +239,36 @@ describe('CloneVmDialog - data loads on open', () => {
     expect(comboboxes[0].textContent).toContain(NODE_NAME)
   })
 
+  it('never hands MUI an out-of-range node value while /nodes is in flight', async () => {
+    // The seeded currentNode has no matching option until the fetch lands, which
+    // used to flood the dev console with "out-of-range value pve1". The delay is
+    // what makes the window observable: without it the provider view only paints
+    // once the nodes are already there.
+    server.use(
+      http.get(`*/api/v1/connections/${CONN_ID}/nodes`, async () => {
+        await new Promise(resolve => setTimeout(resolve, 60))
+
+        return HttpResponse.json({ data: nodes })
+      }),
+    )
+
+    // MUI raises this one through console.warn, not console.error.
+    const logged: string[] = []
+    const collect = (...args: unknown[]) => { logged.push(args.map(String).join(' ')) }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(collect)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(collect)
+
+    try {
+      renderWithProviders(<CloneVmDialog {...makeProps()} />)
+      await waitForDataLoad()
+    } finally {
+      warnSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
+
+    expect(logged.filter(line => /out-of-range value/.test(line))).toEqual([])
+  })
+
   it('opens Target node Select and shows seeded node as option', async () => {
     renderWithProviders(<CloneVmDialog {...makeProps()} />)
     await waitForDataLoad()

--- a/frontend/src/components/hardware/CloneVmDialog.tsx
+++ b/frontend/src/components/hardware/CloneVmDialog.tsx
@@ -415,7 +415,11 @@ return currentScore > bestScore ? current : best
           <FormControl fullWidth size="small">
             <InputLabel>Target node</InputLabel>
             <Select
-              value={targetNode}
+              // The seeded currentNode is not among the options until the async
+              // /nodes fetch lands, and MUI warns loudly about an out-of-range
+              // value. Show nothing until its option exists; the field is
+              // disabled while loading, so the user cannot lose a choice.
+              value={nodes.some(n => n.node === targetNode) ? targetNode : ''}
               onChange={(e) => setTargetNode(e.target.value)}
               label="Target node"
               disabled={nodesLoading}

--- a/frontend/src/components/hardware/utils.test.tsx
+++ b/frontend/src/components/hardware/utils.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Unit tests for hardware/utils.ts — currently fetchNextVmid.
+ * Unit tests for hardware/utils.ts: fetchNextVmid and the VMID scoping helpers.
  *
  * Runs in the jsdom lane (MSW-backed fetch) because fetchNextVmid is a
  * browser-side wrapper around the /cluster/nextid API route. Each case seeds
@@ -9,7 +9,7 @@
 import { describe, it, expect } from 'vitest'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 
-import { fetchNextVmid } from './utils'
+import { fetchNextVmid, usedVmidsOnConnection, nextVmidOnConnection } from './utils'
 
 const CONN_ID = 'conn-1'
 const NEXTID_URL = `*/api/v1/connections/${CONN_ID}/cluster/nextid`
@@ -38,5 +38,47 @@ describe('fetchNextVmid', () => {
   it('returns null when the request throws (network error)', async () => {
     server.use(http.get(NEXTID_URL, () => HttpResponse.error()))
     await expect(fetchNextVmid(CONN_ID)).resolves.toBeNull()
+  })
+})
+
+// Two clusters, both numbering from 100, so 107 exists on each. This is the
+// shape of the environment in #724.
+const TWO_CLUSTERS = [
+  { connId: 'conn-1', vmid: 100 },
+  { connId: 'conn-1', vmid: '105' },
+  { connId: 'conn-2', vmid: 107 },
+  { connId: 'conn-2', vmid: 108 },
+]
+
+describe('usedVmidsOnConnection', () => {
+  it('ignores guests living on another connection (#724)', () => {
+    expect(usedVmidsOnConnection(TWO_CLUSTERS, 'conn-1')).toEqual([100, 105])
+    expect(usedVmidsOnConnection(TWO_CLUSTERS, 'conn-2')).toEqual([107, 108])
+  })
+
+  it('drops unparseable vmids instead of yielding 0', () => {
+    expect(usedVmidsOnConnection([{ connId: 'c', vmid: 'lxc' }, { connId: 'c', vmid: 110 }], 'c')).toEqual([110])
+  })
+
+  it('keeps every connection when no connection is selected yet', () => {
+    expect(usedVmidsOnConnection(TWO_CLUSTERS, undefined)).toEqual([100, 105, 107, 108])
+  })
+
+  it('is empty for a connection with no guests', () => {
+    expect(usedVmidsOnConnection(TWO_CLUSTERS, 'conn-3')).toEqual([])
+  })
+})
+
+describe('nextVmidOnConnection', () => {
+  it('does not skip ahead because of another cluster (#724)', () => {
+    expect(nextVmidOnConnection(TWO_CLUSTERS, 'conn-1')).toBe(106)
+  })
+
+  it('starts at the 100 floor on an empty cluster', () => {
+    expect(nextVmidOnConnection(TWO_CLUSTERS, 'conn-3')).toBe(100)
+  })
+
+  it('never proposes below the 100 floor', () => {
+    expect(nextVmidOnConnection([{ connId: 'c', vmid: 42 }], 'c')).toBe(100)
   })
 })

--- a/frontend/src/components/hardware/utils.ts
+++ b/frontend/src/components/hardware/utils.ts
@@ -53,6 +53,30 @@ export const formatMemory = (bytes?: number): string => {
 return `${gb.toFixed(1)} GB`
 }
 
+// Minimal shape of an inventory guest for VMID accounting. The inventory list
+// merges every connection, hence the connId.
+export type VmidOwner = { connId?: string; vmid: number | string }
+
+// VMIDs already taken on `connId`. Guests on the OTHER connections are left out
+// on purpose: Proxmox only requires a VMID to be unique inside its own cluster,
+// and neither a clone nor a create ever crosses a connection. Feeding the whole
+// inventory to a dialog made it refuse ids that were free on the target cluster
+// (#724). Falls back to every connection while none is selected, which is the
+// best guess available at that point.
+export const usedVmidsOnConnection = <T extends VmidOwner>(vms: T[], connId?: string): number[] =>
+  (connId ? vms.filter(vm => vm.connId === connId) : vms)
+    .map(vm => Number.parseInt(String(vm.vmid), 10))
+    .filter(id => Number.isInteger(id) && id > 0)
+
+// Client-side estimate of the next free VMID on `connId`, used only as a seed
+// or when the server suggestion is unavailable.
+export const nextVmidOnConnection = <T extends VmidOwner>(vms: T[], connId?: string): number => {
+  const used = usedVmidsOnConnection(vms, connId)
+  const highest = used.length === 0 ? 0 : Math.max(...used)
+
+  return Math.max(100, highest + 1)
+}
+
 // Cluster-wide next free VMID from PVE (/cluster/nextid). Returns null when the
 // endpoint fails or yields something below the 100 floor, so callers can fall
 // back to their own estimate. Used by CloneVmDialog (both its open-effect and


### PR DESCRIPTION
Fixes #724.

## The bug

With two clusters connected, cloning a template was impossible. The dialog suggested the id returned by the target cluster, then refused it with "VM ID 107 already in use" and left Clone disabled, so there was no id the form would accept short of typing one by hand.

## Why it happened

The suggestion was right. Proxmox only requires a VMID to be unique inside its own cluster, and neither a clone nor a create ever crosses a connection: 107 was genuinely free where the guest was about to be created.

What was wrong sits one layer up. The dialogs received `allVms`, the merged inventory of every connection, with no `connId` filter. The 107 running on the second cluster therefore rejected the 107 free on the first.

## The fix

`usedVmidsOnConnection()` and `nextVmidOnConnection()` scope that list to the connection the guest is created on. Applied to both clone call sites, the create VM validator and the create LXC validator, which all carried the same defect.

MSP tenants are untouched and keep their cross-cluster rule: a per-tenant VMID range is an explicit, opt-in contract, still enforced server side by `checkVmidAgainstTenantRange` with a 409 on a duplicate anywhere in the tenant's infrastructure.

Also included: on a cluster with no guest, the client-side estimate proposed 101 and skipped 100.

## Two things noticed during review

**Context-menu icons ignored the theme.** The RemixIcon shims read `props.sx.color` and wrote it into a raw `style` attribute, so `sx={{ color: 'warning.main' }}` produced an invalid CSS value that browsers drop silently. Nine of fifteen call sites passed a theme token that never applied, in the context menus and in the confirmation dialogs. They render through `Box` now. The three tree context menus also got a pass of presentation work: one icon size in a fixed gutter so labels align, inset rows, palette tones instead of hard-coded MUI defaults, and a titled header carrying the VMID and the same status dot as the tree row.

**A stray MUI warning.** The clone dialog handed the Target node Select a value before `/nodes` resolved, warning "out-of-range value" on every render. The value now waits for its option, and the field is disabled while loading so no choice can be lost.

**A dead `.npmrc`.** It held three pnpm-only keys and nothing else, while this project installs with npm. Every script run printed "Unknown project config ... This will stop working in the next major version of npm". npm never honoured them, so removing them changes no install behaviour.

## Tests

Full suite green: 528 files, 5432 tests.

New guards, each verified to fail against the previous code before being kept:
- `usedVmidsOnConnection` / `nextVmidOnConnection` on a two-cluster inventory where both clusters number from 100
- typing a VMID used on another connection no longer blocks Create VM or Create LXC
- the clone dialog raises no out-of-range warning while the node list is in flight
