### PR TITLE
fix(task-center): show migration jobs and per-type logs (#767)

### DIFF
--- a/frontend/src/app/(dashboard)/operations/task-center/page.jsx
+++ b/frontend/src/app/(dashboard)/operations/task-center/page.jsx
@@ -9,23 +9,13 @@ import {
   Button,
   Card,
   CardContent,
-  Chip,
   CircularProgress,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  Divider,
   FormControl,
   IconButton,
   InputAdornment,
   LinearProgress,
-  List,
-  ListItem,
-  ListItemIcon,
-  ListItemText,
   MenuItem,
   Select,
-  Stack,
   TextField,
   Tooltip,
   Typography
@@ -33,15 +23,6 @@ import {
 import { DataGrid } from '@mui/x-data-grid'
 import { PieChart, Pie, Cell } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
-// RemixIcon replacements for @mui/icons-material
-const CheckCircleIcon = (props) => <i className="ri-checkbox-circle-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
-const ErrorIcon = (props) => <i className="ri-error-warning-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
-const WarningIcon = (props) => <i className="ri-alert-line" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
-const InfoIcon = (props) => <i className="ri-information-line" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
-const CloseIcon = (props) => <i className="ri-close-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const PauseIcon = (props) => <i className="ri-pause-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const PlayArrowIcon = (props) => <i className="ri-play-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
-const StopIcon = (props) => <i className="ri-stop-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
 
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import EnterpriseGuard from '@/components/guards/EnterpriseGuard'
@@ -49,6 +30,10 @@ import { Features, useLicense } from '@/contexts/LicenseContext'
 import { useJobs } from '@/hooks/useJobs'
 import EmptyState from '@/components/EmptyState'
 import { CardsSkeleton, TableSkeleton } from '@/components/skeletons'
+
+import { runJobAction } from '@/lib/tasks/jobActions'
+import JobDetailDialog from '@/components/tasks/JobDetailDialog'
+import { StatusChip, TypeChip } from '@/components/tasks/JobChips'
 
 /* --------------------------------
    Helpers
@@ -68,70 +53,25 @@ function useTimeAgo(t) {
   }
 }
 
-/* --------------------------------
-   Type Labels (fallback if translation missing)
--------------------------------- */
+// Every control in the filter toolbar is normalised to this height: MUI gives
+// a size='small' TextField/Select 40px but a size='small' Button ~31px, so the
+// row looked ragged.
+const CONTROL_HEIGHT = 40
 
-const TYPE_LABELS = {
-  backup: 'Backup',
-  replication: 'Replication',
-  drs: 'DRS',
-  maintenance: 'Maintenance',
-  migration: 'Migration',
-  rolling_update: 'Rolling Update'
-}
-
-const TYPE_ICONS = {
-  backup: 'ri-hard-drive-2-line',
-  replication: 'ri-repeat-line',
-  drs: 'ri-exchange-line',
-  maintenance: 'ri-tools-line',
-  migration: 'ri-swap-box-line',
-  rolling_update: 'ri-refresh-line'
+// Icon-only toolbar buttons keep the outlined look and the exact height of the
+// text field and the selectors next to them.
+const CONTROL_ICON_BUTTON_SX = {
+  width: CONTROL_HEIGHT,
+  height: CONTROL_HEIGHT,
+  border: '1px solid',
+  borderColor: 'divider',
+  borderRadius: 1
 }
 
 /* --------------------------------
    Components
 -------------------------------- */
 
-function StatusChip({ status, t }) {
-  const config = {
-    running: { label: t('jobsPage.statusRunning'), color: 'info' },
-    success: { label: t('jobsPage.statusSuccess'), color: 'success' },
-    completed: { label: t('jobsPage.statusSuccess'), color: 'success' },
-    failed: { label: t('jobsPage.statusFailed'), color: 'error' },
-    cancelled: { label: t('jobsPage.statusCancelled'), color: 'error' },
-    queued: { label: t('jobsPage.statusQueued'), color: 'default' },
-    pending: { label: t('jobsPage.statusQueued'), color: 'default' },
-    paused: { label: t('jobsPage.statusPaused'), color: 'warning' }
-  }
-
-  const cfg = config[status] || { label: status, color: 'default' }
-
-  return <Chip size='small' label={cfg.label} color={cfg.color} sx={{ minWidth: 80 }} />
-}
-
-function TypeChip({ type, t }) {
-  const TYPE_LABEL_KEYS = {
-    backup: 'jobsPage.typeBackup',
-    replication: 'jobsPage.typeReplication',
-    drs: 'jobsPage.typeDrs',
-    maintenance: 'jobsPage.typeMaintenance',
-    migration: 'jobsPage.typeMigration',
-    rolling_update: 'jobsPage.typeRollingUpdate'
-  }
-  const label = t && TYPE_LABEL_KEYS[type] ? t(TYPE_LABEL_KEYS[type]) : (TYPE_LABELS[type] || type)
-  const icon = TYPE_ICONS[type] || 'ri-file-list-line'
-
-  return (
-    <Chip
-      size='small'
-      label={label}
-      variant='outlined'
-      icon={<i className={icon} style={{ fontSize: 14 }} />}
-    />
-  )
-}
 
 function ProgressCell({ value, status }) {
   if (status === 'queued' || status === 'pending') {
@@ -154,277 +94,6 @@ function ProgressCell({ value, status }) {
   )
 }
 
-function getNodeStatusIcon(status) {
-  switch (status) {
-    case 'completed':
-      return <CheckCircleIcon color="success" fontSize="small" />
-    case 'failed':
-      return <ErrorIcon color="error" fontSize="small" />
-    case 'running':
-    case 'updating':
-    case 'migrating_vms':
-    case 'rebooting':
-    case 'entering_maintenance':
-    case 'exiting_maintenance':
-    case 'verifying_health':
-    case 'waiting_return':
-      return <CircularProgress size={18} />
-    case 'pending':
-      return <InfoIcon color="disabled" fontSize="small" />
-    case 'skipped':
-      return <WarningIcon color="warning" fontSize="small" />
-    default:
-      return <InfoIcon color="disabled" fontSize="small" />
-  }
-}
-
-/* --------------------------------
-   Job Detail Dialog
--------------------------------- */
-
-function JobDetailDialog({ open, onClose, job, onAction, isEnterprise, t }) {
-  const [logs, setLogs] = useState([])
-  const [loading, setLoading] = useState(false)
-
-  // Fetch full job details when dialog opens
-  useEffect(() => {
-    if (open && job?.id && job.type === 'rolling_update' && isEnterprise) {
-      fetchJobDetails()
-    }
-  }, [open, job?.id, isEnterprise])
-
-  const fetchJobDetails = async () => {
-    if (!job?.id || !isEnterprise) return
-
-    setLoading(true)
-    try {
-      const res = await fetch(`/api/v1/orchestrator/rolling-updates/${job.id}`)
-      if (res.ok) {
-        const data = await res.json()
-        const ru = data.data || data
-        if (ru?.logs) {
-          setLogs(ru.logs)
-        }
-      }
-    } catch (e) {
-      console.error('Error fetching job details:', e)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  // Auto-refresh if job is running
-  useEffect(() => {
-    if (open && job?.status === 'running' && isEnterprise) {
-      const interval = setInterval(fetchJobDetails, 3000)
-      return () => clearInterval(interval)
-    }
-  }, [open, job?.status, isEnterprise])
-
-  if (!job) return null
-
-  const nodeStatuses = job.metadata?.nodeStatuses || []
-  const isRunning = job.status === 'running'
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      maxWidth="md"
-      fullWidth
-      PaperProps={{ sx: { maxHeight: '80vh' } }}
-    >
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <TypeChip type={job.type} t={t} />
-          <Typography variant="h6">{job.name}</Typography>
-          <StatusChip status={job.status} t={t} />
-        </Box>
-        <IconButton onClick={onClose} size="small">
-          <CloseIcon />
-        </IconButton>
-      </DialogTitle>
-
-      <DialogContent dividers>
-        <Stack spacing={3}>
-          {/* Progress */}
-          <Box>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-              <Typography variant="body2">
-                {t('jobsPage.progression', { completed: job.metadata?.completedNodes || 0, total: job.metadata?.totalNodes || 0 })}
-              </Typography>
-              {job.metadata?.currentNode && (
-                <Typography variant="body2" color="text.secondary">
-                  {t('jobsPage.currentlyRunning', { node: job.metadata.currentNode })}
-                </Typography>
-              )}
-            </Box>
-            <LinearProgress
-              variant="determinate"
-              value={job.progress || 0}
-              sx={{ height: 8, borderRadius: 1 }}
-            />
-          </Box>
-
-          {/* Info */}
-          <Box sx={{ display: 'flex', gap: 4 }}>
-            <Box>
-              <Typography variant="caption" color="text.secondary">{t('jobsPage.target')}</Typography>
-              <Typography variant="body2">{job.target || '—'}</Typography>
-            </Box>
-            <Box>
-              <Typography variant="caption" color="text.secondary">{t('jobsPage.started')}</Typography>
-              <Typography variant="body2">
-                {job.startedAt ? new Date(job.startedAt).toLocaleString() : '—'}
-              </Typography>
-            </Box>
-            {job.endedAt && (
-              <Box>
-                <Typography variant="caption" color="text.secondary">{t('jobsPage.ended')}</Typography>
-                <Typography variant="body2">
-                  {new Date(job.endedAt).toLocaleString()}
-                </Typography>
-              </Box>
-            )}
-          </Box>
-
-          {/* Actions */}
-          {isRunning && (
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button
-                size="small"
-                variant="outlined"
-                color="warning"
-                startIcon={<PauseIcon />}
-                onClick={() => onAction(job.id, 'pause')}
-              >
-                {t('jobsPage.pause')}
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                color="error"
-                startIcon={<StopIcon />}
-                onClick={() => onAction(job.id, 'cancel')}
-              >
-                {t('common.cancel')}
-              </Button>
-            </Box>
-          )}
-
-          {job.status === 'paused' && (
-            <Box sx={{ display: 'flex', gap: 1 }}>
-              <Button
-                size="small"
-                variant="outlined"
-                color="primary"
-                startIcon={<PlayArrowIcon />}
-                onClick={() => onAction(job.id, 'resume')}
-              >
-                {t('jobsPage.resume')}
-              </Button>
-              <Button
-                size="small"
-                variant="outlined"
-                color="error"
-                startIcon={<StopIcon />}
-                onClick={() => onAction(job.id, 'cancel')}
-              >
-                {t('common.cancel')}
-              </Button>
-            </Box>
-          )}
-
-          {/* Error */}
-          {job.metadata?.error && (
-            <Box sx={{ p: 2, bgcolor: 'error.main', color: 'error.contrastText', borderRadius: 1 }}>
-              <Typography variant="body2">{job.metadata.error}</Typography>
-            </Box>
-          )}
-
-          {/* Node statuses */}
-          {nodeStatuses.length > 0 && (
-            <Card variant="outlined">
-              <CardContent>
-                <Typography variant="subtitle2" fontWeight={700} gutterBottom>
-                  {t('jobsPage.nodeStatuses')}
-                </Typography>
-                <List dense>
-                  {nodeStatuses.map((ns) => (
-                    <ListItem key={ns.node_name}>
-                      <ListItemIcon sx={{ minWidth: 40 }}>
-                        {getNodeStatusIcon(ns.status)}
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={ns.node_name}
-                        secondary={
-                          <>
-                            {ns.status}
-                            {ns.version_before && ns.version_after &&
-                              ` • ${ns.version_before} → ${ns.version_after}`}
-                            {ns.did_reboot && ` • ${t('jobsPage.rebooted')}`}
-                          </>
-                        }
-                      />
-                      {ns.error && (
-                        <Chip size="small" label={t('common.error')} color="error" />
-                      )}
-                    </ListItem>
-                  ))}
-                </List>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Logs */}
-          <Card variant="outlined">
-            <CardContent>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
-                <Typography variant="subtitle2" fontWeight={700}>
-                  {t('jobsPage.logs')}
-                </Typography>
-                {loading && <CircularProgress size={16} />}
-              </Box>
-              <Box
-                sx={{
-                  maxHeight: 300,
-                  overflow: 'auto',
-                  bgcolor: 'background.default',
-                  borderRadius: 1,
-                  p: 1,
-                  fontFamily: 'monospace',
-                  fontSize: 11,
-                }}
-              >
-                {logs.length === 0 ? (
-                  <Typography variant="body2" color="text.secondary">
-                    {t('jobsPage.noLogs')}
-                  </Typography>
-                ) : (
-                  logs.slice(-100).map((log, i) => (
-                    <Box
-                      key={i}
-                      sx={{
-                        color: log.level === 'error' ? 'error.main' :
-                               log.level === 'warning' ? 'warning.main' :
-                               'text.primary',
-                        lineHeight: 1.4,
-                      }}
-                    >
-                      [{new Date(log.timestamp).toLocaleTimeString()}]
-                      {log.node && ` [${log.node}]`}
-                      {' '}{log.message}
-                    </Box>
-                  ))
-                )}
-              </Box>
-            </CardContent>
-          </Card>
-        </Stack>
-      </DialogContent>
-    </Dialog>
-  )
-}
 
 /* --------------------------------
    Page
@@ -441,6 +110,9 @@ export default function JobsPage() {
   // Dialog state
   const [selectedJob, setSelectedJob] = useState(null)
   const [dialogOpen, setDialogOpen] = useState(false)
+  // A rejected action (403 without vm.migrate, 400 on an already-finished job)
+  // must say so instead of looking like the click did nothing.
+  const [actionError, setActionError] = useState(null)
 
   const { setPageInfo } = usePageTitle()
 
@@ -465,27 +137,30 @@ export default function JobsPage() {
     }
   }, [stats.running, isEnterprise, mutate])
 
-  // Handle job action (pause/resume/cancel)
-  const handleJobAction = async (jobId, action) => {
+  // Handle job action (pause/resume/cancel). The endpoint depends on the job
+  // type: a migration is cancelled through /api/v1/migrations, only a rolling
+  // update goes to the orchestrator route.
+  const handleJobAction = async (job, action) => {
     if (!isEnterprise) return
 
-    try {
-      const res = await fetch(`/api/v1/orchestrator/rolling-updates/${jobId}/${action}`, {
-        method: 'POST',
-      })
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.error || `Failed to ${action} job`)
-      }
-      // Refresh jobs list
-      mutate()
-    } catch (e) {
-      console.error(`Error ${action} job:`, e)
+    setActionError(null)
+    const { ok, error: actionFailure } = await runJobAction(job, action)
+    if (!ok) {
+      setActionError(actionFailure)
+
+      return
     }
+
+    // Refresh the list, then re-point the open dialog at the refreshed row so
+    // a cancelled migration stops advertising itself as running.
+    const refreshed = await mutate()
+    const fresh = refreshed?.data?.find(j => j.id === job.id)
+    if (fresh) setSelectedJob(fresh)
   }
 
   // Handle row double-click
   const handleRowDoubleClick = (params) => {
+    setActionError(null)
     setSelectedJob(params.row)
     setDialogOpen(true)
   }
@@ -597,18 +272,6 @@ export default function JobsPage() {
   return (
     <EnterpriseGuard requiredFeature={Features.TASK_CENTER} featureName="Task Center">
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, flex: 1, minHeight: 0 }}>
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2, flexShrink: 0 }}>
-          <Button
-            variant='outlined'
-            size='small'
-            startIcon={isValidating ? <CircularProgress size={14} /> : <i className='ri-refresh-line' />}
-            onClick={() => mutate()}
-            disabled={isValidating}
-          >
-            {t('common.refresh')}
-          </Button>
-        </Box>
-
       {/* Stats */}
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 2, flexShrink: 0 }}>
         {/* Total — full distribution donut */}
@@ -739,13 +402,18 @@ export default function JobsPage() {
       {/* Filtres + Table */}
       <Card variant='outlined' sx={{ flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
         <CardContent sx={{ pb: 0, flexShrink: 0 }}>
-          <Stack direction='row' spacing={1.5} sx={{ flexWrap: 'wrap', alignItems: 'center', mb: 2 }}>
+          {/* Plain flex row, not a Stack: Stack injects margin-left on every
+              sibling with a selector more specific than a child's own sx, so an
+              `ml: auto` meant to push the trailing controls right is silently
+              dropped and everything stays packed on the left. An explicit
+              spacer pins both icon buttons to the right edge instead. */}
+          <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'center', mb: 2 }}>
             <TextField
               size='small'
               placeholder={t('common.search')}
               value={q}
               onChange={e => setQ(e.target.value)}
-              sx={{ minWidth: 220 }}
+              sx={{ minWidth: 220, '& .MuiOutlinedInput-root': { height: CONTROL_HEIGHT } }}
               InputProps={{
                 startAdornment: (
                   <InputAdornment position='start'>
@@ -756,19 +424,21 @@ export default function JobsPage() {
             />
 
             <FormControl size='small' sx={{ minWidth: 150 }}>
-              <Select value={typeFilter} onChange={e => setTypeFilter(e.target.value)}>
+              {/* Only the types the endpoint can actually emit. "Backup" was
+                  offered here with no source feeding it, so the filter always
+                  emptied the table (same trap as "Migration" before #767). */}
+              <Select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} sx={{ height: CONTROL_HEIGHT }}>
                 <MenuItem value='all'>{t('jobsPage.allTypes')}</MenuItem>
                 <MenuItem value='rolling_update'>{t('jobsPage.typeRollingUpdate')}</MenuItem>
-                <MenuItem value='backup'>{t('jobsPage.typeBackup')}</MenuItem>
                 <MenuItem value='replication'>{t('jobsPage.typeReplication')}</MenuItem>
                 <MenuItem value='drs'>{t('jobsPage.typeDrs')}</MenuItem>
                 <MenuItem value='migration'>{t('jobsPage.typeMigration')}</MenuItem>
-                <MenuItem value='maintenance'>{t('jobsPage.typeMaintenance')}</MenuItem>
+                <MenuItem value='site_recovery'>{t('jobsPage.typeSiteRecovery')}</MenuItem>
               </Select>
             </FormControl>
 
             <FormControl size='small' sx={{ minWidth: 130 }}>
-              <Select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+              <Select value={statusFilter} onChange={e => setStatusFilter(e.target.value)} sx={{ height: CONTROL_HEIGHT }}>
                 <MenuItem value='all'>{t('jobsPage.allStatuses')}</MenuItem>
                 <MenuItem value='running'>{t('jobsPage.statusRunning')}</MenuItem>
                 <MenuItem value='queued'>{t('jobsPage.statusQueued')}</MenuItem>
@@ -778,22 +448,33 @@ export default function JobsPage() {
               </Select>
             </FormControl>
 
-            <Button
-              variant='outlined'
-              size='small'
-              onClick={() => {
-                setQ('')
-                setTypeFilter('all')
-                setStatusFilter('all')
-              }}
-            >
-              {t('common.reset')}
-            </Button>
+            <Box sx={{ flexGrow: 1 }} />
 
-            <Typography variant='body2' sx={{ ml: 'auto', opacity: 0.6 }}>
-              {t('jobsPage.jobsCount', { count: filtered.length })}
-            </Typography>
-          </Stack>
+            <Tooltip title={t('common.reset')}>
+              <IconButton
+                sx={CONTROL_ICON_BUTTON_SX}
+                onClick={() => {
+                  setQ('')
+                  setTypeFilter('all')
+                  setStatusFilter('all')
+                }}
+              >
+                <i className='ri-filter-off-line' style={{ fontSize: 18 }} />
+              </IconButton>
+            </Tooltip>
+
+            {/* A disabled button fires no pointer event, so the Tooltip needs a
+                wrapper element to hang on while a refresh is in flight. */}
+            <Tooltip title={t('common.refresh')}>
+              <span>
+                <IconButton sx={CONTROL_ICON_BUTTON_SX} onClick={() => mutate()} disabled={isValidating}>
+                  {isValidating
+                    ? <CircularProgress size={16} />
+                    : <i className='ri-refresh-line' style={{ fontSize: 18 }} />}
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Box>
         </CardContent>
 
         <Box sx={{ flex: 1, minHeight: 0, position: 'relative' }}>
@@ -857,6 +538,7 @@ export default function JobsPage() {
         onClose={() => setDialogOpen(false)}
         job={selectedJob}
         onAction={handleJobAction}
+        actionError={actionError}
         isEnterprise={isEnterprise}
         t={t}
       />

--- a/frontend/src/app/api/v1/orchestrator/jobs/jobsScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/jobsScope.test.ts
@@ -14,11 +14,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "@/__tests__/setup/route-test"
 
-const { getInfraMock, getCurrentTenantIdMock, tenantConnectionIdsMock, findManyMock } = vi.hoisted(() => ({
+const { getInfraMock, getCurrentTenantIdMock, tenantConnectionIdsMock, findManyMock, migrationFindManyMock } = vi.hoisted(() => ({
   getInfraMock: vi.fn(),
   getCurrentTenantIdMock: vi.fn(),
   tenantConnectionIdsMock: vi.fn(),
   findManyMock: vi.fn(),
+  migrationFindManyMock: vi.fn(),
 }))
 
 // Keep the real maskingScope (pure function); only stub the scope resolver.
@@ -27,13 +28,21 @@ vi.mock("@/lib/tenant/infraScope", async (orig) => ({
   getTenantInfrastructureScope: (...a: any[]) => getInfraMock(...a),
 }))
 
+// getSessionPrisma / DEFAULT_TENANT_ID are unused by the route itself but are
+// imported at module scope by @/lib/tasks/sharedTask (sourceTypeLabel,
+// TERMINAL_STATUSES), and a partial factory makes those imports throw.
 vi.mock("@/lib/tenant", () => ({
   getCurrentTenantId: (...a: any[]) => getCurrentTenantIdMock(...a),
   getTenantConnectionIds: (...a: any[]) => tenantConnectionIdsMock(...a),
+  getSessionPrisma: vi.fn(),
+  DEFAULT_TENANT_ID: "default",
 }))
 
 vi.mock("@/lib/db/prisma", () => ({
-  prisma: { connection: { findMany: (...a: any[]) => findManyMock(...a) } },
+  prisma: {
+    connection: { findMany: (...a: any[]) => findManyMock(...a) },
+    migrationJob: { findMany: (...a: any[]) => migrationFindManyMock(...a) },
+  },
 }))
 
 vi.mock("@/lib/rbac", () => ({
@@ -65,6 +74,33 @@ const DRS_MIGRATIONS = [
   { id: "dm-c1", connection_id: "c1", vmid: 100, vm_name: "vm1", status: "completed", started_at: "2026-01-01T00:00:00Z" },
 ]
 
+// External hypervisor -> Proxmox migrations live in our DB, not the
+// orchestrator (#767). Row shape mirrors the MigrationJob model.
+const migrationRow = (over: Record<string, any> = {}) => ({
+  id: "mig-c1",
+  sourceConnectionId: "vmw-1",
+  sourceVmId: "vm-42",
+  sourceVmName: "srv-app",
+  sourceHost: "esxi-1.lab",
+  targetConnectionId: "c1",
+  targetNode: "pve-node-01",
+  targetVmid: 210,
+  config: { sourceType: "vcenter" },
+  status: "transferring",
+  currentStep: "disk 1/2",
+  progress: 42,
+  totalDisks: 2,
+  currentDisk: 1,
+  transferSpeed: "180 MiB/s",
+  error: null,
+  startedAt: new Date("2026-01-02T00:00:00Z"),
+  completedAt: null,
+  createdAt: new Date("2026-01-02T00:00:00Z"),
+  ...over,
+})
+
+const MIGRATION_JOBS = [migrationRow(), migrationRow({ id: "mig-c2", targetConnectionId: "c2" })]
+
 const fetchMock = vi.fn(async (url: string) => {
   if (url.includes("/rolling-updates")) return { ok: true, json: async () => ({ data: ROLLING_UPDATES }) }
   if (url.includes("/drs/migrations")) return { ok: true, json: async () => ({ data: DRS_MIGRATIONS }) }
@@ -82,6 +118,12 @@ beforeEach(() => {
   findManyMock.mockImplementation(async ({ where }: any) => {
     const ids: string[] = where?.id?.in ?? []
     return ALL_CONNS.filter(c => ids.includes(c.id))
+  })
+  // Honour the route's where clause the way Postgres would: no clause means
+  // the whole fleet, a targetConnectionId filter narrows to the perimeter.
+  migrationFindManyMock.mockImplementation(async ({ where }: any) => {
+    const ids: string[] | undefined = where?.targetConnectionId?.in
+    return ids ? MIGRATION_JOBS.filter(j => ids.includes(j.targetConnectionId)) : MIGRATION_JOBS
   })
 })
 
@@ -175,6 +217,115 @@ describe("GET /api/v1/orchestrator/jobs — tenant scoping", () => {
 
     const body = await res.json()
     expect(body.data.map((j: any) => j.id)).toContain("exec-1")
+
+    // A failover/failback/test is Site Recovery, not maintenance, and a
+    // cluster id that resolves to no connection is named as deleted instead of
+    // being printed as a bare cuid.
+    const exec = body.data.find((j: any) => j.id === "exec-1")
+    expect(exec.type).toBe("site_recovery")
+    expect(exec.name).toBe("Failover - dr-plan")
+    expect(exec.target).toBe("pve1.example.com")
+    expect(exec.detail).toBe("pve1.example.com → Deleted connection (c-provid) (0 VMs)")
+  })
+
+  it("provider: external migrations are listed, with the fleet query unfiltered", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    const mig = body.data.find((j: any) => j.id === "mig-c1")
+    expect(mig).toBeDefined()
+    expect(mig.type).toBe("migration")
+    // A pipeline step is neither queued nor terminal: it must read as running.
+    expect(mig.status).toBe("running")
+    expect(mig.progress).toBe(42)
+    expect(mig.name).toBe("Migration - srv-app")
+    expect(mig.target).toBe("pve1.example.com")
+    expect(mig.detail).toBe("vCenter → pve-node-01 (VMID 210) • disk 1/2")
+    expect(mig.metadata.cancellable).toBe(true)
+    expect(body.data.map((j: any) => j.id)).toContain("mig-c2")
+    expect(migrationFindManyMock.mock.calls[0][0].where).toEqual({})
+  })
+
+  it("iaas: a migration landing outside the vDC perimeter is not listed", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("tenant-a")
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
+    getInfraMock.mockResolvedValue({
+      kind: "iaas",
+      vdcScope: { connectionIds: new Set(["c1"]) },
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    const ids = body.data.map((j: any) => j.id)
+    // Scoped on the target cluster only: the source is an external hypervisor
+    // connection a vDC tenant never owns, so requiring it too would hide every
+    // migration from them.
+    expect(ids).toContain("mig-c1")
+    expect(ids).not.toContain("mig-c2")
+    expect(migrationFindManyMock.mock.calls[0][0].where).toEqual({ targetConnectionId: { in: ["c1"] } })
+  })
+
+  it("maps every terminal migration status and never offers cancel on one", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+
+    migrationFindManyMock.mockResolvedValue([
+      migrationRow({ id: "m-done", status: "completed", progress: 100, completedAt: new Date("2026-01-02T01:00:00Z") }),
+      migrationRow({ id: "m-fail", status: "failed", error: "boom" }),
+      migrationRow({ id: "m-cancel", status: "cancelled" }),
+      migrationRow({ id: "m-queued", status: "pending", progress: 0 }),
+      migrationRow({ id: "m-warm", status: "delta_sync" }),
+    ])
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+    const byId = new Map<string, any>(body.data.map((j: any) => [j.id, j] as [string, any]))
+
+    expect(byId.get("m-done").status).toBe("success")
+    expect(byId.get("m-fail").status).toBe("failed")
+    expect(byId.get("m-fail").metadata.error).toBe("boom")
+    expect(byId.get("m-cancel").status).toBe("cancelled")
+    expect(byId.get("m-queued").status).toBe("pending")
+    expect(byId.get("m-warm").status).toBe("running")
+
+    for (const id of ["m-done", "m-fail", "m-cancel"]) {
+      expect(byId.get(id).metadata.cancellable).toBe(false)
+    }
+    expect(byId.get("m-warm").metadata.cancellable).toBe(true)
+
+    // currentStep repeats the status on a finished job: don't echo it.
+    expect(byId.get("m-done").detail).toBe("vCenter → pve-node-01 (VMID 210)")
+    expect(byId.get("m-warm").detail).toBe("vCenter → pve-node-01 (VMID 210) • disk 1/2")
+
+    // Stats must count them like any other job.
+    expect(body.stats.total).toBeGreaterThanOrEqual(5)
+    expect(body.stats.failed).toBeGreaterThanOrEqual(2) // failed + cancelled
+  })
+
+  it("a database error on the migration query does not break the rest of the page", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
+    migrationFindManyMock.mockRejectedValue(new Error("relation does not exist"))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.map((j: any) => j.id)).toContain("ru-c1")
+    expect(body.data.some((j: any) => j.type === "migration")).toBe(false)
   })
 
   it("msp: perimeter uses the owned-connection union (no vDC narrowing)", async () => {

--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -5,6 +5,7 @@ import { getCurrentTenantId, getTenantConnectionIds } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { orchestratorHeaders } from "@/lib/orchestrator/headers"
+import { TERMINAL_STATUSES, sourceTypeLabel } from "@/lib/tasks/sharedTask"
 
 export const runtime = "nodejs"
 
@@ -20,7 +21,25 @@ function extractHostname(baseUrl: string): string {
   }
 }
 
-// GET /api/v1/orchestrator/jobs - List all jobs (rolling updates, future: DRS, migrations, etc.)
+/**
+ * MigrationJob.status -> the status vocabulary the Task Center renders.
+ * The four pipelines (cold, xcpng, virt-v2v, warm) agree on
+ * pending|completed|failed|cancelled and each adds its own in-flight steps
+ * (preflight, creating_vm, transferring, converting_disks, planning,
+ * enabling_cbt, preparing_disks, full_copy, delta_sync, awaiting_cutover,
+ * cutover, verify...). Anything non-terminal that is not still queued is
+ * therefore reported as running rather than enumerated, so a step added by a
+ * future pipeline can never fall through to a status the page cannot render.
+ */
+function migrationJobStatus(status: string): string {
+  if (status === "completed") return "success"
+  if (status === "failed" || status === "cancelled") return status
+  if (status === "pending") return "pending"
+
+  return "running"
+}
+
+// GET /api/v1/orchestrator/jobs - List all jobs (rolling updates, DRS, external migrations, Site Recovery)
 export async function GET(req: Request) {
   try {
     // Gates the "Task Center" page (menuData permissions: ['tasks.view']).
@@ -69,9 +88,23 @@ export async function GET(req: Request) {
       connByName.set(c.name, host)
     }
 
-    /** Resolve a connection identifier (id or name) to its server hostname */
-    const resolve = (idOrName: string): string =>
-      connById.get(idOrName) || connByName.get(idOrName) || idOrName
+    /**
+     * Resolve a connection identifier (id or name) to its server hostname.
+     *
+     * A reference matching neither is a connection that no longer exists: the
+     * orchestrator keeps the raw cluster id in its own rows (a Site Recovery
+     * plan's source_cluster_id is a plain string, not a foreign key to
+     * Connection), so a plan whose clusters were deleted used to print bare
+     * cuids in the Target and Detail columns. Say what it is instead, keeping
+     * the id prefix so the row stays traceable. A surviving row always
+     * resolves for a non-provider caller, since the deny-by-default filter
+     * below drops anything referencing a connection outside its perimeter.
+     */
+    const resolve = (idOrName?: string | null): string => {
+      if (!idOrName) return "unknown"
+
+      return connById.get(idOrName) || connByName.get(idOrName) || `Deleted connection (${idOrName.slice(0, 8)})`
+    }
 
     const jobs: any[] = []
 
@@ -187,6 +220,69 @@ export async function GET(req: Request) {
       }
     }
 
+    // Fetch external hypervisor -> Proxmox migrations (cold, virt-v2v, warm).
+    // These rows live in OUR database, not the orchestrator, which is why the
+    // Task Center never listed a single one (#767): the page offered a
+    // "Migration" type filter that no source could ever emit, so an operator
+    // who started a VMware/XCP-ng/Hyper-V/Nutanix migration found an empty
+    // page and no way to cancel it.
+    //
+    // Perimeter: targetConnectionId only, i.e. the exact rule the shared-task
+    // footer already applies to these same rows (jobPassesSharedTaskScope).
+    // The source is an external hypervisor connection that a vDC tenant never
+    // owns, so also requiring it inside the perimeter would hide every
+    // migration from iaas tenants. Provider keeps the fleet view.
+    try {
+      const migrationJobs = await globalPrisma.migrationJob.findMany({
+        where: infra.kind === "provider"
+          ? {}
+          : { targetConnectionId: { in: Array.from(perimeterConnectionIds) } },
+        orderBy: { createdAt: "desc" },
+        take: 50,
+      })
+
+      for (const mj of migrationJobs) {
+        const migTarget = resolve(mj.targetConnectionId)
+        const vmLabel = mj.sourceVmName || mj.sourceVmId
+        const srcLabel = sourceTypeLabel((mj.config as any)?.sourceType)
+        const route = `${srcLabel} → ${mj.targetNode}${mj.targetVmid ? ` (VMID ${mj.targetVmid})` : ""}`
+        // On a finished job every pipeline sets currentStep to the status word
+        // itself, so appending it would just repeat the status chip. Only an
+        // in-flight step ("disk 1/2", "delta_sync"...) carries information.
+        const isTerminal = (TERMINAL_STATUSES as readonly string[]).includes(mj.status)
+
+        jobs.push({
+          id: mj.id,
+          name: `Migration - ${vmLabel}`,
+          type: "migration",
+          status: migrationJobStatus(mj.status),
+          progress: mj.progress ?? 0,
+          startedAt: mj.startedAt ?? mj.createdAt,
+          endedAt: mj.completedAt ?? undefined,
+          createdAt: mj.createdAt,
+          detail: mj.currentStep && !isTerminal ? `${route} • ${mj.currentStep}` : route,
+          target: migTarget,
+          metadata: {
+            connectionId: mj.targetConnectionId,
+            sourceVmName: mj.sourceVmName,
+            sourceHost: mj.sourceHost,
+            targetNode: mj.targetNode,
+            targetVmid: mj.targetVmid,
+            currentStep: mj.currentStep,
+            totalDisks: mj.totalDisks,
+            currentDisk: mj.currentDisk,
+            transferSpeed: mj.transferSpeed,
+            error: mj.error,
+            // Drives the Cancel button in the detail dialog: the cancel route
+            // rejects a terminal job with a 400, so don't offer it.
+            cancellable: !isTerminal,
+          },
+        })
+      }
+    } catch (e) {
+      console.error("Failed to fetch migration jobs:", e)
+    }
+
     // Fetch Site Recovery replication jobs
     try {
       const replRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/replication/jobs`, {
@@ -277,7 +373,10 @@ export async function GET(req: Request) {
               jobs.push({
                 id: exec.id,
                 name: `${typeLabel} - ${plan.name}`,
-                type: "maintenance",
+                // A failover, a failback or a test failover is Site Recovery,
+                // not maintenance: the old "maintenance" type made the Type
+                // column lie about what the operator had run.
+                type: "site_recovery",
                 status: jobStatus,
                 progress: jobStatus === "success" ? 100 : jobStatus === "running" ? 50 : 0,
                 startedAt: exec.started_at,

--- a/frontend/src/app/api/v1/tasks/shared/[id]/route.test.ts
+++ b/frontend/src/app/api/v1/tasks/shared/[id]/route.test.ts
@@ -69,6 +69,27 @@ describe("GET /api/v1/tasks/shared/[id]", () => {
     expect(res.status).toBe(404)
   })
 
+  it("history=1 returns an old finished job with its logs (Task Center opens the full history)", async () => {
+    h.global.migrationJob.findUnique.mockResolvedValue(
+      job({ status: "completed", updatedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000) }),
+    )
+    h.global.user.findUnique.mockResolvedValue({ name: "Alice", email: "a@x" })
+    const res = await callRoute(GET, { method: "GET", params: { id: "job-1" }, searchParams: { history: "1" } })
+    const body = (await readJson(res)) as any
+    expect(res.status).toBe(200)
+    expect(body.data.logs).toEqual([{ t: 1, m: "started" }])
+  })
+
+  it("history=1 still enforces the tenant scope", async () => {
+    h.getTenantConnectionIds.mockResolvedValue(new Set(["pve-other"]))
+    h.getCurrentTenantId.mockResolvedValue("tenant-a")
+    h.sessionClient.migrationJob.findUnique.mockResolvedValue(
+      job({ status: "completed", updatedAt: new Date(Date.now() - 4 * 24 * 60 * 60 * 1000) }),
+    )
+    const res = await callRoute(GET, { method: "GET", params: { id: "job-1" }, searchParams: { history: "1" } })
+    expect(res.status).toBe(404)
+  })
+
   it("returns the job with logs for an in-scope recent job", async () => {
     h.global.migrationJob.findUnique.mockResolvedValue(job())
     h.global.user.findUnique.mockResolvedValue({ name: "Alice", email: "a@x" })

--- a/frontend/src/app/api/v1/tasks/shared/[id]/route.ts
+++ b/frontend/src/app/api/v1/tasks/shared/[id]/route.ts
@@ -16,9 +16,15 @@ export const runtime = "nodejs"
  * GET /api/v1/tasks/shared/[id]
  * Read-only detail (incl. logs) for a single shared migration task. Same
  * tenant/DEFAULT scope and recency window as the list.
+ *
+ * `?history=1` keeps the tenant scope and the tasks.view check but drops the
+ * recency window. The window mirrors what the footer lists (in-flight plus
+ * recently finished) and is a UI horizon, not a permission: the Task Center
+ * lists the full migration history, so opening a job that finished days ago
+ * must return its logs instead of a 404.
  */
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
@@ -28,12 +34,17 @@ export async function GET(
     const session = await getServerSession(authOptions)
     const myId = (session as any)?.user?.id ?? null
 
+    const includeHistory = new URL(req.url).searchParams.get("history") === "1"
+
     const scope = await resolveSharedTaskScope()
     const { id } = await params
     const job = await scope.client.migrationJob.findUnique({ where: { id } })
 
     const cutoff = new Date(Date.now() - 30 * 60 * 1000)
-    if (!job || !jobPassesSharedTaskScope(job, scope) || !jobInSharedTaskWindow(job, cutoff)) {
+    if (!job || !jobPassesSharedTaskScope(job, scope)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+    if (!includeHistory && !jobInSharedTaskWindow(job, cutoff)) {
       return NextResponse.json({ error: "Not found" }, { status: 404 })
     }
 

--- a/frontend/src/components/TasksFooter.test.tsx
+++ b/frontend/src/components/TasksFooter.test.tsx
@@ -54,12 +54,20 @@ vi.mock('@/hooks/useTaskEvents', () => ({
   useTaskEvents: () => ({ data: { data: [] }, mutate: vi.fn(), isLoading: false }),
 }))
 
+// The ProxCenter tab also lists Task Center jobs now: Enterprise gate, SWR
+// poll and the router used when a job row is clicked.
+vi.mock('@/contexts/LicenseContext', () => ({ useLicense: () => ({ isEnterprise: true }) }))
+vi.mock('@/hooks/useJobs', () => ({ useJobs: () => ({ data: undefined }) }))
+vi.mock('@/hooks/useRefreshInterval', () => ({ useRefreshInterval: () => 0 }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+
 vi.mock('@mui/x-data-grid', () => ({
   DataGrid: () => <div data-testid="datagrid" />,
 }))
 
 vi.mock('./TaskDetailDialog', () => ({ default: () => null }))
 vi.mock('@/components/SharedTaskDetailDialog', () => ({ default: () => null }))
+vi.mock('@/components/tasks/JobDetailDialog', () => ({ default: () => null }))
 
 // ------------------------------------------------------------------ //
 // Helpers

--- a/frontend/src/components/TasksFooter.tsx
+++ b/frontend/src/components/TasksFooter.tsx
@@ -24,9 +24,15 @@ import { DataGrid, GridColDef } from '@mui/x-data-grid'
 import { useTaskEvents } from '@/hooks/useTaskEvents'
 import { useProxCenterTasks, type PCTask } from '@/contexts/ProxCenterTasksContext'
 import { useSharedTasks } from '@/hooks/useSharedTasks'
-import { mergeSharedTasks, type MergedPCTask } from '@/lib/tasks/mergeSharedTasks'
+import { useJobs } from '@/hooks/useJobs'
+import { useRefreshInterval } from '@/hooks/useRefreshInterval'
+import { useLicense } from '@/contexts/LicenseContext'
+import { type MergedPCTask } from '@/lib/tasks/mergeSharedTasks'
+import { mergeTaskbarRows } from '@/lib/tasks/orchestratorTaskRows'
 import TaskDetailDialog from './TaskDetailDialog'
 import SharedTaskDetailDialog from '@/components/SharedTaskDetailDialog'
+import JobDetailDialog from '@/components/tasks/JobDetailDialog'
+import { runJobAction } from '@/lib/tasks/jobActions'
 import {
   TASKBAR_HEADER_HEIGHT,
   TASKBAR_MIN_PANEL_HEIGHT,
@@ -169,7 +175,57 @@ export default function TasksFooter({
   // ProxCenter tasks
   const { tasks: pcTasks, clearDone: clearPCDone, restoreTask } = useProxCenterTasks()
   const { data: sharedResp } = useSharedTasks()
-  const mergedPcTasks: MergedPCTask[] = mergeSharedTasks(pcTasks, sharedResp?.data ?? [])
+
+  // Task Center jobs (rolling updates, DRS, replication, Site Recovery) belong
+  // on this tab too: they are ProxCenter tasks, not Proxmox ones. Enterprise
+  // only, like the Task Center itself.
+  //
+  // Polled at half the cadence of the shared tasks above, because this footer
+  // is mounted on EVERY page: one poll fans out to four orchestrator calls
+  // plus one history call per recovery plan. The Task Center page keeps its
+  // own faster refresh while it is open (and shares this SWR cache key).
+  // useRefreshInterval scales it with the user's global setting and returns 0
+  // on a hidden tab.
+  const { isEnterprise } = useLicense()
+  const jobsRefreshInterval = useRefreshInterval(60000)
+  const { data: jobsResp, mutate: mutateJobs } = useJobs(isEnterprise, jobsRefreshInterval)
+
+  const mergedPcTasks: MergedPCTask[] = useMemo(
+    () => mergeTaskbarRows(pcTasks, sharedResp?.data ?? [], jobsResp?.data ?? []),
+    [pcTasks, sharedResp, jobsResp]
+  )
+
+  // A double-click opens the very same dialog as the Task Center table, so the
+  // logs and the pause/resume/cancel actions of a job are one click away from
+  // any page. Keyed by the job id the row carries.
+  const jobsById = useMemo(
+    () => new Map<string, any>((jobsResp?.data ?? []).map((j: any) => [j.id, j])),
+    [jobsResp]
+  )
+  const [detailJob, setDetailJob] = useState<any>(null)
+  const [jobActionError, setJobActionError] = useState<string | null>(null)
+
+  const openJobDetail = (task: MergedPCTask) => {
+    const job = task.jobId ? jobsById.get(task.jobId) : null
+    if (!job) return
+
+    setJobActionError(null)
+    setDetailJob(job)
+  }
+
+  const handleJobAction = async (job: any, action: any) => {
+    setJobActionError(null)
+    const { ok, error } = await runJobAction(job, action)
+    if (!ok) {
+      setJobActionError(error ?? null)
+
+      return
+    }
+
+    const refreshed = await mutateJobs()
+    const fresh = (refreshed as any)?.data?.find((j: any) => j.id === job.id)
+    if (fresh) setDetailJob(fresh)
+  }
   const [detailJobId, setDetailJobId] = useState<string | null>(null)
   const pcRunningCount = mergedPcTasks.filter(t => t.status === 'running').length
 
@@ -774,9 +830,19 @@ export default function TasksFooter({
                   {mergedPcTasks.map((task) => (
                     <Box
                       key={task.id}
-                      onClick={() => task.shared ? setDetailJobId(task.jobId ?? task.id.replace(/^migration-/, '')) : restoreTask(task.id)}
+                      onDoubleClick={() => openJobDetail(task)}
+                      onClick={() => {
+                        // A row backed by a Task Center job opens its dialog on
+                        // double-click, like the Proxmox tab: nothing to do on a
+                        // single click. The others keep their own behaviour.
+                        if (task.jobId && jobsById.has(task.jobId)) return
+                        if (task.shared) return void setDetailJobId(task.jobId ?? task.id.replace(/^migration-/, ''))
+                        restoreTask(task.id)
+                      }}
                       sx={{
-                        px: 2, py: 1,
+                        // Same row height as the compact DataGrid of the
+                        // Proxmox tab (36px), so both tabs read as one list.
+                        px: 2, py: 0, minHeight: 36,
                         borderBottom: '1px solid rgba(231,227,252,0.08)',
                         display: 'flex', alignItems: 'center', gap: 2,
                         cursor: 'pointer',
@@ -786,24 +852,26 @@ export default function TasksFooter({
                       {/* Icon */}
                       <i
                         className={
+                          task.icon ? task.icon :
                           task.type === 'upload' ? 'ri-upload-2-line' :
                           task.type === 'download' ? 'ri-download-2-line' :
                           'ri-settings-3-line'
                         }
                         style={{ fontSize: 16, opacity: 0.6, flexShrink: 0 }}
                       />
-                      {/* Label */}
-                      <Box sx={{ flex: 1, minWidth: 0 }}>
-                        <Typography variant="caption" sx={{ fontWeight: 600, display: 'block' }} noWrap>
+                      {/* Label, detail and initiator on ONE line: stacked
+                          Typographies made every row two or three lines tall. */}
+                      <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <Typography variant="caption" sx={{ fontWeight: 600, flexShrink: 0, maxWidth: '45%' }} noWrap>
                           {task.label}
                         </Typography>
                         {task.detail && (
-                          <Typography variant="caption" sx={{ opacity: 0.5, fontSize: '0.65rem' }} noWrap>
+                          <Typography variant="caption" sx={{ opacity: 0.5, fontSize: '0.65rem', flex: 1, minWidth: 0 }} noWrap>
                             {task.detail}
                           </Typography>
                         )}
                         {task.shared && task.readOnly && task.startedByName && (
-                          <Typography variant="caption" sx={{ opacity: 0.5, fontSize: '0.65rem' }} noWrap>
+                          <Typography variant="caption" sx={{ opacity: 0.5, fontSize: '0.65rem', flexShrink: 0 }} noWrap>
                             {t('tasks.shared.startedBy', { name: task.startedByName })}
                           </Typography>
                         )}
@@ -937,6 +1005,15 @@ return ''
 
     {/* Shared Task Detail Dialog - outside dark ThemeProvider so it follows user theme */}
     <SharedTaskDetailDialog jobId={detailJobId} onClose={() => setDetailJobId(null)} />
+    <JobDetailDialog
+      open={!!detailJob}
+      job={detailJob}
+      onClose={() => setDetailJob(null)}
+      onAction={handleJobAction}
+      actionError={jobActionError}
+      isEnterprise={isEnterprise}
+      t={t}
+    />
 
     {/* Task Detail Dialog - outside dark ThemeProvider so it follows user theme */}
     {selectedTask && (

--- a/frontend/src/components/tasks/JobChips.jsx
+++ b/frontend/src/components/tasks/JobChips.jsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { Chip } from '@mui/material'
+
+import { JOB_TYPE_FALLBACK_LABELS, JOB_TYPE_LABEL_KEYS, jobTypeIcon } from '@/lib/tasks/jobTypes'
+
+/*
+   Status and type pastilles of a Task Center job. Shared by the Task Center
+   table and the job detail dialog so a job is labelled identically wherever it
+   shows up (#767).
+*/
+
+export function StatusChip({ status, t }) {
+  const config = {
+    running: { label: t('jobsPage.statusRunning'), color: 'info' },
+    success: { label: t('jobsPage.statusSuccess'), color: 'success' },
+    completed: { label: t('jobsPage.statusSuccess'), color: 'success' },
+    failed: { label: t('jobsPage.statusFailed'), color: 'error' },
+    cancelled: { label: t('jobsPage.statusCancelled'), color: 'error' },
+    queued: { label: t('jobsPage.statusQueued'), color: 'default' },
+    pending: { label: t('jobsPage.statusQueued'), color: 'default' },
+    paused: { label: t('jobsPage.statusPaused'), color: 'warning' }
+  }
+
+  const cfg = config[status] || { label: status, color: 'default' }
+
+  return <Chip size='small' label={cfg.label} color={cfg.color} sx={{ minWidth: 80 }} />
+}
+
+export function TypeChip({ type, t }) {
+  const label = t && JOB_TYPE_LABEL_KEYS[type] ? t(JOB_TYPE_LABEL_KEYS[type]) : (JOB_TYPE_FALLBACK_LABELS[type] || type)
+  const icon = jobTypeIcon(type)
+
+  return (
+    <Chip
+      size='small'
+      label={label}
+      variant='outlined'
+      icon={<i className={icon} style={{ fontSize: 14 }} />}
+    />
+  )
+}

--- a/frontend/src/components/tasks/JobDetailDialog.jsx
+++ b/frontend/src/components/tasks/JobDetailDialog.jsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  LinearProgress,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  Typography
+} from '@mui/material'
+
+import { extractLogs, jobActions, jobDetailUrl, normalizeLog, syntheticLogs } from '@/lib/tasks/jobActions'
+
+import { StatusChip, TypeChip } from './JobChips'
+
+// RemixIcon replacements for @mui/icons-material
+const CheckCircleIcon = (props) => <i className="ri-checkbox-circle-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
+const ErrorIcon = (props) => <i className="ri-error-warning-fill" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
+const WarningIcon = (props) => <i className="ri-alert-line" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
+const InfoIcon = (props) => <i className="ri-information-line" style={{ fontSize: props?.sx?.fontSize || 20, color: props?.sx?.color, ...props?.style }} />
+const CloseIcon = (props) => <i className="ri-close-line" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
+const PauseIcon = (props) => <i className="ri-pause-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
+const PlayArrowIcon = (props) => <i className="ri-play-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
+const StopIcon = (props) => <i className="ri-stop-fill" style={{ fontSize: props?.fontSize === 'small' ? 18 : 20, color: props?.sx?.color, ...props?.style }} />
+
+/*
+   Detail of one Task Center job: progress, logs and the actions its type
+   actually supports. Lives here rather than in the Task Center page because
+   the ProxCenter tab of the taskbar opens the very same dialog on a
+   double-click.
+*/
+
+function getNodeStatusIcon(status) {
+  switch (status) {
+    case 'completed':
+      return <CheckCircleIcon color="success" fontSize="small" />
+    case 'failed':
+      return <ErrorIcon color="error" fontSize="small" />
+    case 'running':
+    case 'updating':
+    case 'migrating_vms':
+    case 'rebooting':
+    case 'entering_maintenance':
+    case 'exiting_maintenance':
+    case 'verifying_health':
+    case 'waiting_return':
+      return <CircularProgress size={18} />
+    case 'pending':
+      return <InfoIcon color="disabled" fontSize="small" />
+    case 'skipped':
+      return <WarningIcon color="warning" fontSize="small" />
+    default:
+      return <InfoIcon color="disabled" fontSize="small" />
+  }
+}
+
+/* --------------------------------
+   Job Detail Dialog
+-------------------------------- */
+
+export default function JobDetailDialog({ open, onClose, job, onAction, actionError, isEnterprise, t }) {
+  // Keyed by job id: the dialog is never unmounted, so a plain array kept
+  // showing the previous job's logs under the next job opened.
+  const [logState, setLogState] = useState({ jobId: null, entries: [], error: null })
+  const forThisJob = logState.jobId && logState.jobId === job?.id
+  const fetched = forThisJob ? logState.entries : []
+  // Site Recovery has nothing to fetch: its record is the per-VM results the
+  // row already carries.
+  const logs = fetched.length > 0 ? fetched : syntheticLogs(job)
+  // A refused read (a role with tasks.view but not automation.view on the
+  // orchestrator routes) must say so rather than look like an empty log.
+  const logError = forThisJob ? logState.error : null
+  const [loading, setLoading] = useState(false)
+  // Held per job id rather than as a boolean: a stale confirmation must never
+  // carry over to the next job opened in this (permanently mounted) dialog.
+  const [confirmCancelFor, setConfirmCancelFor] = useState(null)
+  const confirmCancel = open && !!job?.id && confirmCancelFor === job.id
+
+  const detailUrl = jobDetailUrl(job)
+
+  // Fetch full job details when dialog opens
+  useEffect(() => {
+    if (open && detailUrl && isEnterprise) {
+      fetchJobDetails()
+    }
+  }, [open, detailUrl, isEnterprise])
+
+  const fetchJobDetails = async () => {
+    if (!detailUrl || !isEnterprise) return
+
+    setLoading(true)
+    try {
+      const res = await fetch(detailUrl)
+      if (res.ok) {
+        const data = await res.json()
+        setLogState({ jobId: job.id, entries: extractLogs(data), error: null })
+      } else {
+        setLogState({ jobId: job.id, entries: [], error: `HTTP ${res.status}` })
+      }
+    } catch (e) {
+      console.error('Error fetching job details:', e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Auto-refresh if job is running
+  useEffect(() => {
+    if (open && detailUrl && job?.status === 'running' && isEnterprise) {
+      const interval = setInterval(fetchJobDetails, 3000)
+      return () => clearInterval(interval)
+    }
+  }, [open, detailUrl, job?.status, isEnterprise])
+
+  if (!job) return null
+
+  const nodeStatuses = job.metadata?.nodeStatuses || []
+  const actions = jobActions(job)
+  const isRollingUpdate = job.type === 'rolling_update'
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="md"
+      fullWidth
+      PaperProps={{ sx: { maxHeight: '80vh' } }}
+    >
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <TypeChip type={job.type} t={t} />
+          <Typography variant="h6">{job.name}</Typography>
+          <StatusChip status={job.status} t={t} />
+        </Box>
+        <IconButton onClick={onClose} size="small">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+
+      <DialogContent dividers>
+        <Stack spacing={3}>
+          {/* Progress */}
+          <Box>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+              {/* The node counter only means something for a rolling update;
+                  every other type shows its own one-line summary instead of a
+                  hardcoded "0 / 0 nodes". */}
+              <Typography variant="body2">
+                {isRollingUpdate
+                  ? t('jobsPage.progression', { completed: job.metadata?.completedNodes || 0, total: job.metadata?.totalNodes || 0 })
+                  : job.detail || '—'}
+              </Typography>
+              {isRollingUpdate && job.metadata?.currentNode ? (
+                <Typography variant="body2" color="text.secondary">
+                  {t('jobsPage.currentlyRunning', { node: job.metadata.currentNode })}
+                </Typography>
+              ) : (
+                <Typography variant="body2" color="text.secondary">{`${job.progress || 0}%`}</Typography>
+              )}
+            </Box>
+            <LinearProgress
+              variant="determinate"
+              value={job.progress || 0}
+              sx={{ height: 8, borderRadius: 1 }}
+            />
+          </Box>
+
+          {/* Info */}
+          <Box sx={{ display: 'flex', gap: 4 }}>
+            <Box>
+              <Typography variant="caption" color="text.secondary">{t('jobsPage.target')}</Typography>
+              <Typography variant="body2">{job.target || '—'}</Typography>
+            </Box>
+            <Box>
+              <Typography variant="caption" color="text.secondary">{t('jobsPage.started')}</Typography>
+              <Typography variant="body2">
+                {job.startedAt ? new Date(job.startedAt).toLocaleString() : '—'}
+              </Typography>
+            </Box>
+            {job.endedAt && (
+              <Box>
+                <Typography variant="caption" color="text.secondary">{t('jobsPage.ended')}</Typography>
+                <Typography variant="body2">
+                  {new Date(job.endedAt).toLocaleString()}
+                </Typography>
+              </Box>
+            )}
+          </Box>
+
+          {/* Actions */}
+          {actions.length > 0 && !confirmCancel && (
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              {actions.includes('pause') && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="warning"
+                  startIcon={<PauseIcon />}
+                  onClick={() => onAction(job, 'pause')}
+                >
+                  {t('jobsPage.pause')}
+                </Button>
+              )}
+              {actions.includes('resume') && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                  startIcon={<PlayArrowIcon />}
+                  onClick={() => onAction(job, 'resume')}
+                >
+                  {t('jobsPage.resume')}
+                </Button>
+              )}
+              {actions.includes('cancel') && (
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  startIcon={<StopIcon />}
+                  onClick={() => (job.type === 'migration' ? setConfirmCancelFor(job.id) : onAction(job, 'cancel'))}
+                >
+                  {job.type === 'migration' ? t('inventoryPage.esxiMigration.cancelMigration') : t('common.cancel')}
+                </Button>
+              )}
+            </Box>
+          )}
+
+          {/* Cancelling a migration is not a UI-only action: it stops the
+              pipeline and leaves whatever was already copied on the target
+              storage, so it gets the same warning as the inventory panel. */}
+          {confirmCancel && (
+            <Card variant="outlined" sx={{ borderColor: 'error.main' }}>
+              <CardContent>
+                <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+                  {t('inventoryPage.esxiMigration.cancelMigrationConfirmTitle')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t('inventoryPage.esxiMigration.cancelMigrationConfirmStop')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t('inventoryPage.esxiMigration.cancelMigrationConfirmVolumesKept')}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {t('inventoryPage.esxiMigration.cancelMigrationConfirmSourceUntouched')}
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 1, mt: 2 }}>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    color="error"
+                    startIcon={<StopIcon />}
+                    onClick={() => {
+                      setConfirmCancelFor(null)
+                      onAction(job, 'cancel')
+                    }}
+                  >
+                    {t('inventoryPage.esxiMigration.cancelMigration')}
+                  </Button>
+                  <Button size="small" variant="outlined" onClick={() => setConfirmCancelFor(null)}>
+                    {t('common.close')}
+                  </Button>
+                </Box>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Error */}
+          {(actionError || job.metadata?.error) && (
+            <Box sx={{ p: 2, bgcolor: 'error.main', color: 'error.contrastText', borderRadius: 1 }}>
+              <Typography variant="body2">{actionError || job.metadata.error}</Typography>
+            </Box>
+          )}
+
+          {/* Node statuses */}
+          {nodeStatuses.length > 0 && (
+            <Card variant="outlined">
+              <CardContent>
+                <Typography variant="subtitle2" fontWeight={700} gutterBottom>
+                  {t('jobsPage.nodeStatuses')}
+                </Typography>
+                <List dense>
+                  {nodeStatuses.map((ns) => (
+                    <ListItem key={ns.node_name}>
+                      <ListItemIcon sx={{ minWidth: 40 }}>
+                        {getNodeStatusIcon(ns.status)}
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={ns.node_name}
+                        secondary={
+                          <>
+                            {ns.status}
+                            {ns.version_before && ns.version_after &&
+                              ` • ${ns.version_before} → ${ns.version_after}`}
+                            {ns.did_reboot && ` • ${t('jobsPage.rebooted')}`}
+                          </>
+                        }
+                      />
+                      {ns.error && (
+                        <Chip size="small" label={t('common.error')} color="error" />
+                      )}
+                    </ListItem>
+                  ))}
+                </List>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Logs */}
+          <Card variant="outlined">
+            <CardContent>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                <Typography variant="subtitle2" fontWeight={700}>
+                  {t('jobsPage.logs')}
+                </Typography>
+                {loading && <CircularProgress size={16} />}
+              </Box>
+              <Box
+                sx={{
+                  maxHeight: 300,
+                  overflow: 'auto',
+                  bgcolor: 'background.default',
+                  borderRadius: 1,
+                  p: 1,
+                  fontFamily: 'monospace',
+                  fontSize: 11,
+                }}
+              >
+                {logs.length === 0 ? (
+                  <Typography variant="body2" color={logError ? 'error.main' : 'text.secondary'}>
+                    {logError ? `${t('jobsPage.noLogs')} (${logError})` : t('jobsPage.noLogs')}
+                  </Typography>
+                ) : (
+                  logs.slice(-100).map(normalizeLog).map((log, i) => (
+                    <Box
+                      key={i}
+                      sx={{
+                        color: log.level === 'error' ? 'error.main' :
+                               (log.level === 'warning' || log.level === 'warn') ? 'warning.main' :
+                               log.level === 'success' ? 'success.main' :
+                               'text.primary',
+                        lineHeight: 1.4,
+                      }}
+                    >
+                      {log.timestamp && `[${new Date(log.timestamp).toLocaleTimeString()}]`}
+                      {log.node && ` [${log.node}]`}
+                      {' '}{log.message}
+                    </Box>
+                  ))
+                )}
+              </Box>
+            </CardContent>
+          </Card>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/lib/tasks/jobActions.test.ts
+++ b/frontend/src/lib/tasks/jobActions.test.ts
@@ -1,0 +1,204 @@
+/**
+ * #767: the Task Center posted every action to the rolling-updates routes
+ * whatever the job type, so the Cancel button shown on a DRS, replication or
+ * migration job hit the wrong endpoint. These tests pin the per-type routing
+ * and the log normalisation between the two log shapes in the product.
+ */
+import { describe, expect, it } from "vitest"
+
+import { extractLogs, jobActions, jobActionUrl, jobDetailUrl, normalizeLog, syntheticLogs } from "./jobActions"
+
+const migration = (over: Record<string, any> = {}) => ({
+  id: "mig-1",
+  type: "migration",
+  status: "running",
+  metadata: { cancellable: true, ...(over.metadata ?? {}) },
+  ...over,
+})
+
+describe("jobDetailUrl", () => {
+  it("routes a rolling update to the orchestrator detail", () => {
+    expect(jobDetailUrl({ id: "ru-1", type: "rolling_update" })).toBe(
+      "/api/v1/orchestrator/rolling-updates/ru-1",
+    )
+  })
+
+  it("routes a migration to the tasks.view-gated shared detail, not /api/v1/migrations", () => {
+    // history=1 lifts the footer's 30-minute window: the Task Center lists the
+    // full history, so an old finished job must still return its logs.
+    expect(jobDetailUrl(migration())).toBe("/api/v1/tasks/shared/mig-1?history=1")
+  })
+
+  it("routes a replication job to the orchestrator log route", () => {
+    expect(jobDetailUrl({ id: "r-1", type: "replication" })).toBe(
+      "/api/v1/orchestrator/replication/jobs/r-1/logs",
+    )
+  })
+
+  it("routes a DRS migration to the PVE task log, taking the node from the UPID", () => {
+    const drs = {
+      id: "d-1",
+      type: "drs",
+      metadata: { connectionId: "c1", taskId: "UPID:pve3:0000ABCD:001:qmigrate:100:root@pam:", sourceNode: "pve1" },
+    }
+    expect(jobDetailUrl(drs)).toBe(
+      "/api/v1/tasks/c1/pve3/UPID%3Apve3%3A0000ABCD%3A001%3Aqmigrate%3A100%3Aroot%40pam%3A",
+    )
+  })
+
+  it("falls back to the recorded source node when the UPID is not parseable", () => {
+    const drs = { id: "d-1", type: "drs", metadata: { connectionId: "c1", taskId: "weird", sourceNode: "pve1" } }
+    expect(jobDetailUrl(drs)).toBe("/api/v1/tasks/c1/pve1/weird")
+  })
+
+  it("has no detail endpoint for a DRS row without a task id, nor for Site Recovery", () => {
+    expect(jobDetailUrl({ id: "d-1", type: "drs", metadata: { connectionId: "c1" } })).toBeNull()
+    expect(jobDetailUrl({ id: "d-2", type: "drs", metadata: { taskId: "UPID:pve1:x" } })).toBeNull()
+    // A RecoveryExecution has no log column: syntheticLogs covers it instead.
+    expect(jobDetailUrl({ id: "sr-1", type: "site_recovery" })).toBeNull()
+  })
+
+  it("returns null without an id", () => {
+    expect(jobDetailUrl(null)).toBeNull()
+    expect(jobDetailUrl({ type: "rolling_update" })).toBeNull()
+  })
+})
+
+describe("jobActions", () => {
+  it("offers pause/cancel on a running rolling update and resume/cancel when paused", () => {
+    expect(jobActions({ id: "ru-1", type: "rolling_update", status: "running" })).toEqual(["pause", "cancel"])
+    expect(jobActions({ id: "ru-1", type: "rolling_update", status: "paused" })).toEqual(["resume", "cancel"])
+    expect(jobActions({ id: "ru-1", type: "rolling_update", status: "success" })).toEqual([])
+  })
+
+  it("offers cancel on an in-flight migration only", () => {
+    expect(jobActions(migration())).toEqual(["cancel"])
+    expect(jobActions(migration({ status: "success", metadata: { cancellable: false } }))).toEqual([])
+    // No metadata at all (older payload) must not offer a cancel that 400s.
+    expect(jobActions({ id: "mig-2", type: "migration", status: "running" })).toEqual([])
+  })
+
+  it("offers nothing for the types with no cancel route in the orchestrator", () => {
+    expect(jobActions({ id: "d-1", type: "drs", status: "running" })).toEqual([])
+    expect(jobActions({ id: "r-1", type: "replication", status: "running" })).toEqual([])
+    expect(jobActions({ id: "sr-1", type: "site_recovery", status: "running" })).toEqual([])
+    expect(jobActions(null)).toEqual([])
+  })
+})
+
+describe("jobActionUrl", () => {
+  it("keeps rolling updates on the orchestrator route", () => {
+    expect(jobActionUrl({ id: "ru-1", type: "rolling_update" }, "pause")).toBe(
+      "/api/v1/orchestrator/rolling-updates/ru-1/pause",
+    )
+    expect(jobActionUrl({ id: "ru-1", type: "rolling_update" }, "cancel")).toBe(
+      "/api/v1/orchestrator/rolling-updates/ru-1/cancel",
+    )
+  })
+
+  it("cancels a migration through /api/v1/migrations, and supports nothing else", () => {
+    expect(jobActionUrl(migration(), "cancel")).toBe("/api/v1/migrations/mig-1/cancel")
+    expect(jobActionUrl(migration(), "pause")).toBeNull()
+    expect(jobActionUrl(migration(), "resume")).toBeNull()
+  })
+
+  it("never invents an endpoint for a type that has none", () => {
+    expect(jobActionUrl({ id: "d-1", type: "drs" }, "cancel")).toBeNull()
+    expect(jobActionUrl({ id: "r-1", type: "replication" }, "cancel")).toBeNull()
+    expect(jobActionUrl(null, "cancel")).toBeNull()
+  })
+})
+
+describe("extractLogs", () => {
+  it("reads {data:{logs}} (rolling updates, migrations)", () => {
+    expect(extractLogs({ data: { logs: [{ msg: "a" }] } })).toEqual([{ msg: "a" }])
+  })
+
+  it("reads {logs} (PVE task)", () => {
+    expect(extractLogs({ upid: "UPID:pve1:x", logs: [{ n: 1, t: "line" }] })).toEqual([{ n: 1, t: "line" }])
+  })
+
+  it("reads a bare array and {data:[...]} (replication log route)", () => {
+    expect(extractLogs([{ message: "a" }])).toEqual([{ message: "a" }])
+    expect(extractLogs({ data: [{ message: "b" }] })).toEqual([{ message: "b" }])
+  })
+
+  it("returns an empty array for anything else", () => {
+    expect(extractLogs(null)).toEqual([])
+    expect(extractLogs({ data: { logs: "nope" } })).toEqual([])
+    expect(extractLogs({ error: "Not found" })).toEqual([])
+  })
+})
+
+describe("syntheticLogs", () => {
+  const execution = (vmResults: any[]) => ({ id: "sr-1", type: "site_recovery", metadata: { vmResults } })
+
+  it("turns per-VM results into one line each, coloured by outcome", () => {
+    const out = syntheticLogs(
+      execution([
+        { vm_name: "web-01", status: "completed", target_node: "pve2", target_vmid: 70004, restore_point: "snap-1" },
+        { vm_name: "db-01", status: "failed", target_node: "pve2", error: "timeout waiting for boot" },
+      ]),
+    )
+    expect(out).toEqual([
+      { node: "web-01", message: "completed on pve2 (VMID 70004), restore point snap-1", level: "success" },
+      { node: "db-01", message: "failed on pve2: timeout waiting for boot", level: "error" },
+    ])
+  })
+
+  it("names a VM with no name by its id and keeps a running VM neutral", () => {
+    expect(syntheticLogs(execution([{ vm_id: 101, status: "running", step: "restoring" }]))).toEqual([
+      { node: "VM 101", message: "running, step restoring", level: "info" },
+    ])
+  })
+
+  it("stays empty for every other type and for a row without results", () => {
+    expect(syntheticLogs({ id: "ru-1", type: "rolling_update", metadata: { vmResults: [{}] } })).toEqual([])
+    expect(syntheticLogs({ id: "sr-1", type: "site_recovery" })).toEqual([])
+    expect(syntheticLogs({ id: "sr-1", type: "site_recovery", metadata: { vmResults: null } })).toEqual([])
+    expect(syntheticLogs(null)).toEqual([])
+  })
+})
+
+describe("normalizeLog", () => {
+  it("keeps the rolling-update shape", () => {
+    expect(normalizeLog({ timestamp: "2026-08-24T10:00:00Z", node: "pve1", message: "hello", level: "error" })).toEqual({
+      timestamp: "2026-08-24T10:00:00Z",
+      node: "pve1",
+      message: "hello",
+      level: "error",
+    })
+  })
+
+  it("maps the migration pipeline shape {ts,msg}", () => {
+    expect(normalizeLog({ ts: "2026-08-24T10:00:00Z", msg: "disk 1/2 copied", level: "success" })).toEqual({
+      timestamp: "2026-08-24T10:00:00Z",
+      node: null,
+      message: "disk 1/2 copied",
+      level: "success",
+    })
+  })
+
+  it("maps the replication shape {created_at,message,vmid}", () => {
+    expect(normalizeLog({ created_at: "2026-08-24T10:00:00Z", message: "synced", level: "info", vmid: 101 })).toEqual({
+      timestamp: "2026-08-24T10:00:00Z",
+      node: "VM 101",
+      message: "synced",
+      level: "info",
+    })
+  })
+
+  it("maps a PVE task line {n,t}, which carries no timestamp", () => {
+    expect(normalizeLog({ n: 12, t: "migration status: completed" })).toEqual({
+      timestamp: null,
+      node: null,
+      message: "migration status: completed",
+      level: "info",
+    })
+  })
+
+  it("survives a bare string and a malformed entry", () => {
+    expect(normalizeLog("raw line")).toEqual({ timestamp: null, node: null, message: "raw line", level: "info" })
+    expect(normalizeLog(null)).toEqual({ timestamp: null, node: null, message: "", level: "info" })
+  })
+})

--- a/frontend/src/lib/tasks/jobActions.ts
+++ b/frontend/src/lib/tasks/jobActions.ts
@@ -1,0 +1,190 @@
+/**
+ * Per-type endpoints, actions and log extraction for the Task Center.
+ *
+ * The page used to hardcode the rolling-updates routes whatever the job type
+ * (#767): the detail dialog fetched its logs from /rolling-updates/{id} and
+ * its Pause/Cancel buttons posted to /rolling-updates/{id}/{action}, so on a
+ * DRS, replication or migration job the buttons were displayed and did
+ * nothing, and the Logs panel was empty for every type but one. Kept in lib so
+ * every branch is unit-tested and both surfaces that show a job detail (the
+ * Task Center page and the ProxCenter tab of the taskbar) share it.
+ */
+
+export type JobLike = {
+  id?: string
+  type?: string
+  status?: string
+  metadata?: Record<string, any> | null
+} | null | undefined
+
+export type JobAction = 'pause' | 'resume' | 'cancel'
+
+/** `UPID:pve1:0000ABCD:...` -> `pve1`. */
+function upidNode(upid: string): string | null {
+  const parts = String(upid).split(':')
+
+  return parts[0] === 'UPID' && parts[1] ? parts[1] : null
+}
+
+/**
+ * Read-only detail endpoint carrying the job's logs, or null when its type
+ * keeps none server-side.
+ *
+ * Every source has its own log store: the orchestrator for rolling updates
+ * and replication, our database for migrations, PVE itself for a DRS
+ * migration (the orchestrator only records the UPID it triggered).
+ */
+export function jobDetailUrl(job: JobLike): string | null {
+  if (!job?.id) return null
+
+  if (job.type === 'rolling_update') return `/api/v1/orchestrator/rolling-updates/${job.id}`
+
+  // Migrations: the shared-task detail is gated on the same tasks.view
+  // permission as this page (/api/v1/migrations/{id} requires vm.migrate).
+  // history=1 drops its 30-minute recency window, which exists for the tasks
+  // footer: this page lists the whole history, so a job that finished days ago
+  // must still open with its logs.
+  if (job.type === 'migration') return `/api/v1/tasks/shared/${job.id}?history=1`
+
+  if (job.type === 'replication') return `/api/v1/orchestrator/replication/jobs/${job.id}/logs`
+
+  // A DRS migration is a PVE task: the log lives on the node that ran it,
+  // addressed by the UPID the orchestrator recorded. The node is read from the
+  // UPID itself (UPID:<node>:...) and falls back to the recorded source node.
+  if (job.type === 'drs') {
+    const upid = job.metadata?.taskId
+    const connectionId = job.metadata?.connectionId
+    if (!upid || !connectionId) return null
+
+    const node = upidNode(upid) || job.metadata?.sourceNode
+    if (!node) return null
+
+    return `/api/v1/tasks/${encodeURIComponent(connectionId)}/${encodeURIComponent(node)}/${encodeURIComponent(upid)}`
+  }
+
+  // site_recovery: a RecoveryExecution has no log column at all, its record is
+  // the per-VM results already carried by the row (see syntheticLogs).
+  return null
+}
+
+/** Actions the backend can actually honour for this job, in display order. */
+export function jobActions(job: JobLike): JobAction[] {
+  if (!job) return []
+
+  if (job.type === 'rolling_update') {
+    if (job.status === 'running') return ['pause', 'cancel']
+    if (job.status === 'paused') return ['resume', 'cancel']
+
+    return []
+  }
+
+  // metadata.cancellable is set by the jobs route from the row status: the
+  // cancel endpoint answers 400 on an already-finished migration.
+  if (job.type === 'migration') return job.metadata?.cancellable ? ['cancel'] : []
+
+  // DRS, replication and Site Recovery executions: the orchestrator exposes
+  // no cancel route for them, so a button would be a dead end.
+  return []
+}
+
+/** POST endpoint backing an action, or null when unsupported. */
+export function jobActionUrl(job: JobLike, action: JobAction): string | null {
+  if (!job?.id) return null
+  if (job.type === 'rolling_update') return `/api/v1/orchestrator/rolling-updates/${job.id}/${action}`
+  if (job.type === 'migration' && action === 'cancel') return `/api/v1/migrations/${job.id}/cancel`
+
+  return null
+}
+
+/**
+ * Pull the log array out of a detail payload. The four endpoints disagree:
+ * rolling updates and migrations answer {data:{logs:[...]}}, the replication
+ * logs route answers a bare array, a PVE task answers {logs:[...]}.
+ */
+export function extractLogs(payload: any): any[] {
+  if (Array.isArray(payload)) return payload
+
+  const detail = payload?.data ?? payload
+  if (Array.isArray(detail)) return detail
+  if (Array.isArray(detail?.logs)) return detail.logs
+
+  return []
+}
+
+/**
+ * Site Recovery keeps no log: what a failover, failback or test failover
+ * leaves behind is one result per VM. Render those as log lines so the panel
+ * says what happened instead of "no logs available".
+ */
+export function syntheticLogs(job: JobLike): any[] {
+  if (job?.type !== 'site_recovery') return []
+
+  const results = job.metadata?.vmResults
+  if (!Array.isArray(results)) return []
+
+  return results.map((vm: any) => {
+    const name = vm?.vm_name || (vm?.vm_id ? `VM ${vm.vm_id}` : 'VM')
+    const target = vm?.target_node ? ` on ${vm.target_node}` : ''
+    const vmid = vm?.target_vmid ? ` (VMID ${vm.target_vmid})` : ''
+    const restore = vm?.restore_point ? `, restore point ${vm.restore_point}` : ''
+    const step = !vm?.error && vm?.step ? `, step ${vm.step}` : ''
+    const status = vm?.status || 'unknown'
+
+    return {
+      node: name,
+      message: vm?.error
+        ? `${status}${target}${vmid}: ${vm.error}`
+        : `${status}${target}${vmid}${step}${restore}`,
+      level: status === 'failed' ? 'error' : status === 'completed' ? 'success' : 'info',
+    }
+  })
+}
+
+export type NormalizedLog = {
+  timestamp: string | null
+  node: string | null
+  message: string
+  level: string
+}
+
+/**
+ * One shape out of four: rolling updates log {timestamp,node,message,level},
+ * migration pipelines {ts,msg,level}, replication {created_at,message,vmid},
+ * PVE task lines {n,t} (line number and text, no timestamp).
+ */
+export function normalizeLog(entry: any): NormalizedLog {
+  if (typeof entry === 'string') return { timestamp: null, node: null, message: entry, level: 'info' }
+
+  const vmid = entry?.vmid
+  const node = entry?.node || (vmid ? `VM ${vmid}` : null)
+
+  return {
+    timestamp: entry?.timestamp || entry?.ts || entry?.created_at || null,
+    node,
+    message: entry?.message || entry?.msg || entry?.t || '',
+    level: entry?.level || 'info',
+  }
+}
+
+/**
+ * Run one action on a job. Both callers (the Task Center page and the taskbar)
+ * then refresh their own SWR cache and surface `error` to the operator: a
+ * silent no-op on click is exactly what #767 reported.
+ */
+export async function runJobAction(job: JobLike, action: JobAction): Promise<{ ok: boolean; error?: string }> {
+  const url = jobActionUrl(job, action)
+  if (!url) return { ok: false, error: `Unsupported action ${action}` }
+
+  try {
+    const res = await fetch(url, { method: 'POST' })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+
+      return { ok: false, error: data?.error || `Failed to ${action} job` }
+    }
+
+    return { ok: true }
+  } catch (e: any) {
+    return { ok: false, error: e?.message || `Failed to ${action} job` }
+  }
+}

--- a/frontend/src/lib/tasks/jobTypes.ts
+++ b/frontend/src/lib/tasks/jobTypes.ts
@@ -1,0 +1,41 @@
+/**
+ * How a Task Center job type is named and pictured. Shared by the Task Center
+ * page and the ProxCenter tab of the taskbar so both surfaces label the same
+ * job identically.
+ *
+ * `site_recovery` replaced `maintenance` (#767): a failover, a failback or a
+ * test failover is Site Recovery, and the old type made the column lie about
+ * what the operator had run.
+ */
+
+export const JOB_TYPE_ICONS: Record<string, string> = {
+  rolling_update: 'ri-refresh-line',
+  replication: 'ri-repeat-line',
+  drs: 'ri-exchange-line',
+  // Same icon as the Site Recovery menu entry (menuData.js).
+  site_recovery: 'ri-shield-star-line',
+  migration: 'ri-swap-box-line',
+}
+
+export const JOB_TYPE_LABEL_KEYS: Record<string, string> = {
+  rolling_update: 'jobsPage.typeRollingUpdate',
+  replication: 'jobsPage.typeReplication',
+  drs: 'jobsPage.typeDrs',
+  site_recovery: 'jobsPage.typeSiteRecovery',
+  migration: 'jobsPage.typeMigration',
+}
+
+/** Shown only if a type ever reaches the UI without a message-catalogue key. */
+export const JOB_TYPE_FALLBACK_LABELS: Record<string, string> = {
+  rolling_update: 'Rolling Update',
+  replication: 'Replication',
+  drs: 'DRS',
+  site_recovery: 'Site Recovery',
+  migration: 'Migration',
+}
+
+export const JOB_TYPE_FALLBACK_ICON = 'ri-file-list-line'
+
+export function jobTypeIcon(type?: string): string {
+  return (type && JOB_TYPE_ICONS[type]) || JOB_TYPE_FALLBACK_ICON
+}

--- a/frontend/src/lib/tasks/mergeSharedTasks.ts
+++ b/frontend/src/lib/tasks/mergeSharedTasks.ts
@@ -7,6 +7,10 @@ export interface MergedPCTask extends PCTask {
   rawStatus?: string
   startedByName?: string
   jobId?: string
+  /** Remix icon class, set by rows that carry their own job-type icon. */
+  icon?: string
+  /** Task Center job (rolling update, DRS, replication, Site Recovery). */
+  orchestrator?: boolean
 }
 
 function statusFor(raw: string): PCTaskStatus {
@@ -61,7 +65,13 @@ export function mergeSharedTasks(localTasks: PCTask[], serverTasks: SharedTask[]
     // otherwise keep the server row (terminal server, or non-running local)
   }
 
-  return [...byId.values()].sort((a, b) => {
+  return sortPcTasks([...byId.values()])
+}
+
+/** Running first, then most recent first. Exported so rows merged in from
+ *  another source (orchestratorTaskRows) sort exactly the same way. */
+export function sortPcTasks(rows: MergedPCTask[]): MergedPCTask[] {
+  return [...rows].sort((a, b) => {
     const ar = a.status === "running" ? 0 : 1
     const br = b.status === "running" ? 0 : 1
     if (ar !== br) return ar - br

--- a/frontend/src/lib/tasks/orchestratorTaskRows.test.ts
+++ b/frontend/src/lib/tasks/orchestratorTaskRows.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The ProxCenter tab of the taskbar used to list nothing but the external
+ * migrations of the last 30 minutes, so a rolling update, a DRS move, a
+ * replication run, a failover or simply an older migration was nowhere to be
+ * seen outside the Task Center page. It now mirrors the Task Center list.
+ */
+import { describe, expect, it } from "vitest"
+
+import { mergeTaskbarRows, orchestratorTaskRows, taskbarRowId } from "./orchestratorTaskRows"
+
+const T0 = Date.parse("2026-08-24T12:00:00Z")
+const minutesAgo = (n: number) => new Date(T0 - n * 60 * 1000).toISOString()
+
+const job = (over: Record<string, any> = {}) => ({
+  id: "ru-1",
+  name: "Rolling Update - pve1.example.com",
+  type: "rolling_update",
+  status: "running",
+  progress: 40,
+  startedAt: minutesAgo(5),
+  detail: "1/3 nodes",
+  metadata: {},
+  ...over,
+})
+
+const sharedTask = (over: Record<string, any> = {}) => ({
+  id: "mig-1",
+  kind: "migration",
+  label: "srv-app (vCenter -> Proxmox)",
+  status: "transferring",
+  currentStep: "disk 1/2",
+  progress: 42,
+  error: null,
+  isMine: true,
+  createdByName: "Alice",
+  createdAt: minutesAgo(3),
+  ...over,
+})
+
+describe("taskbarRowId", () => {
+  it("puts a migration in the shared-task namespace and everything else in its own", () => {
+    expect(taskbarRowId({ id: "mig-1", type: "migration" })).toBe("migration-mig-1")
+    expect(taskbarRowId({ id: "ru-1", type: "rolling_update" })).toBe("job-ru-1")
+    expect(taskbarRowId({ id: "sr-1", type: "site_recovery" })).toBe("job-sr-1")
+  })
+})
+
+describe("orchestratorTaskRows", () => {
+  it("maps a running rolling update to a read-only taskbar row", () => {
+    expect(orchestratorTaskRows([job()])).toEqual([
+      {
+        id: "job-ru-1",
+        type: "generic",
+        icon: "ri-refresh-line",
+        label: "Rolling Update - pve1.example.com",
+        detail: "1/3 nodes",
+        progress: 40,
+        status: "running",
+        rawStatus: "running",
+        error: undefined,
+        createdAt: Date.parse(minutesAgo(5)),
+        shared: true,
+        readOnly: true,
+        orchestrator: true,
+        jobId: "ru-1",
+      },
+    ])
+  })
+
+  it("keeps finished jobs, however old: the taskbar mirrors the Task Center", () => {
+    const rows = orchestratorTaskRows([
+      job({ id: "old-1", status: "success", startedAt: minutesAgo(60 * 24 * 79), endedAt: minutesAgo(60 * 24 * 79) }),
+      job({ id: "old-2", status: "failed", startedAt: minutesAgo(60 * 24 * 12) }),
+    ])
+    expect(rows.map(r => r.id)).toEqual(["job-old-1", "job-old-2"])
+  })
+
+  it("maps each status onto the three states a row can render", () => {
+    const statuses = ["success", "completed", "failed", "cancelled", "paused", "pending", "queued"]
+    const rows = orchestratorTaskRows(statuses.map((status, i) => job({ id: `j${i}`, status })))
+    expect(rows.map(r => r.status)).toEqual(["done", "done", "error", "error", "running", "running", "running"])
+    // The precise word stays available for the chip label.
+    expect(rows.map(r => r.rawStatus)).toEqual(statuses)
+  })
+
+  it("carries the per-type icon and the error of a failed job", () => {
+    const rows = orchestratorTaskRows([
+      job({ id: "d-1", type: "drs", name: "DRS Migration - vm1" }),
+      job({ id: "r-1", type: "replication", name: "Replication - vm1" }),
+      job({ id: "sr-1", type: "site_recovery", name: "Failover - dr-plan", status: "failed", metadata: { error: "boom" } }),
+      job({ id: "m-1", type: "migration", name: "Migration - srv" }),
+    ])
+    expect(rows.map(r => r.icon)).toEqual([
+      "ri-exchange-line",
+      "ri-repeat-line",
+      "ri-shield-star-line",
+      "ri-swap-box-line",
+    ])
+    expect(rows.find(r => r.id === "job-sr-1")?.error).toBe("boom")
+  })
+
+  it("survives a missing or malformed payload", () => {
+    expect(orchestratorTaskRows(undefined as any)).toEqual([])
+    expect(orchestratorTaskRows([{ status: "running" }] as any)).toEqual([])
+    const [row] = orchestratorTaskRows([{ id: "x", status: "running" }])
+    expect(row.label).toBe("x")
+    expect(row.progress).toBe(0)
+    expect(row.createdAt).toBe(0)
+    expect(row.icon).toBe("ri-file-list-line")
+  })
+})
+
+describe("mergeTaskbarRows", () => {
+  it("lists local tasks, shared migrations and Task Center jobs together", () => {
+    const local = [{ id: "upload-1", type: "upload" as const, label: "ISO", progress: 10, status: "running" as const, createdAt: T0 }]
+    const rows = mergeTaskbarRows(local, [sharedTask()] as any, [job({ id: "sr-1", type: "site_recovery", status: "success" })])
+    expect(rows.map(r => r.id).sort()).toEqual(["job-sr-1", "migration-mig-1", "upload-1"])
+  })
+
+  it("keeps the shared row for a migration the jobs endpoint also returns", () => {
+    const rows = mergeTaskbarRows([], [sharedTask()] as any, [
+      job({ id: "mig-1", type: "migration", name: "Migration - srv-app", status: "transferring" }),
+    ])
+    expect(rows).toHaveLength(1)
+    const row = rows[0]
+    expect(row.id).toBe("migration-mig-1")
+    // The shared row's richer shape survived: initiator, own detail, no
+    // orchestrator flag (so a click still opens the migration dialog).
+    expect(row.startedByName).toBe("Alice")
+    expect(row.detail).toBe("disk 1/2")
+    expect(row.orchestrator).toBeUndefined()
+  })
+
+  it("shows an older migration the shared window no longer returns", () => {
+    const rows = mergeTaskbarRows([], [], [
+      job({ id: "mig-old", type: "migration", name: "Migration - NginX", status: "completed", startedAt: minutesAgo(60 * 96) }),
+    ])
+    expect(rows.map(r => r.id)).toEqual(["migration-mig-old"])
+    expect(rows[0].orchestrator).toBe(true)
+  })
+
+  it("sorts running rows first, then most recent first", () => {
+    const rows = mergeTaskbarRows([], [], [
+      job({ id: "old-done", status: "success", startedAt: minutesAgo(600) }),
+      job({ id: "recent-done", status: "success", startedAt: minutesAgo(10) }),
+      job({ id: "live", status: "running", startedAt: minutesAgo(900) }),
+    ])
+    expect(rows.map(r => r.id)).toEqual(["job-live", "job-recent-done", "job-old-done"])
+  })
+})

--- a/frontend/src/lib/tasks/orchestratorTaskRows.ts
+++ b/frontend/src/lib/tasks/orchestratorTaskRows.ts
@@ -1,0 +1,87 @@
+import type { PCTask } from '@/contexts/ProxCenterTasksContext'
+
+import { mergeSharedTasks, sortPcTasks, type MergedPCTask } from './mergeSharedTasks'
+import type { SharedTask } from './sharedTask'
+import { jobTypeIcon } from './jobTypes'
+
+/**
+ * Turn Task Center jobs (rolling updates, DRS, replication, Site Recovery and
+ * external migrations) into rows for the ProxCenter tab of the taskbar, which
+ * used to list nothing but the migrations of the last 30 minutes.
+ *
+ * The whole list is kept, terminal rows included: the taskbar mirrors what the
+ * Task Center shows, and the jobs endpoint already caps itself (50 rows). Only
+ * duplication is filtered, in mergeTaskbarRows below.
+ */
+
+/** Job status -> the three states a taskbar row can render. */
+function taskbarStatus(status?: string): MergedPCTask['status'] {
+  if (status === 'success' || status === 'completed') return 'done'
+  if (status === 'failed' || status === 'cancelled') return 'error'
+
+  return 'running'
+}
+
+function timeOf(value: unknown): number | null {
+  if (!value) return null
+  const ms = Date.parse(String(value))
+
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Row id. Migrations share the `migration-<jobId>` namespace with the rows
+ * built from /api/v1/tasks/shared so the same migration cannot appear twice:
+ * mergeTaskbarRows keeps the shared row, which carries the initiator's live
+ * progress, the "started by" line and the detail dialog.
+ */
+export function taskbarRowId(job: any): string {
+  return job?.type === 'migration' ? `migration-${job.id}` : `job-${job.id}`
+}
+
+export function orchestratorTaskRows(jobs: any[]): MergedPCTask[] {
+  if (!Array.isArray(jobs)) return []
+
+  return jobs
+    .filter(job => job?.id)
+    .map(job => ({
+      id: taskbarRowId(job),
+      type: 'generic' as const,
+      icon: jobTypeIcon(job.type),
+      label: job.name || job.id,
+      detail: job.detail || undefined,
+      progress: typeof job.progress === 'number' ? job.progress : 0,
+      status: taskbarStatus(job.status),
+      rawStatus: job.status,
+      error: job.metadata?.error || undefined,
+      createdAt: timeOf(job.startedAt) ?? timeOf(job.createdAt) ?? 0,
+      // Not the caller's own client-side task: no restore, no "clear completed".
+      shared: true,
+      readOnly: true,
+      // Clicking one opens the Task Center, not the migration detail dialog:
+      // that dialog only knows migrations, and only recent ones.
+      orchestrator: true,
+      jobId: job.id,
+    }))
+}
+
+/**
+ * Every row of the ProxCenter tab: the caller's own local tasks, the shared
+ * migrations, then the Task Center jobs that are not already one of those.
+ */
+export function mergeTaskbarRows(
+  localTasks: PCTask[],
+  sharedTasks: SharedTask[],
+  jobs: any[],
+): MergedPCTask[] {
+  const rows = mergeSharedTasks(localTasks, sharedTasks)
+  const seen = new Set(rows.map(r => r.id))
+
+  for (const row of orchestratorTaskRows(jobs)) {
+    if (seen.has(row.id)) continue
+    seen.add(row.id)
+    rows.push(row)
+  }
+
+  return sortPcTasks(rows)
+}

--- a/frontend/src/lib/tasks/sharedTask.test.ts
+++ b/frontend/src/lib/tasks/sharedTask.test.ts
@@ -37,6 +37,8 @@ describe("sourceTypeLabel", () => {
   it("maps known source types and falls back to the raw value then External", () => {
     expect(sourceTypeLabel("vcenter")).toBe("vCenter")
     expect(sourceTypeLabel("esxi-direct")).toBe("ESXi")
+    // Raw connection type of an ESXi host (subType != vcenter).
+    expect(sourceTypeLabel("vmware")).toBe("ESXi")
     expect(sourceTypeLabel("xcpng")).toBe("XCP-ng")
     expect(sourceTypeLabel("weirdthing")).toBe("weirdthing")
     expect(sourceTypeLabel(null)).toBe("External")

--- a/frontend/src/lib/tasks/sharedTask.ts
+++ b/frontend/src/lib/tasks/sharedTask.ts
@@ -8,6 +8,10 @@ export const TERMINAL_STATUSES = ["completed", "failed", "cancelled"] as const
 export const SOURCE_TYPE_LABELS: Record<string, string> = {
   esxi: "ESXi",
   "esxi-direct": "ESXi",
+  // A vmware connection whose subType is not "vcenter" is an ESXi host: the
+  // migration route stores the raw connection type in config.sourceType, so
+  // without this entry every ESXi-direct job was labelled "vmware".
+  vmware: "ESXi",
   vcenter: "vCenter",
   hyperv: "Hyper-V",
   nutanix: "Nutanix",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -3692,6 +3692,7 @@
     "typeReplication": "Replikation",
     "typeDrs": "DRS",
     "typeMaintenance": "Wartung",
+    "typeSiteRecovery": "Site Recovery",
     "typeMigration": "Migration",
     "statusRunning": "Laufend",
     "statusSuccess": "Erfolg",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3715,6 +3715,7 @@
     "typeReplication": "Replication",
     "typeDrs": "DRS",
     "typeMaintenance": "Maintenance",
+    "typeSiteRecovery": "Site Recovery",
     "typeMigration": "Migration",
     "statusRunning": "Running",
     "statusSuccess": "Success",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -3715,6 +3715,7 @@
     "typeReplication": "Replicación",
     "typeDrs": "DRS",
     "typeMaintenance": "Mantenimiento",
+    "typeSiteRecovery": "Site Recovery",
     "typeMigration": "Migración",
     "statusRunning": "En ejecución",
     "statusSuccess": "Correcto",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -3715,6 +3715,7 @@
     "typeReplication": "Réplication",
     "typeDrs": "DRS",
     "typeMaintenance": "Maintenance",
+    "typeSiteRecovery": "Site Recovery",
     "typeMigration": "Migration",
     "statusRunning": "En cours",
     "statusSuccess": "Succès",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -3715,6 +3715,7 @@
     "typeReplication": "복제",
     "typeDrs": "DRS",
     "typeMaintenance": "유지 관리",
+    "typeSiteRecovery": "사이트 복구",
     "typeMigration": "마이그레이션",
     "statusRunning": "실행 중",
     "statusSuccess": "성공",

--- a/frontend/src/messages/taskCenterTypesMessages.test.ts
+++ b/frontend/src/messages/taskCenterTypesMessages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+// Every type the Task Center can display. typeSiteRecovery replaced the
+// misleading "Maintenance" chip on failover/failback/test-failover rows.
+const requiredKeys = [
+  'jobsPage.typeRollingUpdate',
+  'jobsPage.typeReplication',
+  'jobsPage.typeDrs',
+  'jobsPage.typeMigration',
+  'jobsPage.typeSiteRecovery',
+]
+
+function get(messages: any, path: string): unknown {
+  return path.split('.').reduce((node, key) => (node ? node[key] : undefined), messages)
+}
+
+describe('Task Center job-type i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} declares every job-type key`, () => {
+      for (const key of requiredKeys) {
+        expect(get(messages, key), `${locale}: ${key}`).toBeTypeOf('string')
+      }
+    })
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -3691,6 +3691,7 @@
     "typeReplication": "复制",
     "typeDrs": "DRS",
     "typeMaintenance": "维护",
+    "typeSiteRecovery": "站点恢复",
     "typeMigration": "迁移",
     "statusRunning": "运行中",
     "statusSuccess": "成功",


### PR DESCRIPTION
## Problem

A migration created from the VM view never appeared in **Operations > Task Center**, so its progress could not be followed and the job could not be cancelled (#767, reported on 1.4.7).

The root cause is in the aggregation route `/api/v1/orchestrator/jobs`: it collected four orchestrator sources only (rolling updates, DRS migrations, replication jobs, replication plans and their history) and never queried the migration jobs table. The page offered a "Migration" filter that nothing could ever fill. The "Backup" filter had the same issue.

## What this changes

**Migration jobs are now a fifth source.** They are scoped by target connection alone, following the same rule as shared tasks: a vDC tenant does not own the source hypervisor connection, so scoping on both ends would hide its own migrations.

**Recovery plan executions are reported as `site_recovery`** instead of being lumped into `maintenance`, with a dedicated label added to the six locales and its own icon.

**Logs now work for every task type.** Each type needed its own path: rolling updates and replication come from the orchestrator, migrations from the shared task history (behind a new `history=1` parameter that lifts the 30 minute window kept for the taskbar), DRS from the PVE task log rebuilt out of the UPID stored in the job metadata, and Site Recovery is synthesized from the per-VM results because a recovery execution carries no log column at all.

**Actions are routed per type.** Cancelling a migration asks for confirmation, action errors are surfaced in the dialog, and the buttons the orchestrator has no route for (DRS, replication, Site Recovery) are no longer rendered as inert controls.

**Deleted connections are named.** A recovery plan can reference a connection that no longer exists (`source_cluster_id` is not a foreign key), which used to print a raw id; it now reads `Deleted connection (<short id>)`.

**The ProxCenter tab of the taskbar is populated** with the same jobs over the whole history, no recency window, deduplicated against the shared task rows. Double clicking a row opens the same detail dialog as the Task Center, which is why the dialog and the status and type chips moved to `src/components/tasks/` and the action helpers to `src/lib/tasks/jobActions.ts`.

**Filter bar cleanup:** a clear-filters and a refresh icon button, aligned with the field height, and the job counter removed.

## Testing

- `npm test`: 117 files, 1041 tests passing, including new suites for the job action routing, the taskbar row merge and the completeness of the type labels across locales.
- `tsc --noEmit`: no new error against the baseline.
- ESLint: clean.
- Checked on the lab cluster: a migration appears while running, its logs stream, and cancelling it works.

## Known limitation

The orchestrator routes require `automation.view` while the Task Center page requires `tasks.view`, so a role holding `tasks.view` alone still sees `No logs available (HTTP 403)` on a rolling update or a replication job. Aligning those permissions is a separate change.

Fixes #767
