### PR TITLE
fix(branding): never let an unparseable primary colour break the app (#754)

### DIFF
--- a/frontend/src/app/api/v1/settings/branding/public/route.test.ts
+++ b/frontend/src/app/api/v1/settings/branding/public/route.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  getCurrentTenantId: vi.fn(async () => 'default'),
+  getSetting: vi.fn(async () => null as any),
+}))
+
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId }))
+vi.mock('@/lib/db/settings', () => ({ getSetting: h.getSetting }))
+
+import { GET } from './route'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+beforeEach(() => {
+  h.getCurrentTenantId.mockReset().mockResolvedValue('default')
+  h.getSetting.mockReset().mockResolvedValue(null)
+})
+
+const primaryColorOf = async () => (await readJson<any>(await callRoute(GET, { method: 'GET' }))).primaryColor
+
+// This payload is what the browser feeds to the MUI palette, so a value MUI
+// cannot parse used to reach lighten()/darken() and 500 every page (#754).
+describe('GET /settings/branding/public primary colour (#754)', () => {
+  it('repairs a colour that was stored without its hash', async () => {
+    h.getSetting.mockResolvedValue({ enabled: true, primaryColor: '00ECB2' })
+
+    expect(await primaryColorOf()).toBe('#00ECB2')
+  })
+
+  it('passes a well-formed colour through', async () => {
+    h.getSetting.mockResolvedValue({ enabled: true, primaryColor: '#00ECB2' })
+
+    expect(await primaryColorOf()).toBe('#00ECB2')
+  })
+
+  it.each(['turquoise', '#ZZZZZZ', '#00EC', '#00-CB2', 42, null])(
+    'never hands %s to the browser',
+    async value => {
+      h.getSetting.mockResolvedValue({ enabled: true, primaryColor: value })
+
+      expect(await primaryColorOf()).toBe('')
+    }
+  )
+
+  it('keeps the empty default when branding is disabled', async () => {
+    h.getSetting.mockResolvedValue({ enabled: false, primaryColor: '00ECB2' })
+
+    expect(await primaryColorOf()).toBe('')
+  })
+})

--- a/frontend/src/app/api/v1/settings/branding/public/route.ts
+++ b/frontend/src/app/api/v1/settings/branding/public/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getSetting } from '@/lib/db/settings'
 import { getCurrentTenantId } from '@/lib/tenant'
+import { normalizeHexColor } from '@/lib/theme/hexColor'
 
 export const dynamic = 'force-dynamic'
 
@@ -50,7 +51,11 @@ export async function GET() {
       logoUrl: fixUrl(settings.logoUrl),
       faviconUrl: fixUrl(settings.faviconUrl),
       loginLogoUrl: fixUrl(settings.loginLogoUrl),
-      primaryColor: settings.primaryColor,
+      // #754: this is where the branding colour enters the browser and, from
+      // there, MUI's palette. A value stored before the colour was validated is
+      // repaired when it can be ('00ECB2' -> '#00ECB2') and dropped otherwise,
+      // so an instance already stuck on the 500 page comes back on its own.
+      primaryColor: settings.primaryColor ? (normalizeHexColor(settings.primaryColor) ?? '') : '',
       browserTitle: settings.browserTitle,
       poweredByVisible: settings.poweredByVisible,
       showGithubStars: settings.showGithubStars,

--- a/frontend/src/app/api/v1/settings/branding/route.test.ts
+++ b/frontend/src/app/api/v1/settings/branding/route.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  checkPermission: vi.fn(async () => null as any),
+  getCurrentTenantId: vi.fn(async () => 'default'),
+  getSetting: vi.fn(async () => null as any),
+  setSetting: vi.fn(async (_key: string, _tenantId: string, _value: unknown) => {}),
+}))
+
+vi.mock('@/lib/rbac', () => ({ checkPermission: h.checkPermission, PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' } }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId }))
+vi.mock('@/lib/db/settings', () => ({ getSetting: h.getSetting, setSetting: h.setSetting }))
+
+import { GET, PUT } from './route'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+beforeEach(() => {
+  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.getCurrentTenantId.mockReset().mockResolvedValue('default')
+  h.getSetting.mockReset().mockResolvedValue(null)
+  h.setSetting.mockReset().mockResolvedValue(undefined)
+})
+
+const storedPrimaryColor = () => (h.setSetting.mock.calls[0]?.[2] as any).primaryColor
+
+describe('PUT /settings/branding primary colour (#754)', () => {
+  it('adds the missing hash instead of storing a value MUI cannot parse', async () => {
+    const res = await callRoute(PUT, { method: 'PUT', body: { enabled: true, primaryColor: '00ECB2' } })
+
+    expect(res.status).toBe(200)
+    expect(storedPrimaryColor()).toBe('#00ECB2')
+    expect(await readJson<any>(res)).toMatchObject({ success: true, primaryColor: '#00ECB2' })
+  })
+
+  it('keeps a well-formed colour untouched', async () => {
+    await callRoute(PUT, { method: 'PUT', body: { enabled: true, primaryColor: '#00ECB2' } })
+
+    expect(storedPrimaryColor()).toBe('#00ECB2')
+  })
+
+  it('rejects a colour that cannot be repaired, storing nothing', async () => {
+    const res = await callRoute(PUT, { method: 'PUT', body: { enabled: true, primaryColor: 'turquoise' } })
+
+    expect(res.status).toBe(400)
+    expect((await readJson<any>(res)).error).toMatch(/primaryColor/)
+    expect(h.setSetting).not.toHaveBeenCalled()
+  })
+
+  it.each(['#ZZZZZZ', '#00-CB2', '#00EC', '#00ECB'])('rejects %s', async value => {
+    const res = await callRoute(PUT, { method: 'PUT', body: { enabled: true, primaryColor: value } })
+
+    expect(res.status).toBe(400)
+    expect(h.setSetting).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty colour as "no override" and still saves the rest', async () => {
+    const res = await callRoute(PUT, { method: 'PUT', body: { enabled: true, appName: 'Almond', primaryColor: '' } })
+
+    expect(res.status).toBe(200)
+    expect(storedPrimaryColor()).toBe('')
+    expect((h.setSetting.mock.calls[0][2] as any).appName).toBe('Almond')
+  })
+
+  it('drops a non-string colour rather than passing it through to the palette', async () => {
+    const res = await callRoute(PUT, { method: 'PUT', body: { enabled: true, primaryColor: { hex: '#00ECB2' } } })
+
+    expect(res.status).toBe(400)
+    expect(h.setSetting).not.toHaveBeenCalled()
+  })
+
+  it('denies without the admin settings permission', async () => {
+    h.checkPermission.mockResolvedValue(new Response('no', { status: 403 }) as any)
+
+    const res = await callRoute(PUT, { method: 'PUT', body: { primaryColor: '#00ECB2' } })
+
+    expect(res.status).toBe(403)
+    expect(h.setSetting).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /settings/branding primary colour (#754)', () => {
+  it('repairs a colour stored before the value was validated', async () => {
+    h.getSetting.mockResolvedValue({ enabled: true, primaryColor: '00ECB2' })
+
+    const res = await callRoute(GET, { method: 'GET' })
+
+    expect(res.status).toBe(200)
+    expect((await readJson<any>(res)).primaryColor).toBe('#00ECB2')
+  })
+
+  it('drops an unrepairable stored colour so the form does not offer it back', async () => {
+    h.getSetting.mockResolvedValue({ enabled: true, primaryColor: 'turquoise' })
+
+    const res = await callRoute(GET, { method: 'GET' })
+
+    expect((await readJson<any>(res)).primaryColor).toBe('')
+  })
+
+  it('leaves an unset colour empty', async () => {
+    h.getSetting.mockResolvedValue({ enabled: true })
+
+    const res = await callRoute(GET, { method: 'GET' })
+
+    expect((await readJson<any>(res)).primaryColor).toBe('')
+  })
+})

--- a/frontend/src/app/api/v1/settings/branding/route.ts
+++ b/frontend/src/app/api/v1/settings/branding/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getSetting, setSetting } from '@/lib/db/settings'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 import { getCurrentTenantId } from '@/lib/tenant'
+import { normalizeHexColor } from '@/lib/theme/hexColor'
 
 
 const DEFAULT_BRANDING = {
@@ -39,6 +40,11 @@ export async function GET() {
     settings.faviconUrl = fixUrl(settings.faviconUrl)
     settings.loginLogoUrl = fixUrl(settings.loginLogoUrl)
 
+    // #754: a value stored before the colour was validated can be missing its
+    // '#'. Hand the settings form the colour the administrator meant, so saving
+    // once is enough to clean the row, and drop what cannot be repaired.
+    settings.primaryColor = settings.primaryColor ? (normalizeHexColor(settings.primaryColor) ?? '') : ''
+
     return NextResponse.json(settings)
   } catch (error: any) {
     return NextResponse.json({ error: error.message }, { status: 500 })
@@ -52,6 +58,27 @@ export async function PUT(req: Request) {
 
     const body = await req.json()
     const settings = { ...DEFAULT_BRANDING, ...body }
+
+    // #754: the primary colour reaches MUI's lighten()/darken() in the theme
+    // provider, which wraps the dashboard AND the login layout, so an
+    // unparseable value here takes the whole tenant down with a 500 and leaves
+    // no UI to undo it. An empty string means "no override" and stays allowed;
+    // anything else has to be a hex colour, and a missing '#' is added rather
+    // than refused.
+    if (settings.primaryColor) {
+      const primaryColor = normalizeHexColor(settings.primaryColor)
+
+      if (primaryColor === null) {
+        return NextResponse.json(
+          { error: 'Invalid primaryColor: expected a hex colour such as #00ECB2' },
+          { status: 400 }
+        )
+      }
+
+      settings.primaryColor = primaryColor
+    } else {
+      settings.primaryColor = ''
+    }
 
     const tenantId = await getCurrentTenantId()
     await setSetting('branding', tenantId, settings)

--- a/frontend/src/components/common/ColorPicker.jsx
+++ b/frontend/src/components/common/ColorPicker.jsx
@@ -23,6 +23,11 @@ export default function ColorPicker({
   // Opt-in: lets the hex field stretch instead of sitting at a fixed 160px.
   // Defaults to false so WhiteLabelTab, the original caller, is untouched.
   fullWidth = false,
+  // Opt-in red outline on the hex field. Default off, so callers that do not
+  // validate (the broadcast banner, whose colours cannot break a render) keep
+  // the previous appearance. The message itself is left to the caller: a
+  // helperText would grow the field and push the swatch out of alignment.
+  error = false,
 }) {
   const inputRef = useRef(null)
   // `value` is free-typed and can be a transient, invalid string (e.g. "#" or
@@ -65,6 +70,7 @@ export default function ColorPicker({
         placeholder={placeholder}
         value={value}
         onChange={e => onChange(e.target.value)}
+        error={error}
         sx={fullWidth ? { flex: 1, minWidth: 0 } : { width: 160 }}
         slotProps={{ htmlInput: { maxLength: 7 } }}
       />

--- a/frontend/src/components/settings/WhiteLabelTab.jsx
+++ b/frontend/src/components/settings/WhiteLabelTab.jsx
@@ -9,6 +9,7 @@ import {
 import { useTranslations } from 'next-intl'
 import { useBranding } from '@/contexts/BrandingContext'
 import ColorPicker from '@/components/common/ColorPicker'
+import { isHexColor, normalizeHexColor } from '@/lib/theme/hexColor'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 
@@ -52,6 +53,12 @@ export default function WhiteLabelTab() {
   const faviconInputRef = useRef(null)
   const loginLogoInputRef = useRef(null)
 
+  // #754: the primary colour ends up in MUI's lighten()/darken() for the whole
+  // application, login page included, so a value that cannot be parsed used to
+  // take the tenant down with a 500 and no UI left to revert it. An empty field
+  // means "no override" and stays valid; anything else has to be a hex colour.
+  const primaryColorInvalid = config.primaryColor !== '' && !isHexColor(config.primaryColor)
+
   // Load settings
   useEffect(() => {
     fetch('/api/v1/settings/branding')
@@ -71,7 +78,18 @@ export default function WhiteLabelTab() {
       const cleanedHighlights = (config.loginHighlights || [])
         .filter(h => h && h.icon && h.text && h.icon.trim() !== '' && h.text.trim() !== '')
         .slice(0, 3)
-      const payload = { ...config, loginHighlights: cleanedHighlights }
+      // A missing '#' is what an administrator meant, not what they typed, so
+      // it is added here rather than refused (#754).
+      const payload = {
+        ...config,
+        primaryColor: config.primaryColor ? (normalizeHexColor(config.primaryColor) ?? '') : '',
+        loginHighlights: cleanedHighlights,
+      }
+
+      if (config.primaryColor && !payload.primaryColor) {
+        throw new Error('Invalid primary colour: use a hex value such as #00ECB2')
+      }
+
       const res = await fetch('/api/v1/settings/branding', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -353,10 +371,17 @@ export default function WhiteLabelTab() {
             placeholder="#7C4DFF"
             fallback={theme.palette.primary.main}
             onReset={() => setConfig(prev => ({ ...prev, primaryColor: '' }))}
+            error={primaryColorInvalid}
           />
-          <Typography variant="caption" sx={{ opacity: 0.5, mt: 1, display: 'block' }}>
-            Overrides the primary color across the entire application (buttons, links, active states, etc.)
-          </Typography>
+          {primaryColorInvalid ? (
+            <Typography variant="caption" color="error" sx={{ mt: 1, display: 'block' }}>
+              Enter a hex colour such as #00ECB2. The leading # is added for you if you leave it out.
+            </Typography>
+          ) : (
+            <Typography variant="caption" sx={{ opacity: 0.5, mt: 1, display: 'block' }}>
+              Overrides the primary color across the entire application (buttons, links, active states, etc.)
+            </Typography>
+          )}
         </CardContent>
       </Card>
 
@@ -522,7 +547,7 @@ export default function WhiteLabelTab() {
         <Button variant="outlined" color="secondary" onClick={handleReset} startIcon={<i className="ri-refresh-line" />}>
           Reset to Default
         </Button>
-        <Button variant="contained" onClick={handleSave} disabled={saving}
+        <Button variant="contained" onClick={handleSave} disabled={saving || primaryColorInvalid}
           startIcon={saving ? <CircularProgress size={16} color="inherit" /> : <i className="ri-save-line" />}>
           Save Changes
         </Button>

--- a/frontend/src/components/settings/WhiteLabelTab.test.tsx
+++ b/frontend/src/components/settings/WhiteLabelTab.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, waitFor, userEvent } from '@/__tests__/setup/renderWithProviders'
+
+const h = vi.hoisted(() => ({ refresh: vi.fn(async () => {}) }))
+
+vi.mock('@/contexts/BrandingContext', () => ({
+  useBranding: () => ({ branding: { primaryColor: '' }, loading: false, refresh: h.refresh }),
+}))
+
+import WhiteLabelTab from './WhiteLabelTab'
+
+const STORED = { enabled: true, appName: 'ProxCenter', primaryColor: '', logoUrl: '', faviconUrl: '', loginLogoUrl: '' }
+
+let putBodies: any[] = []
+
+beforeEach(() => {
+  putBodies = []
+  h.refresh.mockClear()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        putBodies.push(JSON.parse(String(init.body)))
+
+        return new Response(JSON.stringify({ success: true }), { status: 200 })
+      }
+
+      return new Response(JSON.stringify(STORED), { status: 200 })
+    })
+  )
+})
+
+// The RTL harness in this suite has no automatic cleanup.
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const renderTab = async () => {
+  renderWithProviders(<WhiteLabelTab />)
+  await waitFor(() => expect(screen.getByLabelText('Hex Color')).toBeTruthy())
+
+  return {
+    field: screen.getByLabelText('Hex Color') as HTMLInputElement,
+    save: screen.getByRole('button', { name: /save changes/i }) as HTMLButtonElement,
+  }
+}
+
+const typeColor = async (field: HTMLInputElement, value: string) => {
+  await userEvent.clear(field)
+  if (value) await userEvent.type(field, value)
+}
+
+// #754: a colour the palette cannot parse used to be saved without a word of
+// warning and then 500 every page of the tenant, login page included.
+describe('WhiteLabelTab primary colour validation (#754)', () => {
+  it('adds the missing hash to what gets sent', async () => {
+    const { field, save } = await renderTab()
+
+    await typeColor(field, '00ECB2')
+    expect(save.disabled).toBe(false)
+
+    await userEvent.click(save)
+
+    await waitFor(() => expect(putBodies).toHaveLength(1))
+    expect(putBodies[0].primaryColor).toBe('#00ECB2')
+  })
+
+  it('blocks saving and explains itself when the value is not a colour', async () => {
+    const { field, save } = await renderTab()
+
+    await typeColor(field, 'turquoi')
+
+    expect(screen.getByText(/Enter a hex colour/i)).toBeTruthy()
+    await waitFor(() => expect(save.disabled).toBe(true))
+    expect(putBodies).toHaveLength(0)
+  })
+
+  it('accepts an empty field as "no override"', async () => {
+    const { field, save } = await renderTab()
+
+    await typeColor(field, '')
+
+    expect(screen.queryByText(/Enter a hex colour/i)).toBeNull()
+    expect(save.disabled).toBe(false)
+
+    await userEvent.click(save)
+
+    await waitFor(() => expect(putBodies).toHaveLength(1))
+    expect(putBodies[0].primaryColor).toBe('')
+  })
+
+  it('keeps a well-formed colour as typed', async () => {
+    const { field, save } = await renderTab()
+
+    await typeColor(field, '#00ECB2')
+    await userEvent.click(save)
+
+    await waitFor(() => expect(putBodies).toHaveLength(1))
+    expect(putBodies[0].primaryColor).toBe('#00ECB2')
+  })
+})

--- a/frontend/src/components/theme/brandingPrimaryColor.test.tsx
+++ b/frontend/src/components/theme/brandingPrimaryColor.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { useTheme } from '@mui/material/styles'
+
+// `@core/theme` pulls a Google font through the Next build pipeline at import time.
+vi.mock('next/font/google', () => ({ Inter: () => ({ style: { fontFamily: 'Inter' } }) }))
+
+const h = vi.hoisted(() => ({
+  branding: { primaryColor: '' } as { primaryColor: string },
+  settings: { mode: 'light', skin: 'default', primaryColor: '#E57000' } as Record<string, unknown>,
+}))
+
+vi.mock('@/contexts/BrandingContext', () => ({ useBranding: () => ({ branding: h.branding }) }))
+vi.mock('@core/hooks/useSettings', () => ({ useSettings: () => ({ settings: h.settings }) }))
+// ModeChanger reaches for MUI's colour-scheme machinery, which needs a mounted
+// CssVarsProvider it does not get here; the palette is what this suite is about.
+vi.mock('./ModeChanger', () => ({ default: () => null }))
+
+import CustomThemeProvider from './index'
+
+// The RTL harness in this suite has no automatic cleanup.
+afterEach(cleanup)
+
+beforeEach(() => {
+  h.branding = { primaryColor: '' }
+  h.settings = { mode: 'light', skin: 'default', primaryColor: '#E57000' }
+})
+
+/**
+ * jsdom never resolves the CSS variables MUI emits (`cssVariables` is on in
+ * this provider), so a rendered button only ever reports
+ * `var(--variant-containedBg)`. Reading the palette the provider built is the
+ * assertion that actually means something here.
+ */
+const PaletteProbe = () => {
+  const theme = useTheme() as any
+
+  return <output>{theme.colorSchemes.light.palette.primary.main}</output>
+}
+
+const renderWithBrandingColor = (primaryColor: string) => {
+  h.branding = { primaryColor }
+
+  return render(
+    <CustomThemeProvider direction='ltr' systemMode='light'>
+      <PaletteProbe />
+    </CustomThemeProvider>
+  )
+}
+
+const resolvedPrimary = () => screen.getByRole('status').textContent
+
+describe('branding primary colour reaching the palette (#754)', () => {
+  it('reproduces the defect at its source: MUI throws on a colour without its hash', async () => {
+    const { lighten } = await import('@mui/material/styles')
+
+    expect(() => lighten('00ECB2', 0.2)).toThrow(/Unsupported/)
+  })
+
+  it('renders instead of throwing when the stored colour lost its hash', () => {
+    expect(() => renderWithBrandingColor('00ECB2')).not.toThrow()
+  })
+
+  it('applies the colour the administrator meant', () => {
+    renderWithBrandingColor('00ECB2')
+
+    expect(resolvedPrimary()).toBe('#00ECB2')
+  })
+
+  it.each(['turquoise', '#ZZZZZZ', '#00EC', '#00-CB2'])(
+    'falls back to the user palette instead of breaking on %s',
+    value => {
+      expect(() => renderWithBrandingColor(value)).not.toThrow()
+      expect(resolvedPrimary()).toBe('#E57000')
+    }
+  )
+
+  it('honours a well-formed branding colour over the user setting', () => {
+    renderWithBrandingColor('#00ECB2')
+
+    expect(resolvedPrimary()).toBe('#00ECB2')
+  })
+
+  it('keeps the user setting when branding sets no colour', () => {
+    renderWithBrandingColor('')
+
+    expect(resolvedPrimary()).toBe('#E57000')
+  })
+
+  it('survives a user setting that is itself unusable', () => {
+    h.settings = { mode: 'light', skin: 'default', primaryColor: 'not-a-colour' }
+
+    expect(() => renderWithBrandingColor('')).not.toThrow()
+    expect(resolvedPrimary()).toBe('#E57000')
+  })
+})

--- a/frontend/src/components/theme/index.jsx
+++ b/frontend/src/components/theme/index.jsx
@@ -19,12 +19,14 @@ import ModeChanger from './ModeChanger'
 
 // Config Imports
 import themeConfig from '@configs/themeConfig'
+import primaryColorConfig from '@configs/primaryColorConfig'
 import globalThemesConfig, { getGlobalTheme, densityConfig, transitionConfig } from '@configs/globalThemesConfig'
 import lightBackgroundConfig, { getLightBackground } from '@configs/lightBackgroundConfig'
 
 // Hook Imports
 import { useSettings } from '@core/hooks/useSettings'
 import { useBranding } from '@/contexts/BrandingContext'
+import { resolveHexColor } from '@/lib/theme/hexColor'
 
 // Core Theme Imports
 import defaultCoreTheme from '@core/theme'
@@ -1826,8 +1828,19 @@ const CustomThemeProvider = props => {
 
   // Merge the primary color scheme override with the core theme
   const theme = useMemo(() => {
-    // Branding primary color takes precedence over user setting
-    const effectivePrimaryColor = branding.primaryColor || settings.primaryColor
+    // Branding primary color takes precedence over user setting.
+    //
+    // #754: both values are treated as untrusted here. lighten()/darken() throw
+    // on anything MUI cannot parse, and this provider wraps the dashboard AND
+    // the blank layout (login, setup), so one malformed branding colour used to
+    // turn every page of the tenant into a 500 with no UI left to undo it. A
+    // colour that cannot be repaired falls back to the shipped brand colour,
+    // which keeps the instance usable while the administrator fixes the value.
+    const brandingPrimaryColor = branding.primaryColor ? resolveHexColor(branding.primaryColor, '') : ''
+    const effectivePrimaryColor = resolveHexColor(
+      brandingPrimaryColor || settings.primaryColor,
+      primaryColorConfig[0].main
+    )
 
     // Build light palette with custom background
     const lightPalette = {

--- a/frontend/src/lib/theme/hexColor.test.ts
+++ b/frontend/src/lib/theme/hexColor.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { lighten, darken } from '@mui/material/styles'
+
+import { isHexColor, normalizeHexColor, resolveHexColor } from './hexColor'
+
+const BRAND_FALLBACK = '#E57000'
+
+describe('normalizeHexColor', () => {
+  it('keeps a well-formed six-digit hex colour untouched', () => {
+    expect(normalizeHexColor('#00ECB2')).toBe('#00ECB2')
+  })
+
+  it("adds the '#' the administrator left out (the #754 report)", () => {
+    expect(normalizeHexColor('00ECB2')).toBe('#00ECB2')
+  })
+
+  it('accepts the three-digit shorthand, with or without the hash', () => {
+    expect(normalizeHexColor('#0eb')).toBe('#0eb')
+    expect(normalizeHexColor('0eb')).toBe('#0eb')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeHexColor('  #00ECB2  ')).toBe('#00ECB2')
+  })
+
+  it('rejects non-hex characters, which MUI resolves to rgb(NaN, NaN, NaN)', () => {
+    expect(normalizeHexColor('#ZZZZZZ')).toBeNull()
+    expect(normalizeHexColor('#00-CB2')).toBeNull()
+  })
+
+  it('rejects named colours and functional notations', () => {
+    expect(normalizeHexColor('red')).toBeNull()
+    expect(normalizeHexColor('rgb(0, 236, 178)')).toBeNull()
+  })
+
+  it('rejects the alpha hex forms, which produce nonsense shades', () => {
+    expect(normalizeHexColor('#00EC')).toBeNull()
+    expect(normalizeHexColor('#00ECB2FF')).toBeNull()
+  })
+
+  it('rejects lengths that are neither three nor six digits', () => {
+    expect(normalizeHexColor('#00ECB')).toBeNull()
+    expect(normalizeHexColor('#')).toBeNull()
+    expect(normalizeHexColor('')).toBeNull()
+  })
+
+  it('rejects non-string values', () => {
+    expect(normalizeHexColor(undefined)).toBeNull()
+    expect(normalizeHexColor(null)).toBeNull()
+    expect(normalizeHexColor(0x00ecb2)).toBeNull()
+    expect(normalizeHexColor({ primaryColor: '#00ECB2' })).toBeNull()
+  })
+})
+
+describe('isHexColor', () => {
+  it('mirrors normalizeHexColor', () => {
+    expect(isHexColor('00ECB2')).toBe(true)
+    expect(isHexColor('#00ECB2')).toBe(true)
+    expect(isHexColor('nope')).toBe(false)
+    expect(isHexColor('')).toBe(false)
+  })
+})
+
+describe('resolveHexColor', () => {
+  it('returns the repaired colour rather than the fallback', () => {
+    expect(resolveHexColor('00ECB2', BRAND_FALLBACK)).toBe('#00ECB2')
+  })
+
+  it('falls back when the value cannot be repaired', () => {
+    expect(resolveHexColor('red', BRAND_FALLBACK)).toBe(BRAND_FALLBACK)
+    expect(resolveHexColor('', BRAND_FALLBACK)).toBe(BRAND_FALLBACK)
+    expect(resolveHexColor(null, BRAND_FALLBACK)).toBe(BRAND_FALLBACK)
+  })
+})
+
+describe('every accepted value survives the MUI palette maths', () => {
+  // The regression this guards: lighten()/darken() throw on an unsupported
+  // colour, and they run while the theme provider renders every page.
+  const candidates = ['#00ECB2', '00ECB2', '#0eb', '0eb', '  #00ECB2  ', 'red', '#ZZZZZZ', '#00EC', '', null]
+
+  it.each(candidates.map(value => [JSON.stringify(value), value] as const))(
+    'derives light and dark shades from %s',
+    (_label, value) => {
+      const resolved = resolveHexColor(value, BRAND_FALLBACK)
+
+      expect(() => lighten(resolved, 0.2)).not.toThrow()
+      expect(() => darken(resolved, 0.1)).not.toThrow()
+      expect(lighten(resolved, 0.2)).not.toContain('NaN')
+      expect(darken(resolved, 0.1)).not.toContain('NaN')
+    }
+  )
+})

--- a/frontend/src/lib/theme/hexColor.ts
+++ b/frontend/src/lib/theme/hexColor.ts
@@ -1,0 +1,59 @@
+/**
+ * Hex colour normalisation for the branding primary colour (issue #754).
+ *
+ * The White Label primary colour is free text typed by an administrator and it
+ * ends up in `lighten()` / `darken()` in `src/components/theme/index.jsx`, which
+ * throw on anything MUI cannot parse. That palette is built by the theme
+ * provider wrapping BOTH the dashboard layout and the blank layout, so a single
+ * malformed value (`00ECB2` instead of `#00ECB2`) turned every page of the
+ * tenant, login page included, into a 500 with no way back through the UI: the
+ * only recovery was an UPDATE on the `settings` table.
+ *
+ * So the value is normalised on the way in (form + PUT) and on the way out
+ * (both branding GETs), and the theme provider treats whatever is left as
+ * untrusted. Same reasoning as `src/lib/appearance/schema.ts`, which already
+ * guards the per-user appearance blob; the per-tenant branding path was the one
+ * that never got a validator.
+ */
+
+/**
+ * Three- or six-digit hex, `#` optional. Anchored, fixed length, no nested
+ * quantifier: S5852-safe.
+ *
+ * Alpha forms (`#nnnn`, `#nnnnnnnn`) are deliberately rejected. MUI accepts
+ * them but derives nonsense shades from them (`lighten('#00EC', 0.2)` yields
+ * `rgba(51, 51, 241, 0.8)`), and a translucent primary colour is not a thing
+ * the colour picker can produce anyway.
+ */
+const HEX_COLOR_INPUT = /^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/
+
+/**
+ * `value` as a `#`-prefixed hex colour, or `null` when it is not one.
+ *
+ * Adds the missing `#` rather than rejecting the input: an administrator who
+ * typed `00ECB2` meant `#00ECB2`, and a stored value that already lost its `#`
+ * is repaired instead of being silently replaced by the default colour.
+ */
+export function normalizeHexColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+
+  if (!HEX_COLOR_INPUT.test(trimmed)) return null
+
+  return trimmed.startsWith('#') ? trimmed : `#${trimmed}`
+}
+
+/** Whether `value` is a hex colour this application can render. */
+export function isHexColor(value: unknown): boolean {
+  return normalizeHexColor(value) !== null
+}
+
+/**
+ * The normalised colour, or `fallback` when the value is unusable. Callers
+ * pass the colour they would have used anyway, so a malformed stored value
+ * degrades to the shipped palette instead of throwing mid-render.
+ */
+export function resolveHexColor(value: unknown, fallback: string): string {
+  return normalizeHexColor(value) ?? fallback
+}


### PR DESCRIPTION
Fixes #754.

## The defect

A White Label primary colour typed without its leading `#` (for example `00ECB2`) was accepted by the form, stored as is, and then handed to MUI's `lighten()` / `darken()` while the theme provider built the palette. Those throw on anything MUI cannot parse:

```
MUI: Unsupported `00ECB2` color.
The following formats are supported: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla(), color().
```

The branding colour is a per-tenant setting and the theme provider wraps both the dashboard layout and the blank layout, so a single malformed value broke every page for every user of the tenant, login page included. With no page left to render there was no way to undo the change from the UI: recovery required an `UPDATE` on the `settings` table.

The per-user appearance settings were never affected, they already go through the `hexColor` validator added with the server-side appearance work. The per-tenant branding path was the one that never got a validator.

## The fix

One helper, `src/lib/theme/hexColor.ts`, is now the only place that decides what a usable colour is: three- or six-digit hex, `#` optional on input, alpha forms rejected because MUI derives nonsense shades from them (`lighten('#00EC', 0.2)` yields `rgba(51, 51, 241, 0.8)`).

A missing `#` is repaired rather than refused, on the way in and on the way out. That choice matters for an instance that is already down: it comes back on its own after the update, with the colour the administrator meant, instead of needing a database edit or falling back to the default palette.

| Layer | Behaviour |
| --- | --- |
| `WhiteLabelTab` | The field turns red, states the expected format, and Save is blocked. A missing `#` is added before the request is sent. |
| `PUT /api/v1/settings/branding` | 400 for a colour that cannot be repaired, and nothing is stored. An empty value still means "no override". |
| `GET /api/v1/settings/branding` and `.../public` | Repair what is already stored, so a polluted row never reaches the browser or the settings form. |
| `components/theme/index.jsx` | Last line of defence: anything left unusable falls back to the shipped brand colour, which also covers a user setting that is somehow broken. |

`ColorPicker` gains an optional `error` prop only. A `helperText` would grow the field and push the swatch out of alignment, so the message stays with the caller and the broadcast banner keeps its previous appearance.

Two edge cases worth recording: `#ZZZZZZ` and `#00-CB2` do not throw but resolve to `rgb(NaN, NaN, NaN)`, so a `try/catch` around `lighten()` would not have been enough on its own.

## Tests

Five suites, 58 tests: the helper, both branding routes, the settings form, and the real theme provider mounted with a malformed branding colour.

Note for anyone writing a similar test: under jsdom the provider's `cssVariables` mean a rendered button only ever reports `var(--variant-containedBg)`, so the assertion has to read the palette the provider built rather than a computed style.

## Verification

- Full suite: 579 files, 6248 tests, green.
- `tsc --noEmit`: unchanged against the baseline, no new error.
- ESLint clean on the eleven touched files.
- Checked end to end against a running instance with a deliberately polluted `settings` row: the public API returns the repaired colour, the real branding provider and theme provider build a valid palette from it, and the same stored value still throws through the old code path.
