### PR TITLE
chore(ci): group Dependabot npm updates and drop stale resolutions pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,20 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    # One PR for all patches, one for all minors, and one PR per major.
+    # Every npm bump touches the same lockfile, and main requires branches to
+    # be up to date, so N ungrouped PRs cost N rebases and N CI runs: merging
+    # the first one puts every other branch BEHIND. Majors stay ungrouped on
+    # purpose, they are reviewed and released one at a time. Security updates
+    # keep their own PR (applies-to: version-updates) so a CVE fix is never
+    # buried in a maintenance batch.
+    groups:
+      npm-patch:
+        applies-to: version-updates
+        update-types: ["patch"]
+      npm-minor:
+        applies-to: version-updates
+        update-types: ["minor"]
 
   - package-ecosystem: "docker"
     directory: "/frontend"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -124,8 +124,6 @@
     "unicorn-magic": "0.1.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "eslint": "8.57.1",
-    "eslint-config-next": "16.2.10",
     "confbox": "0.2.4",
     "hono": ">=4.12.21",
     "@hono/node-server": ">=1.19.13",


### PR DESCRIPTION
Two config changes, no application code and no lockfile change.

**Grouped npm updates.** Every npm bump touches the same lockfile and `main` requires branches to be up to date, so N ungrouped Dependabot PRs cost N rebases and N CI runs: merging the first one puts every other branch `BEHIND`. The ten PRs that #784, #775 and #780 just cleared are a good illustration, the last one needed three rebases because main moved twice while its CI was running. Patches and minors now arrive as one PR each. Majors stay ungrouped on purpose so they keep being reviewed and merged one at a time, and `applies-to: version-updates` keeps security updates in their own PR so a CVE fix is never buried in a maintenance batch.

**Stale resolutions pins removed.** The `resolutions` block still pinned `eslint` to 8.57.1 and `eslint-config-next` to 16.2.10, while the devDependencies declare eslint 9 and eslint-config-next 16.3.0. npm ignores `resolutions` (it is a Yarn field), so this was inert for our installs, but pnpm does read it and the repo carries pnpm settings in `frontend/.npmrc`: an install with pnpm would have produced ESLint 8 under a flat config that requires 9 or later. The other eleven entries mirror `overrides` and are left as they are, since removing the block entirely would drop those guardrails for pnpm.

The lockfile is untouched, and npm does not record `resolutions` in it, so `npm ci` cannot desync.
