### PR TITLE
feat(tenant): extend optional VMID ranges to vDC tenants (#752)

### DIFF
--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -508,8 +508,8 @@ model Tenant {
   // 'default' (provider) tenant. Enforced by CHECK constraints in the
   // msp_alpha1_schema migration.
   operatingModel String? @map("operating_model")
-  // Optional VMID range for MSP tenants: new guests created through
-  // ProxCenter take a VMID inside [start, end]; existing guests are
+  // Optional VMID range for MSP and vDC (iaas) tenants: new guests created
+  // through ProxCenter take a VMID inside [start, end]; existing guests are
   // left alone. Both set or both NULL (validated in the routes).
   vmidRangeStart Int? @map("vmid_range_start")
   vmidRangeEnd   Int? @map("vmid_range_end")

--- a/frontend/src/app/api/v1/connections/[id]/cluster/nextid/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/cluster/nextid/route.ts
@@ -39,10 +39,10 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> |
     const url = new URL(req.url)
     const vmidParam = url.searchParams.get("vmid")
 
-    // MSP tenant with a VMID range: ProxCenter computes the next free VMID
-    // inside the range across ALL of the tenant's connections. PVE's own
-    // /cluster/nextid can't do this (per-cluster, and its default upper
-    // bound never reaches high ranges like 189334001).
+    // Tenant with a VMID range (msp or vdc/iaas): ProxCenter computes the
+    // next free VMID inside the range across ALL of the tenant's clusters.
+    // PVE's own /cluster/nextid can't do this (per-cluster, and its default
+    // upper bound never reaches high ranges like 189334001).
     const tenantId = await getCurrentTenantId()
     const range = await resolveTenantVmidRange(tenantId)
 

--- a/frontend/src/app/api/v1/tenants/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/tenants/[id]/route.test.ts
@@ -76,12 +76,27 @@ describe('PUT /api/v1/tenants/[id] vmidRange', () => {
     )
   })
 
-  it('rejects a range on a non-MSP tenant with 400', async () => {
+  it('accepts a range on an iaas (vDC) tenant', async () => {
     tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas' })
     const { PUT } = await import('./route')
     const res = await callRoute(PUT, {
       method: 'PUT',
       params: { id: 't1' },
+      body: { vmidRangeStart: 100, vmidRangeEnd: 200 },
+    })
+    expect(res.status).toBe(200)
+    expect(updateTenantMock).toHaveBeenCalledWith(
+      't1',
+      expect.objectContaining({ vmidRangeStart: 100, vmidRangeEnd: 200 }),
+    )
+  })
+
+  it('rejects a range on the provider tenant with 400', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: null })
+    const { PUT } = await import('./route')
+    const res = await callRoute(PUT, {
+      method: 'PUT',
+      params: { id: 'default' },
       body: { vmidRangeStart: 100, vmidRangeEnd: 200 },
     })
     expect(res.status).toBe(400)

--- a/frontend/src/app/api/v1/tenants/[id]/route.ts
+++ b/frontend/src/app/api/v1/tenants/[id]/route.ts
@@ -69,8 +69,8 @@ export async function PUT(req: NextRequest, ctx: Ctx) {
   if (rangeParse.range) {
     const existing = await prisma.tenant.findUnique({ where: { id }, select: { operatingModel: true } })
     if (!existing) return NextResponse.json({ error: "Tenant not found" }, { status: 404 })
-    if (existing.operatingModel !== 'msp') {
-      return NextResponse.json({ error: "A VMID range is only available for MSP tenants" }, { status: 400 })
+    if (existing.operatingModel !== 'msp' && existing.operatingModel !== 'iaas') {
+      return NextResponse.json({ error: "A VMID range is not available on the provider tenant" }, { status: 400 })
     }
     const conflict = await findVmidRangeConflict(rangeParse.range.start, rangeParse.range.end, id)
     if (conflict) {

--- a/frontend/src/app/api/v1/tenants/route.test.ts
+++ b/frontend/src/app/api/v1/tenants/route.test.ts
@@ -63,11 +63,11 @@ describe('POST /api/v1/tenants vmidRange', () => {
     expect(res.status).toBe(201)
     expect(createTenantMock).toHaveBeenCalledWith(expect.objectContaining({ vmidRangeStart: 189334001, vmidRangeEnd: 189334999 }))
   })
-  it('rejects a range on a non-MSP tenant with 400', async () => {
+  it('forwards a valid iaas (vDC) range to createTenant', async () => {
     const { POST } = await import('./route')
     const res = await callRoute(POST, { body: { slug: 'acme', name: 'Acme', operatingModel: 'iaas', vmidRangeStart: 100, vmidRangeEnd: 200 } })
-    expect(res.status).toBe(400)
-    expect(createTenantMock).not.toHaveBeenCalled()
+    expect(res.status).toBe(201)
+    expect(createTenantMock).toHaveBeenCalledWith(expect.objectContaining({ operatingModel: 'iaas', vmidRangeStart: 100, vmidRangeEnd: 200 }))
   })
   it.each([
     [{ vmidRangeStart: 300, vmidRangeEnd: 200 }],

--- a/frontend/src/app/api/v1/tenants/route.ts
+++ b/frontend/src/app/api/v1/tenants/route.ts
@@ -43,17 +43,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "operatingModel must be 'iaas' or 'msp'" }, { status: 400 })
   }
 
-  // Optional MSP VMID range (both bounds or none; MSP only; no overlap
-  // with another tenant's range).
+  // Optional VMID range (both bounds or none; msp and iaas tenants alike;
+  // no overlap with another tenant's range).
   const rangeParse = parseVmidRangeInput(body)
   if (!rangeParse.ok) {
     return NextResponse.json({ error: rangeParse.error }, { status: 400 })
   }
   const vmidRange = rangeParse.range ?? null
   if (vmidRange) {
-    if (body.operatingModel !== 'msp') {
-      return NextResponse.json({ error: "A VMID range is only available for MSP tenants" }, { status: 400 })
-    }
     const conflict = await findVmidRangeConflict(vmidRange.start, vmidRange.end)
     if (conflict) {
       return NextResponse.json(

--- a/frontend/src/components/settings/TenantsTab.tsx
+++ b/frontend/src/components/settings/TenantsTab.tsx
@@ -217,12 +217,14 @@ export default function TenantsTab() {
     }
   }
 
-  const isMspForm = editingTenant ? editingTenant.operatingModel === 'msp' : form.operatingModel === 'msp'
+  // VMID range: every real tenant (msp or vdc/iaas) supports one; only the
+  // provider tenant (operatingModel null) does not.
+  const supportsVmidRange = editingTenant ? !!editingTenant.operatingModel : true
 
   const vmidRangeError = useMemo(() => {
-    // Not an MSP form: the fields are unmounted, so their (possibly stale)
-    // buffers must never gate the Save button.
-    if (!isMspForm) return null
+    // Fields unmounted (provider tenant): their (possibly stale) buffers
+    // must never gate the Save button.
+    if (!supportsVmidRange) return null
 
     const rawStart = form.vmidRangeStart.trim()
     const rawEnd = form.vmidRangeEnd.trim()
@@ -237,7 +239,7 @@ export default function TenantsTab() {
     if (start > end) return t('tenants.vmidRangeInvalid')
 
     return null
-  }, [isMspForm, form.vmidRangeStart, form.vmidRangeEnd, t])
+  }, [supportsVmidRange, form.vmidRangeStart, form.vmidRangeEnd, t])
 
   const handleSave = async () => {
     setSaving(true)
@@ -259,8 +261,8 @@ export default function TenantsTab() {
         body.operatingModel = form.operatingModel
       }
 
-      // VMID range: MSP only; empty fields clear the range (null)
-      if (isMspForm) {
+      // VMID range: any msp/iaas tenant; empty fields clear the range (null)
+      if (supportsVmidRange) {
         body.vmidRangeStart = form.vmidRangeStart.trim() ? Number.parseInt(form.vmidRangeStart, 10) : null
         body.vmidRangeEnd = form.vmidRangeEnd.trim() ? Number.parseInt(form.vmidRangeEnd, 10) : null
       }
@@ -639,9 +641,9 @@ export default function TenantsTab() {
             </FormControl>
           )}
 
-          {/* VMID range — MSP tenants only. Enforced for new guests created
-              through ProxCenter; existing guests are unaffected. */}
-          {isMspForm && (
+          {/* VMID range: msp and vdc/iaas tenants. Enforced for new guests
+              created through ProxCenter; existing guests are unaffected. */}
+          {supportsVmidRange && (
             <Box>
               <Typography variant="subtitle2" sx={{ mb: 2 }}>{t('tenants.vmidRange')}</Typography>
               <Box sx={{ display: 'flex', gap: 2 }}>

--- a/frontend/src/lib/tenant/vmidRange.test.ts
+++ b/frontend/src/lib/tenant/vmidRange.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { tenantFindUniqueMock, tenantFindFirstMock, connectionFindManyMock, pveFetchMock, getConnectionByIdMock } = vi.hoisted(() => ({
+const { tenantFindUniqueMock, tenantFindFirstMock, vdcFindManyMock, connectionFindManyMock, pveFetchMock, getConnectionByIdMock } = vi.hoisted(() => ({
   tenantFindUniqueMock: vi.fn(),
   tenantFindFirstMock: vi.fn(),
+  vdcFindManyMock: vi.fn(),
   connectionFindManyMock: vi.fn(),
   pveFetchMock: vi.fn(),
   getConnectionByIdMock: vi.fn(),
@@ -11,6 +12,7 @@ const { tenantFindUniqueMock, tenantFindFirstMock, connectionFindManyMock, pveFe
 vi.mock('@/lib/db/prisma', () => ({
   prisma: {
     tenant: { findUnique: tenantFindUniqueMock, findFirst: tenantFindFirstMock },
+    vdc: { findMany: vdcFindManyMock },
     connection: { findMany: connectionFindManyMock },
   },
 }))
@@ -31,6 +33,7 @@ import {
 beforeEach(() => {
   tenantFindUniqueMock.mockReset()
   tenantFindFirstMock.mockReset().mockResolvedValue(null)
+  vdcFindManyMock.mockReset().mockResolvedValue([])
   connectionFindManyMock.mockReset().mockResolvedValue([])
   pveFetchMock.mockReset()
   getConnectionByIdMock.mockReset().mockImplementation(async (id: string) => ({ id, baseUrl: 'x', apiToken: 'y' }))
@@ -71,8 +74,16 @@ describe('resolveTenantVmidRange', () => {
     expect(await resolveTenantVmidRange('default')).toBeNull()
     expect(tenantFindUniqueMock).not.toHaveBeenCalled()
   })
-  it('returns null for iaas tenants even with a stored range', async () => {
+  it('returns the range for iaas tenants with one', async () => {
     tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas', vmidRangeStart: 100, vmidRangeEnd: 200 })
+    expect(await resolveTenantVmidRange('t1')).toEqual({ start: 100, end: 200 })
+  })
+  it('returns null for iaas tenants without a stored range', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas', vmidRangeStart: null, vmidRangeEnd: null })
+    expect(await resolveTenantVmidRange('t1')).toBeNull()
+  })
+  it('returns null for provider tenants even with a stored range', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: null, vmidRangeStart: 100, vmidRangeEnd: 200 })
     expect(await resolveTenantVmidRange('t1')).toBeNull()
   })
   it('returns null for MSP tenants without a range', async () => {
@@ -86,7 +97,8 @@ describe('resolveTenantVmidRange', () => {
 })
 
 describe('getUsedVmidsForTenant', () => {
-  it('unions vmids across connections and reports unreachable ones', async () => {
+  it('uses an MSP tenant\'s own PVE connections and unions their vmids', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'msp' })
     connectionFindManyMock.mockResolvedValue([
       { id: 'c1', name: 'alpha', tenantId: 't1' },
       { id: 'c2', name: 'beta', tenantId: 't1' },
@@ -99,6 +111,67 @@ describe('getUsedVmidsForTenant', () => {
     const { used, unreachable } = await getUsedVmidsForTenant('t1')
     expect(used).toEqual(new Set([100, 101, 189334001]))
     expect(unreachable).toEqual(['gamma'])
+    expect(connectionFindManyMock).toHaveBeenCalledWith({
+      where: { tenantId: 't1', type: 'pve' },
+      select: { id: true, name: true, tenantId: true },
+    })
+    expect(vdcFindManyMock).not.toHaveBeenCalled()
+  })
+
+  it('uses the deduplicated union of an iaas tenant\'s vDC connections', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas' })
+    vdcFindManyMock.mockResolvedValue([
+      { connectionId: 'c1' },
+      { connectionId: 'c2' },
+      { connectionId: 'c1' },
+    ])
+    connectionFindManyMock.mockResolvedValue([
+      { id: 'c1', name: 'alpha', tenantId: 'provider' },
+      { id: 'c2', name: 'beta', tenantId: 'provider' },
+    ])
+    pveFetchMock
+      .mockResolvedValueOnce([{ vmid: 100 }, { vmid: '101' }])
+      .mockResolvedValueOnce([{ vmid: 189334001 }])
+
+    const { used, unreachable } = await getUsedVmidsForTenant('t1')
+
+    expect(used).toEqual(new Set([100, 101, 189334001]))
+    expect(unreachable).toEqual([])
+    expect(vdcFindManyMock).toHaveBeenCalledWith({
+      where: { tenantId: 't1' },
+      select: { connectionId: true },
+    })
+    expect(connectionFindManyMock).toHaveBeenCalledWith({
+      where: { id: { in: ['c1', 'c2'] }, type: 'pve' },
+      select: { id: true, name: true, tenantId: true },
+    })
+  })
+
+  it('returns no usage for an iaas tenant with no vDCs', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas' })
+    vdcFindManyMock.mockResolvedValue([])
+
+    const result = await getUsedVmidsForTenant('t1')
+
+    expect(result).toEqual({ used: new Set(), unreachable: [] })
+    expect(connectionFindManyMock).not.toHaveBeenCalled()
+  })
+
+  it('reports an unreachable iaas vDC connection by name', async () => {
+    tenantFindUniqueMock.mockResolvedValue({ operatingModel: 'iaas' })
+    vdcFindManyMock.mockResolvedValue([{ connectionId: 'c1' }, { connectionId: 'c2' }])
+    connectionFindManyMock.mockResolvedValue([
+      { id: 'c1', name: 'alpha', tenantId: 'provider' },
+      { id: 'c2', name: 'beta', tenantId: 'provider' },
+    ])
+    pveFetchMock
+      .mockResolvedValueOnce([{ vmid: 100 }])
+      .mockRejectedValueOnce(new Error('unreachable'))
+
+    const { used, unreachable } = await getUsedVmidsForTenant('t1')
+
+    expect(used).toEqual(new Set([100]))
+    expect(unreachable).toEqual(['beta'])
   })
 })
 

--- a/frontend/src/lib/tenant/vmidRange.ts
+++ b/frontend/src/lib/tenant/vmidRange.ts
@@ -1,7 +1,7 @@
 // src/lib/tenant/vmidRange.ts
-// Optional per-tenant VMID range (MSP tenants only). New guests created
-// through ProxCenter must take a VMID inside the range; pre-existing guests
-// are never checked (relaxed enforcement).
+// Optional per-tenant VMID range (MSP and vDC/iaas tenants). New guests
+// created through ProxCenter must take a VMID inside the range; pre-existing
+// guests are never checked (relaxed enforcement).
 
 import { prisma } from "@/lib/db/prisma"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -58,7 +58,7 @@ export async function resolveTenantVmidRange(tenantId: string): Promise<VmidRang
     select: { operatingModel: true, vmidRangeStart: true, vmidRangeEnd: true },
   })
 
-  if (tenant?.operatingModel !== "msp") return null
+  if (tenant?.operatingModel !== "msp" && tenant?.operatingModel !== "iaas") return null
   if (tenant.vmidRangeStart == null || tenant.vmidRangeEnd == null) return null
   return { start: tenant.vmidRangeStart, end: tenant.vmidRangeEnd }
 }
@@ -72,14 +72,42 @@ export interface TenantVmidUsage {
 }
 
 /**
- * VMIDs currently in use across ALL of the tenant's PVE connections
- * (cross-cluster).
+ * PVE connections whose VMID space the tenant allocates from.
+ *  - msp:  the connections the tenant owns outright.
+ *  - iaas: the provider connections referenced by ALL of the tenant's vDCs
+ *          (full union, never the vDC view context; disabled vDCs included:
+ *          scanning more clusters only makes the uniqueness check stricter).
  */
-export async function getUsedVmidsForTenant(tenantId: string): Promise<TenantVmidUsage> {
-  const conns = await prisma.connection.findMany({
+async function getTenantPveConnections(tenantId: string) {
+  const tenant = await prisma.tenant.findUnique({
+    where: { id: tenantId },
+    select: { operatingModel: true },
+  })
+  if (tenant?.operatingModel === "iaas") {
+    const vdcs = await prisma.vdc.findMany({
+      where: { tenantId },
+      select: { connectionId: true },
+    })
+    const connectionIds = [...new Set(vdcs.map((v) => v.connectionId))]
+    if (connectionIds.length === 0) return []
+    return prisma.connection.findMany({
+      where: { id: { in: connectionIds }, type: "pve" },
+      select: { id: true, name: true, tenantId: true },
+    })
+  }
+  return prisma.connection.findMany({
     where: { tenantId, type: "pve" },
     select: { id: true, name: true, tenantId: true },
   })
+}
+
+/**
+ * VMIDs currently in use across ALL of the tenant's PVE clusters. On a shared
+ * iaas cluster this includes every guest on the cluster, other tenants and
+ * provider included: VMIDs are cluster-global in PVE.
+ */
+export async function getUsedVmidsForTenant(tenantId: string): Promise<TenantVmidUsage> {
+  const conns = await getTenantPveConnections(tenantId)
 
   const used = new Set<number>()
   const unreachable: string[] = []


### PR DESCRIPTION
Closes #752

## What

Optional per-tenant VMID ranges, shipped for MSP tenants in #655, now also apply to vDC (iaas) tenants. A vDC tenant with a configured range gets range-aware VMID suggestions in the VM/CT creation and clone dialogs, and the server enforces the range plus cross-cluster uniqueness on guest create, clone and template deploy.

## How

The restriction was purely application-side (the `tenants.vmid_range_start/end` columns exist since #655, so there is no migration):

- `resolveTenantVmidRange` now honors both the `msp` and `iaas` operating models.
- `getUsedVmidsForTenant` resolves an iaas tenant's PVE connections through its vDCs (full deduplicated union, disabled vDCs included) instead of connection ownership. On a shared cluster the scan reads `/cluster/resources?type=vm`, which returns every guest on the cluster, so uniqueness and next-free suggestions stay correct across tenants sharing that cluster. MSP behavior is unchanged.
- The tenant create/update routes accept ranges for both models; the provider tenant is still rejected with 400. The cross-tenant range overlap check was already global and needed no change.
- Tenant settings shows the range fields for every real tenant (they stay hidden for the provider tenant). The creation dialogs, the range-aware nextid route and the create/clone/deploy enforcement were already model-agnostic.

Known limit, consistent with the relaxed enforcement model of #655: the provider itself has no range and may create a guest inside a tenant's range on a shared cluster; the tenant's next-free suggestion simply skips those VMIDs.

## Testing

- 101 tests green across the 8 touched and adjacent suites (vmidRange, updateTenant, tenant routes, nextid, guest create, clone, template deploy), including new coverage for the iaas resolution and the vDC-based usage scan (deduplication, no-vDC tenant, unreachable connection fail-closed).
- Manually verified on a live setup: range fields on a vDC tenant, in-range suggestion in the dialogs, out-of-range and already-in-use rejections on a shared cluster, provider tenant unaffected.
