### PR TITLE
feat(dashboard): free widget placement and theme logo widget

### DIFF
--- a/frontend/src/components/dashboard/WidgetGrid.jsx
+++ b/frontend/src/components/dashboard/WidgetGrid.jsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useTranslations } from 'next-intl'
-import { ResponsiveGridLayout } from 'react-grid-layout'
+import { ResponsiveGridLayout, getCompactor } from 'react-grid-layout'
 
 import {
   Box, Card, CardContent, CircularProgress, IconButton, Menu, MenuItem,
@@ -12,6 +12,7 @@ import {
 } from '@mui/material'
 
 import { WIDGET_REGISTRY, WIDGET_CATEGORIES, getWidgetsByCategory, isWidgetVisibleForScope } from './widgetRegistry'
+import { computeReclaimedRows, yShiftFor } from './layoutReclaim'
 import { DEFAULT_LAYOUT, PRESET_LAYOUTS } from './types'
 import { CardsSkeleton } from '@/components/skeletons'
 import { useWidgetVisibility } from '@/hooks/useWidgetVisibility'
@@ -20,6 +21,11 @@ import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
 const GRID_COLS = { lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }
 const ROW_HEIGHT = 40
 const MARGIN = [6, 4]
+
+// react-grid-layout v2 configures compaction through a compactor object; the
+// v1 compactType/preventCollision props are silently ignored. Free placement:
+// no compaction, no overlap, dropping onto an occupied spot is refused.
+const FREE_PLACEMENT_COMPACTOR = getCompactor(null, false, true)
 
 const TIME_RANGES = [
   { value: 'hour', label: '1h' },
@@ -468,15 +474,25 @@ return hidden
   const visibleLayout = (editMode ? layout : layout.filter(w => !hiddenBySection.has(w.id)))
     .filter(w => isWidgetVisibleForScope(w.type, { hasInfraScope, hiddenWidgets }))
 
+  // View mode only: close the rows freed by hidden widgets (display-time shift,
+  // never saved: handleLayoutChange is a no-op outside edit mode).
+  const visibleIds = new Set(visibleLayout.map(w => w.id))
+  const reclaimedRows = editMode
+    ? []
+    : computeReclaimedRows(
+        visibleLayout.map(w => ({ y: w.y, h: WIDGET_REGISTRY[w.type]?.isSection ? 0.5 : w.h })),
+        layout.filter(w => !visibleIds.has(w.id))
+      )
+
   // Convertir notre layout en format react-grid-layout (registry overrides saved min/max)
   const gridLayout = visibleLayout.map(w => {
     const def = WIDGET_REGISTRY[w.type]
 
-    
+
 return {
       i: w.id,
       x: w.x,
-      y: w.y,
+      y: w.y - yShiftFor(reclaimedRows, w.y),
       w: w.w,
       h: def?.isSection ? (editMode ? 1 : 0.5) : w.h,
       minW: def?.minSize?.w ?? w.minW ?? 2,
@@ -871,7 +887,7 @@ return () => document.removeEventListener('fullscreenchange', handler)
             draggableHandle=".widget-drag-handle"
             onLayoutChange={(currentLayout, allLayouts) => handleLayoutChange(allLayouts.lg || currentLayout)}
             useCSSTransforms={true}
-            compactType="vertical"
+            compactor={FREE_PLACEMENT_COMPACTOR}
           >
           {visibleLayout.map((config) => (
             <div key={config.id}>

--- a/frontend/src/components/dashboard/layoutReclaim.js
+++ b/frontend/src/components/dashboard/layoutReclaim.js
@@ -1,0 +1,48 @@
+// The widget grid uses free placement (no auto-compaction), so rows vacated by
+// hidden widgets (collapsed sections, scope filtering) must be reclaimed
+// manually at display time. Only rows no visible widget occupies are removed,
+// which preserves the gaps the user left on purpose. Rows are expressed as
+// [start, end) intervals in grid units.
+
+export function mergeIntervals(intervals) {
+  const sorted = [...intervals].sort((a, b) => a[0] - b[0])
+  const merged = []
+
+  for (const [start, end] of sorted) {
+    const last = merged[merged.length - 1]
+
+    if (last && start <= last[1]) last[1] = Math.max(last[1], end)
+    else merged.push([start, end])
+  }
+
+  return merged
+}
+
+// Returns the row intervals covered by hidden widgets and by no visible one.
+export function computeReclaimedRows(visibleItems, hiddenItems) {
+  if (hiddenItems.length === 0) return []
+
+  const occupied = mergeIntervals(visibleItems.map(w => [w.y, w.y + w.h]))
+  const freed = []
+
+  for (const [start, end] of mergeIntervals(hiddenItems.map(w => [w.y, w.y + w.h]))) {
+    let cursor = start
+
+    for (const [oStart, oEnd] of occupied) {
+      if (oEnd <= cursor) continue
+      if (oStart >= end) break
+      if (oStart > cursor) freed.push([cursor, oStart])
+      cursor = oEnd
+      if (cursor >= end) break
+    }
+
+    if (cursor < end) freed.push([cursor, end])
+  }
+
+  return freed
+}
+
+// How far up a widget sitting at row y moves once the freed rows are removed.
+export function yShiftFor(freedIntervals, y) {
+  return freedIntervals.reduce((total, [start, end]) => total + Math.max(0, Math.min(end, y) - start), 0)
+}

--- a/frontend/src/components/dashboard/layoutReclaim.test.js
+++ b/frontend/src/components/dashboard/layoutReclaim.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { mergeIntervals, computeReclaimedRows, yShiftFor } from './layoutReclaim'
+
+describe('mergeIntervals', () => {
+  it('merges overlapping and touching intervals', () => {
+    expect(mergeIntervals([[4, 8], [0, 2], [2, 3], [6, 10]])).toEqual([[0, 3], [4, 10]])
+  })
+
+  it('keeps disjoint intervals apart', () => {
+    expect(mergeIntervals([[5, 6], [0, 2]])).toEqual([[0, 2], [5, 6]])
+  })
+
+  it('handles an empty list', () => {
+    expect(mergeIntervals([])).toEqual([])
+  })
+})
+
+describe('computeReclaimedRows', () => {
+  it('returns nothing when no widget is hidden', () => {
+    expect(computeReclaimedRows([{ y: 0, h: 4 }], [])).toEqual([])
+  })
+
+  it('frees the rows of a fully hidden band (collapsed section)', () => {
+    const visible = [{ y: 0, h: 1 }, { y: 9, h: 4 }]
+    const hidden = [{ y: 1, h: 4 }, { y: 5, h: 4 }]
+
+    expect(computeReclaimedRows(visible, hidden)).toEqual([[1, 9]])
+  })
+
+  it('does not free rows still occupied by a side-by-side visible widget', () => {
+    const visible = [{ y: 4, h: 4 }]
+    const hidden = [{ y: 4, h: 4 }]
+
+    expect(computeReclaimedRows(visible, hidden)).toEqual([])
+  })
+
+  it('frees only the part of a hidden band no visible widget covers', () => {
+    const visible = [{ y: 6, h: 2 }]
+    const hidden = [{ y: 4, h: 6 }]
+
+    expect(computeReclaimedRows(visible, hidden)).toEqual([[4, 6], [8, 10]])
+  })
+})
+
+describe('yShiftFor', () => {
+  const freed = [[1, 3], [6, 10]]
+
+  it('does not move widgets above the first freed band', () => {
+    expect(yShiftFor(freed, 0)).toBe(0)
+    expect(yShiftFor(freed, 1)).toBe(0)
+  })
+
+  it('moves a widget up by the freed rows above it', () => {
+    expect(yShiftFor(freed, 3)).toBe(2)
+    expect(yShiftFor(freed, 6)).toBe(2)
+    expect(yShiftFor(freed, 12)).toBe(6)
+  })
+
+  it('clamps a widget sitting inside a freed band', () => {
+    expect(yShiftFor(freed, 8)).toBe(4)
+  })
+
+  it('preserves deliberate empty rows (not part of any freed band)', () => {
+    expect(yShiftFor([], 7)).toBe(0)
+  })
+})

--- a/frontend/src/components/dashboard/widgetRegistry.js
+++ b/frontend/src/components/dashboard/widgetRegistry.js
@@ -50,6 +50,9 @@ const SectionHeaderWidget = dynamic(() => import('./widgets/SectionHeaderWidget'
 const DrsStatusWidget = dynamic(() => import('./widgets/DrsStatusWidget'), { ssr: false })
 const SiteRecoveryWidget = dynamic(() => import('./widgets/SiteRecoveryWidget'), { ssr: false })
 
+// Other
+const ThemeLogoWidget = dynamic(() => import('./widgets/ThemeLogoWidget'), { ssr: false })
+
 export const WIDGET_REGISTRY = {
   'section-header': {
     type: 'section-header',
@@ -411,6 +414,22 @@ export const WIDGET_REGISTRY = {
     requiresInfraScope: true,
     component: SiteRecoveryWidget,
   },
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // OTHER
+  // ═══════════════════════════════════════════════════════════════════════════
+  'theme-logo': {
+    type: 'theme-logo',
+    name: 'Theme Logo',
+    description: 'Logo of the current theme',
+    icon: 'ri-palette-line',
+    category: 'other',
+    defaultSize: { w: 2, h: 2 },
+    minSize: { w: 1, h: 1 },
+    maxSize: { w: 12, h: 20 },
+    noContainer: true,
+    component: ThemeLogoWidget,
+  },
 }
 
 export const WIDGET_CATEGORIES = [
@@ -420,6 +439,7 @@ export const WIDGET_CATEGORIES = [
   { id: 'storage', name: 'Storage', icon: 'ri-hard-drive-2-line' },
   { id: 'monitoring', name: 'Monitoring', icon: 'ri-alarm-warning-line' },
   { id: 'automation', name: 'Automation', icon: 'ri-robot-2-line' },
+  { id: 'other', name: 'Other', icon: 'ri-more-line' },
 ]
 
 export function getWidgetsByCategory(category, opts = {}) {

--- a/frontend/src/components/dashboard/widgetRegistry.test.tsx
+++ b/frontend/src/components/dashboard/widgetRegistry.test.tsx
@@ -40,6 +40,15 @@ describe('WIDGET_REGISTRY', () => {
     expect(def.requiresInfraScope).toBe(true)
     expect(def.defaultSize).toEqual({ w: 6, h: 5 })
   })
+
+  it('registers the theme logo widget under Other, visible to any scope', () => {
+    const def = WIDGET_REGISTRY['theme-logo']
+
+    expect(def).toBeTruthy()
+    expect(def.category).toBe('other')
+    expect(def.requiresInfraScope).toBeUndefined()
+    expect(getWidgetsByCategory('other').map(w => w.type)).toContain('theme-logo')
+  })
 })
 
 describe('getWidgetsByCategory', () => {

--- a/frontend/src/components/dashboard/widgets/ThemeLogoWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/ThemeLogoWidget.jsx
@@ -1,0 +1,61 @@
+'use client'
+
+import React from 'react'
+
+import { Box, useTheme } from '@mui/material'
+
+import primaryColorConfig from '@configs/primaryColorConfig'
+import themeConfig from '@configs/themeConfig'
+import { useSettings } from '@core/hooks/useSettings'
+import { useBranding } from '@/contexts/BrandingContext'
+import { LogoIcon } from '@components/layout/shared/Logo'
+import { themeNames } from '@components/layout/shared/ThemeDropdown'
+
+// Shows only the logo of the active theme, with the same visuals as the
+// navbar ThemeDropdown: custom branding logo first, then the ProxCenter logo
+// for the default theme, then the theme's colored badge.
+function ThemeLogoWidget() {
+  const theme = useTheme()
+  const { settings } = useSettings()
+  const { branding } = useBranding()
+  const isDark = theme.palette.mode === 'dark'
+
+  const currentTheme = primaryColorConfig.find(c => c.main === settings.primaryColor) || primaryColorConfig[0]
+  const themeInfo = themeNames[currentTheme.name] || { name: currentTheme.name, icon: 'ri-palette-fill' }
+  const isProxcenterLogo = !branding.logoUrl && themeInfo.icon === 'proxmox-logo'
+
+  return (
+    <Box
+      sx={{
+        bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+        border: '1px solid', borderColor: isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        borderRadius: 'var(--proxcenter-card-radius)', p: 1.5, height: '100%',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+    >
+      {branding.logoUrl ? (
+        <Box
+          component='img'
+          src={branding.logoUrl}
+          alt={branding.appName || themeConfig.templateName}
+          sx={{ maxHeight: '100%', maxWidth: '100%', objectFit: 'contain' }}
+        />
+      ) : isProxcenterLogo ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', color: isDark ? '#e0e0e0' : '#333' }}>
+          <LogoIcon size={52} accentColor={currentTheme.main} />
+        </Box>
+      ) : (
+        <Box
+          sx={{
+            width: '3.2em', height: '3.2em', borderRadius: '50%',
+            bgcolor: currentTheme.main, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+        >
+          <Box component='i' className={themeInfo.icon} sx={{ fontSize: '1.5em', color: '#fff', lineHeight: 1 }} />
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default React.memo(ThemeLogoWidget)

--- a/frontend/src/components/dashboard/widgets/ThemeLogoWidget.test.jsx
+++ b/frontend/src/components/dashboard/widgets/ThemeLogoWidget.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders } from '@/__tests__/setup/renderWithProviders'
+
+const mockState = vi.hoisted(() => ({
+  settings: {},
+  branding: {},
+}))
+
+vi.mock('@core/hooks/useSettings', () => ({
+  useSettings: () => ({ settings: mockState.settings, updateSettings: () => {} }),
+}))
+
+vi.mock('@/contexts/BrandingContext', () => ({
+  useBranding: () => ({ branding: mockState.branding, loading: false }),
+}))
+
+import ThemeLogoWidget from './ThemeLogoWidget'
+
+/**
+ * The widget mirrors the navbar ThemeDropdown visuals: branding logo first,
+ * then the ProxCenter logo for the default theme, then the theme's colored
+ * badge. It must stay logo-only: no label, no app or theme name.
+ */
+
+// This project does not enable Vitest globals, so RTL's auto-cleanup is off.
+afterEach(cleanup)
+
+const render = ({ settings = {}, branding = {} } = {}) => {
+  mockState.settings = settings
+  mockState.branding = branding
+
+  return renderWithProviders(<ThemeLogoWidget />)
+}
+
+describe('ThemeLogoWidget', () => {
+  it('shows the ProxCenter logo for the default theme', () => {
+    const { container } = render({ settings: { mode: 'light', primaryColor: '#E57000' } })
+
+    expect(container.querySelector('svg')).toBeTruthy()
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('falls back to the default theme when the primary color is unknown', () => {
+    const { container } = render({ settings: { primaryColor: '#123456' } })
+
+    expect(container.querySelector('svg')).toBeTruthy()
+  })
+
+  it('shows the colored badge with the theme icon for a named theme', () => {
+    const { container } = render({ settings: { mode: 'dark', primaryColor: '#2092EC' } })
+
+    expect(container.querySelector('i.ri-cloud-fill')).toBeTruthy()
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('prefers the custom branding logo over everything else', () => {
+    const { container } = render({
+      settings: { primaryColor: '#E57000' },
+      branding: { logoUrl: '/api/v1/branding/assets/logo.png', appName: 'ACME Cloud' },
+    })
+
+    const img = container.querySelector('img')
+
+    expect(img).toBeTruthy()
+    expect(img.getAttribute('src')).toBe('/api/v1/branding/assets/logo.png')
+    expect(img.getAttribute('alt')).toBe('ACME Cloud')
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('renders the logo alone, without any text', () => {
+    const { container } = render({ settings: { primaryColor: '#2092EC' } })
+
+    expect(container.textContent).toBe('')
+  })
+})

--- a/frontend/src/components/layout/shared/ThemeDropdown.jsx
+++ b/frontend/src/components/layout/shared/ThemeDropdown.jsx
@@ -22,8 +22,8 @@ import primaryColorConfig from '@configs/primaryColorConfig'
 import { useSettings } from '@core/hooks/useSettings'
 import { useBranding } from '@/contexts/BrandingContext'
 
-// Noms des thèmes pour l'affichage
-const themeNames = {
+// Noms des thèmes pour l'affichage (réutilisé par le widget Logo du thème)
+export const themeNames = {
   'primary-1': { name: 'PROXCENTER', icon: 'proxmox-logo' },
   'primary-2': { name: 'Ocean', icon: 'ri-water-flash-fill' },
   'primary-3': { name: 'Cherry', icon: 'ri-heart-fill' },

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -446,7 +446,8 @@
       "backup": "Backups",
       "storage": "Storage",
       "monitoring": "Überwachung",
-      "automation": "Automatisierung"
+      "automation": "Automatisierung",
+      "other": "Sonstiges"
     },
     "widgetNames": {
       "kpiClusters": "Cluster / Nodes",
@@ -475,7 +476,8 @@
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "Guest-Heatmap",
       "drsStatus": "DRS-Status",
-      "siteRecovery": "Site Recovery"
+      "siteRecovery": "Site Recovery",
+      "themeLogo": "Theme-Logo"
     },
     "widgetDescs": {
       "kpiClusters": "Anzahl der Cluster und Nodes",
@@ -509,7 +511,8 @@
       "nodesGauges": "Kreisdiagramme pro Node (CPU, RAM, Disk)",
       "clustersGauges": "Diagramme pro Cluster mit Sparklines und Score",
       "clusterHealth": "Gesundheitsbewertung mit wichtigen Metriken",
-      "sectionHeader": "Einklappbarer Abschnittsseparator"
+      "sectionHeader": "Einklappbarer Abschnittsseparator",
+      "themeLogo": "Zeigt das Logo des aktuellen Themes"
     },
     "widgetDrs": {
       "automatic": "Automatisch",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -458,7 +458,8 @@
       "backup": "Backups",
       "storage": "Storage",
       "monitoring": "Monitoring",
-      "automation": "Automation"
+      "automation": "Automation",
+      "other": "Other"
     },
     "widgetNames": {
       "kpiClusters": "Clusters / Nodes",
@@ -490,7 +491,8 @@
       "backupCalendar": "Backup Calendar",
       "nodesGauges": "Nodes Gauges",
       "clustersGauges": "Clusters Gauges",
-      "clusterHealth": "Cluster Health"
+      "clusterHealth": "Cluster Health",
+      "themeLogo": "Theme Logo"
     },
     "widgetDescs": {
       "kpiClusters": "Shows number of clusters and nodes",
@@ -522,7 +524,8 @@
       "nodesGauges": "Per-node circular gauges (CPU, RAM, Disk)",
       "clustersGauges": "Per-cluster gauges, sparklines and health score",
       "clusterHealth": "Health score with key metrics",
-      "sectionHeader": "Collapsible section separator"
+      "sectionHeader": "Collapsible section separator",
+      "themeLogo": "Shows the current theme logo"
     },
     "widgetDrs": {
       "automatic": "Automatic",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -458,7 +458,8 @@
       "backup": "Backups",
       "storage": "Almacenamiento",
       "monitoring": "Monitorización",
-      "automation": "Automatización"
+      "automation": "Automatización",
+      "other": "Otros"
     },
     "widgetNames": {
       "kpiClusters": "Clusters / Nodos",
@@ -490,7 +491,8 @@
       "backupCalendar": "Calendario de backups",
       "nodesGauges": "Indicadores de nodos",
       "clustersGauges": "Indicadores de clusters",
-      "clusterHealth": "Salud del cluster"
+      "clusterHealth": "Salud del cluster",
+      "themeLogo": "Logo del tema"
     },
     "widgetDescs": {
       "kpiClusters": "Shows number de clusters y nodos",
@@ -522,7 +524,8 @@
       "nodesGauges": "por-nodo circular gauges (RAM, RAM, Disco)",
       "clustersGauges": "por-cluster gauges, sparklines y salud puntuación",
       "clusterHealth": "Salud puntuación con clave metrics",
-      "sectionHeader": "Separador de sección contraíble"
+      "sectionHeader": "Separador de sección contraíble",
+      "themeLogo": "Muestra el logo del tema actual"
     },
     "widgetDrs": {
       "automatic": "Automático",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -458,7 +458,8 @@
       "backup": "Sauvegardes",
       "storage": "Stockage",
       "monitoring": "Monitoring",
-      "automation": "Automation"
+      "automation": "Automation",
+      "other": "Autres"
     },
     "widgetNames": {
       "kpiClusters": "Clusters / Nodes",
@@ -490,7 +491,8 @@
       "backupCalendar": "Calendrier Backups",
       "nodesGauges": "Jauges Nodes",
       "clustersGauges": "Jauges Clusters",
-      "clusterHealth": "Santé Cluster"
+      "clusterHealth": "Santé Cluster",
+      "themeLogo": "Logo du thème"
     },
     "widgetDescs": {
       "kpiClusters": "Affiche le nombre de clusters et nodes",
@@ -522,7 +524,8 @@
       "nodesGauges": "Jauges circulaires par nœud (CPU, RAM, Disk)",
       "clustersGauges": "Jauges par cluster avec sparklines et score",
       "clusterHealth": "Score de santé avec métriques clés",
-      "sectionHeader": "Séparateur de section pliable"
+      "sectionHeader": "Séparateur de section pliable",
+      "themeLogo": "Affiche le logo du thème actuel"
     },
     "widgetDrs": {
       "automatic": "Automatique",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -458,7 +458,8 @@
       "backup": "백업",
       "storage": "스토리지",
       "monitoring": "모니터링",
-      "automation": "자동화"
+      "automation": "자동화",
+      "other": "기타"
     },
     "widgetNames": {
       "kpiClusters": "클러스터 / 노드",
@@ -490,7 +491,8 @@
       "backupCalendar": "백업 캘린더",
       "nodesGauges": "노드 게이지",
       "clustersGauges": "클러스터 게이지",
-      "clusterHealth": "클러스터 상태 점수"
+      "clusterHealth": "클러스터 상태 점수",
+      "themeLogo": "테마 로고"
     },
     "widgetDescs": {
       "kpiClusters": "클러스터 및 노드 수 표시",
@@ -522,7 +524,8 @@
       "nodesGauges": "노드별 원형 게이지 (CPU, RAM, 디스크)",
       "clustersGauges": "클러스터별 게이지, 스파크라인 및 상태 점수",
       "clusterHealth": "핵심 지표가 포함된 상태 점수",
-      "sectionHeader": "접을 수 있는 섹션 구분선"
+      "sectionHeader": "접을 수 있는 섹션 구분선",
+      "themeLogo": "현재 테마의 로고를 표시합니다"
     },
     "widgetDrs": {
       "automatic": "자동",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -446,7 +446,8 @@
       "backup": "备份",
       "storage": "存储",
       "monitoring": "监控",
-      "automation": "自动化"
+      "automation": "自动化",
+      "other": "其他"
     },
     "widgetNames": {
       "kpiClusters": "集群 / 节点",
@@ -475,7 +476,8 @@
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "客户机热力图",
       "drsStatus": "DRS 状态",
-      "siteRecovery": "站点恢复"
+      "siteRecovery": "站点恢复",
+      "themeLogo": "主题标志"
     },
     "widgetDescs": {
       "kpiClusters": "显示集群和节点数量",
@@ -509,7 +511,8 @@
       "nodesGauges": "每节点环形图 (CPU, RAM, 磁盘)",
       "clustersGauges": "每集群图表、趋势线和健康评分",
       "clusterHealth": "关键指标健康评分",
-      "sectionHeader": "可折叠分区分隔符"
+      "sectionHeader": "可折叠分区分隔符",
+      "themeLogo": "显示当前主题的标志"
     },
     "widgetDrs": {
       "automatic": "自动",


### PR DESCRIPTION
## What

The dashboard grid now supports free widget placement: a released widget stays exactly where it was dropped instead of being pulled up against the widget above it. The widget library also gains an "Other" category with a new Theme Logo widget that displays the logo of the active theme.

## How

- react-grid-layout v2 configures compaction through a `compactor` object and silently ignores the v1 `compactType`/`preventCollision` props, so the previous vertical compaction only worked because it matched the library default. The grid now passes `getCompactor(null, false, true)`: no compaction, no overlap, and dropping onto an occupied cell is refused.
- Collapsed sections and RBAC scope filtering relied on vertical compaction to close the rows of hidden widgets in view mode. A display-only shift (`layoutReclaim.js`) now reclaims only the rows that no visible widget occupies, so deliberate gaps in a free arrangement are preserved and nothing is ever written back to the saved layout.
- New `theme-logo` widget under the new "Other" category: it shows the custom branding logo when one is configured, the ProxCenter logo for the default theme, or the theme's colored badge, mirroring the navbar theme dropdown. Logo only, no text.
- `themeNames` is now exported from the navbar ThemeDropdown so the widget reuses the same catalog, and the picker category plus widget name/description are translated in the six locales.

Existing saved layouts are unaffected: they are already compacted, so nothing moves for current users.

## Tests

- `layoutReclaim.test.js`: 11 unit tests on the interval merge and row reclaim logic.
- `ThemeLogoWidget.test.jsx`: render tests for the three logo sources, the unknown-color fallback and the logo-only guarantee.
- `widgetRegistry.test.tsx`: the new entry is registered under "Other" and visible to any scope.
- 71 tests green across the dashboard component suite.
