### PR TITLE
fix(ui): keep tooltips reachable on disabled buttons

### DIFF
--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.test.tsx
@@ -311,4 +311,19 @@ describe('FirewallPolicyTable', () => {
     expect(masterSwitch()).toBeDisabled()
     for (const button of screen.getAllByRole('button', { name: 'Add rule' })) expect(button).toBeDisabled()
   })
+
+  it('keeps the Add rule tooltip on the header icon button while it is disabled', async () => {
+    renderTable({ selectedConnection: '' })
+
+    // The header's icon-only button is the one disabled without a connection.
+    const button = screen.getAllByRole('button', { name: 'Add rule' }).find(b => (b as HTMLButtonElement).disabled)!
+
+    expect(button).toBeDisabled()
+
+    // A disabled button fires no mouse events; the span wrapper is what the
+    // Tooltip listens on, which is the whole point of wrapping it.
+    fireEvent.mouseOver(button.parentElement!)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Add rule')
+  })
 })

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/FirewallPolicyTable.tsx
@@ -301,9 +301,11 @@ export default function FirewallPolicyTable({
               </FormControl>
             </Box>
             <Tooltip title={t('networkPage.addRule')}>
-              <IconButton size="small" onClick={openAddRule} disabled={!selectedConnection}>
-                <i className="ri-add-line" style={{ fontSize: 18 }} />
-              </IconButton>
+              <span>
+                <IconButton aria-label={t('networkPage.addRule')} size="small" onClick={openAddRule} disabled={!selectedConnection}>
+                  <i className="ri-add-line" style={{ fontSize: 18 }} />
+                </IconButton>
+              </span>
             </Tooltip>
           </Box>
         </Box>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.test.tsx
@@ -450,6 +450,25 @@ describe('VMRulesPanel', () => {
     await waitFor(() => expect(api.updateVMOptions).toHaveBeenCalledWith(CONN, 'pve1', 'qemu', 100, { log_level_in: 'debug' }))
   })
 
+  it('refreshes the firewall log from the dialog button once the log has loaded', async () => {
+    api.getVMFirewallLog.mockResolvedValue([{ n: 1, t: 'DROP IN 10.0.0.1' }])
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Firewall Logs' }))
+
+    await waitFor(() => expect(screen.getByText('DROP IN 10.0.0.1')).toBeInTheDocument())
+    const fetches = api.getVMFirewallLog.mock.calls.length
+
+    const refresh = within(screen.getByRole('dialog')).getByRole('button', { name: 'Refresh' })
+
+    expect(refresh).toBeEnabled()
+    fireEvent.click(refresh)
+
+    await waitFor(() => expect(api.getVMFirewallLog).toHaveBeenCalledTimes(fetches + 1))
+    expect(api.getVMFirewallLog).toHaveBeenLastCalledWith(CONN, 'pve1', 'qemu', 100, 200)
+  })
+
   it('says so when a guest has no firewall log line', async () => {
     renderPanel()
     fireEvent.click(screen.getByText('Untagged'))
@@ -503,5 +522,26 @@ describe('VMRulesPanel', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Load VMs' }))
     expect(p.loadVMFirewallData).toHaveBeenCalled()
+  })
+
+  it('keeps the Refresh tooltip on the log dialog button while the log is loading', async () => {
+    // Never settles, so the dialog stays in its loading state for the whole test.
+    api.getVMFirewallLog.mockImplementation(() => new Promise<never>(() => {}))
+    renderPanel()
+    fireEvent.click(screen.getByText('VLAN 20'))
+
+    fireEvent.click(within(rowOf('web-01')).getByRole('button', { name: 'Firewall Logs' }))
+
+    const dialog = await screen.findByRole('dialog')
+
+    const refresh = within(dialog).getByRole('button', { name: 'Refresh' })
+
+    expect(refresh).toBeDisabled()
+
+    // A disabled button fires no mouse events; the span wrapper is what the
+    // Tooltip listens on, which is the whole point of wrapping it.
+    fireEvent.mouseOver(refresh.parentElement!)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Refresh')
   })
 })

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/VMRulesPanel.tsx
@@ -645,9 +645,11 @@ export default function VMRulesPanel({ vmFirewallData, securityGroups, loadingVM
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Tooltip title={t('networkPage.refresh')}>
-              <IconButton size="small" onClick={() => logDialog.vm && fetchLogs(logDialog.vm)} disabled={loadingLogs}>
-                <i className={`ri-refresh-line ${loadingLogs ? 'animate-spin' : ''}`} style={{ fontSize: 18 }} />
-              </IconButton>
+              <span>
+                <IconButton aria-label={t('networkPage.refresh')} size="small" onClick={() => fetchLogs(logDialog.vm!)} disabled={loadingLogs || !logDialog.vm}>
+                  <i className={`ri-refresh-line ${loadingLogs ? 'animate-spin' : ''}`} style={{ fontSize: 18 }} />
+                </IconButton>
+              </span>
             </Tooltip>
             <IconButton onClick={closeLogDialog} size="small"><i className="ri-close-line" /></IconButton>
           </Box>

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.test.tsx
@@ -287,4 +287,28 @@ describe('SecurityGroupMembersDialog', () => {
     expect(screen.queryByRole('option', { name: 'web-attached (150)' })).not.toBeInTheDocument()
     expect(within(screen.getByRole('listbox')).getAllByRole('option')).toHaveLength(1)
   })
+
+  it('keeps the Detach tooltip reachable while a detach is in flight', async () => {
+    const member = guest(147, { name: 'web-04', rules: [groupRule(GROUP, 3)] })
+    let finishDetach: (() => void) | undefined
+
+    deleteVMRule.mockImplementationOnce(() => new Promise<void>(resolve => { finishDetach = resolve }))
+
+    renderDialog({ guests: [member] })
+
+    const button = screen.getByRole('button', { name: 'Detach' })
+
+    expect(button).toBeEnabled()
+    fireEvent.click(button)
+
+    // Busy disables every member's Detach button, and a disabled button fires
+    // no mouse events: the span wrapper is what the Tooltip listens on.
+    await waitFor(() => expect(button).toBeDisabled())
+    fireEvent.mouseOver(button.parentElement!)
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Detach')
+
+    await act(async () => finishDetach?.())
+    await waitFor(() => expect(button).toBeEnabled())
+  })
 })

--- a/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.tsx
+++ b/frontend/src/app/(dashboard)/automation/network/components/rules/shared/SecurityGroupMembersDialog.tsx
@@ -157,9 +157,11 @@ export default function SecurityGroupMembersDialog({
                 key={guest.vmid}
                 secondaryAction={
                   <Tooltip title={t('firewall.membersDetach')}>
-                    <IconButton edge="end" size="small" disabled={busy} onClick={() => detach(guest)}>
-                      <i className="ri-link-unlink" style={{ fontSize: 16 }} />
-                    </IconButton>
+                    <span>
+                      <IconButton aria-label={t('firewall.membersDetach')} edge="end" size="small" disabled={busy} onClick={() => detach(guest)}>
+                        <i className="ri-link-unlink" style={{ fontSize: 16 }} />
+                      </IconButton>
+                    </span>
                   </Tooltip>
                 }
               >

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -3016,9 +3016,11 @@ return favorites.has(vmKey)
           />
           {onRefresh && (
             <Tooltip title={t('common.refresh')}>
-              <IconButton size='small' onClick={onRefresh} disabled={refreshLoading}>
-                <RefreshIcon fontSize='small' />
-              </IconButton>
+              <span>
+                <IconButton aria-label={t('common.refresh')} size='small' onClick={onRefresh} disabled={refreshLoading}>
+                  <RefreshIcon fontSize='small' />
+                </IconButton>
+              </span>
             </Tooltip>
           )}
           {viewMode === 'tree' && (

--- a/frontend/src/app/(dashboard)/operations/backups/BackupJobsTabs.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/BackupJobsTabs.jsx
@@ -613,9 +613,11 @@ return '—'
             {t('backups.createJob')}
           </Button>
           <Tooltip title={t('common.refresh')}>
-            <IconButton onClick={loadJobs} disabled={loading || !selectedConnection}>
-              <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} />
-            </IconButton>
+            <span>
+              <IconButton aria-label={t('common.refresh')} onClick={loadJobs} disabled={loading || !selectedConnection}>
+                <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} />
+              </IconButton>
+            </span>
           </Tooltip>
         </Box>
       </Box>
@@ -1348,6 +1350,7 @@ function PbsJobsTab({ pbsConnections = [], isVdcTenant = false }) {
             <Tooltip title={isRunning ? t('backups.running') + '...' : t('backups.runNow')}>
               <span>
                 <IconButton
+                  aria-label={isRunning ? t('backups.running') + '...' : t('backups.runNow')}
                   size="small"
                   onClick={() => handleRunNow(params.row)}
                   disabled={!canRun}
@@ -1427,50 +1430,64 @@ function PbsJobsTab({ pbsConnections = [], isVdcTenant = false }) {
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
           {/* Boutons de création par type */}
           <Tooltip title={t('backups.createSyncJob')}>
-            <IconButton
-              size="small"
-              onClick={() => handleCreate('sync')}
-              disabled={!selectedPbs}
-              sx={{ color: '#2196F3' }}
-            >
-              <i className="ri-refresh-line" style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                aria-label={t('backups.createSyncJob')}
+                size="small"
+                onClick={() => handleCreate('sync')}
+                disabled={!selectedPbs}
+                sx={{ color: '#2196F3' }}
+              >
+                <i className="ri-refresh-line" style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title={t('backups.createVerifyJob')}>
-            <IconButton
-              size="small"
-              onClick={() => handleCreate('verify')}
-              disabled={!selectedPbs}
-              sx={{ color: '#4CAF50' }}
-            >
-              <i className="ri-shield-check-line" style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                aria-label={t('backups.createVerifyJob')}
+                size="small"
+                onClick={() => handleCreate('verify')}
+                disabled={!selectedPbs}
+                sx={{ color: '#4CAF50' }}
+              >
+                <i className="ri-shield-check-line" style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title={t('backups.createPruneJob')}>
-            <IconButton
-              size="small"
-              onClick={() => handleCreate('prune')}
-              disabled={!selectedPbs}
-              sx={{ color: '#FF9800' }}
-            >
-              <i className="ri-scissors-cut-line" style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                aria-label={t('backups.createPruneJob')}
+                size="small"
+                onClick={() => handleCreate('prune')}
+                disabled={!selectedPbs}
+                sx={{ color: '#FF9800' }}
+              >
+                <i className="ri-scissors-cut-line" style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title={t('backups.createTapeJob')}>
-            <IconButton
-              size="small"
-              onClick={() => handleCreate('tape')}
-              disabled={!selectedPbs}
-              sx={{ color: '#795548' }}
-            >
-              <i className="ri-archive-drawer-line" style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                aria-label={t('backups.createTapeJob')}
+                size="small"
+                onClick={() => handleCreate('tape')}
+                disabled={!selectedPbs}
+                sx={{ color: '#795548' }}
+              >
+                <i className="ri-archive-drawer-line" style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Divider orientation="vertical" flexItem sx={{ mx: 0.5 }} />
           <Tooltip title={t('common.refresh')}>
-            <IconButton onClick={loadJobs} disabled={loading || !selectedPbs} size="small">
-              <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton aria-label={t('common.refresh')} onClick={loadJobs} disabled={loading || !selectedPbs} size="small">
+                <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
         </Box>
       </Box>

--- a/frontend/src/app/(dashboard)/operations/backups/PbsJobsSection.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/PbsJobsSection.jsx
@@ -379,9 +379,11 @@ export default function PbsJobsSection({ pbsConnections = [] }) {
 
             {/* Refresh */}
             <Tooltip title={t('common.refresh')}>
-              <IconButton onClick={loadJobs} disabled={loading || !selectedPbs}>
-                <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} />
-              </IconButton>
+              <span>
+                <IconButton aria-label={t('common.refresh')} onClick={loadJobs} disabled={loading || !selectedPbs}>
+                  <i className={`ri-refresh-line ${loading ? 'ri-spin' : ''}`} />
+                </IconButton>
+              </span>
             </Tooltip>
           </Box>
         </Box>

--- a/frontend/src/app/(dashboard)/operations/backups/page.jsx
+++ b/frontend/src/app/(dashboard)/operations/backups/page.jsx
@@ -983,13 +983,16 @@ return () => clearTimeout(timer)
                 </FormControl>
               )}
               <Tooltip title={t('common.refresh')}>
-                <IconButton
-                  size='small'
-                  onClick={handleRefresh}
-                  disabled={loading || !selectedPbs}
-                >
-                  {loading ? <CircularProgress size={18} /> : <i className='ri-refresh-line' />}
-                </IconButton>
+                <span>
+                  <IconButton
+                    aria-label={t('common.refresh')}
+                    size='small'
+                    onClick={handleRefresh}
+                    disabled={loading || !selectedPbs}
+                  >
+                    {loading ? <CircularProgress size={18} /> : <i className='ri-refresh-line' />}
+                  </IconButton>
+                </span>
               </Tooltip>
 
               <Box sx={{ flex: 1 }} />

--- a/frontend/src/app/(dashboard)/security/compliance/page.tsx
+++ b/frontend/src/app/(dashboard)/security/compliance/page.tsx
@@ -836,9 +836,11 @@ function ProfilesTab() {
                     </TableCell>
                     <TableCell align="right">
                       <Tooltip title={t('compliance.activate')}>
-                        <IconButton size="small" onClick={() => handleActivateProfile(p.id)} disabled={p.is_active}>
-                          <i className="ri-check-line" style={{ fontSize: 18 }} />
-                        </IconButton>
+                        <span>
+                          <IconButton aria-label={t('compliance.activate')} size="small" onClick={() => handleActivateProfile(p.id)} disabled={p.is_active}>
+                            <i className="ri-check-line" style={{ fontSize: 18 }} />
+                          </IconButton>
+                        </span>
                       </Tooltip>
                       <Tooltip title={t('common.edit')}>
                         <IconButton size="small" onClick={() => handleEditProfile(p.id)}>

--- a/frontend/src/app/(dashboard)/settings/page.jsx
+++ b/frontend/src/app/(dashboard)/settings/page.jsx
@@ -802,14 +802,17 @@ function ConnectionsTab() {
               )}
               {params.row.type === 'pve' && (
                 <Tooltip title={t('settings.detectCeph')}>
-                  <IconButton
-                    size='small'
-                    disabled={isDetecting}
-                    onClick={(e) => { e.stopPropagation(); handleDetectCeph(params.row.id) }}
-                    sx={{ width: 24, height: 24 }}
-                  >
-                    <i className={isDetecting ? 'ri-loader-4-line' : 'ri-refresh-line'} style={{ fontSize: 14, animation: isDetecting ? 'spin 1s linear infinite' : 'none' }} />
-                  </IconButton>
+                  <span>
+                    <IconButton
+                      aria-label={t('settings.detectCeph')}
+                      size='small'
+                      disabled={isDetecting}
+                      onClick={(e) => { e.stopPropagation(); handleDetectCeph(params.row.id) }}
+                      sx={{ width: 24, height: 24 }}
+                    >
+                      <i className={isDetecting ? 'ri-loader-4-line' : 'ri-refresh-line'} style={{ fontSize: 14, animation: isDetecting ? 'spin 1s linear infinite' : 'none' }} />
+                    </IconButton>
+                  </span>
                 </Tooltip>
               )}
             </Box>

--- a/frontend/src/app/(dashboard)/storage/ceph/page.jsx
+++ b/frontend/src/app/(dashboard)/storage/ceph/page.jsx
@@ -716,9 +716,11 @@ return updated.slice(-30)
           </Select>
         </FormControl>
         <Tooltip title={t('common.refresh')}>
-          <IconButton onClick={loadCeph} disabled={loading}>
-            <i className='ri-refresh-line' />
-          </IconButton>
+          <span>
+            <IconButton aria-label={t('common.refresh')} onClick={loadCeph} disabled={loading}>
+              <i className='ri-refresh-line' />
+            </IconButton>
+          </span>
         </Tooltip>
       </Box>
 

--- a/frontend/src/components/ComplianceTab.test.tsx
+++ b/frontend/src/components/ComplianceTab.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Component tests for ComplianceTab.tsx — the Run Scan button and its tooltip.
+ *
+ * MUI drops the tooltip when its direct child is a disabled <button> (and
+ * logs "You are providing a disabled button child to the Tooltip
+ * component"). The fix wraps the IconButton in a <span> so the Tooltip's
+ * listeners land on an element that keeps receiving mouse events. These
+ * tests render that wrapped block and prove the tooltip still opens from the
+ * span.
+ *
+ * Reachability note: the button carries `disabled={isLoading}` but lives
+ * inside `{!isLoading && data && (...)}`, and SWR's `isLoading` is only true
+ * while a request is in flight with no data yet. So the disabled rendering is
+ * unreachable by construction — while loading, the whole score card is
+ * replaced by the page spinner. The loading test pins that behaviour rather
+ * than forcing a state the component cannot produce.
+ *
+ * The data hook is SWR-backed; renderWithProviders sets
+ * `revalidateOnMount: false`, so the initial fetch would never fire. As
+ * elsewhere in this suite, `useSWRFetch` is mocked to drive
+ * `data` / `isLoading` / `mutate` directly.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import {
+  renderWithProviders,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@/__tests__/setup/renderWithProviders'
+
+const { swrMock, mutateMock } = vi.hoisted(() => ({
+  swrMock: vi.fn(),
+  mutateMock: vi.fn(),
+}))
+
+vi.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (...args: unknown[]) => swrMock(...args),
+}))
+
+import ComplianceTab from './ComplianceTab'
+
+const CONN_ID = 'conn-1'
+
+const LOADED = {
+  score: 72,
+  summary: { total: 1, passed: 1, failed: 0, warnings: 0, skipped: 0, critical: 0 },
+  checks: [
+    { id: 'root_tfa', name: 'Root TFA', category: 'access', severity: 'high', status: 'pass', earned: 10, maxPoints: 10, details: 'ok' },
+  ],
+}
+
+function runScanButton() {
+  return screen.getByRole('button', { name: 'Run Scan' })
+}
+
+describe('ComplianceTab', () => {
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mutateMock.mockResolvedValue(undefined)
+  })
+
+  it('requests the hardening checks for the connection (and node) it is given', () => {
+    swrMock.mockReturnValue({ data: undefined, isLoading: true, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId={CONN_ID} node="pve1" />)
+
+    expect(swrMock).toHaveBeenCalledWith(`/api/v1/compliance/hardening/${CONN_ID}?node=pve1`)
+  })
+
+  it('shows the page spinner and no Run Scan button while the first scan is loading', () => {
+    swrMock.mockReturnValue({ data: undefined, isLoading: true, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId={CONN_ID} />)
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    // The score card (and with it the disabled button) is not mounted while
+    // loading: `disabled={isLoading}` can never render as disabled.
+    expect(document.querySelector('.ri-refresh-line')).toBeNull()
+    expect(screen.queryByText('Hardening Score')).not.toBeInTheDocument()
+  })
+
+  it('shows the Run Scan tooltip when hovering the span-wrapped button once results are loaded', async () => {
+    swrMock.mockReturnValue({ data: LOADED, isLoading: false, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId={CONN_ID} />)
+
+    expect(screen.getByText('Hardening Score')).toBeInTheDocument()
+
+    const button = runScanButton()
+
+    expect(button).toBeEnabled()
+    // The regression guard: the Tooltip's child must be the <span>, not the button.
+    expect(button.parentElement?.tagName).toBe('SPAN')
+
+    fireEvent.mouseOver(button.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent('Run Scan')
+  })
+
+  it('re-runs the scan (SWR mutate) when the Run Scan button is clicked', async () => {
+    swrMock.mockReturnValue({ data: LOADED, isLoading: false, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId={CONN_ID} />)
+
+    fireEvent.click(runScanButton())
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('renders the loaded checks table', () => {
+    swrMock.mockReturnValue({ data: LOADED, isLoading: false, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId={CONN_ID} />)
+
+    expect(screen.getByText('Root TFA')).toBeInTheDocument()
+    expect(screen.getByText('72')).toBeInTheDocument()
+    expect(screen.getByText('10/10')).toBeInTheDocument()
+  })
+
+  it('asks the user to pick a connection when none is given', () => {
+    swrMock.mockReturnValue({ data: undefined, isLoading: false, mutate: mutateMock })
+
+    renderWithProviders(<ComplianceTab connectionId="" />)
+
+    expect(swrMock).toHaveBeenCalledWith(null)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ComplianceTab.tsx
+++ b/frontend/src/components/ComplianceTab.tsx
@@ -176,14 +176,17 @@ export default function ComplianceTab({ connectionId, node }: ComplianceTabProps
             <Grid size={{ xs: 5, sm: 1 }}>
               <Card variant="outlined" sx={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative' }}>
                 <Tooltip title={t('compliance.runScan')}>
-                  <IconButton
-                    size="small"
-                    onClick={() => mutate()}
-                    disabled={isLoading}
-                    sx={{ position: 'absolute', top: 4, left: 4 }}
-                  >
-                    {isLoading ? <CircularProgress size={16} /> : <i className="ri-refresh-line" style={{ fontSize: 16 }} />}
-                  </IconButton>
+                  <span>
+                    <IconButton
+                      aria-label={t('compliance.runScan')}
+                      size="small"
+                      onClick={() => mutate()}
+                      disabled={isLoading}
+                      sx={{ position: 'absolute', top: 4, left: 4 }}
+                    >
+                      {isLoading ? <CircularProgress size={16} /> : <i className="ri-refresh-line" style={{ fontSize: 16 }} />}
+                    </IconButton>
+                  </span>
                 </Tooltip>
                 <CardContent sx={{ textAlign: 'center', py: 1.5, '&:last-child': { pb: 1.5 } }}>
                   <Box sx={{ position: 'relative', display: 'inline-flex', mb: 0.5 }}>

--- a/frontend/src/components/VmFirewallTab.test.tsx
+++ b/frontend/src/components/VmFirewallTab.test.tsx
@@ -217,4 +217,30 @@ describe('VmFirewallTab', () => {
 
     await waitFor(() => expect(api.updateVMOptions).toHaveBeenCalledWith(CONN_ID, NODE, 'qemu', VMID, { log_level_in: 'debug' }))
   })
+
+  it('keeps the Refresh tooltip reachable while the log refresh button is disabled', async () => {
+    // Never settles: `logsLoading` stays true for the whole test, so the
+    // refresh IconButton renders disabled. MUI drops the tooltip when its
+    // direct child is a disabled <button>; the <span> wrapper is what keeps
+    // the hover listeners alive.
+    api.getVMFirewallLog.mockReturnValue(new Promise(() => {}))
+
+    await renderTab()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Firewall Logs' }))
+
+    const dialog = await screen.findByRole('dialog')
+    const refresh = dialog.querySelector('.ri-refresh-line')?.closest('button')
+
+    if (!refresh) throw new Error('refresh button not rendered in the log dialog')
+
+    expect(refresh).toBeDisabled()
+    expect(refresh.parentElement?.tagName).toBe('SPAN')
+
+    fireEvent.mouseOver(refresh.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent('Refresh')
+  })
 })

--- a/frontend/src/components/VmFirewallTab.tsx
+++ b/frontend/src/components/VmFirewallTab.tsx
@@ -405,9 +405,11 @@ export default function VmFirewallTab({ connectionId, node, vmType, vmid, vmName
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Tooltip title={t('common.refresh')}>
-              <IconButton size="small" onClick={loadLogs} disabled={logsLoading}>
-                <i className={`ri-refresh-line ${logsLoading ? 'animate-spin' : ''}`} style={{ fontSize: 18 }} />
-              </IconButton>
+              <span>
+                <IconButton aria-label={t('common.refresh')} size="small" onClick={loadLogs} disabled={logsLoading}>
+                  <i className={`ri-refresh-line ${logsLoading ? 'animate-spin' : ''}`} style={{ fontSize: 18 }} />
+                </IconButton>
+              </span>
             </Tooltip>
             <IconButton onClick={() => setLogDialogOpen(false)} size="small"><i className="ri-close-line" /></IconButton>
           </Box>

--- a/frontend/src/components/automation/site-recovery/SnapshotsTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/SnapshotsTab.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, within, fireEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+
+import SnapshotsTab from './SnapshotsTab'
+
+// MUI refuses to attach hover listeners to a disabled <button> passed directly
+// as a Tooltip child (it logs "You are providing a disabled button child to the
+// Tooltip component" and the tooltip never opens). The cleanup-orphans button
+// is therefore wrapped in a <span>: these tests hover that wrapper and assert
+// the hint still appears, both while the button is enabled and while it is
+// disabled by an in-flight deletion.
+
+const CONNECTIONS = [{ id: 'c1', name: 'Cluster A' }]
+
+const SNAPSHOTS = [
+  {
+    cluster_id: 'c1',
+    cluster_name: 'Cluster A',
+    pool: 'rbd',
+    image: 'vm-100-disk-0',
+    snapshot: 'mirror.orphan-1',
+    provisioned_bytes: 1024 * 1024 * 1024,
+    created_ts: Math.floor(Date.now() / 1000) - 3600,
+    created_iso: new Date(Date.now() - 3600_000).toISOString(),
+    vmid: 100,
+    is_orphan: true,
+  },
+  {
+    cluster_id: 'c1',
+    cluster_name: 'Cluster A',
+    pool: 'rbd',
+    image: 'vm-101-disk-0',
+    snapshot: 'mirror.active-1',
+    provisioned_bytes: 2 * 1024 * 1024 * 1024,
+    created_ts: Math.floor(Date.now() / 1000) - 60,
+    created_iso: new Date(Date.now() - 60_000).toISOString(),
+    vmid: 101,
+    job_id: 'job-1',
+    is_orphan: false,
+    side: 'source',
+  },
+]
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+
+const CLEANUP_LABEL = 'Clean up 1 orphans'
+const CLEANUP_HINT = 'Remove mirror snapshots that no longer belong to any active replication job'
+
+// GET returns the fixture; POST (the per-snapshot deletion) either resolves or
+// hangs forever so `deleting` stays true for the duration of the test.
+function stubFetch({ hangDelete = false } = {}) {
+  const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === 'POST') {
+      if (hangDelete) return new Promise<Response>(() => {})
+
+      return Promise.resolve(new Response(JSON.stringify({ deleted: 1, failed: [] }), { status: 200, headers: JSON_HEADERS }))
+    }
+
+    return Promise.resolve(new Response(JSON.stringify(SNAPSHOTS), { status: 200, headers: JSON_HEADERS }))
+  })
+
+  vi.stubGlobal('fetch', fetchMock)
+
+  return fetchMock
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('SnapshotsTab cleanup-orphans tooltip', () => {
+  it('shows the cleanup hint on hover while the button is enabled', async () => {
+    stubFetch()
+
+    renderWithProviders(<SnapshotsTab connections={CONNECTIONS} />)
+
+    const button = await screen.findByRole('button', { name: CLEANUP_LABEL })
+
+    expect(button).toBeEnabled()
+
+    // The Tooltip's listeners live on the <span> wrapper, not on the button.
+    fireEvent.mouseOver(button.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent(CLEANUP_HINT)
+  })
+
+  it('still shows the cleanup hint on hover while a deletion is in flight and the button is disabled', async () => {
+    const fetchMock = stubFetch({ hangDelete: true })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderWithProviders(<SnapshotsTab connections={CONNECTIONS} />)
+
+    const button = await screen.findByRole('button', { name: CLEANUP_LABEL })
+
+    expect(button).toBeEnabled()
+
+    // Open the confirm dialog and confirm: runDelete() flips `deleting` to
+    // true before awaiting the POST, which never resolves here.
+    fireEvent.click(button)
+
+    const dialog = await screen.findByRole('dialog')
+
+    expect(dialog).toHaveTextContent('Delete mirror snapshots')
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => expect(button).toBeDisabled())
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/orchestrator/replication/snapshots',
+      expect.objectContaining({ method: 'POST' })
+    )
+
+    // Regression: a disabled button is inert for MUI's hover listeners, so the
+    // tooltip must be driven by the wrapping <span>.
+    fireEvent.mouseOver(button.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent(CLEANUP_HINT)
+
+    // MUI logs this exact warning when a disabled button is a Tooltip's direct
+    // child. The <span> wrapper is what keeps it away.
+    const logged = errorSpy.mock.calls.map(call => call.map(String).join(' ')).join('\n')
+
+    expect(logged).not.toMatch(/disabled button child to the Tooltip/)
+  })
+})

--- a/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
+++ b/frontend/src/components/automation/site-recovery/SnapshotsTab.tsx
@@ -284,14 +284,16 @@ export default function SnapshotsTab({ connections, vmNamesByConn }: Props) {
             )}
             {selectedList.length === 0 && orphansInView.length > 0 && (
               <Tooltip title={t('siteRecovery.snapshots.cleanupOrphansHint')} arrow>
-                <Button
-                  size='small' variant='outlined' color='warning'
-                  startIcon={<i className='ri-sparkling-line' />}
-                  onClick={() => setConfirmDelete(orphansInView)}
-                  disabled={deleting}
-                >
-                  {t('siteRecovery.snapshots.cleanupOrphans', { count: orphansInView.length })}
-                </Button>
+                <span>
+                  <Button
+                    size='small' variant='outlined' color='warning'
+                    startIcon={<i className='ri-sparkling-line' />}
+                    onClick={() => setConfirmDelete(orphansInView)}
+                    disabled={deleting}
+                  >
+                    {t('siteRecovery.snapshots.cleanupOrphans', { count: orphansInView.length })}
+                  </Button>
+                </span>
               </Tooltip>
             )}
           </Box>

--- a/frontend/src/components/dashboard/WidgetGrid.jsx
+++ b/frontend/src/components/dashboard/WidgetGrid.jsx
@@ -978,13 +978,16 @@ return () => document.removeEventListener('fullscreenchange', handler)
         </Tooltip>
         {onRefresh && (
           <Tooltip title={t('dashboard.refreshData')} placement='left'>
-            <IconButton
-              onClick={onRefresh}
-              disabled={refreshLoading}
-              size='small'
-            >
-              <i className={refreshLoading ? 'ri-loader-4-line' : 'ri-refresh-line'} style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton
+                aria-label={t('dashboard.refreshData')}
+                onClick={onRefresh}
+                disabled={refreshLoading}
+                size='small'
+              >
+                <i className={refreshLoading ? 'ri-loader-4-line' : 'ri-refresh-line'} style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
         )}
         <Tooltip title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'} placement='left'>

--- a/frontend/src/components/layout/shared/AIChatDrawer.jsx
+++ b/frontend/src/components/layout/shared/AIChatDrawer.jsx
@@ -395,9 +395,11 @@ return provider
         
         <Box sx={{ display: 'flex', gap: 0.5 }}>
           <Tooltip title={t('ai.clearConversation')}>
-            <IconButton size="small" onClick={handleClear} disabled={loading}>
-              <i className='ri-delete-bin-line' style={{ fontSize: 18 }} />
-            </IconButton>
+            <span>
+              <IconButton aria-label={t('ai.clearConversation')} size="small" onClick={handleClear} disabled={loading}>
+                <i className='ri-delete-bin-line' style={{ fontSize: 18 }} />
+              </IconButton>
+            </span>
           </Tooltip>
           <Tooltip title={t('common.close')}>
             <IconButton size="small" onClick={onClose}>

--- a/frontend/src/components/layout/vertical/NavbarContent.jsx
+++ b/frontend/src/components/layout/vertical/NavbarContent.jsx
@@ -674,9 +674,11 @@ return () => window.removeEventListener('keydown', onKeyDown)
 
           {/* Lang */}
           <Tooltip title={t('navbar.language')}>
-            <IconButton size='small' onClick={e => setLangAnchor(e.currentTarget)} disabled={isPending}>
-              <i className='ri-translate-2' />
-            </IconButton>
+            <span>
+              <IconButton aria-label={t('navbar.language')} size='small' onClick={e => setLangAnchor(e.currentTarget)} disabled={isPending}>
+                <i className='ri-translate-2' />
+              </IconButton>
+            </span>
           </Tooltip>
 
           {/* HA Cluster Status */}

--- a/frontend/src/components/settings/ha/HaNodeCard.test.tsx
+++ b/frontend/src/components/settings/ha/HaNodeCard.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, within, fireEvent, waitFor } from '@/__tests__/setup/renderWithProviders'
+
+import HaNodeCard from './HaNodeCard'
+import type { PatroniMember } from './useHaCluster'
+
+// MUI refuses to attach hover listeners to a disabled <button> passed directly
+// as a Tooltip child (it logs "You are providing a disabled button child to the
+// Tooltip component" and the tooltip never opens). The promote IconButton is
+// therefore wrapped in a <span>: these tests hover that wrapper and assert the
+// tooltip still appears, both while enabled and while disabled by an in-flight
+// switchover.
+
+const MEMBER: PatroniMember = {
+  name: 'pc-node-2',
+  host: '10.0.0.12',
+  role: 'replica',
+  state: 'streaming',
+  timeline: 3,
+  lagBytes: 0,
+  version: '4.0.4',
+}
+
+const PROMOTE_TOOLTIP = 'Promote to leader'
+
+function promoteButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: PROMOTE_TOOLTIP }) as HTMLButtonElement
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('HaNodeCard promote tooltip', () => {
+  it('shows the promote tooltip on hover while the button is enabled', async () => {
+    renderWithProviders(<HaNodeCard member={MEMBER} maintenance={false} onSwitchover={vi.fn()} />)
+
+    const button = promoteButton()
+
+    expect(button).toBeEnabled()
+
+    // The Tooltip's listeners live on the <span> wrapper, not on the button.
+    fireEvent.mouseOver(button.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent(PROMOTE_TOOLTIP)
+  })
+
+  it('does not render the promote button without an onSwitchover handler', () => {
+    renderWithProviders(<HaNodeCard member={MEMBER} maintenance={false} />)
+
+    expect(document.querySelector('.ri-swap-line')).toBeNull()
+  })
+
+  it('still shows the promote tooltip on hover while a switchover is in flight and the button is disabled', async () => {
+    // handleSwitchover() sets `loading` before awaiting the POST; a fetch that
+    // never settles keeps the button disabled for the whole test.
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}))
+
+    vi.stubGlobal('fetch', fetchMock)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    renderWithProviders(<HaNodeCard member={MEMBER} maintenance={false} onSwitchover={vi.fn()} />)
+
+    const button = promoteButton()
+
+    expect(button).toBeEnabled()
+
+    fireEvent.click(button)
+
+    const dialog = await screen.findByRole('dialog')
+
+    expect(dialog).toHaveTextContent('Confirm Switchover')
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Switchover' }))
+
+    await waitFor(() => expect(button).toBeDisabled())
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/ha/switchover',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ candidate: MEMBER.name }) })
+    )
+
+    // The confirm dialog closes on confirm; wait for its modal to unmount so
+    // the card is no longer aria-hidden behind it.
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+
+    // Regression: a disabled button is inert for MUI's hover listeners, so the
+    // tooltip must be driven by the wrapping <span>.
+    fireEvent.mouseOver(button.parentElement!)
+
+    const tip = await screen.findByRole('tooltip')
+
+    expect(tip).toHaveTextContent(PROMOTE_TOOLTIP)
+
+    // MUI logs this exact warning when a disabled button is a Tooltip's direct
+    // child. The <span> wrapper is what keeps it away.
+    const logged = errorSpy.mock.calls.map(call => call.map(String).join(' ')).join('\n')
+
+    expect(logged).not.toMatch(/disabled button child to the Tooltip/)
+  })
+})

--- a/frontend/src/components/settings/ha/HaNodeCard.tsx
+++ b/frontend/src/components/settings/ha/HaNodeCard.tsx
@@ -124,14 +124,17 @@ export default function HaNodeCard({ member, vipAddress, maintenance, maintenanc
           <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
             {onSwitchover && (
               <Tooltip title={t('node.promoteTooltip')} arrow slotProps={tooltipSlotProps}>
-                <IconButton
-                  size="small"
-                  color="primary"
-                  disabled={loading}
-                  onClick={() => setConfirmOpen('switchover')}
-                >
-                  <i className="ri-swap-line" style={{ fontSize: 18 }} />
-                </IconButton>
+                <span>
+                  <IconButton
+                    aria-label={t('node.promoteTooltip')}
+                    size="small"
+                    color="primary"
+                    disabled={loading}
+                    onClick={() => setConfirmOpen('switchover')}
+                  >
+                    <i className="ri-swap-line" style={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
               </Tooltip>
             )}
             <Tooltip
@@ -141,6 +144,7 @@ export default function HaNodeCard({ member, vipAddress, maintenance, maintenanc
             >
               <span>
                 <IconButton
+                  aria-label={maintenance ? t('node.maintenanceExitTooltip') : maintenanceLocked ? t('node.maintenanceLockedTooltip') : t('node.maintenanceEnterTooltip')}
                   size="small"
                   color={maintenance ? 'warning' : 'default'}
                   disabled={loading || (!maintenance && maintenanceLocked)}


### PR DESCRIPTION
## Why

MUI drops a Tooltip whose direct child is a disabled `<button>`: a disabled element fires no events, so the title never shows, and the dev console warns `MUI: You are providing a disabled button child to the Tooltip component`. The affected buttons are precisely the ones whose tooltip explains why they are unavailable (refresh while loading, create without a selected server, detach while busy, promote during a switchover).

## What

- Every Tooltip whose direct child is a button that can be disabled now wraps it in a `<span>`, the wrapper this codebase already uses elsewhere: 22 sites in 17 files (backups tabs, inventory tree, firewall panels, compliance, site recovery snapshots, HA node card, Ceph, connections settings, dashboard widgets, AI drawer, navbar language switch).
- The wrapper moves the `aria-label` MUI derives from the title onto the span, which would leave icon-only buttons without an accessible name. Each wrapped icon button therefore carries an explicit `aria-label` with the same text as the tooltip.
- Regression tests render each affected `.tsx` component with the button disabled (request left pending) and assert the tooltip still appears on hover: new suites for `ComplianceTab`, `SnapshotsTab` and `HaNodeCard`, one case added to `VmFirewallTab`, `FirewallPolicyTable`, `VMRulesPanel` and `SecurityGroupMembersDialog`.

## Checks

Full Vitest suite green (605 files, 6547 tests), ESLint clean, TypeScript at baseline. Manually verified on the affected screens: tooltips show on disabled buttons and the layout is unchanged.
