### PR TITLE
Console: VM power actions in the SPICE console and single-line toolbars

### DIFF
--- a/frontend/public/console/console-ui.bundle.js
+++ b/frontend/public/console/console-ui.bundle.js
@@ -28,6 +28,7 @@ var ConsoleUI = (() => {
     MIN_GUEST_HEIGHT: () => MIN_GUEST_HEIGHT,
     MIN_GUEST_WIDTH: () => MIN_GUEST_WIDTH,
     SCALING_MODES: () => SCALING_MODES,
+    VM_ACTIONS: () => VM_ACTIONS,
     computeFitScale: () => computeFitScale,
     computeGuestResolution: () => computeGuestResolution,
     debounce: () => debounce,
@@ -38,10 +39,12 @@ var ConsoleUI = (() => {
     keyComboSequence: () => keyComboSequence,
     loadScalingMode: () => loadScalingMode,
     parseScalingMode: () => parseScalingMode,
+    parseVmStatus: () => parseVmStatus,
     rfbFlagsForScalingMode: () => rfbFlagsForScalingMode,
     saveScalingMode: () => saveScalingMode,
     scalingStorageKey: () => scalingStorageKey,
-    toggleFullscreen: () => toggleFullscreen
+    toggleFullscreen: () => toggleFullscreen,
+    vmActionsEnabled: () => vmActionsEnabled
   });
   var SCALING_MODES = ["off", "scale", "remote"];
   var DEFAULT_SCALING_MODE = "scale";
@@ -156,6 +159,21 @@ var ConsoleUI = (() => {
     const down = found.strokes.map((s) => ({ ...s, down: true }));
     const up = [...found.strokes].reverse().map((s) => ({ ...s, down: false }));
     return [...down, ...up];
+  }
+  var VM_ACTIONS = ["start", "shutdown", "stop", "suspend"];
+  var VM_STATUSES = ["running", "stopped", "paused", "unknown"];
+  function parseVmStatus(raw) {
+    return VM_STATUSES.includes(raw) ? raw : "unknown";
+  }
+  function vmActionsEnabled(status) {
+    const parsed = parseVmStatus(status);
+    const running = parsed === "running";
+    return {
+      start: !running,
+      shutdown: running,
+      stop: parsed !== "stopped",
+      suspend: running
+    };
   }
   function debounce(fn, delayMs) {
     let timer = null;

--- a/frontend/public/novnc/console.html
+++ b/frontend/public/novnc/console.html
@@ -17,18 +17,23 @@
     #toolbar {
       display: flex; align-items: center; justify-content: space-between;
       padding: 8px 16px; background: #111; border-bottom: 1px solid #333; flex-shrink: 0;
-      flex-wrap: wrap; row-gap: 6px;
+      flex-wrap: nowrap;
     }
-    /* Le nom de la VM cède la place avant les boutons: la barre porte assez de
-       contrôles pour dépasser la largeur d'une fenêtre de console 1024px. */
-    #toolbar .info { display: flex; align-items: center; gap: 12px; min-width: 0; flex: 1 1 auto; }
-    #status-dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; }
+    /* Une seule ligne, toujours. Ordre de compression quand la fenêtre se
+       resserre: d'abord le nom de la VM (ellipse, poids de flex-shrink élevé),
+       puis les deux sélecteurs (min-width 0, leur texte se tronque), et les
+       boutons ne bougent jamais. Sans ce poids, flex répartirait la
+       compression au prorata des largeurs et rognerait les sélecteurs alors
+       que le nom a encore de la place. */
+    #toolbar .info { display: flex; align-items: center; gap: 12px; min-width: 140px; flex: 1 100 auto; overflow: hidden; }
+    #status-dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; flex-shrink: 0; }
     #status-dot.connected { background: #22c55e; }
     #status-dot.connecting { background: #f59e0b; }
     #status-dot.error { background: #ef4444; }
-    #vm-info { color: #fff; font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    #status-text { color: #666; font-size: 12px; }
-    #toolbar .vm-actions { display: flex; gap: 4px; margin: 0 16px; }
+    #vm-info { color: #fff; font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    /* Le texte de statut cède avant le nom: la pastille dit déjà l'état. */
+    #status-text { color: #666; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; flex-shrink: 100; }
+    #toolbar .vm-actions { display: flex; gap: 4px; margin: 0 8px; flex-shrink: 0; }
     #toolbar .vm-actions button {
       padding: 6px 10px; font-size: 16px; background: transparent; border: none;
       color: #888; cursor: pointer; border-radius: 4px; display: flex; align-items: center;
@@ -44,7 +49,8 @@
     #toolbar .vm-actions button.btn-pause { color: #3b82f6; }
     #toolbar .vm-actions button.btn-pause:hover { background: #1e3a8a; }
     #toolbar .vm-actions button.loading { opacity: 0.5; pointer-events: none; }
-    #toolbar .buttons { display: flex; gap: 8px; align-items: center; flex-shrink: 0; }
+    #toolbar .buttons { display: flex; gap: 6px; align-items: center; min-width: 0; }
+    #toolbar .buttons button { flex-shrink: 0; }
     button {
       padding: 6px 12px; font-size: 12px; background: #333; color: #fff;
       border: 1px solid #444; border-radius: 4px; cursor: pointer;
@@ -72,8 +78,10 @@
     }
     #toolbar select {
       padding: 5px 8px; font-size: 12px; background: #333; color: #fff;
-      border: 1px solid #444; border-radius: 4px; cursor: pointer; max-width: 150px;
+      border: 1px solid #444; border-radius: 4px; cursor: pointer; max-width: 150px; min-width: 0;
     }
+    /* Un déclencheur, pas un état: son libellé court n'a pas besoin de la même largeur. */
+    #sendkey { max-width: 120px; }
     #toolbar select:disabled { background: #222; color: #666; cursor: not-allowed; }
     #toolbar .buttons button.icon { padding: 6px 9px; font-size: 14px; line-height: 1; }
     #toolbar .buttons button.active { background: #1e3a8a; border-color: #3b82f6; }
@@ -342,22 +350,16 @@ node bundle-novnc.js
       statusText.textContent = `• ${text}`;
     }
     
-    // Mettre à jour l'état des boutons selon le status de la VM
+    // Les règles vivent dans ConsoleUI, partagées avec la console SPICE pour
+    // que les deux barres offrent les mêmes actions dans les mêmes états.
     function updateVmButtons() {
-      const isRunning = vmStatus === 'running';
-      const isStopped = vmStatus === 'stopped';
-      const isPaused = vmStatus === 'paused';
-      
-      btnStart.disabled = isRunning;
-      btnShutdown.disabled = !isRunning;
-      btnStop.disabled = isStopped;
-      btnPause.disabled = !isRunning;
-      
-      // Opacité visuelle
-      btnStart.style.opacity = isRunning ? '0.3' : '1';
-      btnShutdown.style.opacity = !isRunning ? '0.3' : '1';
-      btnStop.style.opacity = isStopped ? '0.3' : '1';
-      btnPause.style.opacity = !isRunning ? '0.3' : '1';
+      const enabled = ConsoleUI.vmActionsEnabled(vmStatus);
+      const buttons = { start: btnStart, shutdown: btnShutdown, stop: btnStop, suspend: btnPause };
+
+      ConsoleUI.VM_ACTIONS.forEach(function(action) {
+        buttons[action].disabled = !enabled[action];
+        buttons[action].style.opacity = enabled[action] ? '1' : '0.3';
+      });
     }
     
     // Récupérer le status de la VM
@@ -367,7 +369,7 @@ node bundle-novnc.js
         const res = await fetch(apiUrl);
         if (res.ok) {
           const json = await res.json();
-          vmStatus = json?.data?.status || 'unknown';
+          vmStatus = ConsoleUI.parseVmStatus(json?.data?.status);
 
           const name = json?.data?.name;
 

--- a/frontend/public/spice/console.html
+++ b/frontend/public/spice/console.html
@@ -9,18 +9,43 @@
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html, body { width: 100%; height: 100%; overflow: hidden; background: #0c0c0c; color: #ccc;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-    /* Colonne flex plutôt qu'une zone en absolu sous une barre de 41px codée en
-       dur: la barre porte maintenant assez de contrôles pour passer à la ligne
-       dans une fenêtre étroite, et elle recouvrirait l'écran de l'invité. */
+    /* Colonne flex plutôt qu'une zone en absolu sous une barre de hauteur
+       codée en dur: la barre reste sur une seule ligne, c'est le nom de la VM
+       qui cède la place (ellipse) devant les contrôles, jamais l'inverse. */
     body { display: flex; flex-direction: column; }
     #toolbar { display: flex; align-items: center; gap: 12px; padding: 8px 16px;
       background: #111; border-bottom: 1px solid #333; flex-shrink: 0;
-      flex-wrap: wrap; row-gap: 6px; }
+      flex-wrap: nowrap; }
+    /* Ordre de compression, comme sur la console noVNC: le nom d'abord (poids
+       de flex-shrink élevé), le sélecteur ensuite, les boutons jamais. */
+    #toolbar .info { display: flex; align-items: center; gap: 12px; min-width: 140px; flex: 1 100 auto; overflow: hidden; }
     #dot { width: 8px; height: 8px; border-radius: 50%; background: #6b7280; flex-shrink: 0; }
     #dot.connected { background: #22c55e; } #dot.connecting { background: #f59e0b; } #dot.error { background: #ef4444; }
-    #title { font-weight: 600; color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    #status { color: #888; font-size: 12px; white-space: nowrap; }
-    #toolbar .buttons { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+    #title { font-weight: 600; color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+    /* Le texte de statut cède avant le nom: la pastille dit déjà l'état. */
+    #status { color: #888; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; flex-shrink: 100; }
+    #toolbar .vm-actions { display: flex; gap: 4px; margin: 0 4px; flex-shrink: 0; }
+    #toolbar .vm-actions button {
+      padding: 6px 10px; font-size: 16px; background: transparent; border: none;
+      color: #888; cursor: pointer; border-radius: 4px; display: flex; align-items: center;
+    }
+    #toolbar .vm-actions button:hover { background: #333; color: #fff; }
+    #toolbar .vm-actions button.btn-start { color: #22c55e; }
+    #toolbar .vm-actions button.btn-start:hover { background: #14532d; }
+    #toolbar .vm-actions button.btn-shutdown { color: #f59e0b; }
+    #toolbar .vm-actions button.btn-shutdown:hover { background: #78350f; }
+    #toolbar .vm-actions button.btn-stop { color: #ef4444; }
+    #toolbar .vm-actions button.btn-stop:hover { background: #7f1d1d; }
+    #toolbar .vm-actions button.btn-pause { color: #3b82f6; }
+    #toolbar .vm-actions button.btn-pause:hover { background: #1e3a8a; }
+    #toolbar .vm-actions button.loading { opacity: 0.5; pointer-events: none; }
+    /* Après les couleurs par bouton, à spécificité égale l'ordre tranche: un
+       bouton grisé perd sa couleur et son survol. */
+    #toolbar .vm-actions button:disabled, #toolbar .vm-actions button:disabled:hover {
+      color: #444; cursor: not-allowed; background: transparent;
+    }
+    #toolbar .buttons { margin-left: auto; display: flex; align-items: center; gap: 8px; min-width: 0; }
+    #toolbar .buttons button { flex-shrink: 0; }
     #toolbar button {
       padding: 6px 12px; font-size: 12px; background: #333; color: #fff;
       border: 1px solid #444; border-radius: 4px; cursor: pointer;
@@ -31,7 +56,7 @@
     #toolbar button.active { background: #1e3a8a; border-color: #3b82f6; }
     #toolbar select {
       padding: 5px 8px; font-size: 12px; background: #333; color: #fff;
-      border: 1px solid #444; border-radius: 4px; cursor: pointer;
+      border: 1px solid #444; border-radius: 4px; cursor: pointer; min-width: 0;
     }
     #toolbar select option:disabled { color: #666; }
     #spice-area { flex: 1 1 auto; min-height: 0; position: relative; background: #000; overflow: auto; }
@@ -49,7 +74,15 @@
 </head>
 <body>
   <div id="toolbar">
-    <span id="dot"></span><span id="title">SPICE</span><span id="status">• Initializing...</span>
+    <div class="info">
+      <span id="dot"></span><span id="title">SPICE</span><span id="status">• Initializing...</span>
+    </div>
+    <div class="vm-actions">
+      <button id="btn-start" class="btn-start" title="Start">▶</button>
+      <button id="btn-shutdown" class="btn-shutdown" title="Shutdown (graceful)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 2v8"/><path d="M18.36 6.64A9 9 0 1 1 5.64 6.64"/></svg></button>
+      <button id="btn-stop" class="btn-stop" title="Stop (forced)">■</button>
+      <button id="btn-pause" class="btn-pause" title="Pause">⏸</button>
+    </div>
     <div class="buttons">
       <select id="scaling" title="Scaling mode">
         <option value="scale">Fit to window</option>
@@ -88,8 +121,15 @@
     const btnFullscreen = document.getElementById('btn-fullscreen');
     const btnReconnect = document.getElementById('btn-reconnect');
     const btnClose = document.getElementById('btn-close');
+    const actionButtons = {
+      start: document.getElementById('btn-start'),
+      shutdown: document.getElementById('btn-shutdown'),
+      stop: document.getElementById('btn-stop'),
+      suspend: document.getElementById('btn-pause'),
+    };
     let sc = null;
     let agentConnected = false;
+    let vmStatus = 'unknown';
 
     // Même libellé dans la barre d'outils et dans le titre de fenêtre, nom de
     // la VM en tête pour survivre à la troncature de la barre des tâches
@@ -106,9 +146,21 @@
 
     renderVmLabel();
 
-    // Cette page ne suit pas l'état de la VM: un seul GET suffit à nommer la
-    // fenêtre. Un échec laisse simplement le libellé sur son repli.
-    async function fetchVmName() {
+    // Les mêmes règles que la console noVNC, portées par ConsoleUI pour que
+    // les deux barres ne divergent plus.
+    function updateVmButtons() {
+      const enabled = ConsoleUI.vmActionsEnabled(vmStatus);
+
+      ConsoleUI.VM_ACTIONS.forEach(function(action) {
+        actionButtons[action].disabled = !enabled[action];
+      });
+    }
+
+    // Un GET nomme la fenêtre et arme les boutons d'action. Cette page ne
+    // sonde pas l'état en continu: on le relit après chaque action, et à
+    // chaque tentative de connexion. Un échec laisse le libellé sur son repli
+    // et les boutons sur l'état « unknown », qui garde Start et Stop actifs.
+    async function fetchVmStatus() {
       if (!connId || !type || !node || !vmid) return;
 
       try {
@@ -121,8 +173,10 @@
           vmName = json.data.name;
           renderVmLabel();
         }
+        vmStatus = ConsoleUI.parseVmStatus(json?.data?.status);
+        updateVmButtons();
       } catch (e) {
-        console.error('Failed to fetch VM name:', e);
+        console.error('Failed to fetch VM status:', e);
       }
     }
 
@@ -271,6 +325,47 @@
       window.close();
     });
 
+    // Même API que la console noVNC. Un échec se lit dans la ligne de statut
+    // plutôt que dans la boîte de message: celle-ci recouvre l'écran de
+    // l'invité, qui reste pourtant visible et utilisable.
+    async function vmAction(action) {
+      const btn = actionButtons[action];
+
+      btn.classList.add('loading');
+
+      try {
+        const res = await fetch(
+          `/api/v1/connections/${encodeURIComponent(connId)}/guests/${encodeURIComponent(type)}/${encodeURIComponent(node)}/${encodeURIComponent(vmid)}/${action}`,
+          { method: 'POST' }
+        );
+
+        if (!res.ok) {
+          const errText = await res.text();
+          throw new Error(`HTTP ${res.status}: ${errText}`);
+        }
+
+        // L'état PVE ne bascule pas instantanément, on relit après un délai.
+        setTimeout(fetchVmStatus, 1500);
+
+        // Le serveur SPICE n'existe que VM allumée: la session précédente a
+        // forcément échoué, on la relance une fois QEMU démarré.
+        if (action === 'start') {
+          setTimeout(function() {
+            disconnect();
+            connect();
+          }, 3000);
+        }
+      } catch (err) {
+        setStatus('error', `Action ${action} failed: ${err.message}`);
+      } finally {
+        btn.classList.remove('loading');
+      }
+    }
+
+    ConsoleUI.VM_ACTIONS.forEach(function(action) {
+      actionButtons[action].addEventListener('click', function() { vmAction(action); });
+    });
+
     function disconnect() {
       agentConnected = false;
       syncScalingAvailability();
@@ -292,6 +387,7 @@
       if (!connId || !type || !node || !vmid) return fail('Missing parameters');
       messageBox.classList.remove('visible');
       setStatus('connecting', 'Creating session...');
+      fetchVmStatus();
       let json;
       try {
         const res = await fetch(
@@ -338,7 +434,7 @@
     }
 
     syncScalingAvailability();
-    fetchVmName();
+    updateVmButtons();
     connect();
   </script>
 </body>

--- a/frontend/src/lib/console/viewport.test.ts
+++ b/frontend/src/lib/console/viewport.test.ts
@@ -21,6 +21,9 @@ import {
   saveScalingMode,
   scalingStorageKey,
   toggleFullscreen,
+  VM_ACTIONS,
+  parseVmStatus,
+  vmActionsEnabled,
 } from './viewport'
 
 function fakeStorage(initial: Record<string, string> = {}) {
@@ -294,5 +297,37 @@ describe('debounce', () => {
     expect(fn).not.toHaveBeenCalled()
     // Cancelling twice, or with nothing pending, is a no-op.
     d.cancel()
+  })
+})
+
+describe('VM power actions', () => {
+  it('exposes the four toolbar actions in display order', () => {
+    expect(VM_ACTIONS).toEqual(['start', 'shutdown', 'stop', 'suspend'])
+  })
+
+  it('normalises the status reported by the guest API', () => {
+    expect(parseVmStatus('running')).toBe('running')
+    expect(parseVmStatus('stopped')).toBe('stopped')
+    expect(parseVmStatus('paused')).toBe('paused')
+    expect(parseVmStatus('prelaunch')).toBe('unknown')
+    expect(parseVmStatus(undefined)).toBe('unknown')
+    expect(parseVmStatus(null)).toBe('unknown')
+    expect(parseVmStatus(42)).toBe('unknown')
+  })
+
+  it('offers shutdown and pause only while the guest runs, and start only while it does not', () => {
+    expect(vmActionsEnabled('running')).toEqual({ start: false, shutdown: true, stop: true, suspend: true })
+    expect(vmActionsEnabled('stopped')).toEqual({ start: true, shutdown: false, stop: false, suspend: false })
+  })
+
+  it('lets a paused guest be resumed with start or killed with stop', () => {
+    expect(vmActionsEnabled('paused')).toEqual({ start: true, shutdown: false, stop: true, suspend: false })
+  })
+
+  it('keeps the recovery actions reachable when the status is unknown', () => {
+    // A status fetch that failed must not lock the operator out of the
+    // console: start and stop stay available, the graceful ones do not.
+    expect(vmActionsEnabled('unknown')).toEqual({ start: true, shutdown: false, stop: true, suspend: false })
+    expect(vmActionsEnabled('whatever' as never)).toEqual(vmActionsEnabled('unknown'))
   })
 })

--- a/frontend/src/lib/console/viewport.ts
+++ b/frontend/src/lib/console/viewport.ts
@@ -3,7 +3,7 @@
 // Shared viewport logic for the two graphical console pages
 // (public/novnc/console.html and public/spice/console.html): scaling mode
 // persistence, guest-resolution maths for an agent-driven resize, fit
-// scaling, fullscreen helpers and the send-key combos.
+// scaling, fullscreen helpers, the send-key combos and the VM power actions.
 //
 // Those pages are plain static HTML served outside Next (they must load the
 // noVNC / spice-html5 IIFE bundles), so they cannot import from src/. They
@@ -269,6 +269,45 @@ export function keyComboSequence(id: string): { keysym: number; code: string; do
   const up = [...found.strokes].reverse().map(s => ({ ...s, down: false }))
 
   return [...down, ...up]
+}
+
+// --- VM power actions -----------------------------------------------------
+// The toolbar of both consoles carries the four guest power actions, so an
+// operator can start a stopped VM or force it off without leaving the console
+// window. The rules live here so the two pages cannot drift apart again (the
+// SPICE page shipped without them, GIBZ report 2026-08-26).
+
+export type VmStatus = 'running' | 'stopped' | 'paused' | 'unknown'
+
+export type VmAction = 'start' | 'shutdown' | 'stop' | 'suspend'
+
+/** Display order of the toolbar buttons; also the API action names. */
+export const VM_ACTIONS: readonly VmAction[] = ['start', 'shutdown', 'stop', 'suspend']
+
+const VM_STATUSES: readonly VmStatus[] = ['running', 'stopped', 'paused', 'unknown']
+
+/** The guest status route answers `data.status`; anything unexpected is `unknown`. */
+export function parseVmStatus(raw: unknown): VmStatus {
+  return VM_STATUSES.includes(raw as VmStatus) ? (raw as VmStatus) : 'unknown'
+}
+
+/**
+ * Which actions make sense for a status. The graceful ones (shutdown, pause)
+ * need a running guest agent to talk to; start and the forced stop stay
+ * available whenever the status does not rule them out, including when it
+ * could not be fetched at all: the console must never lock the operator out
+ * of recovering the VM.
+ */
+export function vmActionsEnabled(status: VmStatus): Record<VmAction, boolean> {
+  const parsed = parseVmStatus(status)
+  const running = parsed === 'running'
+
+  return {
+    start: !running,
+    shutdown: running,
+    stop: parsed !== 'stopped',
+    suspend: running,
+  }
 }
 
 // --- Misc -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SPICE HTML console shipped in v1.4.8 with no toolbar buttons at all, which a customer reported on 2026-08-26 with side-by-side screenshots of the two consoles. #785 already added the session controls (scaling, Ctrl+Alt+Del, fullscreen, reconnect, close). This PR adds the four VM power actions the noVNC console offers, and makes both toolbars stay on a single line whatever the window width.

## Changes

- **SPICE console**: Start, graceful Shutdown, forced Stop and Pause, driven by the existing guest action API. The VM status is re-read on every connection attempt and 1.5 s after an action. After a Start the console reconnects on its own once QEMU is up, since the SPICE server only exists while the VM runs. Action errors are shown in the status line rather than in the message box, which would cover the guest screen.
- **Shared rules**: which actions are enabled for a given status now lives in `src/lib/console/viewport.ts` (`VM_ACTIONS`, `parseVmStatus`, `vmActionsEnabled`) and reaches both static pages through the ConsoleUI bundle, so the two toolbars cannot drift apart again. The noVNC page switches to it with unchanged behaviour. `public/console/console-ui.bundle.js` is regenerated.
- **Single-line toolbars**: `flex-wrap: nowrap` on both consoles, with an explicit compression order when the window gets narrower: the status text gives way first (the dot already conveys the state), then the VM name (ellipsis, never below 140 px), then the selects shrink, and the buttons never wrap under the guest screen. The noVNC bar also loses a few pixels of margins so the status text survives at the default 1024 px console width.

## Tests

- 5 new unit tests on the enable rules, including the unknown status that keeps Start and Stop reachable so the operator is never locked out of recovering the VM.
- Full suite green: 621 files, 6756 tests.
- Both toolbars rendered with headless Chromium at 1024, 800 and 700 px.
- Manually tested against a live cluster: starting a stopped VM from the SPICE console, automatic reconnection, shutdown, stop and pause.
