### PR TITLE
fix(network-flows): make sFlow configuration succeed, report failures and re-apply after reboot

### DIFF
--- a/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
+++ b/frontend/src/app/(dashboard)/operations/network-flows/FlowsTab.tsx
@@ -100,6 +100,33 @@ function portToService(port: number, protocol: string): string {
   return services[port] || `${port}/${protocol}`
 }
 
+// Empty state for the flow panels.
+//
+// A spinner is only honest while nothing has arrived. Once samples are being
+// decoded and still no flow can be tied to a guest, waiting will not help: the
+// guest interfaces are not visible where the sampling happens. Saying so is the
+// difference between a user who adjusts their setup and one who watches a
+// spinner forever.
+function FlowPanelEmptyState({ totalFlows, activeVMs }: { totalFlows: number; activeVMs: number }) {
+  const t = useTranslations()
+
+  if (totalFlows > 0 && activeVMs === 0) {
+    return (
+      <Alert severity="warning" sx={{ my: 2 }}>
+        <AlertTitle sx={{ fontSize: '0.85rem' }}>{t('networkFlows.noAttributionTitle')}</AlertTitle>
+        <Typography variant="body2">{t('networkFlows.noAttributionHelp')}</Typography>
+      </Alert>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5, py: 4, opacity: 0.5 }}>
+      <CircularProgress size={16} />
+      <Typography variant="body2">{t('networkFlows.waitingForData')}</Typography>
+    </Box>
+  )
+}
+
 export default function FlowsTab() {
   const t = useTranslations()
   const theme = useTheme()
@@ -116,7 +143,12 @@ export default function FlowsTab() {
   const [nodeAgents, setNodeAgents] = useState<Array<{
     node: string; ip: string; connectionId: string; connectionName: string;
     online: boolean; hasOvs: boolean; ovsVersion: string; sflowConfigured: boolean; sflowTarget: string; sflowSampling: number; bridges: string[]
+    portMapError?: string
   }>>([])
+  // Outcome of the last configure run, so a failure is visible instead of silent.
+  const [configResult, setConfigResult] = useState<{
+    configured: number; total: number; failures: Array<{ node: string; error?: string }>
+  } | null>(null)
   const [agentsLoading, setAgentsLoading] = useState(true)
   const [agentsExpanded, setAgentsExpanded] = useState(true)
   const [configuringNodes, setConfiguringNodes] = useState(false)
@@ -299,11 +331,16 @@ export default function FlowsTab() {
       ? [configSingleNode]
       : nodeAgents.filter(n => n.hasOvs && !n.sflowConfigured)
 
-    if (nodesToConfigure.length === 0) return
+    if (nodesToConfigure.length === 0) {
+      setConfigResult({ configured: 0, total: 0, failures: [{ node: '', error: t('networkFlows.noNodeToConfigure') }] })
+
+      return
+    }
 
     setConfigDialogOpen(false)
     setConfigSingleNode(null)
     setConfiguringNodes(true)
+    setConfigResult(null)
     try {
       const res = await fetch('/api/v1/orchestrator/sflow/agents', {
         method: 'POST',
@@ -314,11 +351,26 @@ export default function FlowsTab() {
           samplingRate,
         }),
       })
-      if (res.ok) {
-        // Refresh agent list
-        await loadAgents()
-      }
-    } catch {} finally {
+
+      // The response carries a per-node outcome. Reading it is the whole point:
+      // this action used to return 200 and say nothing when every node failed.
+      const payload = await res.json().catch(() => null)
+      const results: Array<{ node: string; success: boolean; error?: string }> = payload?.results ?? []
+
+      setConfigResult({
+        configured: payload?.configured ?? 0,
+        total: payload?.total ?? nodesToConfigure.length,
+        failures: results.filter(r => !r.success).map(r => ({ node: r.node, error: r.error })),
+      })
+
+      await loadAgents()
+    } catch (e: any) {
+      setConfigResult({
+        configured: 0,
+        total: nodesToConfigure.length,
+        failures: [{ node: '', error: e?.message || t('networkFlows.configureRequestFailed') }],
+      })
+    } finally {
       setConfiguringNodes(false)
     }
   }
@@ -468,6 +520,22 @@ export default function FlowsTab() {
                     </Button>
                   )}
                 </Box>
+                {configResult && (
+                  <Alert
+                    severity={configResult.failures.length === 0 ? 'success' : configResult.configured > 0 ? 'warning' : 'error'}
+                    onClose={() => setConfigResult(null)}
+                    sx={{ mx: 1, mb: 1 }}
+                  >
+                    <AlertTitle sx={{ fontSize: '0.85rem' }}>
+                      {t('networkFlows.configureOutcome', { configured: configResult.configured, total: configResult.total })}
+                    </AlertTitle>
+                    {configResult.failures.map((f, i) => (
+                      <Typography key={`${f.node}-${i}`} variant="body2">
+                        {f.node ? `${f.node}: ${f.error}` : f.error}
+                      </Typography>
+                    ))}
+                  </Alert>
+                )}
                 <Collapse in={agentsExpanded}>
                   <TableContainer sx={{ px: 1, pb: 1.5 }}>
                     <Table size="small">
@@ -530,6 +598,14 @@ export default function FlowsTab() {
                                     <Chip label={t('networkFlows.notConfigured')} size="small" color="warning" variant="outlined" sx={{ height: 20, fontSize: '0.65rem' }} />
                                   ) : (
                                     <Chip label="—" size="small" color="default" variant="outlined" sx={{ height: 20, fontSize: '0.65rem' }} />
+                                  )}
+                                  {/* Only surfaced when the port map push actually failed. Before,
+                                      that failure was swallowed and a node that could never attribute
+                                      a flow looked identical to one simply waiting for traffic. */}
+                                  {agent.portMapError && (
+                                    <Typography variant="caption" display="block" sx={{ color: 'warning.main', fontSize: '0.65rem', mt: 0.25 }}>
+                                      {agent.portMapError}
+                                    </Typography>
                                   )}
                                 </TableCell>
                                 <TableCell sx={{ py: 0.75, fontSize: '0.75rem', fontFamily: 'monospace', color: 'text.secondary' }}>
@@ -648,10 +724,7 @@ export default function FlowsTab() {
                   }}
                 />
                 {topTalkers.length === 0 ? (
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5, py: 4, opacity: 0.5 }}>
-                    <CircularProgress size={16} />
-                    <Typography variant="body2">{t('networkFlows.waitingForData')}</Typography>
-                  </Box>
+                  <FlowPanelEmptyState totalFlows={status?.total_flows ?? 0} activeVMs={status?.active_vms ?? 0} />
                 ) : (
                   <TableContainer sx={{ maxHeight: 400 }}>
                     <Table size="small" stickyHeader>
@@ -736,10 +809,7 @@ export default function FlowsTab() {
                   }}
                 />
                 {topPairs.length === 0 ? (
-                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 1.5, py: 3, opacity: 0.5 }}>
-                    <CircularProgress size={16} />
-                    <Typography variant="body2">{t('networkFlows.waitingForData')}</Typography>
-                  </Box>
+                  <FlowPanelEmptyState totalFlows={status?.total_flows ?? 0} activeVMs={status?.active_vms ?? 0} />
                 ) : (
                   <TableContainer sx={{ maxHeight: 400 }}>
                     <Table size="small" stickyHeader>
@@ -792,9 +862,7 @@ export default function FlowsTab() {
                 </Typography>
               </Box>
               {topPorts.length === 0 ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4, opacity: 0.4 }}>
-                  <Typography variant="body2">{t('networkFlows.waitingForData')}</Typography>
-                </Box>
+                <FlowPanelEmptyState totalFlows={status?.total_flows ?? 0} activeVMs={status?.active_vms ?? 0} />
               ) : (
                 <Box sx={{ height: Math.max(200, topPorts.length * 32 + 40) }}>
                   <ChartContainer>

--- a/frontend/src/app/api/v1/orchestrator/sflow/agents/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/sflow/agents/route.test.ts
@@ -22,17 +22,34 @@ vi.mock('@/lib/ssh/exec', () => ({
   shellEscape: (arg: string) => "'" + arg.replaceAll("'", "'\\''") + "'",
 }))
 
-import { POST } from './route'
+vi.mock('@/lib/audit', () => ({
+  audit: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/sflow/reconciler', () => ({
+  saveDesiredSFlowConfig: vi.fn<(...args: any[]) => Promise<void>>().mockResolvedValue(undefined),
+}))
+
+import { GET, POST } from './route'
 import { getCurrentTenantId, getSessionPrisma } from '@/lib/tenant'
 import { checkPermission } from '@/lib/rbac'
 import { executeSSH } from '@/lib/ssh/exec'
+import { orchestratorFetch } from '@/lib/orchestrator'
+import { audit } from '@/lib/audit'
+import { saveDesiredSFlowConfig } from '@/lib/sflow/reconciler'
 
 const getCurrentTenantIdMock = getCurrentTenantId as any
 const getSessionPrismaMock = getSessionPrisma as any
 const checkPermissionMock = checkPermission as any
 const executeSSHMock = executeSSH as any
+const orchestratorFetchMock = orchestratorFetch as any
+const auditMock = audit as any
+const saveDesiredSFlowConfigMock = saveDesiredSFlowConfig as any
 
 const NODE_REQ = { node: 'pve1', ip: '10.0.0.1', connectionId: 'conn-1' }
+const NODE_REQ_2 = { node: 'pve2', ip: '10.0.0.2', connectionId: 'conn-1' }
+// What the configure command prints when the bridge was set (see configure.ts).
+const ONE_BRIDGE_OK = { success: true, output: 'SFLOW_OK:vmbr0\n' }
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -41,11 +58,11 @@ beforeEach(() => {
   getSessionPrismaMock.mockResolvedValue({
     connection: { findMany: vi.fn().mockResolvedValue([{ id: 'conn-1' }]) },
   })
-  executeSSHMock.mockResolvedValue({ success: true, output: '' })
+  executeSSHMock.mockResolvedValue(ONE_BRIDGE_OK)
 })
 
 describe('POST /sflow/agents — happy path', () => {
-  it('shell-escapes the collector target and coerces the rates into the command', async () => {
+  it('quotes the collector target for ovs-vsctl and coerces the rates into the command', async () => {
     const res = await callRoute(POST as any, {
       method: 'POST',
       body: {
@@ -59,12 +76,26 @@ describe('POST /sflow/agents — happy path', () => {
     const body = await readJson<any>(res)
     expect(body.success).toBe(true)
     expect(body.configured).toBe(1)
+    expect(body.results).toEqual([
+      expect.objectContaining({ node: 'pve1', success: true, bridgesConfigured: 1 }),
+    ])
 
     expect(executeSSHMock).toHaveBeenCalledTimes(1)
     const [, , cmd] = executeSSHMock.mock.calls[0]
-    expect(cmd).toContain("target='10.0.0.5:6343'")
+    // ovs-vsctl needs the target wrapped in literal double quotes, inside the
+    // shell's single quotes. A bare host:port is rejected by ovs-vsctl.
+    expect(cmd).toContain(`target='"10.0.0.5:6343"'`)
+    expect(cmd).not.toContain('clear Bridge')
+    expect(cmd).not.toContain('agent=')
     expect(cmd).toContain('sampling=1024')
     expect(cmd).toContain('polling=15')
+
+    expect(saveDesiredSFlowConfigMock).toHaveBeenCalledWith('tenant-1', {
+      collectorTarget: '10.0.0.5:6343',
+      samplingRate: 1024,
+      pollingInterval: 15,
+    })
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({ resourceType: 'sflow', status: 'success' }))
   })
 
   it('coerces string-typed numeric rates from the body', async () => {
@@ -76,6 +107,52 @@ describe('POST /sflow/agents — happy path', () => {
     const [, , cmd] = executeSSHMock.mock.calls[0]
     expect(cmd).toContain('sampling=256')
     expect(cmd).toContain('polling=20')
+  })
+})
+
+describe('POST /sflow/agents: outcome reporting', () => {
+  it('returns 502 with the reason when no node was configured, and does not store the config', async () => {
+    // The shell exits 0 with an empty bridge list; this used to pass for a success.
+    executeSSHMock.mockResolvedValue({ success: true, output: '' })
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      body: { nodes: [NODE_REQ], collectorTarget: '10.0.0.5:6343' },
+    })
+    expect(res.status).toBe(502)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(false)
+    expect(body.configured).toBe(0)
+    expect(body.error).toMatch(/no OVS bridge/i)
+    expect(body.results[0]).toEqual(expect.objectContaining({ node: 'pve1', success: false }))
+
+    expect(saveDesiredSFlowConfigMock).not.toHaveBeenCalled()
+    expect(auditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceType: 'sflow', status: 'failure', errorMessage: expect.stringContaining('pve1') }),
+    )
+  })
+
+  it('reports a partial outcome per node with a 200 when at least one node succeeded', async () => {
+    executeSSHMock
+      .mockResolvedValueOnce(ONE_BRIDGE_OK)
+      .mockResolvedValueOnce({ success: false, output: '', error: 'ssh: connect to host 10.0.0.2 port 22: No route to host' })
+
+    const res = await callRoute(POST as any, {
+      method: 'POST',
+      body: { nodes: [NODE_REQ, NODE_REQ_2], collectorTarget: '10.0.0.5:6343' },
+    })
+    expect(res.status).toBe(200)
+    const body = await readJson<any>(res)
+    expect(body.success).toBe(true)
+    expect(body.configured).toBe(1)
+    expect(body.total).toBe(2)
+    expect(body.results).toEqual([
+      expect.objectContaining({ node: 'pve1', success: true }),
+      expect.objectContaining({ node: 'pve2', success: false, error: expect.stringContaining('No route to host') }),
+    ])
+
+    expect(saveDesiredSFlowConfigMock).toHaveBeenCalledTimes(1)
+    expect(auditMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'failure' }))
   })
 })
 
@@ -131,4 +208,108 @@ describe('POST /sflow/agents — input validation (command injection)', () => {
       expect(executeSSHMock).not.toHaveBeenCalled()
     })
   }
+})
+
+describe('GET /sflow/agents: node probing and port map push', () => {
+  const MAC_LINES =
+    '/etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=CLIENT\n' +
+    '/etc/pve/nodes/pve3/lxc/109.conf:net0: name=eth0,bridge=vmbr0,hwaddr=AA:BB:CC:DD:EE:FF\n'
+
+  // Dispatch on the command so one mock serves the whole probe sequence.
+  function sshByCommand(opts: { macsFrom: string | null; ovsOn: string[]; sflowOn: string[] }) {
+    return async (_conn: string, ip: string, cmd: string) => {
+      if (cmd.includes('/etc/pve/nodes/')) {
+        if (opts.macsFrom === null || ip !== opts.macsFrom) return { success: false, output: '', error: 'ssh: unreachable' }
+        return { success: true, output: MAC_LINES }
+      }
+      if (cmd.startsWith('ovs-vsctl list-br')) return { success: true, output: opts.ovsOn.includes(ip) ? 'vmbr1\n' : '' }
+      if (cmd.startsWith('which ovs-vsctl')) return { success: true, output: '' }
+      if (cmd.startsWith('ovs-vsctl --version')) return { success: true, output: 'ovs-vsctl (Open vSwitch) 3.5.0\n' }
+      if (cmd.startsWith('ovs-vsctl list sflow')) {
+        return { success: true, output: opts.sflowOn.includes(ip) ? 'agent : []\nsampling : 1\ntargets : ["10.0.0.5:6343"]\n' : '' }
+      }
+      if (cmd.startsWith('ip -o link')) return { success: true, output: '10: ln_CLIENT: <BROADCAST> mtu 1500\n' }
+      throw new Error(`unexpected command ${cmd}`)
+    }
+  }
+
+  function prismaWithHosts() {
+    return {
+      connection: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'conn-1',
+            name: 'LAB',
+            sshKeyEnc: 'enc',
+            hosts: [
+              { node: 'pve1', ip: '10.0.0.1', enabled: true },
+              { node: 'pve2', ip: '10.0.0.2', enabled: true },
+              { node: 'pve-noip', ip: null, enabled: true },
+            ],
+          },
+          // No SSH credential at all: skipped without probing.
+          { id: 'conn-2', name: 'NOKEY', sshKeyEnc: null, sshPassEnc: null, hosts: [{ node: 'x', ip: '10.0.9.9', enabled: true }] },
+          // Credential but no eligible host.
+          { id: 'conn-3', name: 'EMPTY', sshKeyEnc: 'enc', hosts: [{ node: 'y', ip: '10.0.9.8', enabled: false }] },
+        ]),
+      },
+    }
+  }
+
+  it('reads guest MACs from the first node that answers and pushes them with the port map', async () => {
+    // Distinct tenant per test: the route caches results per tenant for 30s.
+    getCurrentTenantIdMock.mockResolvedValue('tenant-get-1')
+    getSessionPrismaMock.mockResolvedValue(prismaWithHosts())
+    // pve1 cannot answer the MAC query, pve2 can: the table must still be complete.
+    executeSSHMock.mockImplementation(sshByCommand({ macsFrom: '10.0.0.2', ovsOn: ['10.0.0.1'], sflowOn: ['10.0.0.1'] }))
+    orchestratorFetchMock.mockResolvedValue({})
+
+    const res = await callRoute(GET as any, { method: 'GET' })
+    expect(res.status).toBe(200)
+    const { data } = await readJson<any>(res)
+
+    expect(data.map((d: any) => d.node)).toEqual(['pve1', 'pve2'])
+    expect(data[0]).toEqual(
+      expect.objectContaining({
+        hasOvs: true,
+        ovsVersion: '3.5.0',
+        sflowConfigured: true,
+        sflowTarget: '10.0.0.5:6343',
+        sflowSampling: 1,
+        bridges: ['vmbr1'],
+        portMapError: '',
+      }),
+    )
+    expect(data[1]).toEqual(expect.objectContaining({ node: 'pve2', hasOvs: false, sflowConfigured: false }))
+
+    // One push, for the OVS node only, carrying the cluster-wide MAC table.
+    expect(orchestratorFetchMock).toHaveBeenCalledTimes(1)
+    const [path, init] = orchestratorFetchMock.mock.calls[0]
+    expect(path).toBe('/sflow/portmap')
+    expect(init.body).toEqual({
+      agent_ip: '10.0.0.1',
+      ip_link_output: expect.stringContaining('ln_CLIENT'),
+      guest_macs: { 'bc:24:11:b6:00:5d': 101, 'aa:bb:cc:dd:ee:ff': 109 },
+    })
+  })
+
+  it('reports a failed port map push on the node instead of swallowing it, with an empty MAC table when no node answers', async () => {
+    getCurrentTenantIdMock.mockResolvedValue('tenant-get-2')
+    getSessionPrismaMock.mockResolvedValue(prismaWithHosts())
+    executeSSHMock.mockImplementation(sshByCommand({ macsFrom: null, ovsOn: ['10.0.0.1', '10.0.0.2'], sflowOn: [] }))
+    orchestratorFetchMock.mockRejectedValue(new Error('orchestrator unreachable'))
+
+    const res = await callRoute(GET as any, { method: 'GET' })
+    expect(res.status).toBe(200)
+    const { data } = await readJson<any>(res)
+
+    expect(data).toHaveLength(2)
+    for (const node of data) {
+      expect(node.hasOvs).toBe(true)
+      expect(node.sflowConfigured).toBe(false)
+      expect(node.portMapError).toBe('orchestrator unreachable')
+    }
+    expect(orchestratorFetchMock).toHaveBeenCalledTimes(2)
+    expect(orchestratorFetchMock.mock.calls[0][1].body.guest_macs).toEqual({})
+  })
 })

--- a/frontend/src/app/api/v1/orchestrator/sflow/agents/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/sflow/agents/route.ts
@@ -2,8 +2,12 @@ import { NextRequest, NextResponse } from "next/server"
 
 import { getCurrentTenantId, getSessionPrisma } from "@/lib/tenant"
 import { orchestratorFetch } from "@/lib/orchestrator"
-import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+import { executeSSH } from "@/lib/ssh/exec"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { audit } from "@/lib/audit"
+import { applySFlowOnNode, type SFlowDesiredConfig } from "@/lib/sflow/configure"
+import { GUEST_MACS_COMMAND, parseGuestMACs } from "@/lib/sflow/guestMacs"
+import { saveDesiredSFlowConfig } from "@/lib/sflow/reconciler"
 
 // sFlow collector target: an "ip:port" / "host:port" string. Constrain it to
 // hostname / IPv4 / IPv6 characters plus the port colon so it can be safely
@@ -24,6 +28,27 @@ interface NodeSFlowStatus {
   sflowTarget: string
   sflowSampling: number
   bridges: string[]
+  // Why the port map push failed, when it did. Swallowing it made a node that
+  // could never attribute a flow look identical to one waiting for traffic.
+  portMapError: string
+}
+
+// Read every guest NIC MAC of a cluster, from any one of its nodes. The command
+// and the parsing live in @/lib/sflow/guestMacs, which documents why the path is
+// what it is.
+//
+// Tries the hosts in turn: one reachable node answers for the whole cluster, and
+// depending on a single one would lose the whole table whenever that node is down.
+async function collectGuestMACs(connId: string, ips: string[]): Promise<Record<string, number>> {
+  for (const ip of ips) {
+    const result = await executeSSH(connId, ip, GUEST_MACS_COMMAND)
+    if (!result.success) continue
+
+    const macs = parseGuestMACs(result.output ?? "")
+    if (Object.keys(macs).length > 0) return macs
+  }
+
+  return {}
 }
 
 // In-memory TTL cache per tenant. Each GET probes every node of every PVE connection
@@ -45,6 +70,7 @@ async function probeHost(
   connName: string,
   nodeName: string,
   ip: string,
+  guestMacs: Record<string, number>,
 ): Promise<NodeSFlowStatus> {
   const nodeStatus: NodeSFlowStatus = {
     node: nodeName,
@@ -58,6 +84,7 @@ async function probeHost(
     sflowTarget: "",
     sflowSampling: 0,
     bridges: [],
+    portMapError: "",
   }
 
   try {
@@ -103,13 +130,23 @@ async function probeHost(
         if (samplingMatch) nodeStatus.sflowSampling = Number.parseInt(samplingMatch[1], 10)
       }
 
-      // Refresh the Go orchestrator port map so sFlow samples can be decoded
-      // with VM context (ifIndex → VMID). Non-critical — don't fail the probe.
-      if (ipLinkResult.success && ipLinkResult.output) {
-        await orchestratorFetch("/sflow/portmap", {
-          method: "POST",
-          body: { agent_ip: ip, ip_link_output: ipLinkResult.output },
-        }).catch(() => {})
+      // Refresh the Go orchestrator port map so sFlow samples can be attributed
+      // to a guest: by ifIndex when the guest port is on the sampled bridge, by
+      // guest MAC otherwise. The failure is reported rather than swallowed,
+      // because a silent failure here is indistinguishable from "no traffic".
+      if ((ipLinkResult.success && ipLinkResult.output) || Object.keys(guestMacs).length > 0) {
+        try {
+          await orchestratorFetch("/sflow/portmap", {
+            method: "POST",
+            body: {
+              agent_ip: ip,
+              ip_link_output: ipLinkResult.output ?? "",
+              guest_macs: guestMacs,
+            },
+          })
+        } catch (e: any) {
+          nodeStatus.portMapError = e?.message || "port map push failed"
+        }
       }
     }
   } catch {
@@ -117,6 +154,41 @@ async function probeHost(
   }
 
   return nodeStatus
+}
+
+// Record the outcome of a configure run. Without this there is no trace at all
+// distinguishing "the user never pressed the button" from "it failed on every
+// node", which is exactly the ambiguity that made this action look inert.
+async function recordSFlowConfigureAudit(
+  results: Array<{ node: string; success: boolean; error?: string; bridgesConfigured?: number }>,
+  collectorTarget: string,
+): Promise<void> {
+  const failures = results.filter(r => !r.success)
+
+  try {
+    await audit({
+      action: "update",
+      category: "nodes",
+      resourceType: "sflow",
+      resourceName: `sFlow -> ${collectorTarget}`,
+      status: failures.length === 0 ? "success" : "failure",
+      errorMessage: failures.length > 0 ? failures.map(f => `${f.node}: ${f.error}`).join("; ") : undefined,
+      details: {
+        collectorTarget,
+        nodes: results.length,
+        configured: results.length - failures.length,
+        perNode: results.map(r => ({
+          node: r.node,
+          success: r.success,
+          bridges: r.bridgesConfigured ?? 0,
+          error: r.error,
+        })),
+      },
+    })
+  } catch {
+    // An audit failure must not mask the configuration result the caller is
+    // about to report.
+  }
 }
 
 // GET /api/v1/orchestrator/sflow/agents — check sFlow status on all nodes
@@ -141,7 +213,12 @@ export async function GET() {
       connections.map(async (conn): Promise<NodeSFlowStatus[]> => {
         if (!conn.sshKeyEnc && !conn.sshPassEnc) return []
         const targets = conn.hosts.filter((h): h is typeof h & { ip: string } => h.enabled && !!h.ip)
-        return Promise.all(targets.map(host => probeHost(conn.id, conn.name, host.node, host.ip)))
+        if (targets.length === 0) return []
+
+        // Cluster-wide, so the first node that answers covers every guest.
+        const guestMacs = await collectGuestMACs(conn.id, targets.map(h => h.ip))
+
+        return Promise.all(targets.map(host => probeHost(conn.id, conn.name, host.node, host.ip, guestMacs)))
       })
     )
     const results: NodeSFlowStatus[] = nested.flat()
@@ -187,13 +264,25 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "pollingInterval must be an integer between 1 and 86400" }, { status: 400 })
     }
 
+    const desiredConfig: SFlowDesiredConfig = {
+      collectorTarget,
+      samplingRate: safeSampling,
+      pollingInterval: safePolling,
+    }
+
     const prisma = await getSessionPrisma()
     const connections = await prisma.connection.findMany({
       where: { type: "pve", sshEnabled: true },
       include: { hosts: true },
     })
 
-    const results: Array<{ node: string; ip: string; success: boolean; error?: string }> = []
+    const results: Array<{
+      node: string
+      ip: string
+      success: boolean
+      error?: string
+      bridgesConfigured?: number
+    }> = []
 
     for (const nodeReq of nodes) {
       const { ip, connectionId } = nodeReq
@@ -204,16 +293,14 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        // Configure sFlow on all OVS bridges
-        const cmd = `for br in $(ovs-vsctl list-br); do ovs-vsctl -- clear Bridge $br sflow; ovs-vsctl -- set Bridge $br sflow=@s -- --id=@s create sflow agent=$br target=${shellEscape(collectorTarget)} header=128 sampling=${safeSampling} polling=${safePolling}; done`
-
-        const result = await executeSSH(conn.id, ip, cmd)
+        const applied = await applySFlowOnNode(conn.id, ip, desiredConfig)
 
         results.push({
           node: nodeReq.node,
           ip,
-          success: result.success,
-          error: result.success ? undefined : result.error,
+          success: applied.success,
+          error: applied.error,
+          bridgesConfigured: applied.bridgesConfigured,
         })
       } catch (e: any) {
         results.push({ node: nodeReq.node, ip, success: false, error: e.message })
@@ -223,14 +310,34 @@ export async function POST(request: NextRequest) {
     const successCount = results.filter(r => r.success).length
 
     // Invalidate the agents cache so the next GET reflects the new sFlow config
-    invalidateAgentsCache(await getCurrentTenantId())
+    const tenantId = await getCurrentTenantId()
+    invalidateAgentsCache(tenantId)
 
-    return NextResponse.json({
-      success: successCount > 0,
-      configured: successCount,
-      total: results.length,
-      results,
-    })
+    // Remember what was asked for, so the reconciler can put it back after a
+    // node loses its OVS database. Only worth storing if it worked somewhere.
+    if (successCount > 0) {
+      await saveDesiredSFlowConfig(tenantId, desiredConfig)
+    }
+
+    await recordSFlowConfigureAudit(results, collectorTarget)
+
+    // A run where every node failed is an error, not a 200 carrying a flag no
+    // caller reads. That silence is what made this action look like a no-op.
+    const status = successCount === 0 ? 502 : 200
+
+    return NextResponse.json(
+      {
+        success: successCount > 0,
+        configured: successCount,
+        total: results.length,
+        results,
+        error:
+          successCount === 0
+            ? results[0]?.error || "sFlow could not be configured on any node"
+            : undefined,
+      },
+      { status }
+    )
   } catch (error: any) {
     return NextResponse.json(
       { error: error.message || "Failed to configure sFlow" },

--- a/frontend/src/instrumentation-node.ts
+++ b/frontend/src/instrumentation-node.ts
@@ -13,6 +13,7 @@ import { startSessionSweeper } from '@/lib/auth/sessionSweeper'
 import { importDiskAssets } from '@/lib/branding/importDiskAssets'
 import { prisma } from '@/lib/db/prisma'
 import { resolveInstanceId, sweepOrphanedMigrationJobs } from '@/lib/migration/orphan-sweep'
+import { startSFlowReconciler } from '@/lib/sflow/reconciler'
 
 export async function registerNode(): Promise<void> {
   // undici 8 negotiates HTTP/2 through ALPN by default. Every hypervisor API we
@@ -55,5 +56,16 @@ export async function registerNode(): Promise<void> {
     // Boot must never depend on this: the rows stay in place and the next
     // boot retries starting the sweeper.
     console.error('[startup] session sweeper failed to start (non-fatal):', err)
+  }
+
+  try {
+    // OVS forgets its sFlow configuration when a node's bridges are recreated,
+    // so a reboot silently stops the flow panels. Nothing used to notice.
+    // Idempotent, so it runs on every replica without leader election.
+    startSFlowReconciler()
+  } catch (err) {
+    // Boot must never depend on this: the nodes simply stay as they are and
+    // the next boot retries starting the reconciler.
+    console.error('[startup] sFlow reconciler failed to start (non-fatal):', err)
   }
 }

--- a/frontend/src/lib/sflow/configure.test.ts
+++ b/frontend/src/lib/sflow/configure.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { executeSSHMock, shellEscapeMock } = vi.hoisted(() => ({
+  executeSSHMock: vi.fn(),
+  shellEscapeMock: vi.fn(),
+}))
+
+vi.mock("@/lib/ssh/exec", () => ({
+  executeSSH: executeSSHMock,
+  shellEscape: shellEscapeMock,
+}))
+
+import {
+  applySFlowOnNode,
+  buildSFlowConfigureCommand,
+  parseConfigureOutput,
+  type SFlowDesiredConfig,
+} from "./configure"
+
+const config: SFlowDesiredConfig = {
+  collectorTarget: "udp:collector.example:6343",
+  samplingRate: 4096,
+  pollingInterval: 30,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  shellEscapeMock.mockImplementation((value: string) => `'${value}'`)
+})
+
+describe("buildSFlowConfigureCommand", () => {
+  it("keeps the SSH allowlist prefix and safe replacement semantics", () => {
+    const command = buildSFlowConfigureCommand(config)
+
+    expect(command.startsWith("for br in $(ovs-vsctl list-br)")).toBe(true)
+    expect(command).not.toMatch(/\bclear\b/)
+    expect(command).not.toMatch(/\bagent=/)
+  })
+
+  it("interpolates the sampling and polling values", () => {
+    const command = buildSFlowConfigureCommand(config)
+
+    expect(command).toContain("sampling=4096")
+    expect(command).toContain("polling=30")
+  })
+
+  // Regression guard for the defect that made this feature never work at all.
+  // `targets` is an OVSDB set of strings: ovs-vsctl rejects a bare host:port
+  // with `unexpected ":" parsing set of 1 or more strings`. Shell quoting is
+  // not enough, because the shell strips its own quotes before ovs-vsctl sees
+  // the value. What must survive is a pair of LITERAL double quotes.
+  // Measured against OVS 3.5.0.
+  it("delivers the target to ovs-vsctl wrapped in literal double quotes", () => {
+    const command = buildSFlowConfigureCommand(config)
+
+    // shellEscape is mocked to the real single-quote behaviour, so this is the
+    // exact argument the shell hands to ovs-vsctl once it strips them.
+    expect(command).toContain(`target='"udp:collector.example:6343"'`)
+  })
+
+  it("passes the collector target through shellEscape", () => {
+    shellEscapeMock.mockReturnValue("'escaped collector target'")
+
+    const command = buildSFlowConfigureCommand(config)
+
+    expect(shellEscapeMock).toHaveBeenCalledWith(`"${config.collectorTarget}"`)
+    expect(command).toContain("target='escaped collector target'")
+  })
+})
+
+describe("parseConfigureOutput", () => {
+  it("counts successful bridge markers and collects failed bridge names", () => {
+    expect(parseConfigureOutput("SFLOW_OK:vmbr0\nSFLOW_OK:vmbr1\nSFLOW_FAILED:vmbr2\n")).toEqual({
+      configured: 2,
+      failedBridges: ["vmbr2"],
+    })
+  })
+
+  it("returns zero configured bridges and no failures for empty output", () => {
+    expect(parseConfigureOutput("")).toEqual({ configured: 0, failedBridges: [] })
+  })
+
+  it("handles mixed output and preserves all failed bridge names", () => {
+    const output = [
+      "ovs-vsctl diagnostic output",
+      "SFLOW_FAILED:vmbr-broken",
+      "SFLOW_OK:vmbr-working",
+      "SFLOW_FAILED:vmbr-other",
+    ].join("\n")
+
+    expect(parseConfigureOutput(output)).toEqual({
+      configured: 1,
+      failedBridges: ["vmbr-broken", "vmbr-other"],
+    })
+  })
+})
+
+describe("applySFlowOnNode", () => {
+  it("succeeds when every bridge is configured", async () => {
+    executeSSHMock.mockResolvedValue({
+      success: true,
+      output: "SFLOW_OK:vmbr0\nSFLOW_OK:vmbr1\n",
+    })
+
+    await expect(applySFlowOnNode("connection-1", "10.0.0.1", config)).resolves.toEqual({
+      success: true,
+      bridgesConfigured: 2,
+      failedBridges: [],
+    })
+    expect(executeSSHMock).toHaveBeenCalledWith(
+      "connection-1",
+      "10.0.0.1",
+      expect.stringMatching(/^for br in \$\(ovs-vsctl list-br\)/),
+    )
+  })
+
+  it("reports partial failures with the failed bridge names", async () => {
+    executeSSHMock.mockResolvedValue({
+      success: true,
+      output: "SFLOW_OK:vmbr0\nSFLOW_FAILED:vmbr1\nSFLOW_FAILED:vmbr2\n",
+    })
+
+    await expect(applySFlowOnNode("connection-1", "10.0.0.1", config)).resolves.toEqual({
+      success: false,
+      bridgesConfigured: 1,
+      failedBridges: ["vmbr1", "vmbr2"],
+      error: "sFlow could not be set on vmbr1, vmbr2",
+    })
+  })
+
+  it("treats empty output as nothing to configure instead of success", async () => {
+    executeSSHMock.mockResolvedValue({ success: true, output: "" })
+
+    const result = await applySFlowOnNode("connection-1", "10.0.0.1", config)
+
+    expect(result).toEqual({
+      success: false,
+      bridgesConfigured: 0,
+      failedBridges: [],
+      error: "no OVS bridge on this node, nothing to configure",
+    })
+    expect(result.error).toContain("nothing to configure")
+  })
+
+  it("returns the SSH error when the command fails without a marker", async () => {
+    executeSSHMock.mockResolvedValue({ success: false, error: "connection refused" })
+
+    await expect(applySFlowOnNode("connection-1", "10.0.0.1", config)).resolves.toEqual({
+      success: false,
+      bridgesConfigured: 0,
+      failedBridges: [],
+      error: "connection refused",
+    })
+  })
+})

--- a/frontend/src/lib/sflow/configure.ts
+++ b/frontend/src/lib/sflow/configure.ts
@@ -1,0 +1,99 @@
+/**
+ * The one place that knows how sFlow is applied to a node.
+ *
+ * Two callers need it: the Configure action in Network Flows, and the periodic
+ * reconciler that puts the configuration back after a node loses it. Keeping
+ * one copy each is how two code paths silently drift apart.
+ */
+import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+
+export interface SFlowDesiredConfig {
+  collectorTarget: string
+  samplingRate: number
+  pollingInterval: number
+}
+
+export interface SFlowApplyResult {
+  success: boolean
+  bridgesConfigured: number
+  failedBridges: string[]
+  error?: string
+}
+
+/**
+ * Build the shell command that configures sFlow on every OVS bridge of a node.
+ *
+ * Three properties this command must keep, each of them a fixed bug:
+ *   - it does NOT clear the existing sFlow first. Setting the column replaces
+ *     the reference anyway, and clearing first left the bridge with no sFlow at
+ *     all whenever the create failed, which is worse than doing nothing.
+ *   - it marks every bridge, because `;` separated statements only surface the
+ *     exit status of the last iteration and an earlier failure was lost.
+ *   - an empty bridge list produces no marker at all, which lets the caller
+ *     tell "nothing to configure" apart from "configured", instead of the loop
+ *     exiting 0 and passing for a success.
+ *
+ * The agent device is deliberately left unset. Pinning it to the bridge broke
+ * on bridges with no IP address, which is the normal case for a bridge that
+ * only carries guest traffic.
+ *
+ * The caller is responsible for validating the values; the target is escaped
+ * here as a second line of defence because it lands in a shell command.
+ */
+export function buildSFlowConfigureCommand(cfg: SFlowDesiredConfig): string {
+  // The target MUST reach ovs-vsctl wrapped in literal double quotes.
+  // `targets` is an OVSDB set of strings, and an unquoted host:port makes
+  // ovs-vsctl fail with `unexpected ":" parsing set of 1 or more strings`.
+  // Shell-quoting alone is not enough: the shell strips its own quotes and
+  // ovs-vsctl then sees the bare value. Measured on OVS 3.5.0.
+  const quotedTarget = shellEscape(`"${cfg.collectorTarget}"`)
+
+  return (
+    `for br in $(ovs-vsctl list-br); do ` +
+    `ovs-vsctl -- --id=@s create sflow target=${quotedTarget} header=128 ` +
+    `sampling=${cfg.samplingRate} polling=${cfg.pollingInterval} -- set Bridge $br sflow=@s ` +
+    `&& echo "SFLOW_OK:$br" || echo "SFLOW_FAILED:$br"; done`
+  )
+}
+
+/** Command that reports whether a node currently has any sFlow collector set. */
+export const SFLOW_PROBE_COMMAND = `ovs-vsctl list sflow 2>/dev/null | grep -c targets || true`
+
+export function parseConfigureOutput(output: string): { configured: number; failedBridges: string[] } {
+  return {
+    configured: (output.match(/SFLOW_OK:/g) || []).length,
+    failedBridges: [...output.matchAll(/SFLOW_FAILED:(\S+)/g)].map(m => m[1]),
+  }
+}
+
+/** Apply the configuration on one node and report precisely what happened. */
+export async function applySFlowOnNode(
+  connectionId: string,
+  ip: string,
+  cfg: SFlowDesiredConfig,
+): Promise<SFlowApplyResult> {
+  const result = await executeSSH(connectionId, ip, buildSFlowConfigureCommand(cfg))
+  const { configured, failedBridges } = parseConfigureOutput(result.output ?? "")
+
+  if (!result.success && configured === 0) {
+    return { success: false, bridgesConfigured: 0, failedBridges, error: result.error || "command failed" }
+  }
+  if (failedBridges.length > 0) {
+    return {
+      success: false,
+      bridgesConfigured: configured,
+      failedBridges,
+      error: `sFlow could not be set on ${failedBridges.join(", ")}`,
+    }
+  }
+  if (configured === 0) {
+    return {
+      success: false,
+      bridgesConfigured: 0,
+      failedBridges: [],
+      error: "no OVS bridge on this node, nothing to configure",
+    }
+  }
+
+  return { success: true, bridgesConfigured: configured, failedBridges: [] }
+}

--- a/frontend/src/lib/sflow/guestMacs.test.ts
+++ b/frontend/src/lib/sflow/guestMacs.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest"
+
+import { GUEST_MACS_COMMAND, parseGuestMACs } from "./guestMacs"
+
+// Real output, taken from a three node lab, asked of a node hosting no guest.
+// That is the case that broke: the answer covers the whole cluster only because
+// the command reads /etc/pve/nodes/*, not the per-node symlink.
+const REAL_OUTPUT = [
+  "/etc/pve/nodes/pve3/qemu-server/100.conf:net0: virtio=BC:24:11:07:B8:AC,bridge=v42fc503",
+  "/etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=CLIENT",
+  "/etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=v42fc503",
+].join("\n")
+
+describe("GUEST_MACS_COMMAND", () => {
+  // `/etc/pve/qemu-server` is a per-node symlink, so it only ever lists the
+  // guests of the node answering. Asking a node that hosts none returned
+  // nothing and no flow was ever attributed. Guard the cluster-wide path.
+  it("reads the cluster-wide path, not the per-node symlink", () => {
+    expect(GUEST_MACS_COMMAND).toContain("/etc/pve/nodes/*/qemu-server/*.conf")
+    expect(GUEST_MACS_COMMAND).toContain("/etc/pve/nodes/*/lxc/*.conf")
+    expect(GUEST_MACS_COMMAND).not.toMatch(/\/etc\/pve\/qemu-server/)
+    expect(GUEST_MACS_COMMAND).not.toMatch(/\/etc\/pve\/lxc/)
+  })
+
+  // The orchestrator authorises SSH commands on an exact prefix
+  // (internal/api/ssh_allowlist.go, entry `grep -H "^net" /etc/pve/`). Changing
+  // the start of this command silently breaks the feature with a 403.
+  it("keeps the prefix the SSH allowlist matches on", () => {
+    expect(GUEST_MACS_COMMAND.startsWith('grep -H "^net" /etc/pve/')).toBe(true)
+  })
+
+  it("cannot fail the whole probe when no config file matches", () => {
+    expect(GUEST_MACS_COMMAND).toContain("|| true")
+  })
+})
+
+describe("parseGuestMACs", () => {
+  it("maps each guest MAC to its guest id", () => {
+    expect(parseGuestMACs(REAL_OUTPUT)).toEqual({
+      "bc:24:11:07:b8:ac": 100,
+      "bc:24:11:b6:00:5d": 101,
+    })
+  })
+
+  // A guest with a pending change yields the live line and the pending one.
+  it("is unaffected by a duplicated line from a pending change", () => {
+    const withPending = [
+      "/etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=CLIENT",
+      "/etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=v42fc503",
+    ].join("\n")
+
+    expect(parseGuestMACs(withPending)).toEqual({ "bc:24:11:b6:00:5d": 101 })
+  })
+
+  it("reads a container NIC, where the address is under hwaddr", () => {
+    const lxc = "/etc/pve/nodes/pve1/lxc/109.conf:net0: name=eth0,bridge=vmbr0,hwaddr=AA:BB:CC:DD:EE:FF,ip=dhcp"
+
+    expect(parseGuestMACs(lxc)).toEqual({ "aa:bb:cc:dd:ee:ff": 109 })
+  })
+
+  it("keeps every NIC of a multi-homed guest", () => {
+    const twoNics = [
+      "/etc/pve/nodes/pve1/qemu-server/200.conf:net0: virtio=AA:00:00:00:00:01,bridge=vmbr0",
+      "/etc/pve/nodes/pve1/qemu-server/200.conf:net1: virtio=AA:00:00:00:00:02,bridge=vmbr1",
+    ].join("\n")
+
+    expect(parseGuestMACs(twoNics)).toEqual({
+      "aa:00:00:00:00:01": 200,
+      "aa:00:00:00:00:02": 200,
+    })
+  })
+
+  // The decoder produces lower case from net.HardwareAddr while Proxmox stores
+  // upper case, so the table has to be normalised on the way in.
+  it("normalises to lower case", () => {
+    const macs = parseGuestMACs(REAL_OUTPUT)
+    for (const key of Object.keys(macs)) {
+      expect(key).toBe(key.toLowerCase())
+    }
+  })
+
+  it("ignores lines carrying no address or no guest id", () => {
+    const noise = [
+      "",
+      "grep: /etc/pve/nodes/*/lxc/*.conf: No such file or directory",
+      "/etc/pve/nodes/pve1/qemu-server/300.conf:net0: virtio,bridge=vmbr0",
+      "/etc/pve/nodes/pve1/qemu-server/notanumber.conf:net0: virtio=AA:BB:CC:DD:EE:01,bridge=vmbr0",
+    ].join("\n")
+
+    expect(parseGuestMACs(noise)).toEqual({})
+  })
+
+  it("returns an empty map for empty output", () => {
+    expect(parseGuestMACs("")).toEqual({})
+  })
+})

--- a/frontend/src/lib/sflow/guestMacs.ts
+++ b/frontend/src/lib/sflow/guestMacs.ts
@@ -1,0 +1,52 @@
+/**
+ * Reading guest NIC MAC addresses off a Proxmox cluster.
+ *
+ * This is what lets a sampled flow be attributed to a guest when the guest's
+ * interface is not a port of the sampled bridge, which is the case for every
+ * guest behind an SDN VNet.
+ */
+
+// Matches an Ethernet address anywhere in a guest NIC line, whichever key
+// carries it: virtio=, e1000=, vmxnet3= for VMs, hwaddr= for containers.
+const MAC_RE = /[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}/
+
+/**
+ * The path matters, and the obvious one is wrong.
+ *
+ * `/etc/pve/qemu-server` is a per-node SYMLINK into `nodes/<local>/qemu-server`,
+ * so it only lists the guests of the node answering the question: asking a node
+ * that happens to host no guest returns nothing and no MAC is ever mapped.
+ * `/etc/pve/nodes/*` is the cluster-wide view, and /etc/pve is a replicated
+ * filesystem, so any member answers for the whole cluster.
+ */
+export const GUEST_MACS_COMMAND =
+  `grep -H "^net" /etc/pve/nodes/*/qemu-server/*.conf /etc/pve/nodes/*/lxc/*.conf 2>/dev/null || true`
+
+/**
+ * Parse the grep output into a MAC (lower case) to guest id map.
+ *
+ * Lines look like:
+ *   /etc/pve/nodes/pve3/qemu-server/101.conf:net0: virtio=BC:24:11:B6:00:5D,bridge=CLIENT
+ *   /etc/pve/nodes/pve3/lxc/109.conf:net0: name=eth0,bridge=vmbr0,hwaddr=AA:BB:CC:DD:EE:FF
+ *
+ * A guest with a pending change yields two lines for the same net index, the
+ * live one and the pending one. Both carry the same MAC and guest id, so the
+ * map is unaffected.
+ *
+ * Keyed by MAC rather than by guest id on purpose: a guest with several NICs
+ * contributes several addresses, and the lookup at attribution time only ever
+ * has a MAC to go on.
+ */
+export function parseGuestMACs(output: string): Record<string, number> {
+  const macs: Record<string, number> = {}
+
+  for (const line of output.split("\n")) {
+    const vmidMatch = /\/(\d+)\.conf:/.exec(line)
+    if (!vmidMatch) continue
+    const macMatch = MAC_RE.exec(line)
+    if (!macMatch) continue
+    macs[macMatch[0].toLowerCase()] = Number.parseInt(vmidMatch[1], 10)
+  }
+
+  return macs
+}

--- a/frontend/src/lib/sflow/reconciler.test.ts
+++ b/frontend/src/lib/sflow/reconciler.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  settingUpsertMock,
+  settingFindManyMock,
+  connectionFindManyMock,
+  executeSSHMock,
+  applySFlowOnNodeMock,
+} = vi.hoisted(() => ({
+  settingUpsertMock: vi.fn(),
+  settingFindManyMock: vi.fn(),
+  connectionFindManyMock: vi.fn(),
+  executeSSHMock: vi.fn(),
+  applySFlowOnNodeMock: vi.fn(),
+}))
+
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: {
+    setting: {
+      upsert: settingUpsertMock,
+      findMany: settingFindManyMock,
+    },
+    connection: {
+      findMany: connectionFindManyMock,
+    },
+  },
+}))
+
+vi.mock("@/lib/ssh/exec", () => ({
+  executeSSH: executeSSHMock,
+}))
+
+vi.mock("@/lib/sflow/configure", () => ({
+  applySFlowOnNode: applySFlowOnNodeMock,
+  SFLOW_PROBE_COMMAND: "sflow-probe-command",
+}))
+
+import {
+  reconcileSFlow,
+  saveDesiredSFlowConfig,
+  SFLOW_DESIRED_CONFIG_KEY,
+  startSFlowReconciler,
+} from "./reconciler"
+
+const desiredConfig = {
+  collectorTarget: "udp:collector.example:6343",
+  samplingRate: 4096,
+  pollingInterval: 30,
+}
+
+function connection(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "connection-1",
+    tenantId: "tenant-1",
+    sshKeyEnc: "encrypted-key",
+    sshPassEnc: null,
+    hosts: [{ enabled: true, ip: "10.0.0.1" }],
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  settingUpsertMock.mockResolvedValue({})
+  settingFindManyMock.mockResolvedValue([])
+  connectionFindManyMock.mockResolvedValue([])
+  executeSSHMock.mockResolvedValue({ success: true, output: "1\n" })
+  applySFlowOnNodeMock.mockResolvedValue({
+    success: true,
+    bridgesConfigured: 1,
+    failedBridges: [],
+  })
+})
+
+describe("saveDesiredSFlowConfig", () => {
+  it("upserts using the setting and tenant composite key", async () => {
+    await saveDesiredSFlowConfig("tenant-1", desiredConfig)
+
+    expect(settingUpsertMock).toHaveBeenCalledWith({
+      where: {
+        key_tenantId: {
+          key: SFLOW_DESIRED_CONFIG_KEY,
+          tenantId: "tenant-1",
+        },
+      },
+      create: {
+        key: SFLOW_DESIRED_CONFIG_KEY,
+        tenantId: "tenant-1",
+        value: desiredConfig,
+      },
+      update: {
+        value: desiredConfig,
+        updatedAt: expect.any(Date),
+      },
+    })
+  })
+})
+
+describe("reconcileSFlow", () => {
+  it("returns an all-zero report when no tenant has stored configuration", async () => {
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 0, reapplied: 0, failed: 0 })
+    expect(connectionFindManyMock).not.toHaveBeenCalled()
+  })
+
+  it("skips malformed stored settings", async () => {
+    settingFindManyMock.mockResolvedValue([
+      {
+        tenantId: "tenant-1",
+        value: { samplingRate: 4096, pollingInterval: 30 },
+      },
+      {
+        tenantId: "tenant-1",
+        value: { ...desiredConfig, samplingRate: 1.5 },
+      },
+      {
+        tenantId: "tenant-1",
+        value: { ...desiredConfig, pollingInterval: 2.5 },
+      },
+    ])
+    connectionFindManyMock.mockResolvedValue([connection()])
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 0, reapplied: 0, failed: 0 })
+    expect(executeSSHMock).not.toHaveBeenCalled()
+    expect(applySFlowOnNodeMock).not.toHaveBeenCalled()
+  })
+
+  it("only considers connections belonging to the setting tenant", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([
+      connection({ id: "wrong-tenant", tenantId: "tenant-2" }),
+      connection({ id: "right-tenant" }),
+    ])
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 1, reapplied: 0, failed: 0 })
+    expect(executeSSHMock).toHaveBeenCalledTimes(1)
+    expect(executeSSHMock).toHaveBeenCalledWith("right-tenant", "10.0.0.1", "sflow-probe-command")
+  })
+
+  it("skips connections without SSH credentials and unusable hosts", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([
+      connection({ id: "no-credentials", sshKeyEnc: null, sshPassEnc: null }),
+      connection({ id: "disabled", hosts: [{ enabled: false, ip: "10.0.0.2" }] }),
+      connection({ id: "no-ip", hosts: [{ enabled: true, ip: null }] }),
+    ])
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 0, reapplied: 0, failed: 0 })
+    expect(executeSSHMock).not.toHaveBeenCalled()
+    expect(applySFlowOnNodeMock).not.toHaveBeenCalled()
+  })
+
+  it("treats a failed probe as unreachable and never reconfigures it", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([connection()])
+    executeSSHMock.mockResolvedValue({ success: false, error: "SSH timeout" })
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 0, reapplied: 0, failed: 0 })
+    expect(applySFlowOnNodeMock).not.toHaveBeenCalled()
+  })
+
+  it("leaves a node with a positive probe count alone", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([connection()])
+    executeSSHMock.mockResolvedValue({ success: true, output: "2\n" })
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 1, reapplied: 0, failed: 0 })
+    expect(applySFlowOnNodeMock).not.toHaveBeenCalled()
+  })
+
+  it("re-applies a node whose probe count is zero", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([connection()])
+    executeSSHMock.mockResolvedValue({ success: true, output: "0\n" })
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 1, reapplied: 1, failed: 0 })
+    expect(applySFlowOnNodeMock).toHaveBeenCalledWith("connection-1", "10.0.0.1", desiredConfig)
+  })
+
+  it("does not count a node with no OVS bridge as a failure", async () => {
+    settingFindManyMock.mockResolvedValue([{ tenantId: "tenant-1", value: desiredConfig }])
+    connectionFindManyMock.mockResolvedValue([connection()])
+    executeSSHMock.mockResolvedValue({ success: true, output: "0\n" })
+    applySFlowOnNodeMock.mockResolvedValue({
+      success: false,
+      bridgesConfigured: 0,
+      failedBridges: [],
+      error: "no OVS bridge on this node, nothing to configure",
+    })
+
+    await expect(reconcileSFlow()).resolves.toEqual({ checked: 1, reapplied: 0, failed: 0 })
+  })
+})
+
+describe("startSFlowReconciler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not run before the first interval elapses", async () => {
+    const reconcile = vi.fn().mockResolvedValue({ checked: 0, reapplied: 0, failed: 0 })
+    const stop = startSFlowReconciler({ intervalMs: 1000, reconcile })
+
+    await vi.advanceTimersByTimeAsync(999)
+    expect(reconcile).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    expect(reconcile).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it("does not overlap a slow pass with later ticks", async () => {
+    let resolvePass: (report: { checked: number; reapplied: number; failed: number }) => void
+    const pending = new Promise<{ checked: number; reapplied: number; failed: number }>(resolve => {
+      resolvePass = resolve
+    })
+    const reconcile = vi.fn().mockReturnValueOnce(pending).mockResolvedValue({
+      checked: 0,
+      reapplied: 0,
+      failed: 0,
+    })
+    const stop = startSFlowReconciler({ intervalMs: 1000, reconcile })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(reconcile).toHaveBeenCalledTimes(1)
+
+    resolvePass!({ checked: 0, reapplied: 0, failed: 0 })
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(reconcile).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("contains a rejected pass inside the timer and continues", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const reconcile = vi.fn().mockRejectedValue(new Error("database unavailable"))
+    const stop = startSFlowReconciler({ intervalMs: 1000, reconcile })
+
+    try {
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(reconcile).toHaveBeenCalledTimes(3)
+      expect(errorSpy).toHaveBeenCalledTimes(3)
+    } finally {
+      stop()
+      errorSpy.mockRestore()
+    }
+  })
+
+  it("returns an idempotent stop function that prevents later passes", async () => {
+    const reconcile = vi.fn().mockResolvedValue({ checked: 0, reapplied: 0, failed: 0 })
+    const stop = startSFlowReconciler({ intervalMs: 1000, reconcile })
+
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(reconcile).toHaveBeenCalledTimes(2)
+    stop()
+    expect(() => stop()).not.toThrow()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(reconcile).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/lib/sflow/reconciler.ts
+++ b/frontend/src/lib/sflow/reconciler.ts
@@ -1,0 +1,149 @@
+/**
+ * Periodic re-application of the sFlow configuration.
+ *
+ * OVS keeps its sFlow setup in its own database, and it is lost whenever the
+ * bridges are recreated, which a Proxmox node does on a network reload or a
+ * reboot. Nothing in the product noticed: a node came back with no sFlow, the
+ * flow panels went quiet, and the only cure was for somebody to spot it and
+ * press Configure again. A customer hit exactly that and reported the action as
+ * doing nothing, because by then it also could not report its own failures.
+ *
+ * This lives in the frontend rather than the orchestrator on purpose: the
+ * orchestrator is handed SSH credentials per request and holds none of its own,
+ * so it cannot open a session by itself.
+ *
+ * Timer discipline copied from sessionSweeper.ts: an in-flight guard so a slow
+ * pass cannot overlap the next tick, unref() so the interval never keeps the
+ * process alive by itself, and an error path that can never throw.
+ */
+import { prisma } from "@/lib/db/prisma"
+import { executeSSH } from "@/lib/ssh/exec"
+import { applySFlowOnNode, SFLOW_PROBE_COMMAND, type SFlowDesiredConfig } from "@/lib/sflow/configure"
+
+export const SFLOW_RECONCILE_INTERVAL_MS = 10 * 60 * 1000
+export const SFLOW_DESIRED_CONFIG_KEY = "sflow.desiredConfig"
+
+export interface SFlowReconcileReport {
+  checked: number
+  reapplied: number
+  failed: number
+}
+
+/** Persist the configuration a successful Configure run asked for. */
+export async function saveDesiredSFlowConfig(tenantId: string, config: SFlowDesiredConfig): Promise<void> {
+  await prisma.setting.upsert({
+    where: { key_tenantId: { key: SFLOW_DESIRED_CONFIG_KEY, tenantId } },
+    create: { key: SFLOW_DESIRED_CONFIG_KEY, tenantId, value: config as unknown as object },
+    update: { value: config as unknown as object, updatedAt: new Date() },
+  })
+}
+
+function isUsableConfig(value: unknown): value is SFlowDesiredConfig {
+  if (!value || typeof value !== "object") return false
+  const c = value as Partial<SFlowDesiredConfig>
+
+  return (
+    typeof c.collectorTarget === "string" &&
+    c.collectorTarget.length > 0 &&
+    Number.isInteger(c.samplingRate) &&
+    Number.isInteger(c.pollingInterval)
+  )
+}
+
+/**
+ * One reconciliation pass over every tenant that has ever configured sFlow.
+ *
+ * A node is only touched when it has OVS bridges and currently reports no
+ * collector at all. A node that is merely unreachable is left alone: this must
+ * never turn a transient SSH failure into a reconfiguration storm.
+ */
+export async function reconcileSFlow(): Promise<SFlowReconcileReport> {
+  const report: SFlowReconcileReport = { checked: 0, reapplied: 0, failed: 0 }
+
+  const desired = await prisma.setting.findMany({ where: { key: SFLOW_DESIRED_CONFIG_KEY } })
+  if (desired.length === 0) return report
+
+  const connections = await prisma.connection.findMany({
+    where: { type: "pve", sshEnabled: true },
+    include: { hosts: true },
+  })
+
+  for (const setting of desired) {
+    if (!isUsableConfig(setting.value)) continue
+    const config = setting.value
+
+    for (const conn of connections) {
+      if (conn.tenantId !== setting.tenantId) continue
+      if (!conn.sshKeyEnc && !conn.sshPassEnc) continue
+
+      for (const host of conn.hosts) {
+        if (!host.enabled || !host.ip) continue
+
+        const probe = await executeSSH(conn.id, host.ip, SFLOW_PROBE_COMMAND)
+        if (!probe.success) continue // unreachable, not drifted
+
+        report.checked++
+        if (Number.parseInt((probe.output ?? "0").trim(), 10) > 0) continue // still configured
+
+        const applied = await applySFlowOnNode(conn.id, host.ip, config)
+        if (applied.success) {
+          report.reapplied++
+        } else if (applied.bridgesConfigured === 0 && applied.failedBridges.length === 0) {
+          // No OVS bridge on this node: nothing to reconcile, not a failure.
+          continue
+        } else {
+          report.failed++
+        }
+      }
+    }
+  }
+
+  return report
+}
+
+export interface SFlowReconcilerOptions {
+  intervalMs?: number
+  reconcile?: () => Promise<SFlowReconcileReport>
+}
+
+/**
+ * Start the periodic reconciliation.
+ *
+ * Safe to run from several replicas: re-applying an sFlow configuration is
+ * idempotent, so no leader election is needed and the only cost of N replicas
+ * is a redundant probe per interval.
+ *
+ * @returns A stop() function, safe to call multiple times.
+ */
+export function startSFlowReconciler(options: SFlowReconcilerOptions = {}): () => void {
+  const { intervalMs = SFLOW_RECONCILE_INTERVAL_MS, reconcile = reconcileSFlow } = options
+  let stopped = false
+  let inFlight = false
+
+  const tick = () => {
+    if (stopped || inFlight) return
+    inFlight = true
+    reconcile()
+      .then(report => {
+        if (report.reapplied > 0 || report.failed > 0) {
+          console.log(
+            `[sflow-reconciler] checked ${report.checked} nodes, re-applied ${report.reapplied}, failed ${report.failed}`
+          )
+        }
+      })
+      .catch(e => {
+        console.error("[sflow-reconciler] pass failed:", e?.message || e)
+      })
+      .finally(() => {
+        inFlight = false
+      })
+  }
+
+  const timer = setInterval(tick, intervalMs)
+  timer.unref?.()
+
+  return () => {
+    stopped = true
+    clearInterval(timer)
+  }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7134,7 +7134,12 @@
     "samplingHigh": "⚡ Hohe Präzision — geeignet für Netzwerke unter 1 Gbit/s",
     "samplingBalanced": "✓ Gutes Verhältnis von Präzision und Leistung — für die meisten Fälle empfohlen",
     "samplingLight": "✓ Ressourcenschonend — geeignet für Netzwerke ab 10 Gbit/s",
-    "samplingVeryLight": "📉 Sehr ressourcenschonend — kann Datenströme mit geringem Volumen übersehen"
+    "samplingVeryLight": "📉 Sehr ressourcenschonend — kann Datenströme mit geringem Volumen übersehen",
+    "noAttributionTitle": "Samples treffen ein, aber kein Flow kann einer VM zugeordnet werden",
+    "noAttributionHelp": "Die Agents funktionieren, die sFlow-Daten werden dekodiert. Für die Zuordnung muss der Gastverkehr dort sichtbar sein, wo das Sampling erfolgt: Eine Gast-NIC muss eine OVS-Bridge erreichen. In einem SDN-VNet verbleibt der Verkehr zwischen zwei Gästen desselben VNets auf der Linux-Bridge und wird nie erfasst.",
+    "noNodeToConfigure": "Kein Node muss konfiguriert werden.",
+    "configureRequestFailed": "Die Konfigurationsanfrage ist fehlgeschlagen.",
+    "configureOutcome": "sFlow auf {configured} von {total} Nodes konfiguriert"
   },
   "myVdc": {
     "title": "Mein Datacenter",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7193,7 +7193,12 @@
     "samplingHigh": "⚡ High precision — suitable for networks under 1 Gbps",
     "samplingBalanced": "✓ Good precision/performance trade-off — recommended for most cases",
     "samplingLight": "✓ Lightweight — suitable for 10 Gbps+ networks",
-    "samplingVeryLight": "📉 Very lightweight — may miss low-volume flows"
+    "samplingVeryLight": "📉 Very lightweight — may miss low-volume flows",
+    "noAttributionTitle": "Samples are arriving, but no flow can be attributed to a VM",
+    "noAttributionHelp": "The agents are working, sFlow data is being decoded. Attribution needs guest traffic to be visible where sampling happens: a guest NIC must reach an OVS bridge. On an SDN VNet, traffic between two guests of the same VNet stays on the Linux bridge and is never sampled.",
+    "noNodeToConfigure": "No node needs configuring.",
+    "configureRequestFailed": "The configuration request failed.",
+    "configureOutcome": "sFlow configured on {configured} of {total} nodes"
   },
   "vdc": {
     "title": "Virtual Datacenters",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7193,7 +7193,12 @@
     "samplingHigh": "⚡ Alta precisión — adecuado para redes de menos de 1 Gbps",
     "samplingBalanced": "✓ Buen equilibrio precisión/rendimiento — recomendado para la mayoría de los casos",
     "samplingLight": "✓ Ligero — adecuado para redes de 10 Gbps o más",
-    "samplingVeryLight": "📉 Muy ligero — puede pasar por alto flujos de bajo volumen"
+    "samplingVeryLight": "📉 Muy ligero — puede pasar por alto flujos de bajo volumen",
+    "noAttributionTitle": "Se están recibiendo muestras, pero no se puede atribuir ningún flujo a una VM",
+    "noAttributionHelp": "Los agentes funcionan y los datos sFlow se están decodificando. Para la atribución, el tráfico de los invitados debe ser visible donde se realiza el muestreo: una NIC de invitado debe llegar a un bridge OVS. En un VNet SDN, el tráfico entre dos invitados del mismo VNet permanece en el bridge Linux y nunca se muestrea.",
+    "noNodeToConfigure": "No hay ningún nodo que configurar.",
+    "configureRequestFailed": "La solicitud de configuración ha fallado.",
+    "configureOutcome": "sFlow configurado en {configured} de {total} nodos"
   },
   "vdc": {
     "title": "Datacenters virtuales",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7194,7 +7194,12 @@
     "samplingHigh": "⚡ Haute précision — adapté aux réseaux de moins de 1 Gbps",
     "samplingBalanced": "✓ Bon compromis précision/performance — recommandé pour la plupart des cas",
     "samplingLight": "✓ Léger — adapté aux réseaux 10 Gbps+",
-    "samplingVeryLight": "📉 Très léger — peut manquer des flux de faible volume"
+    "samplingVeryLight": "📉 Très léger — peut manquer des flux de faible volume",
+    "noAttributionTitle": "Des échantillons arrivent, mais aucun flux n'est attribué à une VM",
+    "noAttributionHelp": "Les agents fonctionnent, les données sFlow sont bien décodées. L'attribution exige que le trafic des invités soit visible là où l'échantillonnage a lieu : une carte d'invité doit atteindre un bridge OVS. Sur un VNet SDN, le trafic entre deux invités du même VNet reste sur le bridge Linux et n'est jamais échantillonné.",
+    "noNodeToConfigure": "Aucun nœud à configurer.",
+    "configureRequestFailed": "La requête de configuration a échoué.",
+    "configureOutcome": "sFlow configuré sur {configured} nœud(s) sur {total}"
   },
   "vdc": {
     "title": "Datacenters Virtuels",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7193,7 +7193,12 @@
     "samplingHigh": "⚡ 높은 정밀도 — 1 Gbps 미만 네트워크에 적합",
     "samplingBalanced": "✓ 정밀도와 성능의 균형 — 대부분의 경우 권장",
     "samplingLight": "✓ 가벼움 — 10 Gbps 이상 네트워크에 적합",
-    "samplingVeryLight": "📉 매우 가벼움 — 소량 플로우를 놓칠 수 있음"
+    "samplingVeryLight": "📉 매우 가벼움 — 소량 플로우를 놓칠 수 있음",
+    "noAttributionTitle": "샘플이 수신되고 있지만 어떤 플로우도 VM에 귀속되지 않습니다",
+    "noAttributionHelp": "에이전트가 정상 작동 중이며 sFlow 데이터도 디코딩되고 있습니다. 귀속을 위해서는 샘플링이 수행되는 위치에서 게스트 트래픽이 보여야 합니다. 즉, 게스트 NIC가 OVS 브리지에 연결되어야 합니다. SDN VNet에서는 동일한 VNet에 속한 두 게스트 간 트래픽이 Linux 브리지에 머물러 샘플링되지 않습니다.",
+    "noNodeToConfigure": "구성할 노드가 없습니다.",
+    "configureRequestFailed": "구성 요청에 실패했습니다.",
+    "configureOutcome": "{configured}개 노드에 sFlow 구성 완료(전체 {total}개)"
   },
   "vdc": {
     "title": "가상 데이터센터",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7136,7 +7136,12 @@
     "samplingHigh": "⚡ 高精度 — 适用于低于 1 Gbps 的网络",
     "samplingBalanced": "✓ 精度/性能兼顾 — 适用于大多数场景",
     "samplingLight": "✓ 轻量 — 适用于 10 Gbps 及以上网络",
-    "samplingVeryLight": "📉 非常轻量 — 可能会遗漏低流量的流"
+    "samplingVeryLight": "📉 非常轻量 — 可能会遗漏低流量的流",
+    "noAttributionTitle": "正在接收样本，但无法将任何流量归属到 VM",
+    "noAttributionHelp": "代理工作正常，sFlow 数据正在被解码。要进行归属，必须能在采样位置看到客户机流量：客户机 NIC 必须经过 OVS 网桥。在 SDN VNet 上，同一 VNet 内两个客户机之间的流量会停留在 Linux 网桥上，永远不会被采样。",
+    "noNodeToConfigure": "没有需要配置的节点。",
+    "configureRequestFailed": "配置请求失败。",
+    "configureOutcome": "已在 {configured} 个节点上配置 sFlow，共 {total} 个节点"
   },
   "myVdc": {
     "title": "我的数据中心",


### PR DESCRIPTION
## Summary

Fixes the sFlow configuration action in Network Flows, which could never succeed and hid its failure, and makes flow attribution work on SDN topologies where guest interfaces are not ports of the sampled OVS bridge.

Closes #708. Also addresses #689 (empty panels while samples are received), whose real cause turned out to be the attribution mechanism rather than the missing `fwpr` regex; the orchestrator side of that fix is a separate change.

## The configure command could never succeed

`ovs-vsctl` stores `targets` as an OVSDB set of strings and requires the collector target wrapped in literal double quotes. The command escaped it with single quotes only, which the shell strips before exec, so every `create` failed with `unexpected ":" parsing set of 1 or more strings`. Because the existing sFlow row was cleared before the create, each press of Configure destroyed the existing configuration and put nothing back, which is exactly the reported "it used to work, it stopped, reconfiguring does nothing".

- The command now lives in `lib/sflow/configure.ts`, shared by the action and the reconciler. It quotes the target for `ovs-vsctl`, sets the new row without clearing first, leaves the `agent` device unset (pinning it to a bridge with no IPv4 address broke datagram emission), and prints a marker per bridge so a failure on one bridge is not lost behind the exit status of the last iteration.
- An empty bridge list no longer passes for a success: it is reported as "no OVS bridge on this node, nothing to configure".

## The action now reports what happened

- The route returns 502 when no node was configured, with the reason, instead of a 200 carrying a `success: false` nobody read.
- Per node results (bridges configured, error) are returned and shown in the UI; the `if (res.ok)` without else and the empty `catch` are gone.
- An audit entry is written for every run with the per node outcome.
- The wanted configuration is stored in the generic `Setting` table (no migration) and a reconciler started from `instrumentation-node.ts` re-applies it every 10 minutes on any node that has OVS bridges and reports no collector, so a node whose bridges were recreated after a reboot comes back on its own. Unreachable nodes are left alone.

## Attribution by guest MAC

On an SDN VNet the guest `tap` is attached to a Linux bridge that reaches OVS through `ln_<vnet>`, so samples carry the ifIndex of the uplink, never the guest's. The route now reads every guest NIC MAC from `/etc/pve/nodes/*/{qemu-server,lxc}/*.conf` (cluster-wide, one SSH call per cluster, tries hosts in turn) and pushes the table to the orchestrator along with the port map. A failed push is surfaced on the node row instead of looking like "waiting for traffic", and the UI warns explicitly when flows are received but no VM is attributed.

## Verification

- Vitest: 55 tests across `lib/sflow` and the route (quoting, marker parsing, partial failures, 502 path, GET probing and port map push, reconciler pass). New code coverage computed with the Sonar formula: 90.8%.
- Lab, through the real route and UI on a 3 node cluster with an OVS bridge carrying an SDN VNet (OVS 3.5.0): configure after a simulated loss (`ovs-vsctl clear Bridge vmbr1 sflow`) returns 200 with 2/3 nodes configured and the OVS-less node reported explicitly; a single OVS-less node returns 502; the collector receives samples and the guest shows up in Top Talkers attributed by MAC; the reconciler re-applied a cleared node at the next tick.
