### PR TITLE
Avoid double disk copy on cold migration to file-based storage (#292)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -68,7 +68,7 @@ import { parseNodeId, parseVmId, HOTPLUG_DEVICES } from '../helpers'
 import { AllVmItem, HostItem } from '../InventoryTree'
 import { PlayArrowIcon, StopIcon, PowerSettingsNewIcon, MoveUpIcon } from './IconWrappers'
 import { StatusIcon } from './TreeIcons'
-import { vsanBlocksMigrationType, warmNeedsBlockStorage, isDowntimeBudgetValid, DOWNTIME_BUDGET_PRESETS, DOWNTIME_BUDGET_DEFAULT_SEC, DOWNTIME_BUDGET_MIN_SEC, DOWNTIME_BUDGET_MAX_SEC, downtimeBudgetIndex, formatDowntimeBudget } from './migrationGuards'
+import { vsanBlocksMigrationType, vsanBlocksDirectEsxiRun, requiredTempBytes, warmNeedsBlockStorage, isDowntimeBudgetValid, DOWNTIME_BUDGET_PRESETS, DOWNTIME_BUDGET_DEFAULT_SEC, DOWNTIME_BUDGET_MIN_SEC, DOWNTIME_BUDGET_MAX_SEC, downtimeBudgetIndex, formatDowntimeBudget } from './migrationGuards'
 import WarmCutoverButton from './WarmCutoverButton'
 import ForcePowerOffButton from './ForcePowerOffButton'
 import RootChoiceButton from './RootChoiceButton'
@@ -3265,6 +3265,13 @@ return
                   // for automatic driver injection, so we gate on the same deps as vCenter.
                   const isDirectEsxiWinCold = !isV2vVcenter && isWindowsGuest && migType === 'cold'
                   const needsV2vDeps = isV2vVcenter || isDirectEsxiWinCold
+                  // vSAN source: tested HERE, above the needsV2vDeps branch, because that
+                  // branch returns false on its own and used to swallow the check for the
+                  // one population that needs it most (direct-ESXi Windows cold, routed to
+                  // virt-v2v over `-i vmx -it ssh`, which cannot read a vSAN object
+                  // either). The alert above the button was always shown; only the gate
+                  // was dead. Found during the #292 recette.
+                  if (vsanBlocksDirectEsxiRun(vsanBlocksMigration, migType, isV2vVcenter)) return true
                   // Power-state gates: cold needs the VM off, live needs it on.
                   // Applies to every source type. Auto-power-off/on is intentionally
                   // NOT done here - the user toggles VM state on the source hypervisor
@@ -3288,11 +3295,13 @@ return
                     // virtio-win is required for Windows guests — without it the
                     // VM will likely BSOD with INACCESSIBLE_BOOT_DEVICE.
                     if (isWindowsGuest && !vcenterPreflight.virtioWinInstalled) return true
-                    // Temp storage must have at least 2x the source VM's committed
-                    // space (rough heuristic: NFC download + virt-v2v converted output).
+                    // Temp storage room: the source download always lands there, the
+                    // converted image only when the target is block storage, since #292
+                    // writes it straight onto a file-based target. requiredTempBytes owns
+                    // that 1x / 2x rule.
                     if (!migTempStorage) return true
                     const sel = vcenterPreflight.tempStorages?.find(s => s.path === migTempStorage)
-                    if (!sel || sel.availableBytes < (esxiMigrateVm?.committed || 0) * 2) return true
+                    if (!sel || sel.availableBytes < requiredTempBytes(esxiMigrateVm?.committed || 0, migTargetStorageType)) return true
                     // Direct-ESXi via v2v also requires SSH + key on the source connection
                     // (virt-v2v -it ssh doesn't do password auth).
                     if (isDirectEsxiWinCold && migTargetConn && !migPveConnections.find((c: any) => c.id === migTargetConn)?.sshEnabled) return true
@@ -3302,10 +3311,6 @@ return
                   // connection and sshfs/pv must be available when those modes selected.
                   if (migTargetConn && !migPveConnections.find((c: any) => c.id === migTargetConn)?.sshEnabled) return true
                   if (migSshfsAvailable === false && (migTransferMode === 'sshfs' || migType === 'sshfs_boot')) return true
-                  // vSAN source on direct-ESXi: the file-based types stay blocked, warm
-                  // does not. Until this was fixed, a vSAN VM could only be migrated
-                  // without vCenter through the API.
-                  if (vsanBlocksSelectedType) return true
                   if (warmStorageBlocked) return true
                   if (downtimeBudgetInvalid) return true
                   // Warm: require a CURRENT successful readiness check for the selected

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/migrationGuards.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/migrationGuards.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 
-import { vsanBlocksMigrationType, warmNeedsBlockStorage, isDowntimeBudgetValid, DOWNTIME_BUDGET_MIN_SEC, DOWNTIME_BUDGET_MAX_SEC, DOWNTIME_BUDGET_PRESETS, DOWNTIME_BUDGET_DEFAULT_SEC, downtimeBudgetIndex, formatDowntimeBudget } from "./migrationGuards"
+import { vsanBlocksMigrationType, vsanBlocksDirectEsxiRun, requiredTempBytes, warmNeedsBlockStorage, isDowntimeBudgetValid, DOWNTIME_BUDGET_MIN_SEC, DOWNTIME_BUDGET_MAX_SEC, DOWNTIME_BUDGET_PRESETS, DOWNTIME_BUDGET_DEFAULT_SEC, downtimeBudgetIndex, formatDowntimeBudget } from "./migrationGuards"
 
 describe("vsanBlocksMigrationType", () => {
   it("blocks the file-based types on a vSAN source", () => {
@@ -120,5 +120,61 @@ describe("formatDowntimeBudget", () => {
     for (const sec of DOWNTIME_BUDGET_PRESETS) {
       expect(formatDowntimeBudget(sec)).not.toContain(".")
     }
+  })
+})
+
+describe("vsanBlocksDirectEsxiRun", () => {
+  it("blocks a direct-ESXi cold run on vSAN, Windows guest included", () => {
+    // The regression this function exists for (#292 recette, 2026-08-24): a
+    // Windows cold run is routed to virt-v2v over `-i vmx -it ssh`, which reads
+    // the vmdk as a file and finds a vsan:// descriptor. The dialog showed the
+    // red alert and left the button clickable, so the job started and died in
+    // the transfer phase.
+    expect(vsanBlocksDirectEsxiRun(true, "cold", false)).toBe(true)
+    expect(vsanBlocksDirectEsxiRun(true, "live", false)).toBe(true)
+  })
+
+  it("lets warm through: VDDK serves vSAN objects on that same direct connection", () => {
+    expect(vsanBlocksDirectEsxiRun(true, "warm", false)).toBe(false)
+  })
+
+  it("exempts a v2v-managed source, whose NFC export is vSAN aware", () => {
+    for (const type of ["cold", "live"]) {
+      expect(vsanBlocksDirectEsxiRun(true, type, true)).toBe(false)
+    }
+  })
+
+  it("blocks nothing when no disk sits on vSAN", () => {
+    for (const managed of [true, false]) {
+      for (const type of ["cold", "live", "warm"]) {
+        expect(vsanBlocksDirectEsxiRun(false, type, managed)).toBe(false)
+      }
+    }
+  })
+})
+
+describe("requiredTempBytes", () => {
+  const oneTB = 1024 ** 4
+
+  it("asks for the source size once on a file-based target: #292 writes the conversion onto the storage", () => {
+    for (const type of ["dir", "nfs", "cifs", "glusterfs", "btrfs"]) {
+      expect(requiredTempBytes(oneTB, type)).toBe(oneTB)
+    }
+  })
+
+  it("still asks for twice on a block target, where the converted image lands on temp", () => {
+    for (const type of ["lvm", "lvmthin", "zfspool", "rbd"]) {
+      expect(requiredTempBytes(oneTB, type)).toBe(2 * oneTB)
+    }
+  })
+
+  it("keeps the conservative factor while the storage type is unknown", () => {
+    expect(requiredTempBytes(oneTB, undefined)).toBe(2 * oneTB)
+    expect(requiredTempBytes(oneTB, "")).toBe(2 * oneTB)
+  })
+
+  it("never demands a negative amount", () => {
+    expect(requiredTempBytes(-1, "nfs")).toBe(0)
+    expect(requiredTempBytes(0, "lvm")).toBe(0)
   })
 })

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/migrationGuards.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/migrationGuards.ts
@@ -26,6 +26,49 @@ export function vsanBlocksMigrationType(hasVsanDisks: boolean, migType: string):
 }
 
 /**
+ * Whether a vSAN-backed source blocks the run on a DIRECT ESXi connection.
+ *
+ * `vsanBlocksMigrationType` states the rule; this states who it applies to, and
+ * that distinction is the whole reason it exists as its own function. A vCenter
+ * (and likewise Hyper-V or Nutanix) source is exempt: virt-v2v reaches those
+ * disks through the NFC export, which is vSAN aware. Everything else reads the
+ * datastore as files and cannot.
+ *
+ * Found during the #292 recette on 2026-08-24: the migrate button tested the
+ * rule only in the branch a direct-ESXi *Linux* guest falls through, so a
+ * Windows guest, which the API routes to virt-v2v over `-i vmx -it ssh` and
+ * which cannot read a vSAN object either, sailed past the red alert with an
+ * enabled button. The rule now sits above that branch, and here so it can be
+ * asserted without rendering the dialog.
+ */
+export function vsanBlocksDirectEsxiRun(
+  hasVsanDisks: boolean,
+  migType: string,
+  isV2vManagedSource: boolean,
+): boolean {
+  return !isV2vManagedSource && vsanBlocksMigrationType(hasVsanDisks, migType)
+}
+
+/**
+ * Temp space a cold virt-v2v run must find on the temp storage, in bytes.
+ *
+ * The old rule always demanded twice the source's committed space, because the
+ * source download AND the converted image both landed on the temp storage.
+ * Since #292 a file-based target has the conversion written straight onto
+ * itself, so only the download still needs temp room. Keeping the doubled
+ * requirement would go on refusing exactly the migrations the change was made
+ * to unlock: a 1 TB VM onto NFS asked for 2 TB of temp space.
+ *
+ * Unknown storage type keeps the conservative factor: the dialog would rather
+ * ask for space that turns out unnecessary than start a run that fills the
+ * filesystem halfway through a disk.
+ */
+export function requiredTempBytes(committedBytes: number, targetStorageType?: string): number {
+  const directWrite = !!targetStorageType && isFileBasedStorage(targetStorageType)
+  return Math.max(0, committedBytes) * (directWrite ? 1 : 2)
+}
+
+/**
  * Whether the selected target storage rules out a warm migration.
  *
  * Warm patches the target by byte offset (`dd seek`), which is only meaningful

--- a/frontend/src/components/tasks/JobDetailDialog.jsx
+++ b/frontend/src/components/tasks/JobDetailDialog.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import {
   Box,
@@ -19,10 +19,12 @@ import {
   ListItemIcon,
   ListItemText,
   Stack,
+  Tooltip,
   Typography
 } from '@mui/material'
 
 import { extractLogs, jobActions, jobDetailUrl, normalizeLog, syntheticLogs } from '@/lib/tasks/jobActions'
+import { useCopyToClipboard } from '@/lib/clipboard'
 
 import { StatusChip, TypeChip } from './JobChips'
 
@@ -67,6 +69,41 @@ function getNodeStatusIcon(status) {
   }
 }
 
+/** Distance from the bottom still counted as "parked at the tail", in px. */
+const TAIL_THRESHOLD_PX = 32
+
+/**
+ * Is this scroller parked at the tail?
+ *
+ * Exported so the follow rule can be asserted on a plain object: jsdom has no
+ * layout engine, so a rendered log panel reports zero for all three metrics and
+ * could never exercise this.
+ */
+export function isAtTail(el, threshold = TAIL_THRESHOLD_PX) {
+  if (!el) return true
+
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold
+}
+
+/**
+ * The log as text, formatted the way the panel prints it.
+ *
+ * Copies EVERY entry, not just the 100 the panel renders: the button exists to
+ * paste a whole run into an issue or a mail, and a truncated log is worse than
+ * none.
+ */
+export function logsAsText(entries) {
+  return entries
+    .map(normalizeLog)
+    .map(log => {
+      const ts = log.timestamp ? `[${new Date(log.timestamp).toLocaleTimeString()}] ` : ''
+      const node = log.node ? `[${log.node}] ` : ''
+
+      return `${ts}${node}${log.message}`
+    })
+    .join('\n')
+}
+
 /* --------------------------------
    Job Detail Dialog
 -------------------------------- */
@@ -84,6 +121,12 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
   // orchestrator routes) must say so rather than look like an empty log.
   const logError = forThisJob ? logState.error : null
   const [loading, setLoading] = useState(false)
+  const logCopy = useCopyToClipboard()
+  const logsRef = useRef(null)
+  // Follow the tail only while the reader is parked at it. A job writes lines
+  // for minutes, so yanking the view back down while they read an earlier line
+  // is worse than not following at all.
+  const followTail = useRef(true)
   // Held per job id rather than as a boolean: a stale confirmation must never
   // carry over to the next job opened in this (permanently mounted) dialog.
   const [confirmCancelFor, setConfirmCancelFor] = useState(null)
@@ -98,10 +141,12 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
     }
   }, [open, detailUrl, isEnterprise])
 
-  const fetchJobDetails = async () => {
+  const fetchJobDetails = async ({ silent = false } = {}) => {
     if (!detailUrl || !isEnterprise) return
 
-    setLoading(true)
+    // A background refresh must not raise the spinner: on a running job it
+    // fires every 3 s and the header blinked continuously.
+    if (!silent) setLoading(true)
     try {
       const res = await fetch(detailUrl)
       if (res.ok) {
@@ -113,17 +158,32 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
     } catch (e) {
       console.error('Error fetching job details:', e)
     } finally {
-      setLoading(false)
+      if (!silent) setLoading(false)
     }
   }
 
   // Auto-refresh if job is running
   useEffect(() => {
     if (open && detailUrl && job?.status === 'running' && isEnterprise) {
-      const interval = setInterval(fetchJobDetails, 3000)
+      const interval = setInterval(() => fetchJobDetails({ silent: true }), 3000)
       return () => clearInterval(interval)
     }
   }, [open, detailUrl, job?.status, isEnterprise])
+
+  // Reopening the dialog, or opening it on another job, starts at the tail
+  // again: the ref survives, the dialog is never unmounted.
+  useEffect(() => {
+    followTail.current = true
+  }, [open, job?.id])
+
+  // Scroll with the job. Keyed on the line count, which is what the 3 s refresh
+  // above changes while a migration runs.
+  useEffect(() => {
+    if (!open) return
+    const el = logsRef.current
+    if (!el || !followTail.current) return
+    el.scrollTop = el.scrollHeight
+  }, [open, logs.length])
 
   if (!job) return null
 
@@ -326,9 +386,25 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
                 <Typography variant="subtitle2" fontWeight={700}>
                   {t('jobsPage.logs')}
                 </Typography>
-                {loading && <CircularProgress size={16} />}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  {loading && <CircularProgress size={16} />}
+                  {logs.length > 0 && (
+                    <Tooltip title={logCopy.copied ? t('common.copied') : t('common.copy')}>
+                      <IconButton
+                        size="small"
+                        aria-label={t('common.copy')}
+                        onClick={() => { void logCopy.copy(logsAsText(logs)) }}
+                        sx={{ opacity: 0.6, '&:hover': { opacity: 1 } }}
+                      >
+                        <i className={logCopy.copied ? 'ri-check-line' : 'ri-file-copy-line'} style={{ fontSize: 14 }} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Box>
               </Box>
               <Box
+                ref={logsRef}
+                onScroll={() => { followTail.current = isAtTail(logsRef.current) }}
                 sx={{
                   maxHeight: 300,
                   overflow: 'auto',

--- a/frontend/src/components/tasks/JobDetailDialog.test.tsx
+++ b/frontend/src/components/tasks/JobDetailDialog.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import JobDetailDialog, { isAtTail, logsAsText } from "./JobDetailDialog"
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("isAtTail", () => {
+  it("counts a scroller parked at the bottom as following", () => {
+    expect(isAtTail({ scrollHeight: 1000, scrollTop: 700, clientHeight: 300 })).toBe(true)
+  })
+
+  it("tolerates the few pixels a smooth scroll leaves behind", () => {
+    expect(isAtTail({ scrollHeight: 1000, scrollTop: 690, clientHeight: 300 })).toBe(true)
+  })
+
+  it("stops following once the reader has scrolled up to an earlier line", () => {
+    expect(isAtTail({ scrollHeight: 1000, scrollTop: 200, clientHeight: 300 })).toBe(false)
+  })
+
+  it("follows by default when there is no element yet", () => {
+    expect(isAtTail(null)).toBe(true)
+  })
+})
+
+describe("logsAsText", () => {
+  it("formats each entry the way the panel prints it", () => {
+    const ts = "2026-08-24T16:58:41.000Z"
+    const text = logsAsText([
+      { ts, msg: "Adopted vm-70011-disk-0.qcow2 (rename, no disk copy)", level: "success" },
+      { ts, msg: "Disk 1 attached as scsi0", level: "info" },
+    ])
+    const stamp = new Date(ts).toLocaleTimeString()
+
+    expect(text).toBe(
+      `[${stamp}] Adopted vm-70011-disk-0.qcow2 (rename, no disk copy)\n[${stamp}] Disk 1 attached as scsi0`,
+    )
+  })
+
+  it("carries the node of an entry that has one", () => {
+    expect(logsAsText([{ message: "entering maintenance", node: "pve1" }])).toBe("[pve1] entering maintenance")
+  })
+
+  it("copies the WHOLE log, not just the 100 lines the panel renders", () => {
+    const entries = Array.from({ length: 250 }, (_, i) => ({ msg: `line ${i}` }))
+    const lines = logsAsText(entries).split("\n")
+
+    expect(lines).toHaveLength(250)
+    expect(lines[0]).toBe("line 0")
+  })
+
+  it("takes a bare string entry, which is what some sources return", () => {
+    expect(logsAsText(["plain line"])).toBe("plain line")
+  })
+})
+
+describe("JobDetailDialog logs panel", () => {
+  const job = { id: "job-1", name: "Migration - NginX", type: "migration", status: "running", progress: 50 }
+  const t = (key: string) => key
+
+  it("copies the fetched log to the clipboard", async () => {
+    const writeText = vi.fn(async () => {})
+    Object.assign(navigator, { clipboard: { writeText } })
+    const ts = "2026-08-24T16:58:41.000Z"
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ data: { logs: [{ ts, msg: "Adopted the converted disk", level: "success" }] } }),
+    })))
+
+    render(
+      <JobDetailDialog open job={job} onClose={() => {}} onAction={() => {}} actionError={null} isEnterprise t={t} />,
+    )
+
+    await waitFor(() => expect(screen.getByText(/Adopted the converted disk/)).toBeTruthy())
+    await userEvent.click(screen.getByLabelText("common.copy"))
+
+    expect(writeText).toHaveBeenCalledWith(`[${new Date(ts).toLocaleTimeString()}] Adopted the converted disk`)
+  })
+
+  it("offers no copy button while there is nothing to copy", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, json: async () => ({ data: { logs: [] } }) })))
+
+    render(
+      <JobDetailDialog open job={job} onClose={() => {}} onAction={() => {}} actionError={null} isEnterprise t={t} />,
+    )
+
+    await waitFor(() => expect(screen.getByText("jobsPage.noLogs")).toBeTruthy())
+    expect(screen.queryByLabelText("common.copy")).toBeNull()
+  })
+})

--- a/frontend/src/lib/migration/adopt-file-volume.test.ts
+++ b/frontend/src/lib/migration/adopt-file-volume.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("@/lib/ssh/exec", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/ssh/exec")>()
+  return { ...actual, executeSSH: vi.fn() }
+})
+import { executeSSH } from "@/lib/ssh/exec"
+import { adoptFileVolume, importOrAdoptFileVolume } from "./adopt-file-volume"
+
+const mockSSH = executeSSH as unknown as ReturnType<typeof vi.fn>
+
+const moved = { success: true, output: "ADOPT_OK" }
+/** What the guarded command yields when a `[ ... ]` test fails: no ADOPT_OK, and
+ *  the non-zero exit of `test` surfaces as an SSH failure. */
+const refused = { success: false, output: "", error: "Exit code 1" }
+
+const args = {
+  connectionId: "conn-1",
+  nodeIp: "10.0.0.1",
+  sourcePath: "/mnt/pve/nfs-01/images/250/proxcenter-mig-job7-disk0.qcow2",
+  targetStorage: "nfs-01",
+  imagesDir: "/mnt/pve/nfs-01/images/250",
+  targetVmid: 250,
+  format: "qcow2" as const,
+}
+
+beforeEach(() => {
+  mockSSH.mockReset()
+})
+
+describe("adoptFileVolume", () => {
+  it("renames the converted image to the canonical volume name and returns its volid", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    const result = await adoptFileVolume({ ...args, vmConf: {} })
+
+    expect(result).toEqual({
+      volumeId: "nfs-01:250/vm-250-disk-0.qcow2",
+      volumePath: "/mnt/pve/nfs-01/images/250/vm-250-disk-0.qcow2",
+      volumeName: "vm-250-disk-0",
+    })
+    const cmd = mockSSH.mock.calls[0][2] as string
+    expect(cmd).toContain("mv -n '/mnt/pve/nfs-01/images/250/proxcenter-mig-job7-disk0.qcow2'")
+    expect(cmd).toContain("'/mnt/pve/nfs-01/images/250/vm-250-disk-0.qcow2'")
+    // A rename is the whole point: no qemu-img, no qm disk import, no dd.
+    expect(cmd).not.toMatch(/qemu-img|qm disk import|\bdd\b|cp /)
+  })
+
+  it("skips the disk number an OVMF shell already owns for its EFI vars", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    const result = await adoptFileVolume({
+      ...args,
+      vmConf: { efidisk0: "nfs-01:250/vm-250-disk-0.qcow2,efitype=4m,size=528K" },
+    })
+
+    expect(result?.volumeId).toBe("nfs-01:250/vm-250-disk-1.qcow2")
+  })
+
+  it("skips the names already claimed by earlier disks of the same run", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    const result = await adoptFileVolume({
+      ...args,
+      vmConf: {},
+      taken: [{ volumeId: "nfs-01:250/vm-250-disk-0.qcow2", devicePath: "" }],
+    })
+
+    expect(result?.volumeId).toBe("nfs-01:250/vm-250-disk-1.qcow2")
+  })
+
+  it("refuses to move across filesystems: the check is in the command, not in a comment", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    await adoptFileVolume({ ...args, vmConf: {} })
+
+    const cmd = mockSSH.mock.calls[0][2] as string
+    // `mv` across devices copies the whole disk silently, which is the very cost
+    // this module exists to remove.
+    expect(cmd).toContain('stat -c %d')
+    // And it must never clobber a volume PVE or an operator already owns.
+    expect(cmd).toContain('[ ! -e ')
+    expect(cmd).toContain('mv -n ')
+  })
+
+  it("refuses to rename a raw image into a qcow2 volume: the extension would lie about the header", async () => {
+    const logs: string[] = []
+
+    const result = await adoptFileVolume({
+      ...args,
+      vmConf: {},
+      format: "qcow2",
+      sourceFormat: "raw",
+      onLog: (m) => { logs.push(m) },
+    })
+
+    expect(result).toBeNull()
+    // Not even a round trip: nothing on the node can make this safe.
+    expect(mockSSH).not.toHaveBeenCalled()
+    expect(logs.join(" ")).toContain("a rename cannot convert")
+  })
+
+  it("returns null instead of throwing when the move is refused, so the caller can import", async () => {
+    mockSSH.mockResolvedValueOnce(refused)
+    const logs: string[] = []
+
+    const result = await adoptFileVolume({ ...args, vmConf: {}, onLog: (m) => { logs.push(m) } })
+
+    expect(result).toBeNull()
+    expect(logs.join(" ")).toContain("falling back to qm disk import")
+  })
+
+  it("treats a command that reports success without ADOPT_OK as a refusal", async () => {
+    mockSSH.mockResolvedValueOnce({ success: true, output: "" })
+
+    expect(await adoptFileVolume({ ...args, vmConf: {} })).toBeNull()
+  })
+
+  it("gives the move more than the 30 s executeSSH default", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    await adoptFileVolume({ ...args, vmConf: {} })
+
+    expect(mockSSH.mock.calls[0][3]).toBeGreaterThan(30_000)
+  })
+})
+
+describe("importOrAdoptFileVolume", () => {
+  it("adopts by rename when it can, and never runs qm disk import in that case", async () => {
+    mockSSH.mockResolvedValueOnce(moved)
+
+    const result = await importOrAdoptFileVolume({ ...args, vmConf: {} })
+
+    expect(result).toEqual({ volumeId: "nfs-01:250/vm-250-disk-0.qcow2", adopted: true })
+    expect(mockSSH).toHaveBeenCalledTimes(1)
+    expect(mockSSH.mock.calls.map(c => c[2]).join(" ")).not.toContain("qm disk import")
+  })
+
+  it("imports when the rename is refused, and reports the volid PVE created", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "Successfully imported disk as 'unused0:nfs-01:250/vm-250-disk-3.qcow2'" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const result = await importOrAdoptFileVolume({ ...args, vmConf: {} })
+
+    expect(result).toEqual({ volumeId: "nfs-01:250/vm-250-disk-3.qcow2", adopted: false })
+    expect(mockSSH.mock.calls[1][2]).toContain("qm disk import 250")
+    // The 30 s default would cut the channel in the middle of a multi-GB import.
+    expect(mockSSH.mock.calls[1][3]).toBeGreaterThanOrEqual(3600_000)
+  })
+
+  it("converts through qm disk import when virt-v2v wrote raw and the volume must be qcow2", async () => {
+    mockSSH
+      .mockResolvedValueOnce({ success: true, output: "Successfully imported disk as 'nfs-01:250/vm-250-disk-0.qcow2'" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const result = await importOrAdoptFileVolume({ ...args, vmConf: {}, format: "qcow2", sourceFormat: "raw" })
+
+    expect(result.adopted).toBe(false)
+    // First call is the import itself: no rename was even attempted.
+    expect(mockSSH.mock.calls[0][2]).toContain("qm disk import 250")
+    expect(mockSSH.mock.calls[0][2]).toContain("--format qcow2")
+  })
+
+  it("also reads the older wording of the import output", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "unused0: successfully imported disk 'nfs-01:250/vm-250-disk-1.qcow2'" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const result = await importOrAdoptFileVolume({ ...args, vmConf: {} })
+
+    expect(result.volumeId).toBe("nfs-01:250/vm-250-disk-1.qcow2")
+  })
+
+  it("deletes the staging copy the import left behind, but never the file it moved", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "Successfully imported disk as 'nfs-01:250/vm-250-disk-0.qcow2'" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    await importOrAdoptFileVolume({ ...args, vmConf: {} })
+    expect(mockSSH.mock.calls[2][2]).toContain(`rm -f '${args.sourcePath}'`)
+
+    mockSSH.mockReset()
+    mockSSH.mockResolvedValueOnce(moved)
+    await importOrAdoptFileVolume({ ...args, vmConf: {} })
+    expect(mockSSH.mock.calls.map(c => c[2]).join(" ")).not.toContain("rm -f")
+  })
+
+  it("asks the caller to read the VM config when the import output cannot be parsed", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "transferred 12.0 GiB of 12.0 GiB (100.00%)" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const result = await importOrAdoptFileVolume({
+      ...args,
+      vmConf: {},
+      resolveUnusedVolume: async () => "nfs-01:250/vm-250-disk-9.qcow2",
+    })
+
+    expect(result).toEqual({ volumeId: "nfs-01:250/vm-250-disk-9.qcow2", adopted: false })
+  })
+
+  it("still returns the expected volume name when nothing else resolves it", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "no wording we know" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+
+    const result = await importOrAdoptFileVolume({
+      ...args,
+      vmConf: { efidisk0: "nfs-01:250/vm-250-disk-0.qcow2,efitype=4m" },
+    })
+
+    expect(result).toEqual({ volumeId: "nfs-01:250/vm-250-disk-1.qcow2", adopted: false })
+  })
+
+  it("fails the migration when the import itself fails", async () => {
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: false, output: "storage 'nfs-01' does not support vm images", error: "Exit code 255" })
+
+    await expect(importOrAdoptFileVolume({ ...args, vmConf: {} })).rejects.toThrow(/does not support vm images/)
+  })
+})

--- a/frontend/src/lib/migration/adopt-file-volume.test.ts
+++ b/frontend/src/lib/migration/adopt-file-volume.test.ts
@@ -4,10 +4,16 @@ vi.mock("@/lib/ssh/exec", async (importActual) => {
   const actual = await importActual<typeof import("@/lib/ssh/exec")>()
   return { ...actual, executeSSH: vi.fn() }
 })
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: vi.fn() }))
+vi.mock("./pve-vm-config", () => ({ pveSetVmConfig: vi.fn() }))
 import { executeSSH } from "@/lib/ssh/exec"
-import { adoptFileVolume, importOrAdoptFileVolume } from "./adopt-file-volume"
+import { pveFetch } from "@/lib/proxmox/client"
+import { pveSetVmConfig } from "./pve-vm-config"
+import { adoptFileVolume, importOrAdoptFileVolume, adoptImportAndAttachFileVolume } from "./adopt-file-volume"
 
 const mockSSH = executeSSH as unknown as ReturnType<typeof vi.fn>
+const mockFetch = pveFetch as unknown as ReturnType<typeof vi.fn>
+const mockSetConfig = pveSetVmConfig as unknown as ReturnType<typeof vi.fn>
 
 const moved = { success: true, output: "ADOPT_OK" }
 /** What the guarded command yields when a `[ ... ]` test fails: no ADOPT_OK, and
@@ -26,6 +32,8 @@ const args = {
 
 beforeEach(() => {
   mockSSH.mockReset()
+  mockFetch.mockReset()
+  mockSetConfig.mockReset()
 })
 
 describe("adoptFileVolume", () => {
@@ -224,5 +232,70 @@ describe("importOrAdoptFileVolume", () => {
       .mockResolvedValueOnce({ success: false, output: "storage 'nfs-01' does not support vm images", error: "Exit code 255" })
 
     await expect(importOrAdoptFileVolume({ ...args, vmConf: {} })).rejects.toThrow(/does not support vm images/)
+  })
+})
+
+describe("adoptImportAndAttachFileVolume", () => {
+  const attachArgs = {
+    ...args,
+    pveConn: { baseUrl: "https://pve:8006", apiToken: "t" } as any,
+    targetNode: "pve1",
+    slot: "scsi0",
+    driveOpts: ",discard=on",
+    diskLabel: "Disk 1",
+  }
+
+  it("adopts by rename, attaches to the slot with the drive options, and reports it adopted", async () => {
+    mockFetch.mockResolvedValueOnce({}) // read the VM config for the taken indexes
+    mockSSH.mockResolvedValueOnce(moved) // the rename
+    mockSetConfig.mockResolvedValueOnce(undefined)
+    const logs: string[] = []
+
+    const result = await adoptImportAndAttachFileVolume({ ...attachArgs, onLog: (m) => { logs.push(m) } })
+
+    expect(result).toEqual({ volumeId: "nfs-01:250/vm-250-disk-0.qcow2", adopted: true })
+    expect(mockSetConfig.mock.calls[0][1]).toBe("pve1")
+    expect(mockSetConfig.mock.calls[0][2]).toBe(250)
+    const body = mockSetConfig.mock.calls[0][3] as URLSearchParams
+    expect(body.get("scsi0")).toBe("nfs-01:250/vm-250-disk-0.qcow2,discard=on")
+    expect(logs.join(" ")).toContain("adopted in place, no copy")
+  })
+
+  it("imports when the rename is refused and reports it imported", async () => {
+    mockFetch.mockResolvedValueOnce({})
+    mockSSH
+      .mockResolvedValueOnce(refused)
+      .mockResolvedValueOnce({ success: true, output: "Successfully imported disk as 'nfs-01:250/vm-250-disk-0.qcow2'" })
+      .mockResolvedValueOnce({ success: true, output: "" })
+    mockSetConfig.mockResolvedValueOnce(undefined)
+    const logs: string[] = []
+
+    const result = await adoptImportAndAttachFileVolume({ ...attachArgs, onLog: (m) => { logs.push(m) } })
+
+    expect(result.adopted).toBe(false)
+    expect(logs.join(" ")).toContain("imported and attached as scsi0")
+  })
+
+  it("never throws when the attach fails: it warns and still returns the volume", async () => {
+    mockFetch.mockResolvedValueOnce({})
+    mockSSH.mockResolvedValueOnce(moved)
+    mockSetConfig.mockRejectedValueOnce(new Error("VM is locked"))
+    const logs: string[] = []
+
+    const result = await adoptImportAndAttachFileVolume({ ...attachArgs, onLog: (m) => { logs.push(m) } })
+
+    expect(result.adopted).toBe(true)
+    expect(logs.join(" ")).toContain("Could not auto-attach scsi0")
+  })
+
+  it("leaves the volid bare when driveOpts is empty, for a block-storage attach", async () => {
+    mockFetch.mockResolvedValueOnce({})
+    mockSSH.mockResolvedValueOnce(moved)
+    mockSetConfig.mockResolvedValueOnce(undefined)
+
+    await adoptImportAndAttachFileVolume({ ...attachArgs, driveOpts: "", onLog: () => {} })
+
+    const body = mockSetConfig.mock.calls[0][3] as URLSearchParams
+    expect(body.get("scsi0")).toBe("nfs-01:250/vm-250-disk-0.qcow2")
   })
 })

--- a/frontend/src/lib/migration/adopt-file-volume.ts
+++ b/frontend/src/lib/migration/adopt-file-volume.ts
@@ -1,5 +1,7 @@
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+import { pveFetch, type ProxmoxClientOptions } from "@/lib/proxmox/client"
 import { nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
+import { pveSetVmConfig } from "./pve-vm-config"
 
 /**
  * Turning an already-converted image into a PVE volume WITHOUT re-copying it (#292).
@@ -192,4 +194,97 @@ export async function importOrAdoptFileVolume(args: ImportOrAdoptArgs): Promise<
   const guessed = nextFreeDiskName(args.vmConf, args.taken ?? [], targetVmid)
   await args.onLog?.(`Falling back to the expected volume name ${targetStorage}:${targetVmid}/${guessed}.${format}`)
   return { volumeId: `${targetStorage}:${targetVmid}/${guessed}.${format}`, adopted: false }
+}
+
+/** Log levels the migration job log accepts, mirrored so the shared helper stays decoupled. */
+type AttachLogLevel = "info" | "success" | "warn" | "error"
+
+export interface AdoptImportAttachArgs {
+  /** PVE client options for the target node's cluster. */
+  pveConn: ProxmoxClientOptions
+  /** PVE node the VM lives on. */
+  targetNode: string
+  connectionId: string
+  nodeIp: string
+  /** Absolute path of the converted image on the target node. */
+  sourcePath: string
+  targetStorage: string
+  /** `<storage path>/images/<vmid>`, where an adopted volume is renamed to. */
+  imagesDir: string
+  targetVmid: number
+  /** Format the volume must have on the target storage. */
+  format: "qcow2" | "raw"
+  /** Real format of `sourcePath` when it differs from `format` (a rename cannot convert). */
+  sourceFormat?: "qcow2" | "raw"
+  /** VM disk slot to attach to, e.g. `scsi0`, `sata0`, `virtio1`. */
+  slot: string
+  /** Extra drive options appended to the volid, e.g. `,discard=on` on a file target. */
+  driveOpts?: string
+  /** Label for the log lines, e.g. `Disk 1`. */
+  diskLabel: string
+  /** Volumes already created by this run, so two disks never claim one name. */
+  taken?: AllocatedVolume[]
+  onLog: (message: string, level?: AttachLogLevel) => Promise<void> | void
+}
+
+/**
+ * The whole file-based finish of a cold migration in one place (#292): read the VM
+ * config for the disk indexes already taken, adopt the converted image by rename
+ * (or import it as the fallback), then attach the resulting volume to `slot` and
+ * log the outcome. Every cold pipeline used to inline this identical block; it
+ * lives here so the guard rails and the wording stay in one spot.
+ *
+ * Returns the attached volume id and whether it was adopted (renamed) rather than
+ * copied, so the caller can register it for its own bookkeeping.
+ */
+export async function adoptImportAndAttachFileVolume(
+  args: AdoptImportAttachArgs,
+): Promise<{ volumeId: string; adopted: boolean }> {
+  const {
+    pveConn, targetNode, connectionId, nodeIp, sourcePath, targetStorage,
+    imagesDir, targetVmid, format, sourceFormat, slot, driveOpts = "",
+    diskLabel, taken, onLog,
+  } = args
+
+  const readVmConfig = () =>
+    pveFetch<Record<string, any>>(
+      pveConn,
+      `/nodes/${encodeURIComponent(targetNode)}/qemu/${targetVmid}/config`,
+    )
+
+  const vmConf = await readVmConfig().catch(() => null)
+
+  const { volumeId, adopted } = await importOrAdoptFileVolume({
+    connectionId,
+    nodeIp,
+    sourcePath,
+    targetStorage,
+    imagesDir,
+    targetVmid,
+    format,
+    ...(sourceFormat ? { sourceFormat } : {}),
+    vmConf,
+    taken,
+    onLog: (m) => onLog(m),
+    resolveUnusedVolume: async () => {
+      const conf = await readVmConfig()
+      const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
+      return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
+    },
+  })
+
+  const attachBody = new URLSearchParams({ [slot]: `${volumeId}${driveOpts}` })
+  try {
+    await pveSetVmConfig(pveConn, targetNode, targetVmid, attachBody)
+    await onLog(
+      adopted
+        ? `${diskLabel} attached as ${slot} (adopted in place, no copy)`
+        : `${diskLabel} imported and attached as ${slot}`,
+      "success",
+    )
+  } catch (attachErr: any) {
+    await onLog(`Warning: Could not auto-attach ${slot}: ${attachErr.message}`, "warn")
+  }
+
+  return { volumeId, adopted }
 }

--- a/frontend/src/lib/migration/adopt-file-volume.ts
+++ b/frontend/src/lib/migration/adopt-file-volume.ts
@@ -1,0 +1,195 @@
+import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+import { nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
+
+/**
+ * Turning an already-converted image into a PVE volume WITHOUT re-copying it (#292).
+ *
+ * Every cold pipeline used to finish a file-based migration with `qm disk import`,
+ * which is a full `qemu-img convert` of the disk into a freshly allocated volume.
+ * When the converted image already sits on the target storage's own filesystem
+ * (and the in-house pipelines write it straight into `<storage path>/images/<vmid>/`),
+ * that copy reads and writes the whole disk a second time for nothing: a 1 TB VM
+ * pays a second full pass and needs room for two copies at once.
+ *
+ * A rename is enough. The file is already in the right format on the right
+ * filesystem, so moving it to the canonical `vm-<vmid>-disk-<N>.<fmt>` name inside
+ * the storage's `images/<vmid>` directory makes it a volume PVE recognises, at
+ * O(1) cost, and the caller then attaches the volid through the VM config API
+ * exactly as it attached the imported one.
+ *
+ * The whole point of this module is that no pipeline re-implements the guard rails:
+ * same-filesystem check, never clobbering an existing file, and the free disk index
+ * (an OVMF shell already owns `disk-0` for its EFI vars). Adoption is best effort by
+ * design: anything unexpected returns null instead of throwing, so the caller falls
+ * back to `qm disk import` and the migration still completes.
+ */
+export interface AdoptFileVolumeArgs {
+  connectionId: string
+  nodeIp: string
+  /** Absolute path of the converted image on the target node. */
+  sourcePath: string
+  /** PVE storage ID the volume must belong to. */
+  targetStorage: string
+  /** The storage's own volume directory for this VM: `<storage path>/images/<vmid>`. */
+  imagesDir: string
+  targetVmid: number | string
+  /** Format the volume must have on the target storage. */
+  format: "qcow2" | "raw"
+  /**
+   * Real format of `sourcePath`, when it differs from the format the volume must
+   * have. A rename cannot convert, so a mismatch disables adoption and the caller
+   * gets a real `qm disk import`, which does convert. Defaults to `format`.
+   */
+  sourceFormat?: "qcow2" | "raw"
+  /** VM config, read for the disk numbers already taken (efidisk0, tpmstate0, ...). */
+  vmConf?: Record<string, unknown> | null
+  /** Volumes already created by this run, so two disks never claim one name. */
+  taken?: AllocatedVolume[]
+  onLog?: (message: string) => Promise<void> | void
+}
+
+export interface AdoptedFileVolume {
+  /** `<storage>:<vmid>/vm-<vmid>-disk-<N>.<fmt>`, the volid to attach. */
+  volumeId: string
+  /** Absolute path of the volume on the node. */
+  volumePath: string
+  /** `vm-<vmid>-disk-<N>`, without the extension. */
+  volumeName: string
+}
+
+/** 60 s: the move itself is a rename, the budget covers a slow SSH round trip. */
+const ADOPT_TIMEOUT_MS = 60_000
+
+/**
+ * Rename an already-converted image into a PVE volume of `targetStorage`.
+ *
+ * Returns the volid to attach, or null when the file cannot be adopted safely
+ * (different filesystem, destination already there, move refused). A null is not
+ * an error: the caller must fall back to `qm disk import`.
+ */
+export async function adoptFileVolume(args: AdoptFileVolumeArgs): Promise<AdoptedFileVolume | null> {
+  const { connectionId, nodeIp, sourcePath, targetStorage, imagesDir, targetVmid, format } = args
+
+  const sourceFormat = args.sourceFormat ?? format
+  if (sourceFormat !== format) {
+    // Renaming a raw image to `.qcow2` would hand PVE a volume whose header does
+    // not match its extension, i.e. a VM that cannot boot. The import converts.
+    await args.onLog?.(
+      `${sourcePath} is ${sourceFormat} and the volume must be ${format}; a rename cannot convert, importing instead`,
+    )
+    return null
+  }
+
+  const volumeName = nextFreeDiskName(args.vmConf, args.taken ?? [], targetVmid)
+  const volumePath = `${imagesDir}/${volumeName}.${format}`
+
+  // One command, so the checks and the move cannot be interleaved with anything
+  // else, and so a single SSH round trip decides the outcome:
+  //  - `stat -c %d` on both sides: a rename across filesystems is a full copy that
+  //    `mv` would perform silently, which is exactly what this module exists to
+  //    avoid. Different device => refuse and let the caller import instead.
+  //  - `[ ! -e ]` + `mv -n`: never clobber a volume PVE (or an operator) already
+  //    owns, belt and braces since the name comes from the VM config we read
+  //    earlier and a concurrent allocation could have taken it since.
+  const cmd =
+    `mkdir -p ${shellEscape(imagesDir)} && ` +
+    `[ "$(stat -c %d ${shellEscape(sourcePath)})" = "$(stat -c %d ${shellEscape(imagesDir)})" ] && ` +
+    `[ ! -e ${shellEscape(volumePath)} ] && ` +
+    `mv -n ${shellEscape(sourcePath)} ${shellEscape(volumePath)} && echo ADOPT_OK`
+
+  const moved = await executeSSH(connectionId, nodeIp, `${cmd} 2>&1`, ADOPT_TIMEOUT_MS)
+
+  if (!moved.success || !(moved.output || "").includes("ADOPT_OK")) {
+    const reason = (moved.output || moved.error || "no output").trim()
+    await args.onLog?.(
+      `Cannot adopt ${sourcePath} as a volume of "${targetStorage}" (${reason}); falling back to qm disk import`,
+    )
+    return null
+  }
+
+  const volumeId = `${targetStorage}:${targetVmid}/${volumeName}.${format}`
+  await args.onLog?.(`Adopted ${volumePath} as ${volumeId} (rename, no disk copy)`)
+
+  return { volumeId, volumePath, volumeName }
+}
+
+/**
+ * Timeout for the `qm disk import` fallback. The command streams the whole disk
+ * into PVE storage and routinely runs 5 to 30 minutes on multi-GB disks, so the
+ * 30 s executeSSH default would cut the channel mid-import.
+ */
+const IMPORT_TIMEOUT_MS = 14_400_000
+
+/** The two shapes `qm disk import` uses to report the volume it created. */
+const IMPORT_VOLID_PATTERNS = [
+  /Successfully imported disk as '(?:unused\d+:)?(.+?)'/,
+  /unused\d+:\s*successfully imported disk '(.+?)'/i,
+]
+
+export interface ImportOrAdoptArgs extends AdoptFileVolumeArgs {
+  /**
+   * Last-resort volid resolution when `qm disk import` succeeds but its output
+   * cannot be parsed: read the VM config and hand back its highest `unusedN`.
+   * Optional, because it needs the PVE client the caller already holds.
+   */
+  resolveUnusedVolume?: () => Promise<string>
+}
+
+export interface ImportedFileVolume {
+  /** The volid to attach to the VM. */
+  volumeId: string
+  /** True when the image became a volume by rename, false when it was copied. */
+  adopted: boolean
+}
+
+/**
+ * Make `sourcePath` a volume of `targetStorage`, by rename when the file already
+ * lives on that storage's filesystem, by `qm disk import` otherwise (#292).
+ *
+ * Either way the source file is consumed: adoption moves it, the import copies it
+ * and this function deletes the leftover, so no caller has to remember which of
+ * the two happened.
+ */
+export async function importOrAdoptFileVolume(args: ImportOrAdoptArgs): Promise<ImportedFileVolume> {
+  const { connectionId, nodeIp, sourcePath, targetStorage, targetVmid, format } = args
+
+  const adopted = await adoptFileVolume(args)
+  if (adopted) return { volumeId: adopted.volumeId, adopted: true }
+
+  const imported = await executeSSH(
+    connectionId, nodeIp,
+    `qm disk import ${targetVmid} ${shellEscape(sourcePath)} ${shellEscape(targetStorage)} --format ${format} 2>&1`,
+    IMPORT_TIMEOUT_MS,
+  )
+
+  if (!imported.success) {
+    // The command runs with `2>&1`, so PVE's real message is on stdout and `error`
+    // only carries a meaningless exit code. Reading `error` first would hide the
+    // diagnosis behind "Exit code 255".
+    throw new Error(
+      `Disk import failed for ${sourcePath}: ${(imported.output || imported.error || "no output").trim()}`,
+    )
+  }
+
+  // The image is inside the storage now, so the staging copy is dead weight: on a
+  // file-based target it is sitting on the very storage the VM will run from.
+  await executeSSH(connectionId, nodeIp, `rm -f ${shellEscape(sourcePath)}`)
+
+  const output = imported.output || ""
+  for (const pattern of IMPORT_VOLID_PATTERNS) {
+    const match = pattern.exec(output)
+    if (match?.[1]) return { volumeId: match[1], adopted: false }
+  }
+
+  // PVE changed the wording again. The volume exists, so find it rather than fail
+  // the migration: the VM config lists it as `unusedN` until we attach it.
+  await args.onLog?.(`Could not parse the import output, reading the VM config to find the imported disk`)
+  const resolved = (await args.resolveUnusedVolume?.()) || ""
+  if (resolved) return { volumeId: resolved, adopted: false }
+
+  // Last resort: the name `qm disk import` allocates is the first free disk index,
+  // which is what nextFreeDiskName just computed for the adoption attempt.
+  const guessed = nextFreeDiskName(args.vmConf, args.taken ?? [], targetVmid)
+  await args.onLog?.(`Falling back to the expected volume name ${targetStorage}:${targetVmid}/${guessed}.${format}`)
+  return { volumeId: `${targetStorage}:${targetVmid}/${guessed}.${format}`, adopted: false }
+}

--- a/frontend/src/lib/migration/pipeline-import-path.test.ts
+++ b/frontend/src/lib/migration/pipeline-import-path.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+
+/**
+ * Regression guard for #292: on file-based storage the cold pipelines used to
+ * finish with their own `qm disk import`, a second full copy of a disk that the
+ * conversion had already written into the target storage. That command now lives
+ * ONLY in the shared adopt-file-volume module, which renames the image into the
+ * storage when it can and imports when it cannot.
+ *
+ * The two pipelines are 3000-line closures over SSH and Prisma with no unit
+ * harness, so this guard works on their source: nobody may quietly reintroduce a
+ * local `qm disk import` (and with it the double copy and the rm -f that would
+ * delete an adopted disk).
+ */
+const PIPELINES = ["pipeline.ts", "xcpng-pipeline.ts"] as const
+
+const sources = Object.fromEntries(
+  PIPELINES.map((name) => [name, readFileSync(new URL(`./${name}`, import.meta.url), "utf8")]),
+) as Record<(typeof PIPELINES)[number], string>
+
+describe.each(PIPELINES)("%s import path (#292)", (name) => {
+  const source = sources[name]
+
+  it("does not build a qm disk import command itself", () => {
+    // A built command always interpolates the vmid right after the verb
+    // (`qm disk import ${targetVmid} ...`); the prose mentions of qm disk import
+    // in comments never do, so they stay allowed.
+    expect(source).not.toContain("qm disk import ${")
+  })
+
+  it("routes file volumes through the shared rename-or-import module", () => {
+    expect(source).toMatch(/import \{[^}]*importOrAdoptFileVolume[^}]*\} from "\.\/adopt-file-volume"/)
+    expect(source).toContain("await importOrAdoptFileVolume(")
+  })
+})

--- a/frontend/src/lib/migration/pipeline-import-path.test.ts
+++ b/frontend/src/lib/migration/pipeline-import-path.test.ts
@@ -29,8 +29,8 @@ describe.each(PIPELINES)("%s import path (#292)", (name) => {
     expect(source).not.toContain("qm disk import ${")
   })
 
-  it("routes file volumes through the shared rename-or-import module", () => {
-    expect(source).toMatch(/import \{[^}]*importOrAdoptFileVolume[^}]*\} from "\.\/adopt-file-volume"/)
-    expect(source).toContain("await importOrAdoptFileVolume(")
+  it("routes file volumes through the shared adopt-and-attach module", () => {
+    expect(source).toMatch(/import \{[^}]*adoptImportAndAttachFileVolume[^}]*\} from "\.\/adopt-file-volume"/)
+    expect(source).toContain("await adoptImportAndAttachFileVolume(")
   })
 })

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -7,7 +7,8 @@
  * 3. Create empty VM shell on Proxmox via API
  * 4. For each disk:
  *    - Block storage (LVM, ZFS, RBD): pvesm alloc → stream raw data directly to device (no temp files)
- *    - File-based storage (dir, NFS, CIFS): download to storage path → convert → qm disk import
+ *    - File-based storage (dir, NFS, CIFS): download to storage path → convert →
+ *      rename into the storage (adopt), with qm disk import as fallback (#292)
  * 5. Attach disks, configure boot order
  * 6. Optionally start the VM
  *
@@ -28,6 +29,7 @@ import {
   allocateAndMapBlockVolume, nextFreeDiskName, volumesToFree,
   PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
 } from "./pvesm-alloc"
+import { importOrAdoptFileVolume } from "./adopt-file-volume"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
 import { convertDisksToQcow2 } from "./qcow2-convert"
@@ -169,6 +171,13 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
   // update so the cleanup only frees true orphans, never volumes the VM
   // already references (the VM-level DELETE handles those).
   const allocatedVolumes: AllocatedVolume[] = []
+  // File volumes turned into PVE volumes by rename during this run (#292).
+  // Name reservation only, so two disks never claim the same vm-<vmid>-disk-<N>.
+  // Deliberately NOT in allocatedVolumes: that registry drives volumesToFree(),
+  // which pvesm-frees non-attached volumes on failure — and the pre-#292
+  // behaviour on a late failure was to leave an unused disk behind, never to
+  // delete the converted image. Keep it that way.
+  const adoptedVolumes: AllocatedVolume[] = []
   // Base directory for large intermediate files on the PVE node (SSHFS mount, VMDK dumps,
   // vmkfstools clone targets). User-selectable; falls back to /tmp for backwards compat.
   // /tmp is often a tiny tmpfs on Proxmox — a multi-GB disk transfer will saturate it.
@@ -1272,43 +1281,53 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       await appendLog(jobId, `Conversion complete: ${diskSizeGB} GB in ${elapsed.toFixed(0)}s (${transferSpeed}), output ${(outputSize / 1073741824).toFixed(1)} GB`, "success")
 
       // Import into Proxmox storage
-      await appendLog(jobId, `Importing disk into storage "${config.targetStorage}"...`)
+      await appendLog(jobId, `Adding disk to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", { currentStep: `importing_disk_${i + 1}` })
 
-      const importResult = await executeSSHWithTimeout(
-        prisma, config.targetConnectionId, nodeIp,
-        `qm disk import ${targetVmid} "${outputFile}" ${config.targetStorage} --format ${importFormat} 2>&1`,
-        3600000
-      )
-      await executeSSH(config.targetConnectionId, nodeIp, `rm -f "${outputFile}"`)
+      // Rename-or-import (#292): the converted image was written into the target
+      // storage's own images/<vmid> directory, so adopting it by rename skips the
+      // second full disk copy `qm disk import` used to do here. The shared module
+      // falls back to a real (converting) import when the file sits on another
+      // filesystem, and it consumes the source file either way — no rm -f of the
+      // converted image here, after an adoption that file IS the VM's disk.
+      const vmConf = await pveFetch<Record<string, any>>(
+        pveConn,
+        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
+      ).catch(() => null)
 
-      if (!importResult.success) {
-        throw new Error(`Disk import failed: ${importResult.error}`)
-      }
-
-      // Parse volume name from import output (same logic as convertAndImportDisk)
-      let diskVolume = ""
-      const importOutput = importResult.output || ""
-      const importMatch = importOutput.match(/Successfully imported disk as '(?:unused\d+:)?(.+?)'/)
-      const altMatch = !importMatch && importOutput.match(/unused\d+:\s*successfully imported disk '(.+?)'/i)
-      if (importMatch?.[1]) {
-        diskVolume = importMatch[1]
-      } else if (altMatch?.[1]) {
-        diskVolume = altMatch[1]
-      } else {
-        try {
-          const vmConf = await pveFetch<Record<string, any>>(pveConn, `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`)
-          const unusedKeys = Object.keys(vmConf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
-          if (unusedKeys.length > 0) diskVolume = vmConf[unusedKeys[unusedKeys.length - 1]] as string
-        } catch {}
-        if (!diskVolume) diskVolume = `${config.targetStorage}:vm-${targetVmid}-disk-${i}`
-      }
+      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        connectionId: config.targetConnectionId,
+        nodeIp,
+        sourcePath: outputFile,
+        targetStorage: config.targetStorage,
+        imagesDir: storageTempDir,
+        targetVmid: targetVmid!,
+        format: importFormat,
+        vmConf,
+        taken: adoptedVolumes,
+        onLog: (m) => appendLog(jobId, m),
+        resolveUnusedVolume: async () => {
+          const conf = await pveFetch<Record<string, any>>(
+            pveConn,
+            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
+          )
+          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
+          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
+        },
+      })
+      if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
 
       // Attach disk
       const attachBody = new URLSearchParams({ [scsiSlot]: `${diskVolume}${isFileBased ? ",discard=on" : ""}` })
       try {
         await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(jobId, `Disk ${i + 1} imported and attached as ${scsiSlot}`, "success")
+        await appendLog(
+          jobId,
+          adopted
+            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
+            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
+          "success",
+        )
       } catch (attachErr: any) {
         await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
       }
@@ -1700,53 +1719,41 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       if (isCancelled(jobId)) throw new Error("Migration cancelled")
 
       // Import disk into Proxmox storage
-      await appendLog(jobId, `Importing disk into storage "${config.targetStorage}"...`)
+      await appendLog(jobId, `Adding disk to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", { currentStep: `importing_disk_${i + 1}` })
 
-      const importResult = await executeSSHWithTimeout(
-        prisma, config.targetConnectionId, nodeIp,
-        `qm disk import ${targetVmid} "${tmpFile}.${importFormat}" ${config.targetStorage} --format ${importFormat} 2>&1`,
-        3600000
-      )
-      await executeSSH(config.targetConnectionId, nodeIp, `rm -f "${tmpFile}.${importFormat}"`)
+      // Rename-or-import (#292): the converted image was written into the target
+      // storage's own images/<vmid> directory, so adopting it by rename skips the
+      // second full disk copy `qm disk import` used to do here. The shared module
+      // falls back to a real (converting) import when the file sits on another
+      // filesystem, and it consumes the source file either way — no rm -f of the
+      // converted image here, after an adoption that file IS the VM's disk.
+      const vmConf = await pveFetch<Record<string, any>>(
+        pveConn,
+        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
+      ).catch(() => null)
 
-      if (!importResult.success) {
-        throw new Error(`Disk import failed: ${importResult.error}`)
-      }
-
-      // Parse the actual disk volume name from qm disk import output
-      let diskVolume = ""
-      const importOutput = importResult.output || ""
-      // Try standard format: "Successfully imported disk as 'unused0:storage:vm-XXX-disk-N'"
-      const importMatch = importOutput.match(/Successfully imported disk as '(?:unused\d+:)?(.+?)'/)
-      // Also try alternate format: "unused0: successfully imported disk 'storage:vm-XXX-disk-N'"
-      const altMatch = !importMatch && importOutput.match(/unused\d+:\s*successfully imported disk '(.+?)'/i)
-      if (importMatch?.[1]) {
-        diskVolume = importMatch[1]
-      } else if (altMatch?.[1]) {
-        diskVolume = altMatch[1]
-      } else {
-        await appendLog(jobId, `Parsing import output failed (output: ${importOutput.substring(0, 200)}), reading VM config to find unused disk...`, "info")
-        try {
-          const vmConf = await pveFetch<Record<string, any>>(
+      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        connectionId: config.targetConnectionId,
+        nodeIp,
+        sourcePath: `${tmpFile}.${importFormat}`,
+        targetStorage: config.targetStorage,
+        imagesDir: storageTempDir,
+        targetVmid: targetVmid!,
+        format: importFormat,
+        vmConf,
+        taken: adoptedVolumes,
+        onLog: (m) => appendLog(jobId, m),
+        resolveUnusedVolume: async () => {
+          const conf = await pveFetch<Record<string, any>>(
             pveConn,
-            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`
+            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
           )
-          const unusedKeys = Object.keys(vmConf)
-            .filter(k => k.startsWith("unused"))
-            .sort((a, b) => a.localeCompare(b))
-          if (unusedKeys.length > 0) {
-            diskVolume = vmConf[unusedKeys[unusedKeys.length - 1]] as string
-            await appendLog(jobId, `Found unused disk in VM config: ${diskVolume}`, "info")
-          }
-        } catch (e: any) {
-          await appendLog(jobId, `Failed to read VM config: ${e.message}`, "warn")
-        }
-        if (!diskVolume) {
-          diskVolume = `${config.targetStorage}:vm-${targetVmid}-disk-${i}`
-          await appendLog(jobId, `Using guessed volume name: ${diskVolume}`, "warn")
-        }
-      }
+          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
+          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
+        },
+      })
+      if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
 
       // Attach disk to SCSI slot via PVE API
       const attachBody = new URLSearchParams({
@@ -1754,7 +1761,13 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       })
       try {
         await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(jobId, `Disk ${i + 1} imported and attached as ${scsiSlot}`, "success")
+        await appendLog(
+          jobId,
+          adopted
+            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
+            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
+          "success",
+        )
       } catch (attachErr: any) {
         await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
       }
@@ -2723,7 +2736,8 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         }
 
         if (isFileBased) {
-          // File-based storage: qemu-img convert directly from SSHFS mount → qm disk import
+          // File-based storage: qemu-img convert directly from SSHFS mount into the
+          // storage's images/<vmid> dir, then adopt by rename (#292)
           await transferDiskViaSshfs(i, vmConfig.disks[i])
         } else {
           // Block storage: dd from SSHFS mount directly to pre-allocated block device
@@ -2747,7 +2761,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         }
 
         if (isFileBased) {
-          // File-based storage: download to storage path → convert → qm disk import
+          // File-based storage: download to storage path → convert → adopt by rename (#292)
           await downloadDisk(i, vmConfig.disks[i])
           if (isCancelled(jobId)) throw new Error("Migration cancelled")
           await convertAndImportDisk(i)

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -29,7 +29,7 @@ import {
   allocateAndMapBlockVolume, nextFreeDiskName, volumesToFree,
   PVESM_FREE_TIMEOUT_MS, type AllocatedVolume,
 } from "./pvesm-alloc"
-import { importOrAdoptFileVolume } from "./adopt-file-volume"
+import { adoptImportAndAttachFileVolume } from "./adopt-file-volume"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
 import { convertDisksToQcow2 } from "./qcow2-convert"
@@ -1286,16 +1286,11 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
 
       // Rename-or-import (#292): the converted image was written into the target
       // storage's own images/<vmid> directory, so adopting it by rename skips the
-      // second full disk copy `qm disk import` used to do here. The shared module
-      // falls back to a real (converting) import when the file sits on another
-      // filesystem, and it consumes the source file either way — no rm -f of the
-      // converted image here, after an adoption that file IS the VM's disk.
-      const vmConf = await pveFetch<Record<string, any>>(
+      // second full disk copy `qm disk import` used to do here. The shared helper
+      // owns the guard rails, the import fallback and the attach.
+      const { volumeId: diskVolume, adopted } = await adoptImportAndAttachFileVolume({
         pveConn,
-        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-      ).catch(() => null)
-
-      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        targetNode: config.targetNode,
         connectionId: config.targetConnectionId,
         nodeIp,
         sourcePath: outputFile,
@@ -1303,34 +1298,13 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         imagesDir: storageTempDir,
         targetVmid: targetVmid!,
         format: importFormat,
-        vmConf,
+        slot: scsiSlot,
+        driveOpts: isFileBased ? ",discard=on" : "",
+        diskLabel: `Disk ${i + 1}`,
         taken: adoptedVolumes,
-        onLog: (m) => appendLog(jobId, m),
-        resolveUnusedVolume: async () => {
-          const conf = await pveFetch<Record<string, any>>(
-            pveConn,
-            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-          )
-          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
-          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
-        },
+        onLog: (m, level) => appendLog(jobId, m, level),
       })
       if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
-
-      // Attach disk
-      const attachBody = new URLSearchParams({ [scsiSlot]: `${diskVolume}${isFileBased ? ",discard=on" : ""}` })
-      try {
-        await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(
-          jobId,
-          adopted
-            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
-            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
-          "success",
-        )
-      } catch (attachErr: any) {
-        await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
-      }
     }
 
     // Stream disk via SSHFS for block storage (dd or qemu-img convert to pre-allocated device)
@@ -1722,18 +1696,12 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
       await appendLog(jobId, `Adding disk to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", { currentStep: `importing_disk_${i + 1}` })
 
-      // Rename-or-import (#292): the converted image was written into the target
-      // storage's own images/<vmid> directory, so adopting it by rename skips the
-      // second full disk copy `qm disk import` used to do here. The shared module
-      // falls back to a real (converting) import when the file sits on another
-      // filesystem, and it consumes the source file either way — no rm -f of the
-      // converted image here, after an adoption that file IS the VM's disk.
-      const vmConf = await pveFetch<Record<string, any>>(
+      // Rename-or-import (#292): the shared helper adopts the converted image by
+      // rename when it can, imports it otherwise, and attaches the result. See
+      // adoptImportAndAttachFileVolume for the guard rails.
+      const { volumeId: diskVolume, adopted } = await adoptImportAndAttachFileVolume({
         pveConn,
-        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-      ).catch(() => null)
-
-      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        targetNode: config.targetNode,
         connectionId: config.targetConnectionId,
         nodeIp,
         sourcePath: `${tmpFile}.${importFormat}`,
@@ -1741,36 +1709,13 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         imagesDir: storageTempDir,
         targetVmid: targetVmid!,
         format: importFormat,
-        vmConf,
+        slot: scsiSlot,
+        driveOpts: isFileBased ? ",discard=on" : "",
+        diskLabel: `Disk ${i + 1}`,
         taken: adoptedVolumes,
-        onLog: (m) => appendLog(jobId, m),
-        resolveUnusedVolume: async () => {
-          const conf = await pveFetch<Record<string, any>>(
-            pveConn,
-            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-          )
-          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
-          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
-        },
+        onLog: (m, level) => appendLog(jobId, m, level),
       })
       if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
-
-      // Attach disk to SCSI slot via PVE API
-      const attachBody = new URLSearchParams({
-        [scsiSlot]: `${diskVolume}${isFileBased ? ",discard=on" : ""}`,
-      })
-      try {
-        await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(
-          jobId,
-          adopted
-            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
-            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
-          "success",
-        )
-      } catch (attachErr: any) {
-        await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
-      }
     }
 
     // Mount SSHFS if transfer mode requires it

--- a/frontend/src/lib/migration/v2v-command.test.ts
+++ b/frontend/src/lib/migration/v2v-command.test.ts
@@ -26,6 +26,7 @@ function build(config: any, opts: {
   disks?: string[]
   xml?: string
   root?: string
+  outputDirOverride?: string
 } = {}) {
   return buildV2vCommand(
     "job-1",
@@ -36,6 +37,7 @@ function build(config: any, opts: {
     opts.disks,
     opts.xml,
     opts.root,
+    opts.outputDirOverride,
   )
 }
 
@@ -144,5 +146,42 @@ describe("buildV2vCommand carries --root on every input path", () => {
 
   it("refuses an unknown source type", () => {
     expect(() => build({ ...base, sourceType: "kvm" })).toThrow(/Unsupported source type/)
+  })
+})
+
+/**
+ * Direct storage write (#292): with the override the conversion lands as qcow2
+ * in a staging dir on the target storage, so Phase 6 can adopt it by rename.
+ * Without it the command must stay byte for byte the legacy one — the
+ * block-storage path feeds that raw output to `qemu-img convert -n`.
+ */
+describe("buildV2vCommand direct storage write (#292)", () => {
+  const stagingDir = "/mnt/pve/nfs-vmstore/proxcenter-v2v/job-1"
+
+  it("converts to qcow2 straight into the staging dir when the override is set", () => {
+    const cmd = build(vcenter, { outputDirOverride: stagingDir })
+    expect(cmd).toContain(`-of qcow2 -o local -os '${stagingDir}' --machine-readable`)
+    // and the temp-storage output dir is nowhere on the command line
+    expect(cmd).not.toContain("/var/lib/vz/v2v-job-1")
+  })
+
+  it("keeps the option order stable around --root and --block-driver", () => {
+    const cmd = build(vcenter, { root: "/dev/system/root", outputDirOverride: stagingDir })
+    expect(cmd).toContain("--root '/dev/system/root' --block-driver virtio-scsi -of qcow2 -o local")
+  })
+
+  it("applies the override on the pre-downloaded disk path too", () => {
+    const cmd = build(vcenter, { disks: ["/var/lib/vz/v2v-job-1/disk-0.vmdk"], outputDirOverride: stagingDir })
+    // the source VMDK stays on the temp storage, only the output moves
+    expect(cmd).toContain("virt-v2v -i disk '/var/lib/vz/v2v-job-1/disk-0.vmdk'")
+    expect(cmd).toContain(`-of qcow2 -o local -os '${stagingDir}'`)
+  })
+
+  it("keeps today's raw command, byte for byte, without the override", () => {
+    const cmd = build(vcenter)
+    // no -of: the block-storage path expects virt-v2v's raw output
+    expect(cmd).not.toContain("-of ")
+    expect(cmd).not.toContain("proxcenter-v2v")
+    expect(cmd).toContain("--block-driver virtio-scsi -o local -os '/var/lib/vz/v2v-job-1' --machine-readable")
   })
 })

--- a/frontend/src/lib/migration/v2v-pipeline.integration.test.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.integration.test.ts
@@ -119,6 +119,12 @@ let currentRun: ScriptedRun | null
 let v2vLaunches: string[]
 /** What Phase 6 "ls -1 <outputDir>" reports as converted disk files. */
 let diskListing: string
+/**
+ * Output of the adoption attempt (#292: `mkdir -p images/<vmid> && stat && mv -n
+ * && echo ADOPT_OK`). Empty = rename refused, so the pipeline falls back to
+ * `qm disk import`, which is what every pre-#292 test exercised.
+ */
+let adoptAnswer: string
 
 function queueV2vRuns(runs: ScriptedRun[]) {
   scriptedRuns.push(...runs)
@@ -151,6 +157,9 @@ async function sshRouter(_connId: string, _host: string, command: string) {
   }
   if (command.startsWith("cat ") && command.includes("*.xml")) return ok("") // no domain XML: fallback VM config
   if (command.startsWith("ls -1 ")) return ok(diskListing)
+  if (command.startsWith("mkdir -p ") && command.includes("echo ADOPT_OK")) {
+    return ok(adoptAnswer)
+  }
   if (command.startsWith("qm disk import ")) {
     return ok("Successfully imported disk as 'unused0:local:120/vm-120-disk-0.qcow2'")
   }
@@ -164,6 +173,9 @@ async function pveRouter(_conn: unknown, path: string, init?: { method?: string 
   // VM create accepted; falsy return skips the task-status polling
   if (path.endsWith("/qemu") && init?.method === "POST") return ""
   if (path.startsWith("/storage/")) return { type: "dir" }
+  // Node-level storage status: the direct-write gate (#292) requires the
+  // storage to be positively active before staging the conversion on it.
+  if (/^\/nodes\/[^/]+\/storage\/[^/]+\/status$/.test(path)) return { active: 1 }
   return {}
 }
 
@@ -231,6 +243,7 @@ beforeEach(() => {
   currentRun = null
   v2vLaunches = []
   diskListing = "testvm-sda\n"
+  adoptAnswer = ""
   prisma = makeFakePrisma()
   vi.mocked(getTenantPrisma).mockImplementation(() => prisma as any)
   vi.mocked(getConnectionById).mockResolvedValue(PVE_CONN as any)
@@ -360,5 +373,81 @@ describe("runV2vMigrationPipeline cleanup guard (#738)", () => {
     expect(destroyPveVm).toHaveBeenCalledTimes(1)
     expect(destroyPveVm).toHaveBeenCalledWith(expect.objectContaining({ id: "conn-target" }), "pve1", 120)
     expect(messages().some(m => m.includes("Cleaned up partial VM 120"))).toBe(true)
+  })
+})
+
+describe("runV2vMigrationPipeline direct storage write (#292)", () => {
+  const sshCommands = () => vi.mocked(executeSSH).mock.calls.map(c => String(c[2]))
+
+  it("converts onto the storage and adopts the disk by rename, no qm disk import", { timeout: 15000 }, async () => {
+    queueV2vRuns([{ exit: 0, log: SUCCESS_LOG }])
+    adoptAnswer = "ADOPT_OK"
+    // A dir/NFS storage's path is arbitrary and comes from the storage config.
+    vi.mocked(pveFetch).mockImplementation((async (conn: unknown, path: string, init?: { method?: string }) => {
+      if (path.startsWith("/storage/")) return { type: "nfs", path: "/mnt/pve/nfs-vmstore" }
+      return pveRouter(conn, path, init)
+    }) as any)
+
+    await runPipelineToEnd("v2v-it-adopt", makeConfig())
+
+    expect(prisma.row.status).toBe("completed")
+    // virt-v2v was pointed at the staging dir ON the storage and asked for qcow2
+    expect(v2vLaunches).toHaveLength(1)
+    expect(v2vLaunches[0]).toContain("-of qcow2")
+    expect(v2vLaunches[0]).toContain("-os '/mnt/pve/nfs-vmstore/proxcenter-v2v/v2v-it-adopt'")
+    // the whole point: the disk is never copied a second time
+    const commands = sshCommands()
+    expect(commands.some(c => c.startsWith("qm disk import "))).toBe(false)
+    // the rename targeted the storage's own images/<vmid> directory
+    const adoptCmd = commands.find(c => c.includes("echo ADOPT_OK")) || ""
+    expect(adoptCmd).toContain("mkdir -p '/mnt/pve/nfs-vmstore/images/120'")
+    expect(adoptCmd).toContain(
+      "mv -n '/mnt/pve/nfs-vmstore/proxcenter-v2v/v2v-it-adopt/testvm-sda' '/mnt/pve/nfs-vmstore/images/120/vm-120-disk-0.qcow2'",
+    )
+    // the adopted volume is what got attached
+    const attach = vi.mocked(pveSetVmConfig).mock.calls.find(c => c[3].has("scsi0"))
+    expect(attach?.[3].get("scsi0")).toBe("local:120/vm-120-disk-0.qcow2,discard=on")
+    // both the staging dir on the storage AND the temp dir are cleaned up
+    expect(commands).toContain("rm -rf '/mnt/pve/nfs-vmstore/proxcenter-v2v/v2v-it-adopt'")
+    expect(commands).toContain("rm -rf '/tmp/v2v-v2v-it-adopt'")
+  })
+
+  it("falls back to qm disk import when the rename is refused, and still completes", { timeout: 15000 }, async () => {
+    queueV2vRuns([{ exit: 0, log: SUCCESS_LOG }])
+    // adoptAnswer stays "": the rename is refused, as on a cross-filesystem move
+
+    await runPipelineToEnd("v2v-it-fallback", makeConfig())
+
+    expect(prisma.row.status).toBe("completed")
+    // direct-write mode was still on (dir storage, path fallback /var/lib/vz)
+    expect(v2vLaunches[0]).toContain("-of qcow2")
+    expect(v2vLaunches[0]).toContain("-os '/var/lib/vz/proxcenter-v2v/v2v-it-fallback'")
+    // the fallback is the converting import, fed with the staged qcow2
+    const importCmd = sshCommands().find(c => c.startsWith("qm disk import ")) || ""
+    expect(importCmd).toContain(
+      "qm disk import 120 '/var/lib/vz/proxcenter-v2v/v2v-it-fallback/testvm-sda' 'local' --format qcow2",
+    )
+    expect(messages().some(m => m.includes("falling back to qm disk import"))).toBe(true)
+    const attach = vi.mocked(pveSetVmConfig).mock.calls.find(c => c[3].has("scsi0"))
+    expect(attach?.[3].get("scsi0")).toBe("local:120/vm-120-disk-0.qcow2,discard=on")
+  })
+
+  it("keeps the legacy temp staging when the storage is not reported active", { timeout: 15000 }, async () => {
+    queueV2vRuns([{ exit: 0, log: SUCCESS_LOG }])
+    // dead NFS mount: writing "onto the storage" would land under the mountpoint
+    vi.mocked(pveFetch).mockImplementation((async (conn: unknown, path: string, init?: { method?: string }) => {
+      if (/\/storage\/.+\/status$/.test(path)) return { active: 0 }
+      return pveRouter(conn, path, init)
+    }) as any)
+
+    await runPipelineToEnd("v2v-it-inactive", makeConfig())
+
+    expect(prisma.row.status).toBe("completed")
+    // no direct write: raw conversion into the temp dir, byte-for-byte legacy
+    expect(v2vLaunches[0]).not.toContain("-of qcow2")
+    expect(v2vLaunches[0]).toContain("-os '/tmp/v2v-v2v-it-inactive'")
+    // and the disk reaches the storage through the converting import
+    const importCmd = sshCommands().find(c => c.startsWith("qm disk import ")) || ""
+    expect(importCmd).toContain("qm disk import 120 '/tmp/v2v-v2v-it-inactive/testvm-sda' 'local' --format qcow2")
   })
 })

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -28,7 +28,7 @@ import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
 import { parseV2vXml, buildPveCreateParams } from "./v2vConfigMapper"
 import type { V2vVmConfig } from "./v2vConfigMapper"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
-import { importOrAdoptFileVolume } from "./adopt-file-volume"
+import { adoptImportAndAttachFileVolume } from "./adopt-file-volume"
 import { convertDisksToQcow2 } from "./qcow2-convert"
 // SOAP imports for the NFC (HttpNfcLease) transport path used when the source VM
 // has any disk on a vSAN datastore. vpx://+HTTPS /folder/ download is broken for
@@ -2830,12 +2830,14 @@ export async function runV2vMigrationPipeline(
         // unsafe: temp dir on another filesystem, raw image (no direct-write
         // mode), destination name taken. Either way the source file is consumed
         // by the helper, so no rm here.
-        const vmConf = await pveFetch<Record<string, any>>(
+        // Adopt the converted image by rename when it already sits on the target
+        // storage (direct-write mode), import it otherwise, then attach it. The
+        // shared helper owns the guard rails and the attach. sourceFormat marks
+        // the file raw unless we asked virt-v2v for qcow2, so a raw image is
+        // converted by the import fallback rather than misnamed.
+        const { volumeId: diskVolume, adopted } = await adoptImportAndAttachFileVolume({
           pveConn,
-          `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-        ).catch(() => null)
-
-        const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+          targetNode: config.targetNode,
           connectionId: config.targetConnectionId,
           nodeIp,
           sourcePath: diskPath,
@@ -2843,39 +2845,14 @@ export async function runV2vMigrationPipeline(
           imagesDir: `${storagePath}/images/${targetVmid}`,
           targetVmid: targetVmid!,
           format: "qcow2",
-          // virt-v2v only writes qcow2 when we asked for it; otherwise the file
-          // is raw and the import must convert, exactly as before #292.
           sourceFormat: directWriteDir ? "qcow2" : "raw",
-          vmConf,
+          slot: diskSlot,
+          driveOpts: ",discard=on",
+          diskLabel: `Disk ${i + 1}`,
           taken: adoptedVolumes,
-          onLog: (m) => appendLog(jobId, m),
-          resolveUnusedVolume: async () => {
-            const conf = await pveFetch<Record<string, any>>(
-              pveConn,
-              `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-            )
-            const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
-            return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
-          },
+          onLog: (m, level) => appendLog(jobId, m, level),
         })
         adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
-
-        // Attach disk via PVE API
-        const attachBody = new URLSearchParams({
-          [diskSlot]: `${diskVolume},discard=on`,
-        })
-        try {
-          await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-          await appendLog(
-            jobId,
-            adopted
-              ? `Disk ${i + 1} attached as ${diskSlot} (adopted in place, no copy)`
-              : `Disk ${i + 1} imported and attached as ${diskSlot}`,
-            "success",
-          )
-        } catch (attachErr: any) {
-          await appendLog(jobId, `Warning: Could not auto-attach ${diskSlot}: ${attachErr.message}`, "warn")
-        }
       } else {
         // Block storage: stat size -> pvesm alloc -> pvesm path -> qemu-img convert
         const statResult = await executeSSH(

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -5,9 +5,12 @@
  * 1. Preflight checks (SSH, virt-v2v installed)
  * 2. Prepare credentials (password file on target node)
  * 3. Create VM shell on Proxmox via API
- * 4. Execute virt-v2v on the target node (converts + downloads to /tmp)
+ * 4. Execute virt-v2v on the target node (converts + downloads to /tmp; on a
+ *    file-based target storage the converted disks are written straight into a
+ *    staging directory on that storage, #292)
  * 5. Parse output XML to configure the VM
- * 6. Import converted disks into Proxmox storage
+ * 6. Import converted disks into Proxmox storage (adopt-by-rename when they
+ *    were staged on the storage itself, `qm disk import` / block write otherwise)
  * 7. Cleanup temp files, optionally start VM
  *
  * virt-v2v runs ON the Proxmox node itself (it connects to the source hypervisor).
@@ -25,6 +28,7 @@ import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
 import { parseV2vXml, buildPveCreateParams } from "./v2vConfigMapper"
 import type { V2vVmConfig } from "./v2vConfigMapper"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
+import { importOrAdoptFileVolume } from "./adopt-file-volume"
 import { convertDisksToQcow2 } from "./qcow2-convert"
 // SOAP imports for the NFC (HttpNfcLease) transport path used when the source VM
 // has any disk on a vSAN datastore. vpx://+HTTPS /folder/ download is broken for
@@ -850,9 +854,16 @@ async function runVirtV2vWithProgress(
   v2vCommand: string,
   progressOffset: number,
   progressScale: number,
+  /**
+   * virt-v2v's output directory when the pipeline stages the conversion on the
+   * target storage (#292). Must match the override given to buildV2vCommand:
+   * the mkdir, the log/exit marker files and the du/df liveness probes all
+   * follow the conversion to where it actually writes.
+   */
+  outputDirOverride?: string,
 ): Promise<{ success: boolean; output: string; error?: string }> {
   const tempBase = config.tempStorage || '/tmp'
-  const outputDir = `${tempBase}/v2v-${jobId}`
+  const outputDir = outputDirOverride || `${tempBase}/v2v-${jobId}`
   const logFile = `${outputDir}/v2v.log`
   const exitFile = `${outputDir}/v2v.exit`
 
@@ -1083,9 +1094,21 @@ function buildV2vCommand(
    * list out of the first attempt's log.
    */
   rootDevice?: string,
+  /**
+   * Convert straight into this directory instead of `<tempStorage>/v2v-<jobId>`
+   * (#292). Set by the pipeline to a staging directory ON the file-based target
+   * storage, so the converted image is born on the storage's own filesystem and
+   * Phase 6 can adopt it by rename instead of paying a second full-disk copy
+   * with `qm disk import`. Also switches the output to qcow2 (`-of qcow2`), the
+   * format that storage wants — producing it here is what used to be `qm disk
+   * import --format qcow2`'s job. Without the override the command stays byte
+   * for byte the legacy one (raw output, no `-of`): the block-storage path
+   * feeds that raw image to `qemu-img convert -n`.
+   */
+  outputDirOverride?: string,
 ): string {
   const tempBase = config.tempStorage || '/tmp'
-  const outputDir = `${tempBase}/v2v-${jobId}`
+  const outputDir = outputDirOverride || `${tempBase}/v2v-${jobId}`
   const pwFile = `${tempBase}/v2v-pwfile-${jobId}`
   const vmNameEsc = shellEscape(config.sourceVmName)
 
@@ -1106,7 +1129,11 @@ function buildV2vCommand(
   // site: this string goes straight onto an SSH command line.
   const safeRoot = sanitizeV2vRoot(rootDevice)
   const rootOpt = safeRoot ? `--root ${shellEscape(safeRoot)} ` : ''
-  const v2vOpts = `${rootOpt}${blockDriverOpt}-o local -os ${shellEscape(outputDir)} --machine-readable`
+  // -of qcow2 ONLY in direct-write mode: the file-based storage wants qcow2 and
+  // producing it here is what makes the qm-disk-import copy skippable (#292).
+  // The legacy raw output must not change otherwise — see outputDirOverride.
+  const outputFormatOpt = outputDirOverride ? '-of qcow2 ' : ''
+  const v2vOpts = `${rootOpt}${blockDriverOpt}${outputFormatOpt}-o local -os ${shellEscape(outputDir)} --machine-readable`
 
   // Pre-downloaded local disks (NFC export path for vSAN). This bypasses the
   // sourceType-specific URI building below since virt-v2v doesn't need to talk
@@ -1302,7 +1329,25 @@ export async function runV2vMigrationPipeline(
    */
   let vmCreated = false
   const tempBase = config.tempStorage || '/tmp'
-  const outputDir = `${tempBase}/v2v-${jobId}`
+  /**
+   * Working directory on the temp storage: the NFC source downloads and the
+   * synthesized libvirt XML always live here, whatever the target storage is.
+   * Keyed on jobId, never on the VMID: the create loop in Phase 5 can pick a
+   * different id on collision (#292).
+   */
+  const tempDir = `${tempBase}/v2v-${jobId}`
+  /**
+   * Where virt-v2v writes the CONVERTED disks. Defaults to the temp directory;
+   * Phase 1 repoints it to a staging directory on the target storage when that
+   * storage is file-based (#292), so the converted image is born on the
+   * storage's own filesystem and Phase 6 adopts it by rename instead of paying
+   * a second full-disk copy through `qm disk import`. Staged OUTSIDE the
+   * storage's images/ tree on purpose: PVE scans images/ for volumes, and a
+   * failed conversion must not leave stray files there.
+   */
+  let outputDir = tempDir
+  /** Non-null exactly when the direct-write staging above is active (#292). */
+  let directWriteDir: string | null = null
   const pwFile = `${tempBase}/v2v-pwfile-${jobId}`
   let nutanixImageUuids: string[] = []  // Track Nutanix images for cleanup
   let hypervMounted = false  // Track CIFS mount for cleanup
@@ -1373,6 +1418,51 @@ export async function runV2vMigrationPipeline(
         "virt-v2v on this node does not support --block-driver. Falling back to virtio-blk: Windows data disks will be attached on virtio0 (matching the injected viostor.sys driver) instead of scsi0.",
         "warn",
       )
+    }
+
+    // Resolve the target storage ONCE, before the conversion (#292). Phase 6
+    // used to fetch it only after virt-v2v had written the converted image to
+    // the temp directory — too late to decide WHERE the conversion writes. The
+    // path MUST come from the storage config: a dir storage points at an
+    // arbitrary path (/mnt/pve/<storage> is NOT a valid assumption), and
+    // /var/lib/vz only covers the API omitting the field on stock "local".
+    const storageConfig = await pveFetch<any>(
+      pveConn,
+      `/storage/${encodeURIComponent(config.targetStorage)}`
+    )
+    const storageType = storageConfig?.type || "dir"
+    const isFileBased = isFileBasedStorage(storageType)
+    const storagePath: string = storageConfig?.path || '/var/lib/vz'
+    if (isFileBased && storagePath) {
+      // Guard against a dead mount (#292): converting "onto the storage" while
+      // its NFS/CIFS mount is down would silently fill the root filesystem
+      // under the mountpoint and hide the files once the mount returns. The
+      // legacy flow failed loudly at `qm disk import` in that state, so
+      // anything but a positively active storage keeps the legacy temp path
+      // (correct, just twice the I/O).
+      const storageStatus = await pveFetch<any>(
+        pveConn,
+        `/nodes/${encodeURIComponent(config.targetNode)}/storage/${encodeURIComponent(config.targetStorage)}/status`,
+      ).catch(() => null)
+      const storageActive = storageStatus?.active === 1 || storageStatus?.active === true
+      if (storageActive) {
+        directWriteDir = `${storagePath}/proxcenter-v2v/${jobId}`
+        outputDir = directWriteDir
+        await appendLog(
+          jobId,
+          `Target storage "${config.targetStorage}" (${storageType}) is file-based: ` +
+          `virt-v2v will convert straight into ${directWriteDir}, so the disks can be ` +
+          `adopted in place instead of paying a second full copy through qm disk import.`,
+          "info",
+        )
+      } else {
+        await appendLog(
+          jobId,
+          `Target storage "${config.targetStorage}" is file-based but not reported active on ${config.targetNode}; ` +
+          `keeping the conversion on the temp storage (qm disk import will copy the disks).`,
+          "warn",
+        )
+      }
     }
 
     if (isCancelled(jobId)) throw new Error("Migration cancelled")
@@ -2003,7 +2093,9 @@ export async function runV2vMigrationPipeline(
         config,
         nodeIp,
         vmwareSession,
-        outputDir,
+        // Source VMDKs land on the TEMP storage even in direct-write mode:
+        // only the converted output moves to the target storage (#292).
+        tempDir,
         sourceVmwareConfig,
         liveSnapshotMor,
       )
@@ -2085,7 +2177,10 @@ export async function runV2vMigrationPipeline(
     // an XML we write ourselves using the source VM's metadata from SOAP.
     let libvirtXmlPath: string | undefined
     if (nfcDownloadedDisks.length > 1) {
-      libvirtXmlPath = `${outputDir}/vm.xml`
+      // In the temp dir (which the NFC export already created), NOT in the
+      // conversion output dir: Phase 5 does `cat <outputDir>/*.xml` and must
+      // only ever see virt-v2v's own output XML (#292).
+      libvirtXmlPath = `${tempDir}/vm.xml`
       const xml = buildSynthesizedLibvirtXml(
         config.sourceVmName,
         sourceVmwareConfig?.memoryMB || 1024,
@@ -2131,6 +2226,7 @@ export async function runV2vMigrationPipeline(
       nfcDownloadedDisks.length > 0 ? nfcDownloadedDisks : undefined,
       libvirtXmlPath,
       pinnedRoot || undefined,
+      directWriteDir || undefined,
     )
     await appendLog(jobId, `Running virt-v2v on ${config.targetNode}...`)
 
@@ -2148,6 +2244,7 @@ export async function runV2vMigrationPipeline(
       v2vCommand,
       v2vProgressOffset,
       v2vProgressScale,
+      directWriteDir || undefined,
     )
 
     // Parse progress from output
@@ -2194,9 +2291,11 @@ export async function runV2vMigrationPipeline(
       if (retryRoot) {
         // Drop the partial converted disks of the failed attempt: Phase 6 lists
         // everything in outputDir that is not a .xml/.vmdk and would otherwise
-        // attach a truncated leftover as an extra disk. The NFC source VMDKs and
-        // the synthesized vm.xml live in the same directory and must survive,
-        // hence the narrow `*-sd?` pattern (virt-v2v's -o local naming).
+        // attach a truncated leftover as an extra disk. Since #292 the NFC
+        // source VMDKs and the synthesized vm.xml live in the temp directory,
+        // but the narrow `*-sd?` pattern (virt-v2v's -o local naming) is kept:
+        // in non-direct-write mode outputDir IS the temp directory and those
+        // inputs must survive the retry.
         await executeSSH(
           config.targetConnectionId,
           nodeIp,
@@ -2211,6 +2310,7 @@ export async function runV2vMigrationPipeline(
           nfcDownloadedDisks.length > 0 ? nfcDownloadedDisks : undefined,
           libvirtXmlPath,
           retryRoot,
+          directWriteDir || undefined,
         )
         v2vResult = await runVirtV2vWithProgress(
           jobId,
@@ -2219,6 +2319,7 @@ export async function runV2vMigrationPipeline(
           retryCommand,
           v2vProgressOffset,
           v2vProgressScale,
+          directWriteDir || undefined,
         )
         if (v2vResult.output) {
           await processV2vOutput(jobId, v2vResult.output, v2vProgressOffset, v2vProgressScale)
@@ -2291,7 +2392,7 @@ export async function runV2vMigrationPipeline(
       for (const p of nfcDownloadedDisks) {
         await executeSSH(config.targetConnectionId, nodeIp, `rm -f ${shellEscape(p)}`).catch(() => {})
       }
-      await appendLog(jobId, `Cleaned up ${nfcDownloadedDisks.length} NFC source VMDK(s) from ${outputDir}`, "info")
+      await appendLog(jobId, `Cleaned up ${nfcDownloadedDisks.length} NFC source VMDK(s) from ${tempDir}`, "info")
       // Clear the array so the finally-block doesn't try to rm them again.
       nfcDownloadedDisks = []
     }
@@ -2661,15 +2762,13 @@ export async function runV2vMigrationPipeline(
 
     await appendLog(jobId, `Found ${diskFiles.length} disk file(s): ${diskFiles.join(", ")}`)
 
-    // Determine storage type
-    const storageConfig = await pveFetch<any>(
-      pveConn,
-      `/storage/${encodeURIComponent(config.targetStorage)}`
-    )
-    const storageType = storageConfig?.type || "dir"
-    const isFileBased = isFileBasedStorage(storageType)
+    // Storage type and path were resolved once in Phase 1 (#292): isFileBased
+    // picks the import strategy here, storagePath locates the images/<vmid>
+    // directory the adoption renames into.
 
-    // Track the highest disk number used (EFI VMs may have disk-0 for efidisk0)
+    // Track the highest disk number used (EFI VMs may have disk-0 for efidisk0).
+    // Only the block branch still consumes it; the file-based branch gets its
+    // index from importOrAdoptFileVolume via nextFreeDiskName.
     let nextDiskNum = isEfi ? 1 : 0
 
     // Block volumes created by THIS migration, for the optional post-migration
@@ -2677,6 +2776,13 @@ export async function runV2vMigrationPipeline(
     // registry, so this list exists only to tell the conversion which attached
     // disks are ours — it must never convert a disk an operator attached.
     const blockVolumes: AllocatedVolume[] = []
+
+    // File-based volumes created by THIS migration (adopted or imported), so two
+    // disks never claim the same vm-<vmid>-disk-<N> name (#292). Deliberately NOT
+    // pushed into blockVolumes: that list drives the optional post-migration
+    // qcow2 conversion (#595) and the failure cleanup, and these volumes are
+    // already qcow2 and already the VM's disks.
+    const adoptedVolumes: AllocatedVolume[] = []
 
     // When virt-v2v can't inject virtio-scsi (`--block-driver` missing), it falls
     // back to virtio-blk (viostor.sys) as the boot-critical driver on Windows.
@@ -2708,61 +2814,51 @@ export async function runV2vMigrationPipeline(
         ? (i === 0 ? "sata0" : `scsi${i - 1}`)
         : (useVirtioBlk ? `virtio${i}` : `scsi${i}`)
 
-      await appendLog(jobId, `[Disk ${i + 1}/${diskFiles.length}] Importing ${diskFile}...`)
+      // "Adding", not "importing": on a file-based target the disk is usually
+      // adopted by rename and nothing is copied at all (#292).
+      await appendLog(jobId, `[Disk ${i + 1}/${diskFiles.length}] Adding ${diskFile} to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", {
         currentStep: `importing_disk_${i + 1}`,
         progress: Math.round(70 + (i / diskFiles.length) * 25),
       })
 
       if (isFileBased) {
-        // File-based storage: qm disk import. Same 30s-default-timeout problem
-        // as the dd path below — qm disk import streams the entire disk into
-        // PVE storage and routinely runs for 5-30 min on multi-GB disks. Use a
-        // 4h cap so SSH doesn't kill the import mid-stream.
-        const FOUR_HOURS_MS = 14_400_000
-        const importResult = await executeSSH(
-          config.targetConnectionId, nodeIp,
-          `qm disk import ${targetVmid} ${shellEscape(diskPath)} ${shellEscape(config.targetStorage)} --format qcow2 2>&1`,
-          FOUR_HOURS_MS,
-        )
+        // File-based storage (#292): the converted image usually already sits in
+        // the staging directory ON this storage, as qcow2. importOrAdoptFileVolume
+        // renames it into images/<vmid>/ (O(1), no second full-disk copy) and
+        // falls back to a converting `qm disk import` whenever the rename is
+        // unsafe: temp dir on another filesystem, raw image (no direct-write
+        // mode), destination name taken. Either way the source file is consumed
+        // by the helper, so no rm here.
+        const vmConf = await pveFetch<Record<string, any>>(
+          pveConn,
+          `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
+        ).catch(() => null)
 
-        if (!importResult.success) {
-          throw new Error(`Disk import failed for ${diskFile}: ${importResult.error || importResult.output}`)
-        }
-
-        // Parse disk volume name from qm disk import output
-        let diskVolume = ""
-        const importOutput = importResult.output || ""
-        const importMatch = importOutput.match(/Successfully imported disk as '(?:unused\d+:)?(.+?)'/)
-        const altMatch = !importMatch && importOutput.match(/unused\d+:\s*successfully imported disk '(.+?)'/i)
-
-        if (importMatch?.[1]) {
-          diskVolume = importMatch[1]
-        } else if (altMatch?.[1]) {
-          diskVolume = altMatch[1]
-        } else {
-          // Fallback: read VM config to find unused disk
-          await appendLog(jobId, `Parsing import output failed, reading VM config to find unused disk...`, "info")
-          try {
-            const vmConf = await pveFetch<Record<string, any>>(
+        const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+          connectionId: config.targetConnectionId,
+          nodeIp,
+          sourcePath: diskPath,
+          targetStorage: config.targetStorage,
+          imagesDir: `${storagePath}/images/${targetVmid}`,
+          targetVmid: targetVmid!,
+          format: "qcow2",
+          // virt-v2v only writes qcow2 when we asked for it; otherwise the file
+          // is raw and the import must convert, exactly as before #292.
+          sourceFormat: directWriteDir ? "qcow2" : "raw",
+          vmConf,
+          taken: adoptedVolumes,
+          onLog: (m) => appendLog(jobId, m),
+          resolveUnusedVolume: async () => {
+            const conf = await pveFetch<Record<string, any>>(
               pveConn,
-              `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`
+              `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
             )
-            const unusedKeys = Object.keys(vmConf)
-              .filter(k => k.startsWith("unused"))
-              .sort((a, b) => a.localeCompare(b))
-            if (unusedKeys.length > 0) {
-              diskVolume = vmConf[unusedKeys[unusedKeys.length - 1]] as string
-              await appendLog(jobId, `Found unused disk in VM config: ${diskVolume}`, "info")
-            }
-          } catch (e: any) {
-            await appendLog(jobId, `Failed to read VM config: ${e.message}`, "warn")
-          }
-          if (!diskVolume) {
-            diskVolume = `${config.targetStorage}:vm-${targetVmid}-disk-${nextDiskNum}`
-            await appendLog(jobId, `Using guessed volume name: ${diskVolume}`, "warn")
-          }
-        }
+            const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
+            return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
+          },
+        })
+        adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
 
         // Attach disk via PVE API
         const attachBody = new URLSearchParams({
@@ -2770,7 +2866,13 @@ export async function runV2vMigrationPipeline(
         })
         try {
           await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-          await appendLog(jobId, `Disk ${i + 1} imported and attached as ${diskSlot}`, "success")
+          await appendLog(
+            jobId,
+            adopted
+              ? `Disk ${i + 1} attached as ${diskSlot} (adopted in place, no copy)`
+              : `Disk ${i + 1} imported and attached as ${diskSlot}`,
+            "success",
+          )
         } catch (attachErr: any) {
           await appendLog(jobId, `Warning: Could not auto-attach ${diskSlot}: ${attachErr.message}`, "warn")
         }
@@ -2878,6 +2980,12 @@ export async function runV2vMigrationPipeline(
     // ── PHASE 7: Finish ──
     await appendLog(jobId, "Cleaning up temporary files...")
     await executeSSH(config.targetConnectionId, nodeIp, `rm -rf ${shellEscape(outputDir)}`).catch(() => {})
+    if (directWriteDir) {
+      // Direct-write mode (#292): the rm above removed the staging dir on the
+      // target storage; the temp dir (NFC downloads, synthesized XML) is a
+      // separate path there and needs its own removal.
+      await executeSSH(config.targetConnectionId, nodeIp, `rm -rf ${shellEscape(tempDir)}`).catch(() => {})
+    }
 
     // Unmount Hyper-V share if we mounted it
     if (hypervMounted) {
@@ -3004,6 +3112,14 @@ export async function runV2vMigrationPipeline(
       const nodeIp = await getNodeIp(pveConn, config.targetNode)
       const rmOutput = await executeSSH(config.targetConnectionId, nodeIp, `rm -rf ${shellEscape(outputDir)}`, CLEANUP_TIMEOUT_MS)
       if (!rmOutput.success) failedCleanups.push(`${outputDir}: ${rmOutput.error || "unknown"}`)
+      if (directWriteDir) {
+        // Direct-write mode (#292): the rm above covered the staging dir on the
+        // PRODUCTION storage — leftovers there are worse than leftovers on /tmp,
+        // so this path runs on every failure and cancellation. The temp dir is
+        // a distinct path in this mode and needs its own removal.
+        const rmTemp = await executeSSH(config.targetConnectionId, nodeIp, `rm -rf ${shellEscape(tempDir)}`, CLEANUP_TIMEOUT_MS)
+        if (!rmTemp.success) failedCleanups.push(`${tempDir}: ${rmTemp.error || "unknown"}`)
+      }
       const rmPw = await executeSSH(config.targetConnectionId, nodeIp, `rm -f ${shellEscape(pwFile)}`, CLEANUP_TIMEOUT_MS)
       if (!rmPw.success) failedCleanups.push(`${pwFile}: ${rmPw.error || "unknown"}`)
       // If we bootstrapped a one-shot ESXi key (password-auth source), remove the

--- a/frontend/src/lib/migration/v2v-preflight.ts
+++ b/frontend/src/lib/migration/v2v-preflight.ts
@@ -163,7 +163,15 @@ export async function runV2vPreflight(
   // 4c. Check virt-customize (for guest tools injection)
   result.virtCustomizeAvailable = virtCustomizeCheck.success && virtCustomizeCheck.output?.trim().endsWith('yes')
 
-  // 5. Check disk space on /tmp
+  // 5. Check disk space on /tmp.
+  // NOTE (#292): on a file-based target storage the pipeline now converts
+  // straight into a staging dir ON that storage, so the converted image no
+  // longer needs room on the temp storage — only the source download does.
+  // This check cannot tell the modes apart: it receives a single
+  // requiredDiskBytes and no target storage identity from the route, so it
+  // stays deliberately conservative (worst case: it demands more temp space
+  // than direct-write mode really uses). Splitting the requirement would need
+  // the route and the dialog to send the target storage along.
   if (dfCheck.success && dfCheck.output?.trim()) {
     const availableBytes = Number.parseInt(dfCheck.output.trim(), 10)
     if (!Number.isNaN(availableBytes)) {

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -7,7 +7,8 @@
  * 3. Create empty VM shell on Proxmox via API
  * 4. For each disk:
  *    - Block storage (LVM, ZFS, RBD): download VHD → pvesm alloc → qemu-img convert directly to device
- *    - File-based storage (dir, NFS, CIFS): download VHD to storage path → convert → qm disk import
+ *    - File-based storage (dir, NFS, CIFS): download VHD to storage path → convert →
+ *      rename into the storage (adopt), with qm disk import as fallback (#292)
  * 5. Attach disks, configure boot order
  * 6. Optionally start the VM
  *
@@ -33,6 +34,7 @@ import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
+import { importOrAdoptFileVolume } from "./adopt-file-volume"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { convertDisksToQcow2 } from "./qcow2-convert"
 import { startJobHeartbeat } from "./job-heartbeat"
@@ -416,8 +418,21 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     await executeSSH(config.targetConnectionId, nodeIp, `mkdir -p "${storageTempDir}"`)
     await appendLog(jobId, `Temp directory: ${storageTempDir}`)
 
+    // The storage's own volume directory, where a converted image must sit to
+    // be adopted by rename (#292). NOT storageTempDir: the operator may have
+    // picked a temp storage on another filesystem — the adoption module then
+    // refuses the rename and the disk goes through a converting `qm disk import`
+    // instead, which is the wanted fallback.
+    const targetImagesDir = `${storageConfig?.path || '/var/lib/vz'}/images/${targetVmid}`
+
     // Track allocated block volumes (for cleanup on error)
     const allocatedVolumes: AllocatedVolume[] = []
+    // File volumes turned into PVE volumes by rename during this run (#292).
+    // Name reservation only, so two disks never claim the same
+    // vm-<vmid>-disk-<N>. Deliberately NOT in allocatedVolumes: that registry is
+    // pvesm-freed on failure, and the pre-#292 behaviour on a late failure was
+    // to leave an unused disk behind, never to delete the converted image.
+    const adoptedVolumes: AllocatedVolume[] = []
 
     // Allocate a raw volume on block storage and return the device path
     async function allocateBlockVolume(sizeBytes: number): Promise<{ volumeId: string, devicePath: string, rbdMapped?: boolean }> {
@@ -612,51 +627,43 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
 
       // Import disk into Proxmox storage
       const importFile = `${tmpFile}.${importFormat}`
-      await appendLog(jobId, `Importing disk into storage "${config.targetStorage}"...`)
+      await appendLog(jobId, `Adding disk to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", { currentStep: `importing_disk_${i + 1}` })
 
-      const importResult = await executeSSHWithTimeout(
-        prisma, config.targetConnectionId, nodeIp,
-        `qm disk import ${targetVmid} "${importFile}" ${config.targetStorage} --format ${importFormat} 2>&1`,
-        3600000
-      )
-      await executeSSH(config.targetConnectionId, nodeIp, `rm -f "${importFile}"`)
+      // Rename-or-import (#292): when the converted image already sits on the
+      // target storage's filesystem (the default temp dir IS its images/<vmid>
+      // directory), adopting it by rename skips the second full disk copy
+      // `qm disk import` used to do here. With an operator-picked temp storage on
+      // another filesystem the shared module refuses the rename and falls back to
+      // a real (converting) import. Either way it consumes the source file — no
+      // rm -f of the converted image here, after an adoption that file IS the
+      // VM's disk.
+      const vmConf = await pveFetch<Record<string, any>>(
+        pveConn,
+        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
+      ).catch(() => null)
 
-      if (!importResult.success) {
-        throw new Error(`Disk import failed: ${importResult.error}`)
-      }
-
-      // Parse the actual disk volume name from qm disk import output
-      let diskVolume = ""
-      const importOutput = importResult.output || ""
-      const importMatch = importOutput.match(/Successfully imported disk as '(?:unused\d+:)?(.+?)'/)
-      const altMatch = !importMatch && importOutput.match(/unused\d+:\s*successfully imported disk '(.+?)'/i)
-      if (importMatch?.[1]) {
-        diskVolume = importMatch[1]
-      } else if (altMatch?.[1]) {
-        diskVolume = altMatch[1]
-      } else {
-        await appendLog(jobId, `Parsing import output failed (output: ${importOutput.substring(0, 200)}), reading VM config to find unused disk...`, "info")
-        try {
-          const vmConf = await pveFetch<Record<string, any>>(
+      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        connectionId: config.targetConnectionId,
+        nodeIp,
+        sourcePath: importFile,
+        targetStorage: config.targetStorage,
+        imagesDir: targetImagesDir,
+        targetVmid: targetVmid!,
+        format: importFormat,
+        vmConf,
+        taken: adoptedVolumes,
+        onLog: (m) => appendLog(jobId, m),
+        resolveUnusedVolume: async () => {
+          const conf = await pveFetch<Record<string, any>>(
             pveConn,
-            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`
+            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
           )
-          const unusedKeys = Object.keys(vmConf)
-            .filter(k => k.startsWith("unused"))
-            .sort((a, b) => a.localeCompare(b))
-          if (unusedKeys.length > 0) {
-            diskVolume = vmConf[unusedKeys[unusedKeys.length - 1]] as string
-            await appendLog(jobId, `Found unused disk in VM config: ${diskVolume}`, "info")
-          }
-        } catch (e: any) {
-          await appendLog(jobId, `Failed to read VM config: ${e.message}`, "warn")
-        }
-        if (!diskVolume) {
-          diskVolume = `${config.targetStorage}:vm-${targetVmid}-disk-${i}`
-          await appendLog(jobId, `Using guessed volume name: ${diskVolume}`, "warn")
-        }
-      }
+          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
+          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
+        },
+      })
+      if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
 
       // Attach disk to SCSI slot via PVE API
       const attachBody = new URLSearchParams({
@@ -664,7 +671,13 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       })
       try {
         await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(jobId, `Disk ${i + 1} imported and attached as ${scsiSlot}`, "success")
+        await appendLog(
+          jobId,
+          adopted
+            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
+            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
+          "success",
+        )
       } catch (attachErr: any) {
         await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
       }

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -34,7 +34,7 @@ import { fetchWithInsecureTLS } from "@/lib/http/insecure-fetch"
 import { mapXoToPveConfig, isWindowsXoVm } from "./xcpngConfigMapper"
 import type { XoVmConfig, XoDiskInfo } from "@/lib/xcpng/client"
 import { allocateAndMapBlockVolume, nextFreeDiskName, type AllocatedVolume } from "./pvesm-alloc"
-import { importOrAdoptFileVolume } from "./adopt-file-volume"
+import { adoptImportAndAttachFileVolume } from "./adopt-file-volume"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { convertDisksToQcow2 } from "./qcow2-convert"
 import { startJobHeartbeat } from "./job-heartbeat"
@@ -630,20 +630,13 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
       await appendLog(jobId, `Adding disk to storage "${config.targetStorage}"...`)
       await updateJob(jobId, "transferring", { currentStep: `importing_disk_${i + 1}` })
 
-      // Rename-or-import (#292): when the converted image already sits on the
-      // target storage's filesystem (the default temp dir IS its images/<vmid>
-      // directory), adopting it by rename skips the second full disk copy
-      // `qm disk import` used to do here. With an operator-picked temp storage on
-      // another filesystem the shared module refuses the rename and falls back to
-      // a real (converting) import. Either way it consumes the source file — no
-      // rm -f of the converted image here, after an adoption that file IS the
-      // VM's disk.
-      const vmConf = await pveFetch<Record<string, any>>(
+      // Rename-or-import (#292): the shared helper adopts the converted image by
+      // rename when it already sits on the target storage's filesystem (the
+      // default temp dir IS its images/<vmid> directory), imports it otherwise,
+      // and attaches the result. See adoptImportAndAttachFileVolume.
+      const { volumeId: diskVolume, adopted } = await adoptImportAndAttachFileVolume({
         pveConn,
-        `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-      ).catch(() => null)
-
-      const { volumeId: diskVolume, adopted } = await importOrAdoptFileVolume({
+        targetNode: config.targetNode,
         connectionId: config.targetConnectionId,
         nodeIp,
         sourcePath: importFile,
@@ -651,36 +644,13 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
         imagesDir: targetImagesDir,
         targetVmid: targetVmid!,
         format: importFormat,
-        vmConf,
+        slot: scsiSlot,
+        driveOpts: isFileBased ? ",discard=on" : "",
+        diskLabel: `Disk ${i + 1}`,
         taken: adoptedVolumes,
-        onLog: (m) => appendLog(jobId, m),
-        resolveUnusedVolume: async () => {
-          const conf = await pveFetch<Record<string, any>>(
-            pveConn,
-            `/nodes/${encodeURIComponent(config.targetNode)}/qemu/${targetVmid}/config`,
-          )
-          const unusedKeys = Object.keys(conf).filter(k => k.startsWith("unused")).sort((a, b) => a.localeCompare(b))
-          return unusedKeys.length > 0 ? String(conf[unusedKeys[unusedKeys.length - 1]]) : ""
-        },
+        onLog: (m, level) => appendLog(jobId, m, level),
       })
       if (adopted) adoptedVolumes.push({ volumeId: diskVolume, devicePath: "" })
-
-      // Attach disk to SCSI slot via PVE API
-      const attachBody = new URLSearchParams({
-        [scsiSlot]: `${diskVolume}${isFileBased ? ",discard=on" : ""}`,
-      })
-      try {
-        await pveSetVmConfig(pveConn, config.targetNode, targetVmid!, attachBody)
-        await appendLog(
-          jobId,
-          adopted
-            ? `Disk ${i + 1} attached as ${scsiSlot} (adopted in place, no copy)`
-            : `Disk ${i + 1} imported and attached as ${scsiSlot}`,
-          "success",
-        )
-      } catch (attachErr: any) {
-        await appendLog(jobId, `Warning: Could not auto-attach ${scsiSlot}: ${attachErr.message}`, "warn")
-      }
     }
 
     if (isLive) {


### PR DESCRIPTION
## What

Cold migrations onto a file-based target storage (dir, nfs, cifs, glusterfs, btrfs) used to write the converted disk twice: the conversion produced the image, and the final `qm disk import` re-copied it into the target volume. For a multi-hundred GB or TB VM that doubled the disk I/O and forced the filesystem to hold two copies of the disk at once for the duration of the migration. This PR removes the second write by adopting the converted image in place.

## How

The converted image now lands on the target storage's own filesystem and becomes a volume by being renamed to the canonical `vm-<vmid>-disk-<N>` name, then attached by volid through the VM config API, at O(1) cost. A shared module, `adopt-file-volume`, owns the guard rails so no pipeline reimplements them: both sides must be on the same filesystem (`stat -c %d`), an existing volume is never clobbered (`[ ! -e ]` plus `mv -n`), the free disk index comes from the existing helper so an OVMF `efidisk0` or a `tpmstate0` is skipped, a source/target format mismatch disables the rename because a rename cannot convert, and anything unexpected falls back to `qm disk import` so the migration always completes.

- In-house pipelines (ESXi-direct Linux, XCP-ng): they already converted into `<storage path>/images/<vmid>/`, so the final import was copying the disk inside a single directory. It is replaced by the rename.
- virt-v2v pipeline (vCenter, Hyper-V, Nutanix, ESXi-direct Windows): the conversion is staged on the target storage itself, in `<storage path>/proxcenter-v2v/<jobId>` outside `images/` so a failed run leaves nothing where PVE scans for volumes, asked for qcow2 output, then renamed into `images/<vmid>/`.

Block targets (LVM, LVM-thin, ZFS, RBD, iSCSI) and the warm pipeline already streamed into a pre-allocated volume with `qemu-img convert -n` and are untouched. When the target storage is not positively reported active, the legacy temp-plus-import path is kept, so a dead NFS or CIFS mount fails loudly exactly as before instead of silently filling the root filesystem under the mountpoint.

## Bundled on the same migration dialog

Small fixes requested alongside this work, all on the migration path:

- Drop a dead vSAN guard that blocked cold Windows guests on direct ESXi.
- Require 1x rather than 2x temporary space when the target is a file storage, since the converted image no longer needs a second home there.
- Job detail dialog: copy the full log to the clipboard, and follow the tail while the log streams.

## Testing

Validated end to end against a vCenter source (two thin disks on vSAN, NFC transport) onto a `dir` target: both disks were adopted by rename with no second copy, and the migrated guest booted. The converted qcow2 images check out clean (valid partition table, no zeroed boot sector), stay thin, and the staging directory is removed on success. The regression suites for the shared module, the two rename call sites, the migration guards and the job dialog run in CI.

One operational note worth surfacing to reviewers: the direct-write path asks QEMU for sparse qcow2, which exercises a concurrent write plus write-zeroes code path. A data-loss regression in that path existed briefly in `pve-qemu-kvm` 11.0.0-1 and 11.0.0-2 and is fixed from 11.0.3 onward. Target nodes should run a current `pve-qemu-kvm`; a docs note is being added to say so. The legacy sequential `qm disk import` was never affected, and the fallback keeps that path available.

Closes #292
