### PR TITLE
fix(security): force deepmerge-ts >= 8.0.2 to clear CVE-2026-40345

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -102,6 +102,9 @@
         "tailwindcss-logical": "4.2.0",
         "tsx": "4.23.12",
         "vitest": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -8390,12 +8393,22 @@
       "license": "MIT"
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/define-data-property": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -131,7 +131,8 @@
     "@hono/node-server": ">=1.19.13",
     "defu": ">=6.1.5",
     "fast-uri": "^3.1.4",
-    "shell-quote": ">=1.10.0"
+    "shell-quote": ">=1.10.0",
+    "deepmerge-ts": ">=8.0.2"
   },
   "overrides": {
     "rimraf": "5.0.7",
@@ -150,6 +151,7 @@
     "postcss": "$postcss",
     "js-cookie": "^3.0.7",
     "shell-quote": ">=1.10.0",
+    "deepmerge-ts": ">=8.0.2",
     "tmp": "^0.2.6",
     "uuid": "^11.1.1"
   }


### PR DESCRIPTION
## What

Adds a `resolutions`/`overrides` floor forcing `deepmerge-ts` to `>= 8.0.2` in the frontend, following the pattern already used for the other security floors. The lockfile diff also picks up the root `engines` field that previous lockfile-only updates never resynchronized.

## Why

Dependabot alert #252 and code scanning alerts #891/#892 flag deepmerge-ts 7.1.5 for CVE-2026-40345 / GHSA-ggr8-5vv4-36mx (stack exhaustion when merging recursive object graphs, HIGH). The package is pinned to the exact version 7.1.5 by `@prisma/config` 7.9.1 and no newer Prisma release is available, so an override is the only way to pick up the fix. `@prisma/config` only uses the plain `deepmerge` export, which is unaffected by the v8 breaking changes (Map merging defaults, type renames, `deepmergeInto` semantics).

## Verification

- `npm ci`, `prisma generate` and `next build` are green on this branch.
- Full test suite green: 582 files / 6290 tests.
- A Trivy filesystem scan of the updated lockfile reports no findings besides the already dismissed sharp advisory.
- The remaining alerts close automatically on the next scheduled image scan after merge.
