### PR TITLE
fix(users): restore the Community super-admin grant (#755)

### DIFF
--- a/frontend/src/app/(dashboard)/security/users/page.jsx
+++ b/frontend/src/app/(dashboard)/security/users/page.jsx
@@ -372,6 +372,23 @@ function UserDialog({ open, onClose, user, onSave, rbacRoles, t, showRbac = true
     }
   }, [selectedTenants, selectedRole, enableTenantMgmt, currentSessionTenantId, user])
 
+  // The account write already succeeded when a role write fails, so the list
+  // must still refresh, but the dialog stays open with the reason instead of
+  // closing on an account whose rights are not what the operator just picked.
+  // Left silent, this produced accounts that could see nothing at all and no
+  // error anywhere to explain it (issue #755).
+  const reportRoleWriteFailure = async res => {
+    const data = await res.json().catch(() => ({}))
+
+    onSave()
+    setError(
+      data.error ||
+        (t
+          ? t('usersPage.roleAssignmentFailed')
+          : 'The account was saved but its role could not be assigned. Check its permissions.')
+    )
+  }
+
   const handleSave = async () => {
     setError('')
 
@@ -481,15 +498,17 @@ return
         if (isEdit && user.roles) {
           for (const role of user.roles) {
             if (role.assignment_id) {
-              await fetch(`/api/v1/rbac/assignments/${role.assignment_id}`, {
+              const dropRes = await fetch(`/api/v1/rbac/assignments/${role.assignment_id}`, {
                 method: 'DELETE'
               })
+
+              if (!dropRes.ok) return reportRoleWriteFailure(dropRes)
             }
           }
         }
 
         if (selectedRole) {
-          await fetch('/api/v1/rbac/assignments', {
+          const assignRes = await fetch('/api/v1/rbac/assignments', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
@@ -500,6 +519,8 @@ return
               scope_target: null
             })
           })
+
+          if (!assignRes.ok) return reportRoleWriteFailure(assignRes)
         }
       }
 

--- a/frontend/src/app/api/v1/users/route.test.ts
+++ b/frontend/src/app/api/v1/users/route.test.ts
@@ -8,7 +8,7 @@
  * picker instead. Detection uses getServerLicense() (fail-closed to
  * Community), the same signal that drives RBAC picker visibility in the UI.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { callRoute, readJson } from "@/__tests__/setup/route-test"
 
 const checkPermissionMock = vi.fn()
@@ -159,13 +159,17 @@ describe("POST /api/v1/users — Community auto super-admin (issue #512)", () =>
 })
 
 /**
- * The auto-grant may only fire on a POSITIVELY established Community verdict.
+ * The auto-grant may only fire on a trustworthy Community verdict.
  * getServerLicense() fails closed to a Community-looking payload whenever the
  * orchestrator is unreachable or answers non-2xx, and an expired Enterprise
- * licence also reports enterprise:false — granting global super-admin on
+ * licence also reports enterprise:false: granting global super-admin on
  * either would be a privilege escalation (issue #633 follow-up).
+ *
+ * A resolved verdict is not the test though, because a Community install has
+ * no orchestrator to answer and so never resolves. What tells the two apart is
+ * whether an orchestrator is configured at all (issue #755).
  */
-describe("POST /api/v1/users, the grant needs a resolved licence (issue #633)", () => {
+describe("POST /api/v1/users, the grant needs a trustworthy verdict (issues #633, #755)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     checkPermissionMock.mockResolvedValue(null)
@@ -173,7 +177,12 @@ describe("POST /api/v1/users, the grant needs a resolved licence (issue #633)", 
     userFindUniqueMock.mockResolvedValue(null)
   })
 
-  it("does not grant super-admin when the license verdict is unresolved", async () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("does not grant super-admin when a configured orchestrator failed to answer", async () => {
+    vi.stubEnv("ORCHESTRATOR_URL", "http://orchestrator:8080")
     getServerLicenseMock.mockResolvedValue({
       enterprise: false, edition: "community", licensed: false, expired: false,
       features: [], options: [], resolved: false,
@@ -184,6 +193,30 @@ describe("POST /api/v1/users, the grant needs a resolved licence (issue #633)", 
     expect(rbacUserRoleCreateMock).not.toHaveBeenCalled()
     expect(userCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ role: "user" }) }),
+    )
+  })
+
+  // The #755 regression itself: this is what every Community install looks
+  // like, and it produced accounts that could see nothing at all.
+  it("grants super-admin when no orchestrator is configured, unresolved verdict and all", async () => {
+    vi.stubEnv("ORCHESTRATOR_URL", "")
+    getServerLicenseMock.mockResolvedValue({
+      enterprise: false, edition: "community", licensed: false, expired: false,
+      features: [], options: [], resolved: false,
+    })
+    const res = await createUser()
+
+    expect(res.status).toBe(200)
+    expect(userCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ role: "super_admin" }) }),
+    )
+    expect(rbacUserRoleCreateMock).toHaveBeenCalledTimes(1)
+    expect(rbacUserRoleCreateMock.mock.calls[0][0].data).toMatchObject({
+      roleId: "role_super_admin",
+      scopeType: "global",
+    })
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ details: expect.objectContaining({ superAdminGranted: true }) }),
     )
   })
 

--- a/frontend/src/app/api/v1/users/route.ts
+++ b/frontend/src/app/api/v1/users/route.ts
@@ -11,6 +11,7 @@ import { authOptions } from "@/lib/auth/config"
 import { checkPermission, PERMISSIONS, isUserSuperAdmin, PROTECTED_ROLE_IDS } from "@/lib/rbac"
 import { DEFAULT_TENANT_ID, getCurrentTenantId } from "@/lib/tenant"
 import { getServerLicense } from "@/lib/auth/requireEnterprise"
+import { isCommunityDeployment } from "@/lib/auth/communitySuperAdmin"
 import { aliveWhere } from "@/lib/auth/sessions"
 
 export const runtime = "nodejs"
@@ -236,12 +237,13 @@ export async function POST(req: Request) {
     // Enterprise leaves the grant out: scoped roles are assigned separately
     // through the RBAC picker.
     //
-    // The verdict must be POSITIVELY established: an unreachable orchestrator
+    // The Community verdict must be trustworthy: an unreachable orchestrator
     // or an expired Enterprise licence both report enterprise:false, and
     // granting global super-admin on either would be a privilege escalation.
-    // Only a resolved Community edition qualifies.
+    // A Community install has no orchestrator to answer at all, so "resolved"
+    // alone would never fire there. See isCommunityDeployment (issue #755).
     const license = await getServerLicense()
-    const grantSuperAdmin = license.resolved === true && license.edition === "community"
+    const grantSuperAdmin = isCommunityDeployment(license)
 
     await prisma.$transaction([
       prisma.user.create({

--- a/frontend/src/lib/auth/communitySuperAdmin.db.test.ts
+++ b/frontend/src/lib/auth/communitySuperAdmin.db.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Community super-admin backfill against a real Postgres schema (issue #755).
+ *
+ * The unit suite proves the decision logic; this one proves the write lands:
+ * the grant row satisfies its foreign key to rbac_roles, it is filed on the
+ * tenant the session will run in, the legacy column moves with it in the same
+ * transaction, and a second sign-in does not stack a duplicate grant.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { prismaTest, truncate } from "../../__tests__/setup/prisma-test"
+
+const getServerLicenseMock = vi.fn()
+
+vi.mock("@/lib/db/prisma", () => ({ prisma: prismaTest }))
+vi.mock("./requireEnterprise", () => ({ getServerLicense: getServerLicenseMock }))
+vi.mock("@/lib/audit", () => ({ audit: vi.fn(async () => {}) }))
+
+const { backfillCommunitySuperAdmin } = await import("./communitySuperAdmin")
+
+const TABLES = [
+  "rbac_user_roles",
+  "rbac_user_permissions",
+  "user_tenants",
+  "users",
+  "rbac_roles",
+  "tenants",
+]
+
+const COMMUNITY = {
+  enterprise: false,
+  edition: "community",
+  licensed: false,
+  expired: false,
+  features: [],
+  options: [],
+  resolved: false,
+}
+
+async function seedInstall(tenantId = "default") {
+  const now = new Date()
+
+  await prismaTest.tenant.create({
+    data: { id: tenantId, slug: tenantId, name: tenantId, createdAt: now, updatedAt: now },
+  })
+  await prismaTest.rbacRole.create({
+    data: {
+      id: "role_super_admin",
+      name: "Super Admin",
+      description: "Full access",
+      isSystem: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  })
+}
+
+async function seedRightsLessUser(id: string, tenantId = "default") {
+  const now = new Date()
+
+  await prismaTest.user.create({
+    data: {
+      id,
+      email: `${id}@example.com`,
+      password: "x",
+      role: "user",
+      authProvider: "credentials",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    },
+  })
+  await prismaTest.userTenant.create({
+    data: { userId: id, tenantId, isDefault: true, joinedAt: now },
+  })
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+  // No orchestrator configured: the shape of every Community install.
+  vi.stubEnv("ORCHESTRATOR_URL", "")
+  getServerLicenseMock.mockResolvedValue(COMMUNITY)
+  await truncate(TABLES)
+  await seedInstall()
+})
+
+describe("backfillCommunitySuperAdmin against Postgres", () => {
+  it("repairs a rights-less account on the tenant it belongs to", async () => {
+    const now = new Date()
+
+    // Only the provider tenant may go without an operating model.
+    await prismaTest.tenant.create({
+      data: { id: "tenant-b", slug: "tenant-b", name: "B", operatingModel: "msp", createdAt: now, updatedAt: now },
+    })
+    await seedRightsLessUser("u1", "tenant-b")
+
+    expect(await backfillCommunitySuperAdmin("u1")).toBe(true)
+
+    const grants = await prismaTest.rbacUserRole.findMany({ where: { userId: "u1" } })
+    expect(grants).toHaveLength(1)
+    expect(grants[0]).toMatchObject({
+      roleId: "role_super_admin",
+      scopeType: "global",
+      scopeTarget: null,
+      tenantId: "tenant-b",
+      expiresAt: null,
+    })
+
+    const user = await prismaTest.user.findUnique({ where: { id: "u1" } })
+    expect(user?.role).toBe("super_admin")
+  })
+
+  it("is idempotent across sign-ins", async () => {
+    await seedRightsLessUser("u2")
+
+    expect(await backfillCommunitySuperAdmin("u2")).toBe(true)
+    expect(await backfillCommunitySuperAdmin("u2")).toBe(false)
+    expect(await prismaTest.rbacUserRole.count({ where: { userId: "u2" } })).toBe(1)
+  })
+
+  it("leaves an account that already holds a scoped role untouched", async () => {
+    const now = new Date()
+
+    await prismaTest.rbacRole.create({
+      data: { id: "role_viewer", name: "Viewer", isSystem: true, createdAt: now, updatedAt: now },
+    })
+    await seedRightsLessUser("u3")
+    await prismaTest.rbacUserRole.create({
+      data: {
+        id: "grant-u3",
+        userId: "u3",
+        roleId: "role_viewer",
+        scopeType: "connection",
+        scopeTarget: "conn-1",
+        tenantId: "default",
+        grantedAt: now,
+      },
+    })
+
+    expect(await backfillCommunitySuperAdmin("u3")).toBe(false)
+
+    const grants = await prismaTest.rbacUserRole.findMany({ where: { userId: "u3" } })
+    expect(grants).toHaveLength(1)
+    expect(grants[0].roleId).toBe("role_viewer")
+    expect((await prismaTest.user.findUnique({ where: { id: "u3" } }))?.role).toBe("user")
+  })
+
+  it("repairs an account whose only grant has expired", async () => {
+    const now = new Date()
+
+    await prismaTest.rbacRole.create({
+      data: { id: "role_operator", name: "Operator", isSystem: true, createdAt: now, updatedAt: now },
+    })
+    await seedRightsLessUser("u4")
+    await prismaTest.rbacUserRole.create({
+      data: {
+        id: "grant-u4",
+        userId: "u4",
+        roleId: "role_operator",
+        scopeType: "global",
+        tenantId: "default",
+        grantedAt: new Date("2026-01-01T00:00:00.000Z"),
+        expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+    })
+
+    expect(await backfillCommunitySuperAdmin("u4")).toBe(true)
+    expect(
+      await prismaTest.rbacUserRole.count({ where: { userId: "u4", roleId: "role_super_admin" } }),
+    ).toBe(1)
+  })
+
+  it("writes nothing at all on an Enterprise deployment", async () => {
+    vi.stubEnv("ORCHESTRATOR_URL", "http://orchestrator:8080")
+    await seedRightsLessUser("u5")
+
+    expect(await backfillCommunitySuperAdmin("u5")).toBe(false)
+    expect(await prismaTest.rbacUserRole.count({ where: { userId: "u5" } })).toBe(0)
+    expect((await prismaTest.user.findUnique({ where: { id: "u5" } }))?.role).toBe("user")
+  })
+})

--- a/frontend/src/lib/auth/communitySuperAdmin.test.ts
+++ b/frontend/src/lib/auth/communitySuperAdmin.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Community super-admin grant (issues #512, #633, #755).
+ *
+ * A Community install runs the frontend alone, with no orchestrator, so its
+ * licence verdict is never "resolved". Gating the auto-grant on a resolved
+ * verdict therefore switched it off everywhere it was supposed to fire, and
+ * every account created after the first one saw an empty UI (#755). The gate
+ * must key on deployment shape instead, without reopening the escalation the
+ * resolved check closed (#633): an Enterprise install whose orchestrator is
+ * down, and an expired Enterprise licence, both still get nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+const {
+  getServerLicenseMock,
+  auditMock,
+  rbacUserRoleFindFirstMock,
+  rbacUserRoleCreateMock,
+  rbacUserPermissionFindFirstMock,
+  userTenantFindFirstMock,
+  userUpdateMock,
+  transactionMock,
+} = vi.hoisted(() => ({
+  getServerLicenseMock: vi.fn(),
+  auditMock: vi.fn(async () => {}),
+  rbacUserRoleFindFirstMock: vi.fn(),
+  rbacUserRoleCreateMock: vi.fn((args: any) => ({ __op: "rbacUserRole.create", args })),
+  rbacUserPermissionFindFirstMock: vi.fn(),
+  userTenantFindFirstMock: vi.fn(),
+  userUpdateMock: vi.fn((args: any) => ({ __op: "user.update", args })),
+  transactionMock: vi.fn(async (ops: any[]) => ops),
+}))
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    rbacUserRole: { findFirst: rbacUserRoleFindFirstMock, create: rbacUserRoleCreateMock },
+    rbacUserPermission: { findFirst: rbacUserPermissionFindFirstMock },
+    userTenant: { findFirst: userTenantFindFirstMock },
+    user: { update: userUpdateMock },
+    $transaction: transactionMock,
+  },
+}))
+vi.mock("@/lib/audit", () => ({ audit: auditMock }))
+vi.mock("./requireEnterprise", () => ({ getServerLicense: getServerLicenseMock }))
+
+import {
+  isCommunityDeployment,
+  isOrchestratorConfigured,
+  hasAnyActiveGrant,
+  grantSuperAdmin,
+  backfillCommunitySuperAdmin,
+} from "./communitySuperAdmin"
+
+import type { ServerLicense } from "./requireEnterprise"
+
+/** An empty value means "no orchestrator configured", same as an unset var. */
+const NO_ORCHESTRATOR = ""
+const ORCHESTRATOR = "http://orchestrator:8080"
+
+function licence(overrides: Partial<ServerLicense> = {}): ServerLicense {
+  return {
+    enterprise: false,
+    edition: "community",
+    licensed: false,
+    expired: false,
+    features: [],
+    options: [],
+    resolved: false,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  rbacUserRoleFindFirstMock.mockResolvedValue(null)
+  rbacUserPermissionFindFirstMock.mockResolvedValue(null)
+  userTenantFindFirstMock.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe("isOrchestratorConfigured", () => {
+  it("reads the environment at call time, not at import time", () => {
+    vi.stubEnv("ORCHESTRATOR_URL", NO_ORCHESTRATOR)
+    expect(isOrchestratorConfigured()).toBe(false)
+
+    vi.stubEnv("ORCHESTRATOR_URL", ORCHESTRATOR)
+    expect(isOrchestratorConfigured()).toBe(true)
+  })
+})
+
+describe("isCommunityDeployment", () => {
+  const cases: Array<[string, ServerLicense, string, boolean]> = [
+    ["community, verdict resolved, orchestrator present", licence({ resolved: true }), ORCHESTRATOR, true],
+    ["community, verdict resolved, no orchestrator", licence({ resolved: true }), NO_ORCHESTRATOR, true],
+    // The #755 regression: a real Community install can never resolve.
+    ["community, unresolved, no orchestrator", licence(), NO_ORCHESTRATOR, true],
+    // The #633 escalation: an Enterprise deployment whose orchestrator is down.
+    ["community fallback while an orchestrator is configured", licence(), ORCHESTRATOR, false],
+    [
+      "expired enterprise licence",
+      licence({ edition: "enterprise", licensed: true, expired: true, resolved: true }),
+      ORCHESTRATOR,
+      false,
+    ],
+    [
+      "expired enterprise licence, orchestrator unreachable",
+      licence({ edition: "enterprise", licensed: true, expired: true }),
+      NO_ORCHESTRATOR,
+      false,
+    ],
+    [
+      "live enterprise licence",
+      licence({ enterprise: true, edition: "enterprise", licensed: true, resolved: true }),
+      ORCHESTRATOR,
+      false,
+    ],
+  ]
+
+  it.each(cases)("%s", (_label, lic, orchestrator, expected) => {
+    vi.stubEnv("ORCHESTRATOR_URL", orchestrator)
+    expect(isCommunityDeployment(lic)).toBe(expected)
+  })
+})
+
+describe("hasAnyActiveGrant", () => {
+  it("is true on a role grant", async () => {
+    rbacUserRoleFindFirstMock.mockResolvedValue({ id: "grant-1" })
+    expect(await hasAnyActiveGrant("u1")).toBe(true)
+  })
+
+  it("is true on a direct permission grant alone", async () => {
+    rbacUserPermissionFindFirstMock.mockResolvedValue({ id: "perm-1" })
+    expect(await hasAnyActiveGrant("u1")).toBe(true)
+  })
+
+  it("is false when the user holds neither", async () => {
+    expect(await hasAnyActiveGrant("u1")).toBe(false)
+  })
+
+  it("ignores expired grants", async () => {
+    await hasAnyActiveGrant("u1")
+
+    for (const mock of [rbacUserRoleFindFirstMock, rbacUserPermissionFindFirstMock]) {
+      const where = mock.mock.calls[0][0].where
+      expect(where.userId).toBe("u1")
+      expect(where.OR[0]).toEqual({ expiresAt: null })
+      expect(where.OR[1].expiresAt.gt).toBeInstanceOf(Date)
+    }
+  })
+})
+
+describe("grantSuperAdmin", () => {
+  it("files a global grant on the tenant the session will run in", async () => {
+    userTenantFindFirstMock.mockResolvedValue({ tenantId: "tenant-b" })
+
+    await grantSuperAdmin("u1")
+
+    expect(userTenantFindFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "u1", isDefault: true } }),
+    )
+    expect(rbacUserRoleCreateMock.mock.calls[0][0].data).toMatchObject({
+      userId: "u1",
+      roleId: "role_super_admin",
+      scopeType: "global",
+      scopeTarget: null,
+      tenantId: "tenant-b",
+    })
+    expect(userUpdateMock.mock.calls[0][0]).toMatchObject({
+      where: { id: "u1" },
+      data: expect.objectContaining({ role: "super_admin" }),
+    })
+    // Grant and legacy column move together or not at all.
+    expect(transactionMock).toHaveBeenCalledTimes(1)
+    expect(transactionMock.mock.calls[0][0]).toHaveLength(2)
+  })
+
+  it("falls back to the default tenant when the user has no default membership", async () => {
+    await grantSuperAdmin("u1")
+
+    expect(rbacUserRoleCreateMock.mock.calls[0][0].data.tenantId).toBe("default")
+  })
+})
+
+describe("backfillCommunitySuperAdmin", () => {
+  it("leaves a user who already holds a grant alone, without probing the licence", async () => {
+    rbacUserRoleFindFirstMock.mockResolvedValue({ id: "grant-1" })
+    vi.stubEnv("ORCHESTRATOR_URL", NO_ORCHESTRATOR)
+
+    expect(await backfillCommunitySuperAdmin("u1")).toBe(false)
+    expect(getServerLicenseMock).not.toHaveBeenCalled()
+    expect(transactionMock).not.toHaveBeenCalled()
+  })
+
+  it("grants and audits a rights-less user on a Community install", async () => {
+    getServerLicenseMock.mockResolvedValue(licence())
+    vi.stubEnv("ORCHESTRATOR_URL", NO_ORCHESTRATOR)
+
+    expect(await backfillCommunitySuperAdmin("u1")).toBe(true)
+    expect(rbacUserRoleCreateMock.mock.calls[0][0].data).toMatchObject({
+      userId: "u1",
+      roleId: "role_super_admin",
+    })
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceId: "u1",
+        details: { superAdminGranted: true, reason: "community_backfill" },
+      }),
+    )
+  })
+
+  it("never escalates a rights-less user on an Enterprise deployment", async () => {
+    getServerLicenseMock.mockResolvedValue(licence())
+    vi.stubEnv("ORCHESTRATOR_URL", ORCHESTRATOR)
+
+    expect(await backfillCommunitySuperAdmin("u1")).toBe(false)
+    expect(transactionMock).not.toHaveBeenCalled()
+    expect(auditMock).not.toHaveBeenCalled()
+  })
+
+  it("does nothing without a user id", async () => {
+    expect(await backfillCommunitySuperAdmin("")).toBe(false)
+    expect(rbacUserRoleFindFirstMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/auth/communitySuperAdmin.ts
+++ b/frontend/src/lib/auth/communitySuperAdmin.ts
@@ -1,0 +1,144 @@
+// src/lib/auth/communitySuperAdmin.ts
+//
+// Community edition has no RBAC role-management UI (that is Enterprise only),
+// so an account created there receives no grant and can see nothing at all:
+// the dashboard renders, every other page and menu entry is filtered out
+// (issue #512). Community therefore grants every user full super-admin.
+//
+// The grant may only fire on a Community *deployment*. getServerLicense()
+// fails closed to a community-looking payload with `resolved: false` whenever
+// the orchestrator is unreachable, and an expired Enterprise licence also
+// reports enterprise:false, so auto-granting global super-admin on either
+// would be a privilege escalation (issue #633 follow-up).
+//
+// A resolved verdict alone is not the right test though: a genuine Community
+// install runs the frontend ALONE, with no orchestrator to ask, so its verdict
+// is never resolved and the grant never fired, so the #512 dead-end came back
+// in v1.4.7 (issue #755). What separates the two cases is deployment shape, not
+// the answer: every Enterprise deployment sets ORCHESTRATOR_URL explicitly
+// (docker-compose.enterprise.yml, docker-compose.ha.yml, install-enterprise.sh)
+// while the Community compose ships without it ("# No ORCHESTRATOR_URL =
+// Community mode"). An unset ORCHESTRATOR_URL means there is no orchestrator
+// to be unreachable, so a community verdict is the only verdict there can be.
+
+import { nanoid } from "nanoid"
+
+import { prisma } from "@/lib/db/prisma"
+import { DEFAULT_TENANT_ID } from "@/lib/tenant/constants"
+
+import type { ServerLicense } from "./requireEnterprise"
+
+export const SUPER_ADMIN_ROLE_ID = "role_super_admin"
+
+/**
+ * True when this installation was deployed without an orchestrator, i.e. the
+ * Community compose. Read at call time, never cached at module scope, so tests
+ * and a runtime env change both see the current value.
+ */
+export function isOrchestratorConfigured(): boolean {
+  return Boolean(process.env.ORCHESTRATOR_URL)
+}
+
+/**
+ * True when the installation is Community and we can say so without guessing:
+ * either the orchestrator positively answered "community", or there is no
+ * orchestrator configured at all. An Enterprise deployment whose orchestrator
+ * is merely down keeps `resolved: false` with ORCHESTRATOR_URL set and is
+ * refused, as is an expired Enterprise licence (edition stays "enterprise").
+ */
+export function isCommunityDeployment(license: ServerLicense): boolean {
+  if (license.edition !== "community") return false
+
+  return license.resolved === true || !isOrchestratorConfigured()
+}
+
+/** Active-grant filter, mirroring the private one in lib/rbac. */
+function activeGrantFilter() {
+  return { OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }] }
+}
+
+/**
+ * Whether the user holds any active RBAC authority at all: a role grant or a
+ * direct permission grant. A user with none of either sees nothing.
+ */
+export async function hasAnyActiveGrant(userId: string): Promise<boolean> {
+  const [role, permission] = await Promise.all([
+    prisma.rbacUserRole.findFirst({
+      where: { userId, ...activeGrantFilter() },
+      select: { id: true },
+    }),
+    prisma.rbacUserPermission.findFirst({
+      where: { userId, ...activeGrantFilter() },
+      select: { id: true },
+    }),
+  ])
+
+  return Boolean(role || permission)
+}
+
+/**
+ * Give `userId` the global super-admin grant, filed on the tenant their session
+ * will actually run in (`loadJwtContext` reads the isDefault membership), and
+ * mirror it on the legacy users.role column. Caller decides *whether* to grant.
+ */
+export async function grantSuperAdmin(userId: string): Promise<void> {
+  const membership = await prisma.userTenant.findFirst({
+    where: { userId, isDefault: true },
+    select: { tenantId: true },
+  })
+  const now = new Date()
+
+  await prisma.$transaction([
+    prisma.rbacUserRole.create({
+      data: {
+        id: nanoid(),
+        userId,
+        roleId: SUPER_ADMIN_ROLE_ID,
+        scopeType: "global",
+        scopeTarget: null,
+        tenantId: membership?.tenantId ?? DEFAULT_TENANT_ID,
+        grantedAt: now,
+      },
+    }),
+    prisma.user.update({
+      where: { id: userId },
+      data: { role: "super_admin", updatedAt: now },
+    }),
+  ])
+}
+
+/**
+ * Repair pass for accounts created while the grant was wrongly withheld
+ * (issue #755): every user created through the UI between v1.4.7 and this fix
+ * on a Community install has zero grants, and Community offers no way to give
+ * them any, the role picker is Enterprise-gated, so the operator is stuck.
+ *
+ * Runs on sign-in. The cheap grant lookup comes first so an installation whose
+ * users all have roles (every Enterprise one) never pays for the licence
+ * probe. Idempotent: a user who already holds anything is left untouched, so a
+ * deliberately scoped Enterprise account is never escalated.
+ *
+ * Returns true when a grant was written.
+ */
+export async function backfillCommunitySuperAdmin(userId: string): Promise<boolean> {
+  if (!userId) return false
+  if (await hasAnyActiveGrant(userId)) return false
+
+  const { getServerLicense } = await import("./requireEnterprise")
+  if (!isCommunityDeployment(await getServerLicense())) return false
+
+  await grantSuperAdmin(userId)
+
+  const { audit } = await import("@/lib/audit")
+  await audit({
+    action: "update",
+    category: "users",
+    resourceType: "user",
+    resourceId: userId,
+    userId,
+    details: { superAdminGranted: true, reason: "community_backfill" },
+    status: "success",
+  })
+
+  return true
+}

--- a/frontend/src/lib/auth/config.ts
+++ b/frontend/src/lib/auth/config.ts
@@ -679,6 +679,18 @@ export const authOptions: NextAuthOptions = {
   },
   events: {
     async signIn({ user }) {
+      // Repair accounts created while the Community super-admin grant was
+      // wrongly withheld (issue #755): Community hides the role picker, so
+      // without this the operator has no way to give them any right at all.
+      // No-op on every other installation, and on any user who already holds
+      // a grant. Never allowed to block a login that already succeeded.
+      try {
+        const { backfillCommunitySuperAdmin } = await import("@/lib/auth/communitySuperAdmin")
+        await backfillCommunitySuperAdmin(user.id)
+      } catch (e) {
+        console.error("[auth] Community super-admin backfill failed:", e)
+      }
+
       // Audit login réussi
       const { audit } = await import("@/lib/audit")
 

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5672,6 +5672,7 @@
     "roleDefinesPermissions": "The role defines user Berechtigungen",
     "protectedRolesNote": "Super Admin und Provider Admin werden unter Sicherheit › RBAC › Zuweisungen verwaltet.",
     "communityAdminNotice": "In der Community Edition hat jeder Benutzer vollen Administratorzugriff. Rollenbasierte, eingeschränkte Berechtigungen erfordern die Enterprise Edition.",
+    "roleAssignmentFailed": "Das Konto wurde gespeichert, aber die Rolle konnte nicht zugewiesen werden. Prüfen Sie die Berechtigungen, bevor sich der Benutzer anmeldet.",
     "newPassword": "Neues Passwort (leer lassen, um das aktuelle beizubehalten)",
     "minChars": "minimal 8 characters",
     "accountActive": "Konto aktiv",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5717,6 +5717,7 @@
     "roleDefinesPermissions": "The role defines user permissions",
     "protectedRolesNote": "Super Admin and Provider Admin are managed in Security › RBAC › Assignments.",
     "communityAdminNotice": "In Community edition, every user has full administrator access. Scoped, role-based permissions require the Enterprise edition.",
+    "roleAssignmentFailed": "The account was saved but its role could not be assigned. Check its permissions before the user signs in.",
     "newPassword": "New password (leave empty to keep current)",
     "minChars": "Minimum 8 characters",
     "accountActive": "Account active",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -5717,6 +5717,7 @@
     "roleDefinesPermissions": "El rol define los permisos de usuario",
     "protectedRolesNote": "Super Admin y Provider Admin se gestionan en Seguridad › RBAC › Asignaciones.",
     "communityAdminNotice": "En la edición Community, todos los usuarios tienen acceso de administrador completo. Los permisos acotados basados en roles requieren la edición Enterprise.",
+    "roleAssignmentFailed": "La cuenta se guardó pero no se pudo asignar su rol. Revise sus permisos antes de que el usuario inicie sesión.",
     "newPassword": "Nueva contraseña (dejar vacío para mantener la actual)",
     "minChars": "Mínimo 8 caracteres",
     "accountActive": "Cuenta activa",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5717,6 +5717,7 @@
     "roleDefinesPermissions": "Le rôle définit les permissions de l'utilisateur",
     "protectedRolesNote": "Super Admin et Provider Admin se gèrent dans Sécurité › RBAC › Assignations.",
     "communityAdminNotice": "En édition Community, chaque utilisateur dispose d'un accès administrateur complet. Les permissions scopées basées sur les rôles nécessitent l'édition Enterprise.",
+    "roleAssignmentFailed": "Le compte a été enregistré mais son rôle n'a pas pu être attribué. Vérifiez ses permissions avant sa connexion.",
     "newPassword": "Nouveau mot de passe (laisser vide pour ne pas changer)",
     "minChars": "Minimum 8 caractères",
     "accountActive": "Compte actif",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -5717,6 +5717,7 @@
     "roleDefinesPermissions": "역할이 사용자 권한을 정의합니다",
     "protectedRolesNote": "Super Admin 및 Provider Admin은 보안 › RBAC › 할당에서 관리됩니다.",
     "communityAdminNotice": "Community 에디션에서는 모든 사용자가 전체 관리자 권한을 갖습니다. 범위 지정 역할 기반 권한은 Enterprise 에디션이 필요합니다.",
+    "roleAssignmentFailed": "계정은 저장되었지만 역할을 할당하지 못했습니다. 사용자가 로그인하기 전에 권한을 확인하세요.",
     "newPassword": "새 비밀번호 (현재 비밀번호를 유지하려면 비워 두세요)",
     "minChars": "최소 8자",
     "accountActive": "계정 활성",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5674,6 +5674,7 @@
     "roleDefinesPermissions": "角色定义用户权限",
     "protectedRolesNote": "超级管理员和提供商管理员在 安全 › RBAC › 分配 中管理。",
     "communityAdminNotice": "在社区版中，每个用户都拥有完整的管理员权限。基于角色的精细化权限需要企业版。",
+    "roleAssignmentFailed": "账户已保存，但未能分配角色。请在该用户登录前检查其权限。",
     "newPassword": "新密码（留空保持不变）",
     "minChars": "至少 8 个字符",
     "accountActive": "账户已激活",


### PR DESCRIPTION
## Problem

Community edition has no RBAC role picker, so ProxCenter grants every account created from Settings > Security > Users the same full administrator access as the setup account (#512). Since v1.4.7 that grant no longer fires: the second user of a Community install lands on a dashboard with an empty menu, placeholders flashing over an empty page, and the operator has no way to give them any right, because the picker is Enterprise gated.

The hardening in #650 (issue #633) made the grant conditional on a positively resolved licence verdict, since an unreachable orchestrator and an expired Enterprise licence both report `enterprise: false` and either one used to mint a global super-admin. A Community install, though, runs the frontend alone with no orchestrator to ask, so its verdict is never resolved and the grant became unreachable exactly where it was meant to fire. The route test pinned that behaviour, and the Community cases were written with `resolved: true`, a state no Community install ever produces.

## Fix

`isCommunityDeployment()` keys on deployment shape rather than on the verdict alone: Community edition, plus either a resolved verdict or no `ORCHESTRATOR_URL` configured. Every Enterprise deployment sets that variable (both compose files and the Enterprise installer) while the Community compose ships without it, so the two cases #633 closed stay closed: an Enterprise install whose orchestrator is down keeps `ORCHESTRATOR_URL` set and is refused, and an expired Enterprise licence still reports `edition: enterprise`.

Accounts already created without a grant cannot be repaired from the UI, so a backfill runs on sign-in: it grants super-admin to a rights-less account on a Community deployment and is a no-op everywhere else. The grant lookup comes first, so an installation whose users all hold roles never pays for the licence probe, and an account that already holds anything is left untouched. LDAP auto-provisioned accounts, created as viewers with no grant, are repaired by the same pass.

Failed role writes in the user dialog were silent as well: the account was created, the follow-up assignment could legitimately answer 400, and the dialog closed on an account whose rights were not the ones just picked. They now surface, in the six shipped locales.

## Tests

- 18 unit tests on the new module, covering the seven edition and orchestrator combinations
- 5 integration tests against a real Postgres schema: the grant satisfies its foreign key, lands on the tenant the session runs in, moves with the legacy column in a single transaction, does not stack on a second sign-in, and writes nothing on an Enterprise deployment
- the route test that pinned the regression now pins both halves of the contract
- full suite green, 580 files and 6267 tests

## Validation

Verified against a live instance. With an Enterprise licence, a rights-less account signs in, receives nothing, and `/api/v1/rbac/effective` returns no permission while `/api/v1/connections` answers 403, which is the reported symptom. With the orchestrator stopped and no `ORCHESTRATOR_URL`, a newly created account gets `role_super_admin` on the global scope, and after deleting that grant by hand it is recreated on the next sign-in, with a `community_backfill` audit entry and no duplicate.

Closes #755
