### PR TITLE
feat(console): fullscreen and scaling controls for VNC and SPICE (#783)

### DIFF
--- a/frontend/bundle-console.js
+++ b/frontend/bundle-console.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Bundle the shared console viewport logic (src/lib/console/viewport.ts) into
+ * a single browser file exposing window.ConsoleUI.
+ *
+ * The two graphical console pages (public/novnc/console.html and
+ * public/spice/console.html) are static HTML served outside Next, because they
+ * have to load the noVNC / spice-html5 IIFE bundles. They cannot import from
+ * src/, so this is how they reach logic that is unit-tested
+ * (src/lib/console/viewport.test.ts) instead of living inline in a <script>.
+ *
+ * Usage: node bundle-console.js   (re-run after editing viewport.ts)
+ */
+const path = require('path')
+
+const esbuild = require('esbuild')
+
+async function bundle() {
+  try {
+    await esbuild.build({
+      entryPoints: [path.join(__dirname, 'src/lib/console/viewport.ts')],
+      bundle: true,
+      outfile: path.join(__dirname, 'public/console/console-ui.bundle.js'),
+      format: 'iife',
+      globalName: 'ConsoleUI',
+      platform: 'browser',
+      target: ['es2020'],
+      minify: false,
+      sourcemap: false,
+    })
+    console.log('✅ console viewport helpers bundled to public/console/console-ui.bundle.js')
+  } catch (err) {
+    console.error('❌ Failed to bundle console viewport helpers:', err.message)
+    process.exit(1)
+  }
+}
+bundle()

--- a/frontend/public/console/console-ui.bundle.js
+++ b/frontend/public/console/console-ui.bundle.js
@@ -1,0 +1,176 @@
+var ConsoleUI = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // src/lib/console/viewport.ts
+  var viewport_exports = {};
+  __export(viewport_exports, {
+    DEFAULT_SCALING_MODE: () => DEFAULT_SCALING_MODE,
+    GUEST_SIZE_ALIGNMENT: () => GUEST_SIZE_ALIGNMENT,
+    KEYSYM: () => KEYSYM,
+    KEY_COMBOS: () => KEY_COMBOS,
+    MAX_GUEST_DIMENSION: () => MAX_GUEST_DIMENSION,
+    MIN_GUEST_HEIGHT: () => MIN_GUEST_HEIGHT,
+    MIN_GUEST_WIDTH: () => MIN_GUEST_WIDTH,
+    SCALING_MODES: () => SCALING_MODES,
+    computeFitScale: () => computeFitScale,
+    computeGuestResolution: () => computeGuestResolution,
+    debounce: () => debounce,
+    findKeyCombo: () => findKeyCombo,
+    fullscreenElement: () => fullscreenElement,
+    fullscreenSupported: () => fullscreenSupported,
+    isFullscreen: () => isFullscreen,
+    keyComboSequence: () => keyComboSequence,
+    loadScalingMode: () => loadScalingMode,
+    parseScalingMode: () => parseScalingMode,
+    rfbFlagsForScalingMode: () => rfbFlagsForScalingMode,
+    saveScalingMode: () => saveScalingMode,
+    scalingStorageKey: () => scalingStorageKey,
+    toggleFullscreen: () => toggleFullscreen
+  });
+  var SCALING_MODES = ["off", "scale", "remote"];
+  var DEFAULT_SCALING_MODE = "scale";
+  function scalingStorageKey(kind) {
+    return `proxcenter.console.scaling.${kind}`;
+  }
+  function parseScalingMode(raw, fallback = DEFAULT_SCALING_MODE) {
+    return SCALING_MODES.includes(raw) ? raw : fallback;
+  }
+  function loadScalingMode(storage, kind) {
+    try {
+      return parseScalingMode(storage?.getItem(scalingStorageKey(kind)));
+    } catch {
+      return DEFAULT_SCALING_MODE;
+    }
+  }
+  function saveScalingMode(storage, kind, mode) {
+    try {
+      storage?.setItem(scalingStorageKey(kind), parseScalingMode(mode));
+      return Boolean(storage);
+    } catch {
+      return false;
+    }
+  }
+  function rfbFlagsForScalingMode(mode) {
+    const parsed = parseScalingMode(mode);
+    return {
+      scaleViewport: parsed === "scale",
+      resizeSession: parsed === "remote",
+      clipViewport: parsed !== "scale"
+    };
+  }
+  var GUEST_SIZE_ALIGNMENT = 8;
+  var MIN_GUEST_WIDTH = 320;
+  var MIN_GUEST_HEIGHT = 200;
+  var MAX_GUEST_DIMENSION = 8192;
+  function computeGuestResolution(width, height) {
+    if (!Number.isFinite(width) || !Number.isFinite(height)) return null;
+    const align = (value) => Math.floor(value / GUEST_SIZE_ALIGNMENT) * GUEST_SIZE_ALIGNMENT;
+    const w = Math.min(align(width), MAX_GUEST_DIMENSION);
+    const h = Math.min(align(height), MAX_GUEST_DIMENSION);
+    if (w < MIN_GUEST_WIDTH || h < MIN_GUEST_HEIGHT) return null;
+    return { width: w, height: h };
+  }
+  function computeFitScale(source, container, opts = {}) {
+    const { width: sw, height: sh } = source;
+    const { width: cw, height: ch } = container;
+    if (![sw, sh, cw, ch].every((v) => Number.isFinite(v) && v > 0)) return 1;
+    const scale = Math.min(cw / sw, ch / sh);
+    if (!opts.allowUpscale && scale > 1) return 1;
+    return scale;
+  }
+  function fullscreenElement(doc) {
+    if (!doc) return null;
+    return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? doc.msFullscreenElement ?? null;
+  }
+  function isFullscreen(doc) {
+    return Boolean(fullscreenElement(doc));
+  }
+  function fullscreenSupported(el) {
+    return Boolean(el && (el.requestFullscreen || el.webkitRequestFullscreen || el.msRequestFullscreen));
+  }
+  function toggleFullscreen(doc, el) {
+    if (isFullscreen(doc)) {
+      const exit = doc?.exitFullscreen ?? doc?.webkitExitFullscreen ?? doc?.msExitFullscreen;
+      exit?.call(doc);
+      return false;
+    }
+    const request = el?.requestFullscreen ?? el?.webkitRequestFullscreen ?? el?.msRequestFullscreen;
+    if (!request) return false;
+    const result = request.call(el);
+    if (result && typeof result.catch === "function") {
+      ;
+      result.catch(() => {
+      });
+    }
+    return true;
+  }
+  var KEYSYM = {
+    ControlLeft: 65507,
+    AltLeft: 65513,
+    Escape: 65307,
+    Tab: 65289,
+    Backspace: 65288,
+    Delete: 65535,
+    F1: 65470
+  };
+  function combo(id, label, ...strokes) {
+    return { id, label, strokes };
+  }
+  var CTRL = { keysym: KEYSYM.ControlLeft, code: "ControlLeft" };
+  var ALT = { keysym: KEYSYM.AltLeft, code: "AltLeft" };
+  function functionKeyCombos() {
+    return Array.from({ length: 12 }, (_, i) => {
+      const n = i + 1;
+      return combo(`ctrl-alt-f${n}`, `Ctrl+Alt+F${n}`, CTRL, ALT, { keysym: KEYSYM.F1 + i, code: `F${n}` });
+    });
+  }
+  var KEY_COMBOS = [
+    combo("ctrl-alt-del", "Ctrl+Alt+Del", CTRL, ALT, { keysym: KEYSYM.Delete, code: "Delete" }),
+    combo("ctrl-alt-backspace", "Ctrl+Alt+Backspace", CTRL, ALT, { keysym: KEYSYM.Backspace, code: "Backspace" }),
+    combo("ctrl-esc", "Ctrl+Esc", CTRL, { keysym: KEYSYM.Escape, code: "Escape" }),
+    combo("alt-tab", "Alt+Tab", ALT, { keysym: KEYSYM.Tab, code: "Tab" }),
+    ...functionKeyCombos()
+  ];
+  function findKeyCombo(id) {
+    return KEY_COMBOS.find((c) => c.id === id) ?? null;
+  }
+  function keyComboSequence(id) {
+    const found = findKeyCombo(id);
+    if (!found) return [];
+    const down = found.strokes.map((s) => ({ ...s, down: true }));
+    const up = [...found.strokes].reverse().map((s) => ({ ...s, down: false }));
+    return [...down, ...up];
+  }
+  function debounce(fn, delayMs) {
+    let timer = null;
+    const wrapped = (...args) => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        fn(...args);
+      }, delayMs);
+    };
+    wrapped.cancel = () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+    };
+    return wrapped;
+  }
+  return __toCommonJS(viewport_exports);
+})();

--- a/frontend/public/novnc/console.html
+++ b/frontend/public/novnc/console.html
@@ -17,13 +17,16 @@
     #toolbar {
       display: flex; align-items: center; justify-content: space-between;
       padding: 8px 16px; background: #111; border-bottom: 1px solid #333; flex-shrink: 0;
+      flex-wrap: wrap; row-gap: 6px;
     }
-    #toolbar .info { display: flex; align-items: center; gap: 12px; }
+    /* Le nom de la VM cède la place avant les boutons: la barre porte assez de
+       contrôles pour dépasser la largeur d'une fenêtre de console 1024px. */
+    #toolbar .info { display: flex; align-items: center; gap: 12px; min-width: 0; flex: 1 1 auto; }
     #status-dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; }
     #status-dot.connected { background: #22c55e; }
     #status-dot.connecting { background: #f59e0b; }
     #status-dot.error { background: #ef4444; }
-    #vm-info { color: #fff; font-size: 14px; font-weight: 600; }
+    #vm-info { color: #fff; font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     #status-text { color: #666; font-size: 12px; }
     #toolbar .vm-actions { display: flex; gap: 4px; margin: 0 16px; }
     #toolbar .vm-actions button {
@@ -41,7 +44,7 @@
     #toolbar .vm-actions button.btn-pause { color: #3b82f6; }
     #toolbar .vm-actions button.btn-pause:hover { background: #1e3a8a; }
     #toolbar .vm-actions button.loading { opacity: 0.5; pointer-events: none; }
-    #toolbar .buttons { display: flex; gap: 8px; }
+    #toolbar .buttons { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
     button {
       padding: 6px 12px; font-size: 12px; background: #333; color: #fff;
       border: 1px solid #444; border-radius: 4px; cursor: pointer;
@@ -67,6 +70,22 @@
     #novnc-instructions code {
       display: block; background: #1c1917; padding: 12px; border-radius: 4px; text-align: left; font-size: 12px; margin: 12px 0;
     }
+    #toolbar select {
+      padding: 5px 8px; font-size: 12px; background: #333; color: #fff;
+      border: 1px solid #444; border-radius: 4px; cursor: pointer; max-width: 150px;
+    }
+    #toolbar select:disabled { background: #222; color: #666; cursor: not-allowed; }
+    #toolbar .buttons button.icon { padding: 6px 9px; font-size: 14px; line-height: 1; }
+    #toolbar .buttons button.active { background: #1e3a8a; border-color: #3b82f6; }
+    /* Plein écran: la barre quitte le flux pour laisser tout l'écran à
+       l'invité, et revient quand le pointeur atteint le bord haut ou la
+       survole. Elle reste un élément vivant, donc chaque contrôle est à un
+       geste sans quitter le plein écran. */
+    body.fs #toolbar {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 20; opacity: 0.97;
+      transform: translateY(-100%); transition: transform 0.18s ease;
+    }
+    body.fs #toolbar.peek, body.fs #toolbar:hover { transform: none; }
   </style>
 </head>
 <body>
@@ -84,7 +103,17 @@
         <button id="btn-pause" class="btn-pause" title="Pause">⏸</button>
       </div>
       <div class="buttons">
+        <select id="scaling" title="Scaling mode">
+          <option value="scale">Fit to window</option>
+          <option value="remote">Resize guest</option>
+          <option value="off">No scaling (1:1)</option>
+        </select>
+        <select id="sendkey" title="Send a key combination the browser would otherwise swallow" disabled>
+          <option value="">Send key</option>
+        </select>
+        <button id="btn-paste" title="Send text to the guest clipboard, then paste inside the guest" disabled>Paste</button>
         <button id="btn-cad" disabled>Ctrl+Alt+Del</button>
+        <button id="btn-fullscreen" class="icon" title="Fullscreen">&#9974;</button>
         <button id="btn-reconnect">Reconnect</button>
         <button id="btn-close">Close</button>
       </div>
@@ -110,6 +139,9 @@ node bundle-novnc.js
 
   <!-- Charger noVNC bundle (IIFE) -->
   <script src="/novnc/rfb.bundle.js"></script>
+  <!-- Helpers partagés avec la console SPICE, testés dans
+       src/lib/console/viewport.test.ts et bundlés par bundle-console.js -->
+  <script src="/console/console-ui.bundle.js"></script>
   
   <script>
     let RFB;
@@ -132,6 +164,7 @@ node bundle-novnc.js
       return typeof RFB === 'function';
     }
     
+    const toolbar = document.getElementById('toolbar');
     const statusDot = document.getElementById('status-dot');
     const vmInfo = document.getElementById('vm-info');
     const statusText = document.getElementById('status-text');
@@ -142,6 +175,10 @@ node bundle-novnc.js
     const loadingSubtext = document.getElementById('loading-subtext');
     const novncInstructions = document.getElementById('novnc-instructions');
     const btnCad = document.getElementById('btn-cad');
+    const btnPaste = document.getElementById('btn-paste');
+    const btnFullscreen = document.getElementById('btn-fullscreen');
+    const scalingSelect = document.getElementById('scaling');
+    const sendKeySelect = document.getElementById('sendkey');
     const btnReconnect = document.getElementById('btn-reconnect');
     const btnClose = document.getElementById('btn-close');
     const btnStart = document.getElementById('btn-start');
@@ -178,6 +215,127 @@ node bundle-novnc.js
     }
 
     renderVmLabel();
+
+    // Toute interaction avec la barre d'outils vole le clavier à l'invité, il
+    // faut le lui rendre à chaque fois.
+    function focusCanvas() {
+      const canvas = screen.querySelector('canvas');
+
+      if (!canvas) return;
+      canvas.setAttribute('tabindex', '0');
+      canvas.style.outline = 'none';
+      canvas.focus({ preventScroll: true });
+    }
+
+    // --- Mise à l'échelle ---------------------------------------------------
+    // Trois modes, nommés comme le réglage `resize` de la console Proxmox
+    // d'origine. Le défaut reste "scale", c'est-à-dire le comportement que
+    // cette console a toujours eu. "remote" demande à l'invité de changer de
+    // résolution: noVNC n'envoie SetDesktopSize que si le serveur a annoncé
+    // ExtendedDesktopSize, donc le mode se dégrade en silence là où l'invité
+    // n'a pas le pilote qui sait l'honorer.
+    let scalingMode = ConsoleUI.loadScalingMode(window.localStorage, 'novnc');
+
+    scalingSelect.value = scalingMode;
+
+    function applyScalingMode() {
+      if (!rfb) return;
+
+      const flags = ConsoleUI.rfbFlagsForScalingMode(scalingMode);
+
+      rfb.scaleViewport = flags.scaleViewport;
+      rfb.clipViewport = flags.clipViewport;
+      rfb.resizeSession = flags.resizeSession;
+    }
+
+    scalingSelect.addEventListener('change', () => {
+      scalingMode = ConsoleUI.parseScalingMode(scalingSelect.value);
+      scalingSelect.value = scalingMode;
+      ConsoleUI.saveScalingMode(window.localStorage, 'novnc', scalingMode);
+      applyScalingMode();
+      focusCanvas();
+    });
+
+    // --- Plein écran --------------------------------------------------------
+    function syncFullscreenUi() {
+      const on = ConsoleUI.isFullscreen(document);
+
+      document.body.classList.toggle('fs', on);
+      btnFullscreen.classList.toggle('active', on);
+      btnFullscreen.title = on ? 'Leave fullscreen' : 'Fullscreen';
+      if (!on) toolbar.classList.remove('peek');
+      focusCanvas();
+    }
+
+    if (!ConsoleUI.fullscreenSupported(document.documentElement)) {
+      btnFullscreen.style.display = 'none';
+    }
+
+    btnFullscreen.addEventListener('click', () => {
+      ConsoleUI.toggleFullscreen(document, document.documentElement);
+    });
+
+    ['fullscreenchange', 'webkitfullscreenchange', 'MSFullscreenChange'].forEach(function(evt) {
+      document.addEventListener(evt, syncFullscreenUi);
+    });
+
+    // En plein écran la barre est hors écran: le bord haut la ramène.
+    document.addEventListener('mousemove', function(e) {
+      if (!document.body.classList.contains('fs')) return;
+      toolbar.classList.toggle('peek', e.clientY <= 4);
+    });
+
+    // --- Combinaisons de touches -------------------------------------------
+    // Celles que le navigateur ou le bureau hôte intercepte et que l'invité ne
+    // verrait jamais si on les tapait.
+    ConsoleUI.KEY_COMBOS.forEach(function(combo) {
+      const opt = document.createElement('option');
+
+      opt.value = combo.id;
+      opt.textContent = combo.label;
+      sendKeySelect.appendChild(opt);
+    });
+
+    sendKeySelect.addEventListener('change', () => {
+      const id = sendKeySelect.value;
+
+      // Le select est un déclencheur, pas un état: on le remet sur son libellé.
+      sendKeySelect.value = '';
+      if (!id || !rfb) return;
+
+      ConsoleUI.keyComboSequence(id).forEach(function(stroke) {
+        rfb.sendKey(stroke.keysym, stroke.code, stroke.down);
+      });
+      focusCanvas();
+    });
+
+    // clipboardPasteFrom remplit le presse-papier DE L'INVITÉ (RFB n'a pas de
+    // primitive "tape ce texte"), l'utilisateur colle ensuite avec le raccourci
+    // de son invité.
+    btnPaste.addEventListener('click', async () => {
+      if (!rfb) return;
+
+      let text = '';
+
+      try {
+        text = await navigator.clipboard.readText();
+      } catch {
+        // Pas de permission, pas d'API en HTTP simple, ou presse-papier vide.
+        text = '';
+      }
+
+      if (!text) text = window.prompt('Text to send to the guest clipboard:') || '';
+      if (!text) return;
+
+      rfb.clipboardPasteFrom(text);
+      focusCanvas();
+    });
+
+    function setInputControlsEnabled(enabled) {
+      btnCad.disabled = !enabled;
+      btnPaste.disabled = !enabled;
+      sendKeySelect.disabled = !enabled;
+    }
 
     function setStatus(status, text) {
       statusDot.className = status;
@@ -289,47 +447,19 @@ node bundle-novnc.js
         console.log('WebSocket URL:', wsFullUrl);
         
         rfb = new RFB(screen, wsFullUrl, { credentials: { password } });
-        
-        rfb.scaleViewport = true;
-        rfb.resizeSession = false;  // Désactivé car cause des erreurs
-        rfb.clipViewport = false;
+
         rfb.viewOnly = false;
         rfb.focusOnClick = true;
         rfb.qualityLevel = 6;
         rfb.compressionLevel = 2;
         rfb.background = '#000';
-        
-        // Debug: log des événements
-        console.log('RFB config:', {
-          scaleViewport: rfb.scaleViewport,
-          resizeSession: rfb.resizeSession,
-          viewOnly: rfb.viewOnly,
-          focusOnClick: rfb.focusOnClick,
-          qualityLevel: rfb.qualityLevel,
-          compressionLevel: rfb.compressionLevel
-        });
-        
-        // Vérifier si viewOnly est bien false
-        if (rfb.viewOnly) {
-          console.error('WARNING: viewOnly is true!');
-        }
-        
-        // Debug: intercepter les événements sur le canvas après connexion
-        setTimeout(() => {
-          const canvas = screen.querySelector('canvas');
-          if (canvas) {
-            canvas.addEventListener('keydown', (e) => {
-              console.log('KEY DOWN:', e.key, e.keyCode);
-            }, true);
-            canvas.addEventListener('mousedown', (e) => {
-              console.log('MOUSE DOWN:', e.button, e.clientX, e.clientY);
-            }, true);
-            canvas.addEventListener('click', (e) => {
-              console.log('CLICK:', e.button, e.clientX, e.clientY);
-            }, true);
-          }
-        }, 500);
-        
+
+        // scaleViewport / resizeSession / clipViewport viennent tous du mode
+        // enregistré. noVNC observe le conteneur #screen avec un
+        // ResizeObserver, donc masquer la barre en plein écran suffit à
+        // déclencher une remise à l'échelle (ou un redimensionnement invité).
+        applyScalingMode();
+
         rfb.addEventListener('connect', () => {
           console.log('VNC connected');
           loading.style.display = 'none';
@@ -339,19 +469,8 @@ node bundle-novnc.js
             clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-          btnCad.disabled = false;
-          
-          // Focus agressif sur le canvas
-          const focusCanvas = () => {
-            const canvas = screen.querySelector('canvas');
-            if (canvas) {
-              canvas.setAttribute('tabindex', '0');
-              canvas.style.outline = 'none';
-              canvas.focus({ preventScroll: true });
-              console.log('Canvas focused, activeElement:', document.activeElement.tagName);
-            }
-          };
-          
+          setInputControlsEnabled(true);
+
           // Focus immédiat et répété
           focusCanvas();
           setTimeout(focusCanvas, 100);
@@ -374,7 +493,7 @@ node bundle-novnc.js
         
         rfb.addEventListener('disconnect', (e) => {
           console.log('VNC disconnected:', e.detail);
-          btnCad.disabled = true;
+          setInputControlsEnabled(false);
 
           if (userDisconnected) {
             setStatus('', 'Disconnected');

--- a/frontend/public/spice/console.html
+++ b/frontend/public/spice/console.html
@@ -9,37 +9,87 @@
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; overflow: hidden; background: #0c0c0c; color: #ccc;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    /* Colonne flex plutôt qu'une zone en absolu sous une barre de 41px codée en
+       dur: la barre porte maintenant assez de contrôles pour passer à la ligne
+       dans une fenêtre étroite, et elle recouvrirait l'écran de l'invité. */
+    body { display: flex; flex-direction: column; }
     #toolbar { display: flex; align-items: center; gap: 12px; padding: 8px 16px;
-      background: #111; border-bottom: 1px solid #333; }
-    #dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; }
+      background: #111; border-bottom: 1px solid #333; flex-shrink: 0;
+      flex-wrap: wrap; row-gap: 6px; }
+    #dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; flex-shrink: 0; }
     #dot.connected { background: #22c55e; } #dot.connecting { background: #f59e0b; } #dot.error { background: #ef4444; }
-    #title { font-weight: 600; color: #fff; } #status { color: #888; font-size: 12px; }
-    #spice-area { position: absolute; top: 41px; bottom: 0; left: 0; right: 0; background: #000; overflow: auto; }
-    #message { position: absolute; inset: 0; top: 41px; display: none; place-items: center; text-align: center; padding: 24px; }
+    #title { font-weight: 600; color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #status { color: #888; font-size: 12px; white-space: nowrap; }
+    #toolbar .buttons { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+    #toolbar button {
+      padding: 6px 12px; font-size: 12px; background: #333; color: #fff;
+      border: 1px solid #444; border-radius: 4px; cursor: pointer;
+    }
+    #toolbar button:hover { background: #444; }
+    #toolbar button:disabled { background: #222; color: #666; cursor: not-allowed; }
+    #toolbar button.icon { padding: 6px 9px; font-size: 14px; line-height: 1; }
+    #toolbar button.active { background: #1e3a8a; border-color: #3b82f6; }
+    #toolbar select {
+      padding: 5px 8px; font-size: 12px; background: #333; color: #fff;
+      border: 1px solid #444; border-radius: 4px; cursor: pointer;
+    }
+    #toolbar select option:disabled { color: #666; }
+    #spice-area { flex: 1 1 auto; min-height: 0; position: relative; background: #000; overflow: auto; }
+    #message { position: absolute; inset: 0; display: none; place-items: center; text-align: center; padding: 24px; }
     #message.visible { display: grid; }
     #message .big { font-size: 15px; color: #fecaca; } #message .small { font-size: 13px; color: #9ca3af; margin-top: 8px; }
+    /* Plein écran: la barre quitte le flux pour laisser tout l'écran à
+       l'invité, et revient quand le pointeur atteint le bord haut. */
+    body.fs #toolbar {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 20; opacity: 0.97;
+      transform: translateY(-100%); transition: transform 0.18s ease;
+    }
+    body.fs #toolbar.peek, body.fs #toolbar:hover { transform: none; }
   </style>
 </head>
 <body>
   <div id="toolbar">
     <span id="dot"></span><span id="title">SPICE</span><span id="status">• Initializing...</span>
+    <div class="buttons">
+      <select id="scaling" title="Scaling mode">
+        <option value="scale">Fit to window</option>
+        <option value="remote">Resize guest</option>
+        <option value="off">No scaling (1:1)</option>
+      </select>
+      <button id="btn-cad" disabled>Ctrl+Alt+Del</button>
+      <button id="btn-fullscreen" class="icon" title="Fullscreen">&#9974;</button>
+      <button id="btn-reconnect">Reconnect</button>
+      <button id="btn-close">Close</button>
+    </div>
   </div>
-  <div id="spice-area"></div>
-  <div id="message"><div><div class="big" id="msg-big"></div><div class="small" id="msg-small"></div></div></div>
+  <div id="spice-area">
+    <div id="message"><div><div class="big" id="msg-big"></div><div class="small" id="msg-small"></div></div></div>
+  </div>
 
   <script src="/spice/spice.bundle.js"></script>
+  <!-- Helpers partagés avec la console noVNC, testés dans
+       src/lib/console/viewport.test.ts et bundlés par bundle-console.js -->
+  <script src="/console/console-ui.bundle.js"></script>
   <script>
     const params = new URLSearchParams(location.search);
     const connId = params.get('connId');
     const type = params.get('type');
     const node = params.get('node');
     const vmid = params.get('vmid');
+    const toolbar = document.getElementById('toolbar');
     const dot = document.getElementById('dot');
     const status = document.getElementById('status');
     const title = document.getElementById('title');
     const area = document.getElementById('spice-area');
     const messageBox = document.getElementById('message');
+    const scalingSelect = document.getElementById('scaling');
+    const remoteOption = scalingSelect.querySelector('option[value="remote"]');
+    const btnCad = document.getElementById('btn-cad');
+    const btnFullscreen = document.getElementById('btn-fullscreen');
+    const btnReconnect = document.getElementById('btn-reconnect');
+    const btnClose = document.getElementById('btn-close');
     let sc = null;
+    let agentConnected = false;
 
     // Même libellé dans la barre d'outils et dans le titre de fenêtre, nom de
     // la VM en tête pour survivre à la troncature de la barre des tâches
@@ -84,8 +134,163 @@
       messageBox.classList.add('visible');
     }
 
+    // --- Mise à l'échelle ---------------------------------------------------
+    // Mêmes trois modes que la console noVNC, mais rien n'est fourni par
+    // spice-html5: il dessine le framebuffer invité à sa taille natale dans un
+    // canvas, sans mise à l'échelle ni redimensionnement automatique.
+    //  - "scale"  transformation CSS sur le canvas, l'invité n'est pas touché.
+    //  - "remote" demande une résolution à l'agent invité (spice-vdagent).
+    //  - "off"    taille natale, la zone défile.
+    let scalingMode = ConsoleUI.loadScalingMode(window.localStorage, 'spice');
+
+    scalingSelect.value = scalingMode;
+
+    function guestCanvas() {
+      return area.querySelector('canvas');
+    }
+
+    // Sans agent invité, "remote" ne peut rien demander: on retombe sur la mise
+    // à l'échelle locale pour que la fenêtre reste utilisable au lieu de
+    // n'avoir aucun effet.
+    function effectiveScalingMode() {
+      return scalingMode === 'remote' && !agentConnected ? 'scale' : scalingMode;
+    }
+
+    function applyFitScale() {
+      const canvas = guestCanvas();
+      const fitting = effectiveScalingMode() === 'scale';
+
+      // Une transformation CSS ne change pas la boîte de mise en page: sans
+      // cela, un canvas 1920x1080 réduit de moitié garderait ses ascenseurs.
+      area.style.overflow = fitting ? 'hidden' : 'auto';
+
+      if (!canvas) return;
+
+      if (!fitting) {
+        canvas.style.transform = '';
+        canvas.style.transformOrigin = '';
+
+        return;
+      }
+
+      // On agrandit aussi, pas seulement on réduit: c'est déjà ce que fait
+      // scaleViewport côté noVNC, et "Fit to window" doit vouloir dire la même
+      // chose dans les deux consoles. Un invité en 720x400 (console texte) dans
+      // une fenêtre 1024x768 doit remplir la fenêtre.
+      const scale = ConsoleUI.computeFitScale(
+        { width: canvas.width, height: canvas.height },
+        { width: area.clientWidth, height: area.clientHeight },
+        { allowUpscale: true }
+      );
+
+      canvas.style.transformOrigin = 'top left';
+      canvas.style.transform = scale === 1 ? '' : `scale(${scale})`;
+    }
+
+    // Un flux d'événements resize deviendrait un flux de changements de
+    // résolution invitée, donc on attend que le redimensionnement se calme.
+    const requestGuestResize = ConsoleUI.debounce(function() {
+      if (!sc || !agentConnected || effectiveScalingMode() !== 'remote') return;
+
+      const res = ConsoleUI.computeGuestResolution(area.clientWidth, area.clientHeight);
+
+      if (!res) return;
+
+      sc.resize_window(0, res.width, res.height, 32, 0, 0);
+    }, 200);
+
+    // Sans agent invité, "Resize guest" ne peut rien faire: le dire plutôt que
+    // de laisser choisir un mode inerte.
+    function syncScalingAvailability() {
+      remoteOption.disabled = !agentConnected;
+      remoteOption.textContent = agentConnected ? 'Resize guest' : 'Resize guest (no agent)';
+      scalingSelect.title = agentConnected
+        ? 'Scaling mode'
+        : 'Scaling mode. Resizing the guest needs the SPICE guest agent (spice-vdagent) running inside the VM.';
+    }
+
+    function applyScalingMode() {
+      applyFitScale();
+      requestGuestResize();
+    }
+
+    scalingSelect.addEventListener('change', () => {
+      scalingMode = ConsoleUI.parseScalingMode(scalingSelect.value);
+      scalingSelect.value = scalingMode;
+      ConsoleUI.saveScalingMode(window.localStorage, 'spice', scalingMode);
+      applyScalingMode();
+    });
+
+    // Le canvas est recréé à chaque changement de résolution invitée, donc on
+    // surveille la zone plutôt que de ne réagir qu'aux resize de fenêtre.
+    new MutationObserver(applyFitScale).observe(area, { childList: true, subtree: true });
+    new ResizeObserver(function() {
+      applyFitScale();
+      requestGuestResize();
+    }).observe(area);
+
+    // --- Plein écran --------------------------------------------------------
+    function syncFullscreenUi() {
+      const on = ConsoleUI.isFullscreen(document);
+
+      document.body.classList.toggle('fs', on);
+      btnFullscreen.classList.toggle('active', on);
+      btnFullscreen.title = on ? 'Leave fullscreen' : 'Fullscreen';
+      if (!on) toolbar.classList.remove('peek');
+    }
+
+    if (!ConsoleUI.fullscreenSupported(document.documentElement)) {
+      btnFullscreen.style.display = 'none';
+    }
+
+    btnFullscreen.addEventListener('click', () => {
+      ConsoleUI.toggleFullscreen(document, document.documentElement);
+    });
+
+    ['fullscreenchange', 'webkitfullscreenchange', 'MSFullscreenChange'].forEach(function(evt) {
+      document.addEventListener(evt, syncFullscreenUi);
+    });
+
+    document.addEventListener('mousemove', function(e) {
+      if (!document.body.classList.contains('fs')) return;
+      toolbar.classList.toggle('peek', e.clientY <= 4);
+    });
+
+    // --- Actions ------------------------------------------------------------
+    btnCad.addEventListener('click', () => {
+      if (sc) window.SpiceHtml5.sendCtrlAltDel(sc);
+    });
+
+    btnReconnect.addEventListener('click', () => {
+      disconnect();
+      connect();
+    });
+
+    btnClose.addEventListener('click', () => {
+      disconnect();
+      window.close();
+    });
+
+    function disconnect() {
+      agentConnected = false;
+      syncScalingAvailability();
+      btnCad.disabled = true;
+      requestGuestResize.cancel();
+
+      if (sc) {
+        try { sc.stop(); } catch (e) { console.error('SPICE stop failed:', e); }
+        sc = null;
+      }
+
+      // stop() détruit les surfaces mais laisse le canvas (et le curseur
+      // simulé) dans le DOM: sans ce nettoyage, une reconnexion empile les
+      // écrans. La boîte de message vit dans la même zone, on la garde.
+      area.replaceChildren(messageBox);
+    }
+
     async function connect() {
       if (!connId || !type || !node || !vmid) return fail('Missing parameters');
+      messageBox.classList.remove('visible');
       setStatus('connecting', 'Creating session...');
       let json;
       try {
@@ -116,10 +321,23 @@
           password,
           onerror: (e) => fail('SPICE connection failed',
             'Check that ProxCenter can reach the node on TCP 3128, or use the noVNC console.'),
-          onsuccess: () => setStatus('connected', 'Connected'),
+          onsuccess: () => {
+            setStatus('connected', 'Connected');
+            btnCad.disabled = false;
+            applyFitScale();
+          },
+          // spice-html5 appelle onagent quand spice-vdagent répond, ce qui est
+          // le seul moment où une demande de résolution a une chance d'aboutir.
+          onagent: () => {
+            agentConnected = true;
+            syncScalingAvailability();
+            applyScalingMode();
+          },
         });
       } catch (e) { fail('SPICE init failed', e.message); }
     }
+
+    syncScalingAvailability();
     fetchVmName();
     connect();
   </script>

--- a/frontend/src/lib/console/viewport.test.ts
+++ b/frontend/src/lib/console/viewport.test.ts
@@ -1,0 +1,298 @@
+// frontend/src/lib/console/viewport.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  DEFAULT_SCALING_MODE,
+  GUEST_SIZE_ALIGNMENT,
+  KEY_COMBOS,
+  MAX_GUEST_DIMENSION,
+  SCALING_MODES,
+  computeFitScale,
+  computeGuestResolution,
+  debounce,
+  findKeyCombo,
+  fullscreenElement,
+  fullscreenSupported,
+  isFullscreen,
+  keyComboSequence,
+  loadScalingMode,
+  parseScalingMode,
+  rfbFlagsForScalingMode,
+  saveScalingMode,
+  scalingStorageKey,
+  toggleFullscreen,
+} from './viewport'
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial))
+
+  return {
+    map,
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => void map.set(k, v),
+  }
+}
+
+describe('scaling mode', () => {
+  it('keeps a per-console-kind storage key so a mode is never inherited across protocols', () => {
+    expect(scalingStorageKey('novnc')).toBe('proxcenter.console.scaling.novnc')
+    expect(scalingStorageKey('spice')).toBe('proxcenter.console.scaling.spice')
+    expect(scalingStorageKey('novnc')).not.toBe(scalingStorageKey('spice'))
+  })
+
+  it('accepts the three known modes and falls back on anything else', () => {
+    for (const mode of SCALING_MODES) expect(parseScalingMode(mode)).toBe(mode)
+
+    expect(parseScalingMode('scaledown')).toBe(DEFAULT_SCALING_MODE)
+    expect(parseScalingMode(null)).toBe(DEFAULT_SCALING_MODE)
+    expect(parseScalingMode(undefined)).toBe(DEFAULT_SCALING_MODE)
+    expect(parseScalingMode(42)).toBe(DEFAULT_SCALING_MODE)
+    expect(parseScalingMode('off', 'remote')).toBe('off')
+    expect(parseScalingMode('nope', 'remote')).toBe('remote')
+  })
+
+  it('defaults to local scaling, the behaviour the console had before the setting existed', () => {
+    expect(DEFAULT_SCALING_MODE).toBe('scale')
+    expect(loadScalingMode(fakeStorage(), 'novnc')).toBe('scale')
+  })
+
+  it('round-trips a stored mode', () => {
+    const storage = fakeStorage()
+
+    expect(saveScalingMode(storage, 'spice', 'remote')).toBe(true)
+    expect(storage.map.get('proxcenter.console.scaling.spice')).toBe('remote')
+    expect(loadScalingMode(storage, 'spice')).toBe('remote')
+    // ... and the other console is unaffected.
+    expect(loadScalingMode(storage, 'novnc')).toBe('scale')
+  })
+
+  it('never persists a bogus mode', () => {
+    const storage = fakeStorage()
+
+    saveScalingMode(storage, 'novnc', 'sideways' as never)
+    expect(storage.map.get('proxcenter.console.scaling.novnc')).toBe('scale')
+  })
+
+  it('survives a storage that throws (private window, site data blocked)', () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error('SecurityError')
+      },
+      setItem: () => {
+        throw new Error('SecurityError')
+      },
+    }
+
+    expect(loadScalingMode(throwing, 'novnc')).toBe(DEFAULT_SCALING_MODE)
+    expect(saveScalingMode(throwing, 'novnc', 'off')).toBe(false)
+  })
+
+  it('survives a missing storage object', () => {
+    expect(loadScalingMode(null, 'novnc')).toBe(DEFAULT_SCALING_MODE)
+    expect(loadScalingMode(undefined, 'spice')).toBe(DEFAULT_SCALING_MODE)
+    expect(saveScalingMode(null, 'novnc', 'off')).toBe(false)
+  })
+
+  it('maps each mode to the matching noVNC RFB flags', () => {
+    expect(rfbFlagsForScalingMode('scale')).toEqual({ scaleViewport: true, resizeSession: false, clipViewport: false })
+    expect(rfbFlagsForScalingMode('remote')).toEqual({ scaleViewport: false, resizeSession: true, clipViewport: true })
+    expect(rfbFlagsForScalingMode('off')).toEqual({ scaleViewport: false, resizeSession: false, clipViewport: true })
+  })
+
+  it('never sets scaleViewport and resizeSession together', () => {
+    for (const mode of SCALING_MODES) {
+      const flags = rfbFlagsForScalingMode(mode)
+
+      expect(flags.scaleViewport && flags.resizeSession).toBe(false)
+    }
+  })
+})
+
+describe('computeGuestResolution', () => {
+  it('rounds both dimensions down to an 8-pixel boundary', () => {
+    expect(computeGuestResolution(1917, 1075)).toEqual({ width: 1912, height: 1072 })
+    expect(computeGuestResolution(1920, 1080)).toEqual({ width: 1920, height: 1080 })
+
+    const r = computeGuestResolution(1279, 799)
+
+    expect(r!.width % GUEST_SIZE_ALIGNMENT).toBe(0)
+    expect(r!.height % GUEST_SIZE_ALIGNMENT).toBe(0)
+  })
+
+  it('never rounds up, so the guest screen always fits the window', () => {
+    const r = computeGuestResolution(1000, 700)!
+
+    expect(r.width).toBeLessThanOrEqual(1000)
+    expect(r.height).toBeLessThanOrEqual(700)
+  })
+
+  it('clamps to a size a display device can allocate', () => {
+    const r = computeGuestResolution(20000, 20000)!
+
+    expect(r.width).toBe(MAX_GUEST_DIMENSION)
+    expect(r.height).toBe(MAX_GUEST_DIMENSION)
+  })
+
+  it('returns null rather than a size when the container is unusable', () => {
+    // A hidden or not-yet-laid-out area: sending 0x0 to the agent would black
+    // out the guest screen.
+    expect(computeGuestResolution(0, 0)).toBeNull()
+    expect(computeGuestResolution(1024, 0)).toBeNull()
+    expect(computeGuestResolution(200, 600)).toBeNull()
+    expect(computeGuestResolution(600, 100)).toBeNull()
+    expect(computeGuestResolution(Number.NaN, 600)).toBeNull()
+    expect(computeGuestResolution(Number.POSITIVE_INFINITY, 600)).toBeNull()
+  })
+})
+
+describe('computeFitScale', () => {
+  it('fits on the limiting axis and keeps the aspect ratio', () => {
+    // 1920x1080 guest in a 960x1000 area: width is the constraint.
+    expect(computeFitScale({ width: 1920, height: 1080 }, { width: 960, height: 1000 })).toBeCloseTo(0.5)
+    // Same guest in a 1900x540 area: height is the constraint.
+    expect(computeFitScale({ width: 1920, height: 1080 }, { width: 1900, height: 540 })).toBeCloseTo(0.5)
+  })
+
+  it('does not upscale by default, and does when asked', () => {
+    expect(computeFitScale({ width: 640, height: 480 }, { width: 1920, height: 1080 })).toBe(1)
+    expect(
+      computeFitScale({ width: 640, height: 480 }, { width: 1920, height: 1080 }, { allowUpscale: true })
+    ).toBeCloseTo(2.25)
+  })
+
+  it('falls back to 1 when a dimension is not measurable', () => {
+    expect(computeFitScale({ width: 0, height: 0 }, { width: 800, height: 600 })).toBe(1)
+    expect(computeFitScale({ width: 800, height: 600 }, { width: 0, height: 600 })).toBe(1)
+    expect(computeFitScale({ width: 800, height: 600 }, { width: Number.NaN, height: 600 })).toBe(1)
+  })
+})
+
+describe('fullscreen helpers', () => {
+  it('reads the fullscreen element through every vendor spelling', () => {
+    const el = {} as Element
+
+    expect(fullscreenElement({ fullscreenElement: el })).toBe(el)
+    expect(fullscreenElement({ webkitFullscreenElement: el })).toBe(el)
+    expect(fullscreenElement({ msFullscreenElement: el })).toBe(el)
+    expect(fullscreenElement({ fullscreenElement: null })).toBeNull()
+    expect(fullscreenElement(null)).toBeNull()
+    expect(isFullscreen({ fullscreenElement: el })).toBe(true)
+    expect(isFullscreen({})).toBe(false)
+  })
+
+  it('detects support', () => {
+    expect(fullscreenSupported({ requestFullscreen: () => {} })).toBe(true)
+    expect(fullscreenSupported({ webkitRequestFullscreen: () => {} })).toBe(true)
+    expect(fullscreenSupported({})).toBe(false)
+    expect(fullscreenSupported(null)).toBe(false)
+  })
+
+  it('enters fullscreen and reports the state it asked for', () => {
+    const requestFullscreen = vi.fn()
+    const el = { requestFullscreen }
+
+    expect(toggleFullscreen({}, el)).toBe(true)
+    expect(requestFullscreen).toHaveBeenCalledOnce()
+  })
+
+  it('leaves fullscreen when already in it, without requesting again', () => {
+    const exitFullscreen = vi.fn()
+    const requestFullscreen = vi.fn()
+
+    expect(toggleFullscreen({ fullscreenElement: {} as Element, exitFullscreen }, { requestFullscreen })).toBe(false)
+    expect(exitFullscreen).toHaveBeenCalledOnce()
+    expect(requestFullscreen).not.toHaveBeenCalled()
+  })
+
+  it('uses the vendor-prefixed exit when that is all there is', () => {
+    const webkitExitFullscreen = vi.fn()
+
+    toggleFullscreen({ webkitFullscreenElement: {} as Element, webkitExitFullscreen }, {})
+    expect(webkitExitFullscreen).toHaveBeenCalledOnce()
+  })
+
+  it('swallows a rejected request instead of leaving an unhandled rejection', async () => {
+    const el = { requestFullscreen: () => Promise.reject(new Error('not allowed')) }
+
+    expect(toggleFullscreen({}, el)).toBe(true)
+    await Promise.resolve()
+  })
+
+  it('reports false when fullscreen is not available at all', () => {
+    expect(toggleFullscreen({}, {})).toBe(false)
+    expect(toggleFullscreen(null, null)).toBe(false)
+  })
+})
+
+describe('key combos', () => {
+  it('offers Ctrl+Alt+Del plus the twelve virtual consoles', () => {
+    const ids = KEY_COMBOS.map(c => c.id)
+
+    expect(ids).toContain('ctrl-alt-del')
+    expect(ids).toContain('ctrl-alt-f1')
+    expect(ids).toContain('ctrl-alt-f12')
+    expect(ids.filter(id => /^ctrl-alt-f\d+$/.test(id))).toHaveLength(12)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('numbers the function keysyms contiguously from F1', () => {
+    expect(findKeyCombo('ctrl-alt-f1')!.strokes.at(-1)).toEqual({ keysym: 0xffbe, code: 'F1' })
+    expect(findKeyCombo('ctrl-alt-f12')!.strokes.at(-1)).toEqual({ keysym: 0xffc9, code: 'F12' })
+  })
+
+  it('presses in order then releases in reverse, so no modifier stays latched', () => {
+    expect(keyComboSequence('ctrl-alt-del')).toEqual([
+      { keysym: 0xffe3, code: 'ControlLeft', down: true },
+      { keysym: 0xffe9, code: 'AltLeft', down: true },
+      { keysym: 0xffff, code: 'Delete', down: true },
+      { keysym: 0xffff, code: 'Delete', down: false },
+      { keysym: 0xffe9, code: 'AltLeft', down: false },
+      { keysym: 0xffe3, code: 'ControlLeft', down: false },
+    ])
+  })
+
+  it('presses and releases every key of every combo', () => {
+    for (const c of KEY_COMBOS) {
+      const seq = keyComboSequence(c.id)
+
+      expect(seq).toHaveLength(c.strokes.length * 2)
+      expect(seq.filter(s => s.down)).toHaveLength(c.strokes.length)
+    }
+  })
+
+  it('returns an empty sequence for an unknown combo instead of throwing', () => {
+    expect(findKeyCombo('ctrl-alt-f99')).toBeNull()
+    expect(keyComboSequence('nope')).toEqual([])
+  })
+})
+
+describe('debounce', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('runs once on the trailing edge with the last arguments', () => {
+    const fn = vi.fn()
+    const d = debounce(fn, 200)
+
+    d(1)
+    d(2)
+    d(3)
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(199)
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(fn).toHaveBeenCalledExactlyOnceWith(3)
+  })
+
+  it('can be cancelled, so a closing console sends no resize', () => {
+    const fn = vi.fn()
+    const d = debounce(fn, 200)
+
+    d()
+    d.cancel()
+    vi.advanceTimersByTime(1000)
+    expect(fn).not.toHaveBeenCalled()
+    // Cancelling twice, or with nothing pending, is a no-op.
+    d.cancel()
+  })
+})

--- a/frontend/src/lib/console/viewport.ts
+++ b/frontend/src/lib/console/viewport.ts
@@ -1,0 +1,298 @@
+// frontend/src/lib/console/viewport.ts
+//
+// Shared viewport logic for the two graphical console pages
+// (public/novnc/console.html and public/spice/console.html): scaling mode
+// persistence, guest-resolution maths for an agent-driven resize, fit
+// scaling, fullscreen helpers and the send-key combos.
+//
+// Those pages are plain static HTML served outside Next (they must load the
+// noVNC / spice-html5 IIFE bundles), so they cannot import from src/. They
+// consume this file through `node bundle-console.js`, which esbuilds it into
+// public/console/console-ui.bundle.js and exposes it as `window.ConsoleUI`.
+// Keeping the logic here rather than inline in the pages is what makes it
+// unit-testable.
+
+/**
+ * The three scaling modes, deliberately named like the upstream Proxmox
+ * noVNC `resize` setting (novnc-pve 1.6.0 maps `resizeSession` to
+ * `getSetting('resize') === 'remote'`), so behaviour matches what an
+ * operator already knows from the Proxmox console:
+ *
+ * - `off`    the guest framebuffer is shown 1:1 and clipped/scrolled.
+ * - `scale`  the framebuffer is scaled to fit the window, guest untouched.
+ * - `remote` the guest is asked to change its resolution to the window size.
+ */
+export type ScalingMode = 'off' | 'scale' | 'remote'
+
+export const SCALING_MODES: readonly ScalingMode[] = ['off', 'scale', 'remote']
+
+/** Same default as before this feature existed: scale locally, never touch the guest. */
+export const DEFAULT_SCALING_MODE: ScalingMode = 'scale'
+
+export type ConsoleKind = 'novnc' | 'spice'
+
+/**
+ * One key per console kind. `remote` needs guest support that differs per
+ * protocol (a VNC server advertising ExtendedDesktopSize vs a running
+ * spice-vdagent), so a mode that works in one console is not evidence it
+ * works in the other and the two must not share a preference.
+ */
+export function scalingStorageKey(kind: ConsoleKind): string {
+  return `proxcenter.console.scaling.${kind}`
+}
+
+export function parseScalingMode(raw: unknown, fallback: ScalingMode = DEFAULT_SCALING_MODE): ScalingMode {
+  return SCALING_MODES.includes(raw as ScalingMode) ? (raw as ScalingMode) : fallback
+}
+
+/** The subset of the Web Storage API we need, so tests can pass a stub. */
+export type StorageLike = {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+/**
+ * Reads the persisted mode. Every access is guarded: a console opened in a
+ * private window, or with site data blocked, throws on `localStorage` access
+ * itself, and a console that cannot open is a worse outcome than a forgotten
+ * preference.
+ */
+export function loadScalingMode(storage: StorageLike | null | undefined, kind: ConsoleKind): ScalingMode {
+  try {
+    return parseScalingMode(storage?.getItem(scalingStorageKey(kind)))
+  } catch {
+    return DEFAULT_SCALING_MODE
+  }
+}
+
+/** Returns whether the preference was actually persisted. */
+export function saveScalingMode(storage: StorageLike | null | undefined, kind: ConsoleKind, mode: ScalingMode): boolean {
+  try {
+    storage?.setItem(scalingStorageKey(kind), parseScalingMode(mode))
+
+    return Boolean(storage)
+  } catch {
+    return false
+  }
+}
+
+/** noVNC RFB flags for a mode. `clipViewport` pans instead of squeezing when unscaled. */
+export function rfbFlagsForScalingMode(mode: ScalingMode): {
+  scaleViewport: boolean
+  resizeSession: boolean
+  clipViewport: boolean
+} {
+  const parsed = parseScalingMode(mode)
+
+  return {
+    scaleViewport: parsed === 'scale',
+    resizeSession: parsed === 'remote',
+    clipViewport: parsed !== 'scale',
+  }
+}
+
+// A guest display device rejects sizes it cannot allocate, and X.Org wants
+// both dimensions on an 8-pixel boundary (the upstream spice-html5
+// resize_helper rounds down for exactly that reason).
+export const GUEST_SIZE_ALIGNMENT = 8
+export const MIN_GUEST_WIDTH = 320
+export const MIN_GUEST_HEIGHT = 200
+export const MAX_GUEST_DIMENSION = 8192
+
+/**
+ * Turns a container size in CSS pixels into a resolution to request from the
+ * guest agent. Returns null when the container is too small or not measurable
+ * yet (a hidden or zero-height area during layout), which the caller must
+ * treat as "do not send a resize" rather than as a size.
+ */
+export function computeGuestResolution(width: number, height: number): { width: number; height: number } | null {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) return null
+
+  const align = (value: number) => Math.floor(value / GUEST_SIZE_ALIGNMENT) * GUEST_SIZE_ALIGNMENT
+
+  const w = Math.min(align(width), MAX_GUEST_DIMENSION)
+  const h = Math.min(align(height), MAX_GUEST_DIMENSION)
+
+  if (w < MIN_GUEST_WIDTH || h < MIN_GUEST_HEIGHT) return null
+
+  return { width: w, height: h }
+}
+
+export type Size = { width: number; height: number }
+
+/**
+ * Scale factor to fit `source` inside `container` while keeping the aspect
+ * ratio. spice-html5 draws the guest framebuffer at its native size into a
+ * canvas and has no scaler of its own, so the SPICE page applies this as a
+ * CSS transform. Returns 1 when nothing is measurable, and never upscales
+ * unless asked (blowing a 640x480 text console up to 4K is not readable).
+ */
+export function computeFitScale(source: Size, container: Size, opts: { allowUpscale?: boolean } = {}): number {
+  const { width: sw, height: sh } = source
+  const { width: cw, height: ch } = container
+
+  if (![sw, sh, cw, ch].every(v => Number.isFinite(v) && v > 0)) return 1
+
+  const scale = Math.min(cw / sw, ch / sh)
+
+  if (!opts.allowUpscale && scale > 1) return 1
+
+  return scale
+}
+
+// --- Fullscreen -----------------------------------------------------------
+// The pages target the browsers ProxCenter supports, but the console is also
+// the one page users open in whatever is installed on a hypervisor jump host,
+// so the WebKit and legacy MS spellings are honoured too.
+
+type FullscreenDocument = {
+  fullscreenElement?: Element | null
+  webkitFullscreenElement?: Element | null
+  msFullscreenElement?: Element | null
+  exitFullscreen?: () => unknown
+  webkitExitFullscreen?: () => unknown
+  msExitFullscreen?: () => unknown
+}
+
+type FullscreenElement = {
+  requestFullscreen?: (options?: unknown) => unknown
+  webkitRequestFullscreen?: () => unknown
+  msRequestFullscreen?: () => unknown
+}
+
+export function fullscreenElement(doc: FullscreenDocument | null | undefined): Element | null {
+  if (!doc) return null
+
+  return doc.fullscreenElement ?? doc.webkitFullscreenElement ?? doc.msFullscreenElement ?? null
+}
+
+export function isFullscreen(doc: FullscreenDocument | null | undefined): boolean {
+  return Boolean(fullscreenElement(doc))
+}
+
+export function fullscreenSupported(el: FullscreenElement | null | undefined): boolean {
+  return Boolean(el && (el.requestFullscreen || el.webkitRequestFullscreen || el.msRequestFullscreen))
+}
+
+/**
+ * Enters or leaves fullscreen and returns the state we asked for (true =
+ * entering). The request is fire-and-forget: a rejected promise only means
+ * the gesture was not accepted, and there is nothing useful to tell the user
+ * beyond the button not latching.
+ */
+export function toggleFullscreen(
+  doc: FullscreenDocument | null | undefined,
+  el: FullscreenElement | null | undefined
+): boolean {
+  if (isFullscreen(doc)) {
+    const exit = doc?.exitFullscreen ?? doc?.webkitExitFullscreen ?? doc?.msExitFullscreen
+
+    exit?.call(doc)
+
+    return false
+  }
+
+  const request = el?.requestFullscreen ?? el?.webkitRequestFullscreen ?? el?.msRequestFullscreen
+
+  if (!request) return false
+
+  const result = request.call(el) as unknown
+
+  if (result && typeof (result as Promise<void>).catch === 'function') {
+    ;(result as Promise<void>).catch(() => {})
+  }
+
+  return true
+}
+
+// --- Send key combos ------------------------------------------------------
+// X11 keysyms, the alphabet noVNC's sendKey() speaks. Ctrl+Alt+Fn is how you
+// reach a Linux text console, Ctrl+Esc opens the Windows start menu, and
+// neither can be typed in the browser: the host desktop swallows them.
+
+export const KEYSYM = {
+  ControlLeft: 0xffe3,
+  AltLeft: 0xffe9,
+  Escape: 0xff1b,
+  Tab: 0xff09,
+  Backspace: 0xff08,
+  Delete: 0xffff,
+  F1: 0xffbe,
+} as const
+
+export type KeyStroke = { keysym: number; code: string }
+
+export type KeyCombo = { id: string; label: string; strokes: KeyStroke[] }
+
+function combo(id: string, label: string, ...strokes: KeyStroke[]): KeyCombo {
+  return { id, label, strokes }
+}
+
+const CTRL: KeyStroke = { keysym: KEYSYM.ControlLeft, code: 'ControlLeft' }
+const ALT: KeyStroke = { keysym: KEYSYM.AltLeft, code: 'AltLeft' }
+
+/**
+ * F1..F12 are contiguous from F1, so the table is generated rather than
+ * typed out twelve times.
+ */
+function functionKeyCombos(): KeyCombo[] {
+  return Array.from({ length: 12 }, (_, i) => {
+    const n = i + 1
+
+    return combo(`ctrl-alt-f${n}`, `Ctrl+Alt+F${n}`, CTRL, ALT, { keysym: KEYSYM.F1 + i, code: `F${n}` })
+  })
+}
+
+export const KEY_COMBOS: readonly KeyCombo[] = [
+  combo('ctrl-alt-del', 'Ctrl+Alt+Del', CTRL, ALT, { keysym: KEYSYM.Delete, code: 'Delete' }),
+  combo('ctrl-alt-backspace', 'Ctrl+Alt+Backspace', CTRL, ALT, { keysym: KEYSYM.Backspace, code: 'Backspace' }),
+  combo('ctrl-esc', 'Ctrl+Esc', CTRL, { keysym: KEYSYM.Escape, code: 'Escape' }),
+  combo('alt-tab', 'Alt+Tab', ALT, { keysym: KEYSYM.Tab, code: 'Tab' }),
+  ...functionKeyCombos(),
+]
+
+export function findKeyCombo(id: string): KeyCombo | null {
+  return KEY_COMBOS.find(c => c.id === id) ?? null
+}
+
+/**
+ * Expands a combo into the ordered sendKey calls a VNC server expects: every
+ * key pressed in order, then released in reverse, so the modifiers frame the
+ * final key and nothing stays latched in the guest.
+ */
+export function keyComboSequence(id: string): { keysym: number; code: string; down: boolean }[] {
+  const found = findKeyCombo(id)
+
+  if (!found) return []
+
+  const down = found.strokes.map(s => ({ ...s, down: true }))
+  const up = [...found.strokes].reverse().map(s => ({ ...s, down: false }))
+
+  return [...down, ...up]
+}
+
+// --- Misc -----------------------------------------------------------------
+
+/**
+ * Trailing-edge debounce. Resizing a window fires a continuous stream of
+ * events and every one of them would otherwise be a resolution change
+ * request to the guest, which is both slow and visibly ugly.
+ */
+export function debounce<A extends unknown[]>(fn: (...args: A) => void, delayMs: number): ((...args: A) => void) & { cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const wrapped = (...args: A) => {
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => {
+      timer = null
+      fn(...args)
+    }, delayMs)
+  }
+
+  wrapped.cancel = () => {
+    if (timer) clearTimeout(timer)
+    timer = null
+  }
+
+  return wrapped
+}


### PR DESCRIPTION
Closes #783.

### What was missing

Both graphical consoles opened in a 1024x768 popup with no way to make them bigger and no say over how the guest screen was scaled. The noVNC page scaled the framebuffer locally and hardcoded `resizeSession = false` behind a comment claiming it caused errors. The SPICE page had no controls at all: no fullscreen, no scaling, no reconnect, not even Ctrl+Alt+Del.

### What this adds

**Fullscreen**, on both pages. The toolbar slides out of the way and comes back when the pointer reaches the top edge, so every control stays one gesture away without leaving fullscreen.

**A scaling selector**, on both pages, with the three modes the Proxmox console already names: fit to window (the previous behaviour, still the default), resize the guest, and no scaling at 1:1. The choice is remembered per console kind, because guest support for resizing differs between the two protocols: a mode that works over SPICE is no evidence it works over VNC.

**Guest resizing**, opt-in rather than a new default. QEMU does advertise `ExtendedDesktopSize`, and when the guest cannot honour the request noVNC only logs a warning, so the mode degrades quietly where no driver can follow it. Over SPICE the request goes through the guest agent, so the mode is announced as unavailable until an agent has connected instead of being offered as an inert option, and local scaling stands in meanwhile.

**The controls the SPICE page never had**: reconnect (which also clears the previous screen, so a reconnection no longer stacks canvases), close, and Ctrl+Alt+Del.

**A send-key menu** on the noVNC page for the combinations the browser or the host desktop swallows (Ctrl+Alt+Del, Ctrl+Alt+Backspace, Ctrl+Esc, Alt+Tab, Ctrl+Alt+F1 through F12), plus sending text to the guest clipboard.

### Two things fixed along the way

The noVNC page logged **every keystroke typed into a guest**, passwords included, to the browser console through three leftover debug listeners. They are gone.

The SPICE page positioned its screen area below a hardcoded 41px toolbar. With the new controls the toolbar wraps on a narrow window and would have covered the guest screen, so the layout is now a flex column.

### On testability

These two pages are static HTML served outside Next, so they cannot import from `src/` and nothing in them was measurable or unit-testable. The shared logic now lives in `src/lib/console/viewport.ts` with 30 unit tests, and reaches the pages through `bundle-console.js`, which esbuilds it into a browser global. `public/console/console-ui.bundle.js` is a committed artifact: re-run `node bundle-console.js` after touching the module.

### Verification

Full suite green. Behaviour verified against a Proxmox VE 9.1 cluster (QEMU 10.1) on a qxl guest: fullscreen and its toolbar reveal, the three scaling modes and their persistence, the send-key menu switching virtual consoles in the guest, reconnect, close, and the SPICE page still refusing a guest without a SPICE display with its existing message.

Two claims were measured rather than assumed. QEMU advertises `ExtendedDesktopSize` on the VNC socket, and a refused resize produces only a `Log.Warn` in noVNC, no exception and no disconnection: that is what makes the opt-in mode safe, and it contradicts the comment the old code carried. And `offsetX` follows a CSS transform in the browser, which is what keeps mouse coordinates correct in the SPICE fit mode, since spice-html5 derives guest coordinates from it.

Not covered by the lab: no guest with a graphical driver or a SPICE agent was available, so guest resizing could not be seen taking effect. That path is opt-in and degrades to a warning, which is the behaviour that was verified.
