### PR TITLE
chore(next): rename middleware to proxy for Next 16

### DIFF
--- a/frontend/src/app/(dashboard)/layout.jsx
+++ b/frontend/src/app/(dashboard)/layout.jsx
@@ -37,7 +37,7 @@ import { getMode, getSystemMode } from '@core/utils/serverHelpers'
 const Layout = async props => {
   const { children } = props
 
-  // Authoritative 2FA enrollment gate. The Edge middleware only consults the
+  // Authoritative 2FA enrollment gate. The proxy only consults the
   // JWT hint, so sessions minted before the policy was turned on slip past
   // it. This DB check catches them on every protected page navigation.
   const session = await getServerSession(authOptions)

--- a/frontend/src/app/api/v1/public/health/route.ts
+++ b/frontend/src/app/api/v1/public/health/route.ts
@@ -8,7 +8,7 @@ import type { Principal } from "@/lib/auth/principal"
 export const runtime = "nodejs"
 
 // Authenticated companion of the unauthenticated /api/health liveness probe
-// (frontend/src/middleware.ts), which stays the load-balancer probe. This
+// (frontend/src/proxy.ts), which stays the load-balancer probe. This
 // one adds the per-connection detail, filtered by tenant and token
 // perimeter.
 async function handler(_req: Request, ctx: { principal?: Principal }) {

--- a/frontend/src/app/api/v1/storage/route.ts
+++ b/frontend/src/app/api/v1/storage/route.ts
@@ -62,7 +62,7 @@ async function handler(req: Request, ctx: GuardedRouteContext) {
     // Gate BEFORE canReadFleetStorage() is ever consulted (never merely
     // after): a token principal must not get the fleet branch even when a
     // live super-admin session cookie also rides along on the same request
-    // (spec D2 exclusivity; src/middleware.ts strips x-pxc-* but never
+    // (spec D2 exclusivity; src/proxy.ts strips x-pxc-* but never
     // Cookie). Short-circuit `&&` means the session read itself is never
     // invoked for a token, not just its result discarded.
     const fleet = ctx?.principal?.kind !== "token" && (await canReadFleetStorage())

--- a/frontend/src/components/SessionExpiryGuard.jsx
+++ b/frontend/src/components/SessionExpiryGuard.jsx
@@ -22,7 +22,7 @@ export default function SessionExpiryGuard({ children }) {
     // on "loading" would bounce every user on every page load.
     if (status !== 'unauthenticated') return
 
-    // callbackUrl matches middleware.ts's own no-token redirect
+    // callbackUrl matches proxy.ts's own no-token redirect
     // (`loginUrl.searchParams.set("callbackUrl", pathname)`) so
     // re-authenticating returns the user where they were.
     const loginUrl = `/login?callbackUrl=${encodeURIComponent(pathname)}`

--- a/frontend/src/components/SessionExpiryGuard.test.tsx
+++ b/frontend/src/components/SessionExpiryGuard.test.tsx
@@ -52,7 +52,7 @@ describe('SessionExpiryGuard', () => {
     expect(replaceMock).not.toHaveBeenCalled()
   })
 
-  it('encodes the current path in callbackUrl, matching middleware.ts', () => {
+  it('encodes the current path in callbackUrl, matching proxy.ts', () => {
     currentPathname = '/settings/security'
     useSessionMock.mockReturnValue({ status: 'unauthenticated' })
 

--- a/frontend/src/hooks/useSWRFetch.ts
+++ b/frontend/src/hooks/useSWRFetch.ts
@@ -40,7 +40,7 @@ export function redirectToLoginOnce() {
   // Hard navigation (not next/navigation's router — this is a plain module,
   // not a component). replace(), not assign(), so the dead page doesn't
   // stay in history — consistent with SessionExpiryGuard's router.replace().
-  // callbackUrl mirrors SessionExpiryGuard's and middleware.ts's own
+  // callbackUrl mirrors SessionExpiryGuard's and proxy.ts's own
   // no-token redirect so re-authenticating returns the user where they were.
   const callbackUrl = encodeURIComponent(window.location.pathname)
   window.location.replace(`/login?callbackUrl=${callbackUrl}`)

--- a/frontend/src/lib/api-tokens/allowlist.ts
+++ b/frontend/src/lib/api-tokens/allowlist.ts
@@ -1,6 +1,6 @@
-// PURE data module: imported by BOTH the Edge middleware (D7) and
-// principal.ts (D8). NO DB access, NO Node-only import, ever.
-// Single source of truth for: the middleware derogation, the authorization
+// PURE data module: imported by BOTH the proxy (D7) and
+// principal.ts (D8). NO DB access, ever.
+// Single source of truth for: the proxy derogation, the authorization
 // (getPrincipal step 10), the OpenAPI generation and the contract tests.
 
 export type AllowlistQueryParam = {
@@ -130,7 +130,7 @@ export function getAllowlistEntryById(id: string): AllowlistEntry | null {
 /**
  * Pre-match rejections (spec section 8): encoded slash or backslash, empty
  * segment (double slash), '.' or '..' segments, trailing slash on a non-root
- * path. Rejection = no match = the existing middleware cookie 401, nothing
+ * path. Rejection = no match = the existing proxy cookie 401, nothing
  * is disclosed.
  */
 export function isRejectedPath(pathname: string): boolean {
@@ -162,7 +162,7 @@ function matchPattern(pattern: string, pathname: string): Record<string, string>
 
 export type AllowlistMatch = { ok: boolean; entryId?: string; params?: Record<string, string> }
 
-/** THE single shared matcher: the Edge middleware and getPrincipal both use it. */
+/** THE single shared matcher: the proxy and getPrincipal both use it. */
 export function matchPublicApiPath(pathname: string): AllowlistMatch {
   if (isRejectedPath(pathname)) return { ok: false }
   for (const entry of PUBLIC_API_ALLOWLIST) {

--- a/frontend/src/lib/api-tokens/contract.test.ts
+++ b/frontend/src/lib/api-tokens/contract.test.ts
@@ -67,7 +67,7 @@ function walkImportGraph(entryFile: string): Map<string, string> {
  * - `lib/storage/fleetScope.ts` (`canReadFleetStorage`) reads
  *   `getServerSession()` DIRECTLY, independent of `getPrincipal()`/the
  *   principal passed to the route. It WAS a genuine, if narrow, violation:
- *   `src/middleware.ts` only strips inbound `x-pxc-*` headers (spec D7) and
+ *   `src/proxy.ts` only strips inbound `x-pxc-*` headers (spec D7) and
  *   never touches `Cookie`, so a request carrying BOTH a live
  *   provider-tenant super-admin session cookie AND ANY valid `pxc_` bearer
  *   token reached the handler with `ctx.principal.kind === "token"` while

--- a/frontend/src/lib/auth/cookies.ts
+++ b/frontend/src/lib/auth/cookies.ts
@@ -1,7 +1,7 @@
 // Single source of truth for NextAuth cookie names and the `secure` flag.
 //
 // The NAMES stay derived from NEXTAUTH_URL and static for the process
-// lifetime: three readers (middleware.ts twice, the 2FA verify route) must
+// lifetime: three readers (proxy.ts twice, the 2FA verify route) must
 // look up the same name the issuer wrote, and they have no per-request
 // agreement with it.
 //

--- a/frontend/src/lib/auth/durations.ts
+++ b/frontend/src/lib/auth/durations.ts
@@ -1,10 +1,12 @@
 // Session timeout configuration, read fresh from the environment on every
 // call so a changed timeout applies immediately without a restart.
 //
-// This module must import NOTHING beyond process.env: Task 8's middleware
-// needs sessionDurations() and runs in the Edge runtime, which cannot load
-// sessions.ts (it imports Prisma). Keeping this file import-free keeps the
-// middleware bundle clean.
+// This module must import NOTHING beyond process.env: `proxy.ts` needs
+// sessionDurations() and must not pull in sessions.ts, which imports Prisma.
+// That was an Edge-runtime constraint until Next 16 renamed `middleware` to
+// `proxy` and pinned it to the nodejs runtime; it is now a deliberate rule,
+// so the hop in front of every page keeps doing zero DB work. Keeping this
+// file import-free keeps the proxy bundle clean.
 
 const DEFAULT_IDLE_SECONDS = 12 * 3600
 const DEFAULT_ABSOLUTE_SECONDS = 7 * 86400
@@ -29,14 +31,14 @@ export function sessionDurations(): SessionDurations {
 }
 
 /**
- * The one absolute-cap rule, shared by both sides of the Edge boundary:
- * `sessions.ts:evaluateSession` (Node, DB-backed session rows) and
- * `middleware.ts` (Edge, the JWT's `authAt` claim) each need "has this long
- * elapsed since the start instant exceeded the cap", and had drifted into
- * two separately-written copies of the same comparison. This file already
- * has zero imports and is loaded by both, so the predicate lives here rather
- * than in `sessions.ts` (Prisma-adjacent, Edge-hostile) or `middleware.ts`
- * (would leave `sessions.ts` still duplicating it).
+ * The one absolute-cap rule, shared by both sides of the DB boundary:
+ * `sessions.ts:evaluateSession` (DB-backed session rows) and `proxy.ts` (the
+ * JWT's `authAt` claim, no DB access) each need "has this long elapsed since
+ * the start instant exceeded the cap", and had drifted into two
+ * separately-written copies of the same comparison. This file already has
+ * zero imports and is loaded by both, so the predicate lives here rather
+ * than in `sessions.ts` (Prisma-adjacent) or `proxy.ts` (would leave
+ * `sessions.ts` still duplicating it).
  *
  * Strictly greater-than, matching the existing behaviour in both callers: an
  * elapsed time exactly equal to the cap is NOT past it.

--- a/frontend/src/lib/connections/getConnection.ts
+++ b/frontend/src/lib/connections/getConnection.ts
@@ -45,7 +45,7 @@ async function assertProviderFleetViewFromSession(id: string, kind: "pve" | "pbs
   // 401 = no session at all: a background/internal caller (poller, detached
   // migration pipeline) rather than a scoped user, so trusted server code
   // passes. This cannot be reached by an unauthenticated HTTP caller: the
-  // global middleware (src/middleware.ts) returns 401 for any /api request
+  // global proxy (src/proxy.ts) returns 401 for any /api request
   // without a valid JWT before route handlers run, so sessionless execution
   // here can only be non-request server code. The guard bounds AUTHENTICATED
   // users (403 = authenticated but lacking the grant).

--- a/frontend/src/lib/internal-auth.ts
+++ b/frontend/src/lib/internal-auth.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server"
 import { constantTimeStringEqual } from "@/lib/crypto/constantTime"
 
 // Server-side caller authentication for /api/internal/* routes. These
-// routes are listed in publicApiRoutes in middleware.ts because they
+// routes are listed in publicApiRoutes in proxy.ts because they
 // have to be reachable by the ws-proxy process without a NextAuth
 // session, but that makes them reachable by anyone who can hit the
 // Next.js port. A plain x-internal-caller string header is trivially

--- a/frontend/src/proxy.authAt.test.ts
+++ b/frontend/src/proxy.authAt.test.ts
@@ -8,7 +8,7 @@ vi.mock('next-auth/jwt', () => ({ getToken: getTokenMock }))
 
 import { NextRequest } from 'next/server'
 
-import { middleware } from './middleware'
+import { proxy } from './proxy'
 
 afterEach(() => {
   vi.clearAllMocks()
@@ -17,12 +17,12 @@ afterEach(() => {
 
 const req = (path: string) => new NextRequest(new URL(`http://h:3000${path}`))
 
-describe('middleware enforces the absolute cap from authAt, with no DB access', () => {
+describe('proxy enforces the absolute cap from authAt, with no DB access', () => {
   it('redirects to /login when authAt is past the cap', async () => {
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
-    const res = await middleware(req('/dashboard'))
+    const res = await proxy(req('/dashboard'))
 
     expect(res?.status).toBe(307)
     expect(res?.headers.get('location')).toContain('/login')
@@ -32,7 +32,7 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 60_000 })
 
-    const res = await middleware(req('/dashboard'))
+    const res = await proxy(req('/dashboard'))
 
     expect(res?.headers.get('location')).toBeNull()
   })
@@ -40,7 +40,7 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
   it('lets a token with no authAt through, leaving refusal to the read path', async () => {
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1' })
 
-    const res = await middleware(req('/dashboard'))
+    const res = await proxy(req('/dashboard'))
 
     expect(res?.headers.get('location')).toBeNull()
   })
@@ -49,7 +49,7 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
-    const res = await middleware(req('/login'))
+    const res = await proxy(req('/login'))
 
     expect(res?.headers.get('location')).toBeNull()
   })
@@ -66,7 +66,7 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
-    const res = await middleware(req('/api/auth/session'))
+    const res = await proxy(req('/api/auth/session'))
 
     expect(res?.headers.get('location')).toBeNull()
     expect(getTokenMock).not.toHaveBeenCalled()
@@ -76,7 +76,7 @@ describe('middleware enforces the absolute cap from authAt, with no DB access', 
     process.env.SESSION_ABSOLUTE_TIMEOUT = '3600'
     getTokenMock.mockResolvedValue({ id: 'u1', sid: 's1', authAt: Date.now() - 7200_000 })
 
-    const res = await middleware(req('/api/health'))
+    const res = await proxy(req('/api/health'))
 
     expect(res?.headers.get('location')).toBeNull()
     expect(getTokenMock).not.toHaveBeenCalled()

--- a/frontend/src/proxy.dotPath.test.ts
+++ b/frontend/src/proxy.dotPath.test.ts
@@ -9,7 +9,7 @@ vi.mock('@/lib/demo/demo-api', () => ({ demoResponse: () => null }))
 
 import { NextRequest } from 'next/server'
 
-import { middleware } from './middleware'
+import { proxy } from './proxy'
 
 function request(path: string, init: { method?: string; headers?: Record<string, string> } = {}) {
   return new NextRequest(`http://test.local${path}`, {
@@ -18,7 +18,7 @@ function request(path: string, init: { method?: string; headers?: Record<string,
   })
 }
 
-/** A middleware pass-through, i.e. the handler behind the path will run. */
+/** A proxy pass-through, i.e. the handler behind the path will run. */
 function passedThrough(res: Response): boolean {
   return res.headers.get('x-middleware-next') === '1'
 }
@@ -46,7 +46,7 @@ describe('dotted API paths never bypass authentication', () => {
 
   for (const path of dotted) {
     it(`answers 401 to an unauthenticated GET ${path}`, async () => {
-      const res = await middleware(request(path) as any)
+      const res = await proxy(request(path) as any)
 
       expect(res.status).toBe(401)
       expect(await res.json()).toEqual({ error: 'Not authenticated' })
@@ -54,7 +54,7 @@ describe('dotted API paths never bypass authentication', () => {
   }
 
   it('answers 401 to an unauthenticated write on a dotted API path', async () => {
-    const res = await middleware(
+    const res = await proxy(
       request('/api/v1/guests/conn1:qemu:pve1.internal:100/notes', {
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
@@ -67,7 +67,7 @@ describe('dotted API paths never bypass authentication', () => {
   it('lets an authenticated caller through a dotted API path', async () => {
     getTokenMock.mockResolvedValue({ sub: 'u1', authAt: Date.now() })
 
-    const res = await middleware(request('/api/v1/guests/conn1:qemu:pve1.internal:100/notes') as any)
+    const res = await proxy(request('/api/v1/guests/conn1:qemu:pve1.internal:100/notes') as any)
 
     expect(passedThrough(res)).toBe(true)
   })
@@ -80,7 +80,7 @@ describe('static assets and public routes keep passing', () => {
 
   for (const path of assets) {
     it(`passes ${path} through unauthenticated`, async () => {
-      const res = await middleware(request(path) as any)
+      const res = await proxy(request(path) as any)
 
       expect(passedThrough(res)).toBe(true)
     })
@@ -96,7 +96,7 @@ describe('static assets and public routes keep passing', () => {
 
   for (const path of publicApi) {
     it(`keeps the public API route ${path} reachable unauthenticated`, async () => {
-      const res = await middleware(request(path) as any)
+      const res = await proxy(request(path) as any)
 
       expect(passedThrough(res)).toBe(true)
     })

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -16,7 +16,7 @@ import { NextRequest } from 'next/server'
 
 // Static instance: module-scope env constants (HA_ENABLED, VIP, ...) are baked
 // at file load, BEFORE any vi.stubEnv from the VIP describes below runs.
-import { middleware } from './middleware'
+import { proxy } from './proxy'
 
 function makeRequest(url: string, host: string) {
   return {
@@ -51,9 +51,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/home', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://192.0.2.100:3000/home')
@@ -64,9 +64,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.100/home', '192.0.2.100')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -76,9 +76,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.100:3000/home', '192.0.2.100:3000')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -88,9 +88,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/api/health', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -100,9 +100,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/api/v1/ha/cluster', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -112,9 +112,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://localhost/home', 'localhost')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -125,9 +125,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('HA_REDIRECT_DISABLED', 'true')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/home', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -135,9 +135,9 @@ describe('VIP redirect', () => {
   it('does not redirect when HA_ENABLED is not set', async () => {
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/home', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -147,9 +147,9 @@ describe('VIP redirect', () => {
     vi.stubEnv('VIP', '192.0.2.100')
     vi.stubEnv('NEXTAUTH_SECRET', 'test-secret')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/settings?tab=ha', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://192.0.2.100:3000/settings?tab=ha')
@@ -172,9 +172,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('NEXTAUTH_URL', 'https://proxcenter.example.com')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('https://proxcenter.example.com/home', 'proxcenter.example.com')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -183,9 +183,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('NEXTAUTH_URL', 'https://proxcenter.example.com')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('https://proxcenter.example.com/home', 'ProxCenter.Example.com:443')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -194,9 +194,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('NEXTAUTH_URL', 'https://proxcenter.example.com')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/home', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).toBe(302)
     expect(res.headers.get('location')).toBe('http://192.0.2.100:3000/home')
@@ -206,9 +206,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('NEXTAUTH_URL', 'https://proxcenter.example.com')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.100:3000/home', '192.0.2.100:3000')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -217,9 +217,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('HA_REDIRECT_EXEMPT_HOSTS', ' proxy-a.internal , Proxy-B.internal ')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://proxy-b.internal/home', 'proxy-b.internal')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -228,9 +228,9 @@ describe('VIP redirect host exemptions', () => {
     stubHaEnv()
     vi.stubEnv('NEXTAUTH_URL', 'not a url at all')
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/home', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).toBe(302)
   })
@@ -238,9 +238,9 @@ describe('VIP redirect host exemptions', () => {
   it('exempts /api/health/live on a non-exempt host (liveness path)', async () => {
     stubHaEnv()
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/api/health/live', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -248,9 +248,9 @@ describe('VIP redirect host exemptions', () => {
   it('exempts /api/health?live=1 on a non-exempt host', async () => {
     stubHaEnv()
 
-    const { middleware } = await import('./middleware')
+    const { proxy } = await import('./proxy')
     const req = makeRequest('http://192.0.2.101/api/health?live=1', '192.0.2.101')
-    const res = await middleware(req as any)
+    const res = await proxy(req as any)
 
     expect(res.status).not.toBe(302)
   })
@@ -258,7 +258,7 @@ describe('VIP redirect host exemptions', () => {
 
 describe('gesture 1: unconditional x-pxc-* strip on /api/*', () => {
   it('strips forged x-pxc-* headers on the storage upload bypass path', async () => {
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/v1/connections/c1/nodes/n1/storage/local/upload', {
         method: 'POST',
         headers: { 'x-pxc-entry': 'vms-list', 'x-pxc-path': '/api/v1/vms', 'x-pxc-method': 'GET' },
@@ -277,7 +277,7 @@ describe('gesture 1: unconditional x-pxc-* strip on /api/*', () => {
 
   it('strips forged x-pxc-* on an authenticated API pass-through', async () => {
     getTokenMock.mockResolvedValue({ sub: 'u1' })
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/v1/users', { headers: { cookie: 'x', 'x-pxc-entry': 'evil' } }),
     )
     const overridden = res.headers.get('x-middleware-override-headers')
@@ -289,7 +289,7 @@ describe('gesture 1: unconditional x-pxc-* strip on /api/*', () => {
 describe('gesture 3: bounded derogation', () => {
   it('answers 405 Allow: GET, HEAD to OPTIONS on an allowlisted path, with or without Bearer', async () => {
     for (const headers of [{}, { authorization: 'Bearer pxc_x'.padEnd(50, 'a') }]) {
-      const res = await middleware(apiRequest('/api/v1/vms', { method: 'OPTIONS', headers }))
+      const res = await proxy(apiRequest('/api/v1/vms', { method: 'OPTIONS', headers }))
       expect(res.status).toBe(405)
       expect(res.headers.get('Allow')).toBe('GET, HEAD')
       expect(await res.json()).toEqual({ error: 'API tokens are read-only', method: 'OPTIONS' })
@@ -297,7 +297,7 @@ describe('gesture 3: bounded derogation', () => {
   })
 
   it('derogates a Bearer pxc_ on an allowlisted path and stamps the three internal headers', async () => {
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/v1/pbs/conn-9/backups', { headers: { authorization: 'Bearer pxc_abcdefgh123' } }),
     )
     expect(res.status).toBe(200) // NextResponse.next()
@@ -308,7 +308,7 @@ describe('gesture 3: bounded derogation', () => {
   })
 
   it('gives NO derogation to a Bearer on a non-allowlisted path: existing cookie 401', async () => {
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/v1/license/status', { headers: { authorization: 'Bearer pxc_abcdefgh123' } }),
     )
     expect(res.status).toBe(401)
@@ -316,14 +316,14 @@ describe('gesture 3: bounded derogation', () => {
   })
 
   it('gives NO derogation without a Bearer on an allowlisted path', async () => {
-    const res = await middleware(apiRequest('/api/v1/vms'))
+    const res = await proxy(apiRequest('/api/v1/vms'))
     expect(res.status).toBe(401)
     expect(await res.json()).toEqual({ error: 'Not authenticated' })
   })
 
   it('rejected paths (trailing slash, dotdot, %2F) never derogate', async () => {
     for (const path of ['/api/v1/vms/', '/api/v1/pbs/..%2Fx/backups', '/api/v1/pbs/a%2Fb/backups']) {
-      const res = await middleware(
+      const res = await proxy(
         apiRequest(path, { headers: { authorization: 'Bearer pxc_abcdefgh123' } }),
       )
       expect(res.status).toBe(401)
@@ -331,12 +331,12 @@ describe('gesture 3: bounded derogation', () => {
   })
 
   it('keeps the existing behavior of public API routes', async () => {
-    const res = await middleware(apiRequest('/api/health'))
+    const res = await proxy(apiRequest('/api/health'))
     expect(res.status).toBe(200)
   })
 
   it('answers the existing cookie 401 to an OPTIONS preflight on a non-allowlisted path', async () => {
-    const res = await middleware(apiRequest('/api/v1/users', { method: 'OPTIONS' }))
+    const res = await proxy(apiRequest('/api/v1/users', { method: 'OPTIONS' }))
     expect(res.status).toBe(401)
     expect(await res.json()).toEqual({ error: 'Not authenticated' })
   })
@@ -345,7 +345,7 @@ describe('gesture 3: bounded derogation', () => {
 describe('demo mode: x-pxc-* strip on the API pass-through', () => {
   it('strips forged x-pxc-* headers on a /api/v1/* path the demo interceptor has no mock for', async () => {
     process.env.DEMO_MODE = 'true'
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/v1/public/metrics', {
         headers: { 'x-pxc-entry': 'public-metrics', 'x-pxc-path': '/api/v1/public/metrics', 'x-pxc-method': 'GET' },
       }),
@@ -368,7 +368,7 @@ describe('demo mode: x-pxc-* strip on the API pass-through', () => {
 
   it('strips forged x-pxc-* headers on a non-v1 API path in demo mode', async () => {
     process.env.DEMO_MODE = 'true'
-    const res = await middleware(
+    const res = await proxy(
       apiRequest('/api/internal/some-route', { headers: { 'x-pxc-entry': 'evil' } }),
     )
     const overridden = res.headers.get('x-middleware-override-headers')
@@ -380,7 +380,7 @@ describe('demo mode: x-pxc-* strip on the API pass-through', () => {
 describe('cookie-authenticated behavior unchanged', () => {
   it('keeps the 2FA enrollment gate for cookie-authenticated API requests', async () => {
     getTokenMock.mockResolvedValue({ sub: 'u1', mustEnroll2fa: true })
-    const res = await middleware(apiRequest('/api/v1/users', { headers: { cookie: 'x' } }))
+    const res = await proxy(apiRequest('/api/v1/users', { headers: { cookie: 'x' } }))
     expect(res.status).toBe(403)
     expect(await res.json()).toEqual({
       error: 'ENROLLMENT_REQUIRED',

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,4 +1,12 @@
-// src/middleware.ts
+// src/proxy.ts
+//
+// Was `src/middleware.ts`: Next 16 deprecated the `middleware` filename and
+// its named export in favour of `proxy`, to make the network boundary the
+// point of the file. The routing logic below is unchanged. One consequence is
+// NOT cosmetic: `proxy` always runs on the **nodejs** runtime and that cannot
+// be configured, where `middleware` defaulted to edge. Staying free of Prisma
+// and of any DB round-trip here is therefore now a deliberate choice (see the
+// absolute-cap note below), not a constraint the runtime imposes.
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
@@ -74,7 +82,7 @@ function isEnrollBypass(pathname: string): boolean {
 }
 
 // Strips every inbound x-pxc-* header from a forwarded-request Headers
-// object. These are internal signals set ONLY by this middleware (gesture 3
+// object. These are internal signals set ONLY by this proxy (gesture 3
 // below), never legitimate client input: forwarding a client-supplied
 // x-pxc-entry/-path/-method would let a request forge the allowlist
 // decision that getPrincipal() trusts blindly. Two call sites: the demo-mode
@@ -148,7 +156,7 @@ function getLocale(request: NextRequest): string {
   return getLocaleFromHeader(request)
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const isDemoMode = process.env.DEMO_MODE === 'true'
 
@@ -241,7 +249,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Gesture 2 (existing bypass, unchanged semantics, now AFTER the strip):
-  // skip middleware for large upload routes (auth handled in route handler
+  // skip the proxy for large upload routes (auth handled in route handler
   // via checkPermission)
   if (pathname.includes('/storage/') && pathname.endsWith('/upload')) {
     return NextResponse.next({ request: { headers: requestHeaders } })
@@ -304,9 +312,9 @@ export async function middleware(request: NextRequest) {
 
     // Absolute cap, checked here so it also holds for page navigation. getToken
     // only decodes the JWT (jwt/index.js:118) — no callbacks, so the read-path
-    // validation never runs for the middleware. authAt makes the one deadline
+    // validation never runs for the proxy. authAt makes the one deadline
     // that matters against a stolen cookie enforceable with pure arithmetic,
-    // keeping this file Prisma-free and Edge-valid. isPastAbsoluteCap is the
+    // keeping this file Prisma-free. isPastAbsoluteCap is the
     // same predicate lib/auth/sessions.ts:evaluateSession uses for the DB-backed
     // row's createdAt, so the two never drift into separately-worded copies of
     // one rule.
@@ -333,7 +341,7 @@ export async function middleware(request: NextRequest) {
 
   // Gesture 3: bounded API-token derogation, kept BEFORE the early return
   // below so the OPTIONS 405 and the header stamping always win over it. The
-  // middleware never validates the token (edge runtime, no DB): it only
+  // proxy never validates the token (no DB round-trip here, by design): it only
   // matches the path via the shared matcher and stamps the internal headers;
   // hash, license, tenant, scopes and quota live in getPrincipal().
   const hasApiTokenBearer =
@@ -342,7 +350,7 @@ export async function middleware(request: NextRequest) {
     const matched = matchPublicApiPath(pathname)
     if (matched.ok) {
       // Server-to-server only (spec section 8): explicit 405 to any OPTIONS
-      // on the exposed surface, answered by the middleware itself.
+      // on the exposed surface, answered by the proxy itself.
       if (request.method === 'OPTIONS') {
         return NextResponse.json(
           { error: 'API tokens are read-only', method: 'OPTIONS' },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,7 +27,7 @@ sonar.typescript.lcov.reportPaths=frontend/coverage/lcov.info
 # Coverage exclusions. Keep this list small and defensible: only files
 # whose presence in the denominator dilutes the % without telling us
 # anything about real test risk. Business-logic carriers (lib/**,
-# app/api/**, components/**, middleware.ts) stay measured.
+# app/api/**, components/**, proxy.ts) stay measured.
 #
 # - hooks/useFrameworkAssessments.ts: thin SWR data hook (same rationale as
 #   the existing useSharedTasks.ts entry; no logic, just wraps useSWR).
@@ -232,7 +232,7 @@ sonar.coverage.exclusions=\
   frontend/src/lib/compliance/collectHardeningData.ts,\
   frontend/src/components/inventory/GreenScoreCard.tsx,\
   frontend/src/components/settings/green/DatacenterDialog.tsx,\
-  frontend/src/middleware.ts,\
+  frontend/src/proxy.ts,\
   frontend/src/components/settings/ha/*.tsx,\
   frontend/scripts/**,\
   frontend/src/components/templates/DeploymentDetailDialog.tsx,\


### PR DESCRIPTION
Next 16 deprecated the `middleware` filename and its named export in favour of `proxy`. This is that rename, plus the comments and the one config line that named the old file.

`src/middleware.ts` becomes `src/proxy.ts` and the exported `middleware` function becomes `proxy`. The routing logic is untouched: same `config.matcher`, same gestures in the same order. The three test files follow the same rename (`proxy.test.ts`, `proxy.authAt.test.ts`, `proxy.dotPath.test.ts`) and keep asserting on Next's internal `x-middleware-*` headers, which the framework still emits under the new convention.

**The runtime changes, and that is the only behavioural part of this PR.** `proxy` always runs on the nodejs runtime and that cannot be configured, where `middleware` defaulted to edge. Nothing in the file needed an edge-only API, and node is a superset, so no code had to change. What did need updating is every comment that presented a design choice as an edge constraint: staying free of Prisma and of any DB round-trip on the request path in front of every page is now a deliberate rule, not something the runtime imposes. `lib/auth/durations.ts` and `lib/api-tokens/allowlist.ts` carried most of those claims.

`sonar-project.properties` listed `frontend/src/middleware.ts` in the coverage exclusions by hard path: renamed too, otherwise the exclusion would have silently stopped matching and the file would have re-entered the coverage denominator.

Comments that talk about "the middleware" as a concept without naming the file are left alone. Next itself calls it "proxy (previously called middleware)", and rewriting that prose everywhere would have inflated the diff for nothing.

Verified locally: the three renamed suites plus `SessionExpiryGuard` and the API-token contract tests are green (65 tests), ESLint reports no error, and `next build` picks up `proxy.ts` with no duplicate-convention error.
