### PR TITLE
fix(site-recovery): replicate powered-off VMs and surface the no-match job state

### DIFF
--- a/frontend/src/app/api/v1/connections/[id]/ceph-vms/route.test.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph-vms/route.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn<(...args: any[]) => Promise<Response | null | undefined>>(),
+  PERMISSIONS: { CONNECTION_VIEW: 'connection.view' },
+}))
+
+vi.mock('@/lib/connections/getConnection', () => ({
+  getConnectionById: vi.fn<(id: string) => Promise<any>>(),
+}))
+
+vi.mock('@/lib/proxmox/client', () => ({
+  pveFetch: vi.fn<(...args: any[]) => Promise<any>>(),
+}))
+
+import { checkPermission } from '@/lib/rbac'
+import { getConnectionById } from '@/lib/connections/getConnection'
+import { pveFetch } from '@/lib/proxmox/client'
+
+const { GET } = await import('./route')
+
+const checkPermissionMock = vi.mocked(checkPermission)
+const getConnectionByIdMock = vi.mocked(getConnectionById)
+const pveFetchMock = vi.mocked(pveFetch)
+
+describe('GET /api/v1/connections/:id/ceph-vms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkPermissionMock.mockResolvedValue(null)
+    getConnectionByIdMock.mockResolvedValue({ id: 'conn-1' })
+    pveFetchMock.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/storage') {
+        return [{ type: 'rbd', storage: 'cephpool' }]
+      }
+      if (path === '/cluster/resources') {
+        return [
+          { type: 'qemu', vmid: 100, node: 'pve1', status: 'running' },
+          { type: 'qemu', vmid: 101, node: 'pve1', status: 'stopped' },
+          { type: 'lxc', vmid: 102, node: 'pve1', status: 'running' },
+          { type: 'qemu', vmid: 103, node: 'pve1', status: 'stopped', template: 1 },
+        ]
+      }
+      if (path === '/nodes/pve1/qemu/100/config') {
+        return { scsi0: 'cephpool:vm-100-disk-0,size=32G' }
+      }
+      if (path === '/nodes/pve1/qemu/101/config') {
+        return { scsi0: 'cephpool:vm-101-disk-0,size=32G' }
+      }
+      throw new Error(`Unexpected PVE path: ${path}`)
+    })
+  })
+
+  it('returns running and stopped QEMU guests with Ceph disks, but excludes LXC guests and templates', async () => {
+    const response = await callRoute(GET as any, {
+      method: 'GET',
+      params: { id: 'conn-1' },
+    })
+    const body = await readJson<{ data: Array<{ vmid: number; cephDiskGb: number }> }>(response)
+
+    expect(response.status).toBe(200)
+    expect(body?.data).toEqual([
+      { vmid: 100, cephDiskGb: 32 },
+      { vmid: 101, cephDiskGb: 32 },
+    ])
+    expect(body?.data.some(vm => vm.vmid === 102)).toBe(false)
+    expect(pveFetchMock).toHaveBeenCalledWith({ id: 'conn-1' }, '/nodes/pve1/qemu/100/config')
+    expect(pveFetchMock).toHaveBeenCalledWith({ id: 'conn-1' }, '/nodes/pve1/qemu/101/config')
+    expect(pveFetchMock).not.toHaveBeenCalledWith({ id: 'conn-1' }, '/nodes/pve1/qemu/102/config')
+    expect(pveFetchMock).not.toHaveBeenCalledWith({ id: 'conn-1' }, '/nodes/pve1/qemu/103/config')
+  })
+})

--- a/frontend/src/app/api/v1/connections/[id]/ceph-vms/route.ts
+++ b/frontend/src/app/api/v1/connections/[id]/ceph-vms/route.ts
@@ -34,10 +34,12 @@ export async function GET(
       return NextResponse.json({ data: [] })
     }
 
-    // 2. Get all QEMU VMs from cluster resources
+    // 2. Get all QEMU VMs from cluster resources. Power state is irrelevant:
+    // replication is RBD-level and a stopped guest replicates fine (#687).
+    // Templates stay excluded: a replica of one could not start at failover.
     const resources = await pveFetch<any[]>(conn, "/cluster/resources")
     const qemuVMs = (resources || []).filter(
-      (r: any) => r.type === "qemu" && r.status === "running"
+      (r: any) => r.type === "qemu" && r.template !== 1
     )
 
     // 3. Fetch configs in parallel to check disk storage

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.test.tsx
@@ -14,6 +14,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import { SWRConfig } from 'swr'
+import type { ComponentProps } from 'react'
 
 import { renderWithProviders, screen, userEvent, fireEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
 
@@ -28,6 +29,35 @@ function renderDialog() {
   renderWithProviders(
     <CreateJobDialog open onClose={vi.fn()} onSubmit={vi.fn()} connections={[]} allVMs={[]} />,
   )
+}
+
+function renderDialogWithVMs(allVMs: ComponentProps<typeof CreateJobDialog>['allVMs']) {
+  vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+    if (url === '/api/v1/connections/src/ceph-vms') {
+      return new Response(JSON.stringify({
+        data: allVMs.map(vm => ({ vmid: vm.vmid, cephDiskGb: vm.diskGb })),
+      }), { status: 200 })
+    }
+
+    return new Response('{}', { status: 200 })
+  }))
+
+  renderWithProviders(
+    <SWRConfig value={{ revalidateOnMount: true }}>
+      <CreateJobDialog
+        open
+        onClose={vi.fn()}
+        onSubmit={vi.fn()}
+        connections={[{ id: 'src', name: 'Source', hasCeph: true }]}
+        allVMs={allVMs}
+      />
+    </SWRConfig>,
+  )
+}
+
+async function selectSourceCluster() {
+  fireEvent.mouseDown(screen.getAllByRole('combobox')[0])
+  await userEvent.click(await screen.findByRole('option', { name: 'Source' }))
 }
 
 // No bandwidth window and no cluster selected, so the numeric inputs are, in
@@ -145,5 +175,33 @@ describe('CreateJobDialog snapshot retention (issue #664)', () => {
       snapshot_keep_source: 3,
       snapshot_keep_target: 3,
     }))
+  })
+})
+
+describe('CreateJobDialog stopped VM replication (issue #687)', () => {
+  it('lists and allows selecting a stopped qemu VM on Ceph storage', async () => {
+    renderDialogWithVMs([
+      { vmid: 200, name: 'stopped-db', node: 'node1', connId: 'src', type: 'qemu', status: 'stopped', tags: [], diskGb: 20 },
+    ])
+
+    await selectSourceCluster()
+
+    const stoppedVM = await screen.findByRole('checkbox', { name: /stopped-db.*200/ })
+    expect(stoppedVM).not.toBeChecked()
+
+    await userEvent.click(stoppedVM)
+
+    expect(stoppedVM).toBeChecked()
+  })
+
+  it('offers tags belonging to a stopped VM in tag selection mode', async () => {
+    renderDialogWithVMs([
+      { vmid: 201, name: 'stopped-app', node: 'node1', connId: 'src', type: 'qemu', status: 'stopped', tags: ['disaster-recovery'], diskGb: 15 },
+    ])
+
+    await selectSourceCluster()
+    await userEvent.click(screen.getByRole('button', { name: 'Tags' }))
+
+    expect(await screen.findByRole('checkbox', { name: /disaster-recovery/ })).toBeInTheDocument()
   })
 })

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
@@ -146,11 +146,11 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
     cephConnections.filter(c => c.id !== sourceCluster)
   , [cephConnections, sourceCluster])
 
-  // VMs filtered by source cluster (only running qemu VMs on Ceph storage)
+  // VMs filtered by source cluster (qemu VMs on Ceph storage, any power
+  // state: replication is RBD-level and handles stopped guests, #687)
   const sourceVMs = useMemo(() =>
     allVMs.filter(vm =>
       vm.connId === sourceCluster &&
-      vm.status === 'running' &&
       vm.type === 'qemu' &&
       cephVMMap.has(vm.vmid)
     )

--- a/frontend/src/components/automation/site-recovery/DashboardTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import type { ReplicationHealthStatus } from '@/lib/orchestrator/site-recovery.types'
+
+import DashboardTab from './DashboardTab'
+
+afterEach(cleanup)
+
+function health(overrides: Partial<ReplicationHealthStatus> = {}): ReplicationHealthStatus {
+  return {
+    sites: [{
+      cluster_id: 'source-cluster',
+      name: 'Source cluster',
+      role: 'primary',
+      status: 'online',
+      node_count: 1,
+      vm_count: 3,
+    }],
+    connectivity: 'connected',
+    latency_ms: 2,
+    kpis: {
+      protected_vms: 3,
+      unprotected_vms: 0,
+      avg_rpo_seconds: 60,
+      last_sync: '',
+      replicated_bytes: 0,
+      error_count: 0,
+      total_jobs: 3,
+      rpo_compliance: 100,
+      concurrent_jobs: 0,
+      max_concurrent_jobs: 2,
+    },
+    recent_activity: [],
+    job_summary: {
+      synced: 1,
+      syncing: 0,
+      pending: 0,
+      error: 0,
+      paused: 0,
+      no_match: 0,
+    },
+    ...overrides,
+  }
+}
+
+function renderDashboard(value: ReplicationHealthStatus | undefined) {
+  renderWithProviders(
+    <DashboardTab
+      health={value}
+      loading={false}
+      jobs={[]}
+      connections={[]}
+      vmNamesByConn={{}}
+      onSyncJob={vi.fn()}
+    />,
+  )
+}
+
+describe('DashboardTab job status distribution', () => {
+  it('renders the no-match segment and count', () => {
+    renderDashboard(health({
+      job_summary: {
+        synced: 1,
+        syncing: 0,
+        pending: 0,
+        error: 0,
+        paused: 0,
+        no_match: 2,
+      },
+    }))
+
+    const label = screen.getByText(/No matching VMs/)
+    expect(label).toHaveTextContent('No matching VMs: 2')
+  })
+
+  it('treats a missing no_match count as zero', () => {
+    renderDashboard(health({
+      job_summary: {
+        synced: 1,
+        syncing: 0,
+        pending: 0,
+        error: 0,
+        paused: 0,
+      } as any,
+    }))
+
+    expect(screen.getByText(/Synced/)).toHaveTextContent('Synced: 1')
+    expect(screen.queryByText(/No matching VMs/)).not.toBeInTheDocument()
+  })
+
+  it('renders the empty state when health is unavailable', () => {
+    renderDashboard(undefined)
+
+    expect(screen.getByText('No replication job configured')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/site-recovery/DashboardTab.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.tsx
@@ -150,14 +150,16 @@ const RPOGauge = ({ compliance, t }: { compliance: number; t: any }) => {
 
 const JobStatusDistribution = ({ summary, t }: { summary: JobStatusSummary; t: any }) => {
   const theme = useTheme()
-  const total = summary.synced + summary.syncing + summary.pending + summary.error + summary.paused
+  const noMatch = summary.no_match || 0
+  const total = summary.synced + summary.syncing + summary.pending + summary.error + summary.paused + noMatch
 
   const segments = [
     { key: 'synced', count: summary.synced, color: theme.palette.success.main, label: t('siteRecovery.status.synced') },
     { key: 'syncing', count: summary.syncing, color: theme.palette.primary.main, label: t('siteRecovery.status.syncing') },
     { key: 'pending', count: summary.pending, color: theme.palette.warning.main, label: t('siteRecovery.status.pending') },
     { key: 'error', count: summary.error, color: theme.palette.error.main, label: t('siteRecovery.status.error') },
-    { key: 'paused', count: summary.paused, color: theme.palette.text.disabled, label: t('siteRecovery.status.paused') }
+    { key: 'paused', count: summary.paused, color: theme.palette.text.disabled, label: t('siteRecovery.status.paused') },
+    { key: 'no_match', count: noMatch, color: theme.palette.warning.dark, label: t('siteRecovery.status.noMatch') }
   ].filter(s => s.count > 0)
 
   if (total === 0) return null
@@ -919,7 +921,7 @@ export default function DashboardTab({ health, loading, jobs, connections, vmNam
   }, [health])
 
   const jobSummary = useMemo(() => health?.job_summary || {
-    synced: 0, syncing: 0, pending: 0, error: 0, paused: 0
+    synced: 0, syncing: 0, pending: 0, error: 0, paused: 0, no_match: 0
   }, [health])
 
   if (loading) {

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Component tests for EmergencyDRTab's job status chip (issue #687): a job
+ * whose tags currently match no VMs carries the new "no_match" status, which
+ * must render as a translated warning chip, not as the raw enum value.
+ */
+
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import type { ReplicationJob } from '@/lib/orchestrator/site-recovery.types'
+
+import EmergencyDRTab from './EmergencyDRTab'
+
+afterEach(cleanup)
+
+function job(overrides: Partial<ReplicationJob> = {}): ReplicationJob {
+  return {
+    id: 'job-1',
+    name: '',
+    vm_ids: [100],
+    vm_names: ['web-01'],
+    tags: [],
+    source_cluster: 'src',
+    target_cluster: 'dst',
+    target_pool: 'rbd',
+    vmid_prefix: 0,
+    status: 'pending',
+    schedule: '*/15 * * * *',
+    schedule_spec: null,
+    timezone: '',
+    rpo_target: 900,
+    last_sync: null,
+    next_sync: null,
+    retry_count: 0,
+    next_retry_at: null,
+    throughput_bps: 0,
+    rate_limit_mbps: 0,
+    bandwidth_windows: [],
+    network_mapping: {},
+    progress_percent: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function renderTab(jobs: ReplicationJob[]) {
+  renderWithProviders(
+    <EmergencyDRTab
+      jobs={jobs}
+      plans={[]}
+      loading={false}
+      connections={[]}
+      vmNamesByConn={{}}
+      onStartVM={vi.fn()}
+      onExecuteFailover={vi.fn()}
+      onExecuteFailback={vi.fn()}
+    />,
+  )
+}
+
+describe('EmergencyDRTab: job status chip', () => {
+  it('renders a translated warning chip for a no_match job instead of the raw value', () => {
+    renderTab([job({ status: 'no_match' })])
+
+    const chipLabel = screen.getByText('No matching VMs')
+    const chip = chipLabel.closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorWarning')
+    expect(screen.queryByText('no_match')).not.toBeInTheDocument()
+  })
+
+  it('keeps the existing raw labels for the other statuses', () => {
+    renderTab([job({ status: 'synced' })])
+
+    const chip = screen.getByText('synced').closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorSuccess')
+  })
+})

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
@@ -178,9 +178,10 @@ export default function EmergencyDRTab({
 
   const statusChip = (status: string) => {
     const colorMap: Record<string, 'success' | 'warning' | 'error' | 'default' | 'info'> = {
-      synced: 'success', syncing: 'info', paused: 'warning', error: 'error', pending: 'default',
+      synced: 'success', syncing: 'info', paused: 'warning', error: 'error', pending: 'default', no_match: 'warning',
     }
-    return <Chip size="small" label={status} color={colorMap[status] || 'default'} sx={{ textTransform: 'capitalize' }} />
+    const label = status === 'no_match' ? t('status.noMatch') : status
+    return <Chip size="small" label={label} color={colorMap[status] || 'default'} sx={{ textTransform: 'capitalize' }} />
   }
 
   const formatLastSync = (ls: string | null) => {

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 
-import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import { renderWithProviders, screen, userEvent, fireEvent } from '@/__tests__/setup/renderWithProviders'
 import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
 import type { ReplicationJob } from '@/lib/orchestrator/site-recovery.types'
 
@@ -131,5 +131,32 @@ describe('ProtectionTab — failed-over job lockdown', () => {
 
     expect(await screen.findByRole('button', { name: 'Sync Now' })).not.toBeDisabled()
     expect(screen.getByRole('button', { name: 'Resume' })).not.toBeDisabled()
+  })
+})
+
+describe('ProtectionTab: no matching VMs status (issue #687)', () => {
+  it('shows the "No matching VMs" chip for a no_match job', () => {
+    renderTab([job({ status: 'no_match' })])
+
+    const chipLabel = screen.getByText('No matching VMs')
+    const chip = chipLabel.closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorWarning')
+    expect(chip?.querySelector('.ri-price-tag-3-line')).toBeInTheDocument()
+  })
+
+  it('offers no_match in the status filter and filters the job list to matching jobs', async () => {
+    renderTab([
+      job({ id: 'job-no-match', status: 'no_match', vm_ids: [200], vm_names: ['no-match-vm'] }),
+      job({ id: 'job-pending', status: 'pending', vm_ids: [201], vm_names: ['pending-vm'] }),
+    ])
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    const noMatchOption = await screen.findByRole('option', { name: 'No matching VMs' })
+    expect(noMatchOption).toBeInTheDocument()
+    await userEvent.click(noMatchOption)
+
+    expect(screen.getByText('200 - no-match-vm')).toBeInTheDocument()
+    expect(screen.queryByText('201 - pending-vm')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -73,7 +73,8 @@ const StatusChip = ({ status, t }: { status: ReplicationJobStatus; t: any }) => 
     error: { label: t('siteRecovery.status.error'), color: 'error' },
     paused: { label: t('siteRecovery.status.paused'), color: 'default' },
     pending: { label: t('siteRecovery.status.pending'), color: 'warning' },
-    failed_over: { label: t('siteRecovery.jobs.failedOver'), color: 'warning', icon: 'ri-shield-star-line' }
+    failed_over: { label: t('siteRecovery.jobs.failedOver'), color: 'warning', icon: 'ri-shield-star-line' },
+    no_match: { label: t('siteRecovery.status.noMatch'), color: 'warning', icon: 'ri-price-tag-3-line' }
   }
 
   const c = config[status] || config.paused
@@ -592,6 +593,7 @@ export default function ProtectionTab({
               <MenuItem value='syncing'>{t('siteRecovery.status.syncing')}</MenuItem>
               <MenuItem value='paused'>{t('siteRecovery.status.paused')}</MenuItem>
               <MenuItem value='error'>{t('siteRecovery.status.error')}</MenuItem>
+              <MenuItem value='no_match'>{t('siteRecovery.status.noMatch')}</MenuItem>
             </Select>
             {(q || statusFilter !== 'all') && (
               <Button size='small' onClick={() => { setQ(''); setStatusFilter('all') }} startIcon={<i className='ri-close-line' />}>

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -6,7 +6,7 @@ import type { ScheduleSpec } from '@/components/automation/site-recovery/schedul
 // Replication Jobs
 // ============================================
 
-export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending' | 'failed_over'
+export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending' | 'failed_over' | 'no_match'
 
 export interface BandwidthWindow {
   days: number[]          // 0=Sun, 1=Mon, …, 6=Sat
@@ -265,6 +265,7 @@ export interface JobStatusSummary {
   pending: number
   error: number
   paused: number
+  no_match: number
 }
 
 export interface ReplicationHealthStatus {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4127,7 +4127,8 @@
       "syncing": "Synchronisierung",
       "error": "Fehler",
       "paused": "Pausiert",
-      "pending": "Ausstehend"
+      "pending": "Ausstehend",
+      "noMatch": "Keine passenden VMs"
     },
     "planStatus": {
       "ready": "Bereit",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4150,7 +4150,8 @@
       "syncing": "Syncing",
       "error": "Error",
       "paused": "Paused",
-      "pending": "Pending"
+      "pending": "Pending",
+      "noMatch": "No matching VMs"
     },
     "planStatus": {
       "ready": "Ready",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4150,7 +4150,8 @@
       "syncing": "Sincronizando",
       "error": "Error",
       "paused": "En pausa",
-      "pending": "Pendiente"
+      "pending": "Pendiente",
+      "noMatch": "Sin VMs coincidentes"
     },
     "planStatus": {
       "ready": "Listo",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4150,7 +4150,8 @@
       "syncing": "En cours",
       "error": "Erreur",
       "paused": "En pause",
-      "pending": "En attente"
+      "pending": "En attente",
+      "noMatch": "Aucune VM correspondante"
     },
     "planStatus": {
       "ready": "Prêt",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4150,7 +4150,8 @@
       "syncing": "동기화 중",
       "error": "오류",
       "paused": "일시 중지됨",
-      "pending": "대기 중"
+      "pending": "대기 중",
+      "noMatch": "일치하는 VM 없음"
     },
     "planStatus": {
       "ready": "준비됨",

--- a/frontend/src/messages/siteRecoveryNoMatchMessages.test.ts
+++ b/frontend/src/messages/siteRecoveryNoMatchMessages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+const requiredKeys = ['siteRecovery.status.noMatch']
+
+function get(messages: any, path: string): unknown {
+  return path.split('.').reduce((node, key) => (node ? node[key] : undefined), messages)
+}
+
+describe('Site Recovery no-match i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} declares every Site Recovery no-match key`, () => {
+      for (const key of requiredKeys) {
+        expect(get(messages, key), `${locale}: ${key}`).toBeTypeOf('string')
+      }
+    })
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4126,7 +4126,8 @@
       "syncing": "同步中",
       "error": "错误",
       "paused": "已暂停",
-      "pending": "等待中"
+      "pending": "等待中",
+      "noMatch": "无匹配的虚拟机"
     },
     "planStatus": {
       "ready": "就绪",


### PR DESCRIPTION
## Summary

A powered-off VM could not be selected for Site Recovery replication, and a tag-based job silently dropped guests that were powered off by the next tag re-resolution. The replication engine itself is Ceph RBD level and power-state agnostic: only the selection was filtering on the running state. This PR removes those filters in the UI and pairs with the orchestrator change that does the same in tag resolution, surfaces every change to the protected set in the job log, and reports a tag job that currently matches nothing with the new explicit `no_match` status instead of an error about tags.

## Changes

- The ceph-vms API route no longer filters guests on `status === "running"`. Templates are now excluded explicitly: the old power filter only kept them out by accident, and a replica of a template could not start at failover.
- The create-job dialog lists powered-off guests again, with the status dots for stopped and paused guests that already existed but were unreachable behind the filter. Their tags contribute to tag selection mode as well.
- New `no_match` value in `ReplicationJobStatus` and `JobStatusSummary`, rendered as a warning chip in the Protection tab (with a dedicated status filter option), translated in the Emergency DR chip instead of showing the raw enum value, and counted as its own segment in the dashboard job distribution.
- New i18n key `siteRecovery.status.noMatch` in the six catalogs.

## Tests

- `ceph-vms` route: running and stopped QEMU guests with RBD disks are returned, LXC guests and templates are not.
- CreateJobDialog: a stopped Ceph-backed guest is listed and selectable, and its tags are offered in tag mode.
- ProtectionTab: the `no_match` chip renders with the warning color, and the status filter offers and applies the new value.
- EmergencyDRTab: `no_match` renders translated with the warning color, other statuses keep their existing rendering.
- DashboardTab: the job distribution shows the `no_match` segment, treats a missing count as zero, and the empty state still renders without health data.
- i18n parity test for the new key across the six catalogs.

Closes #687
