### PR TITLE
Hyper-V: inventory timeout, disk paths, retry engine and Compact OS conversion

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryDetails.tsx
@@ -312,7 +312,7 @@ export default function InventoryDetails({
   const [nodeActionLocalVms, setNodeActionLocalVms] = useState<Set<string>>(new Set())
   const [nodeActionStorageLoading, setNodeActionStorageLoading] = useState(false)
   const [nodeActionShutdownLocal, setNodeActionShutdownLocal] = useState(false)
-  const [esxiMigrateVm, setEsxiMigrateVm] = useState<{ vmid: string; name: string; connId: string; connName: string; cpu?: number; memoryMB?: number; committed?: number; guestOS?: string; licenseFull?: boolean; hostType?: string; connSubType?: string | null; diskPaths?: string[]; vcenterDatacenter?: string; vcenterCluster?: string; vcenterHost?: string; status?: string; toolsStatus?: string; toolsRunningStatus?: string } | null>(null)
+  const [esxiMigrateVm, setEsxiMigrateVm] = useState<{ vmid: string; name: string; connId: string; connName: string; cpu?: number; memoryMB?: number; committed?: number; guestOS?: string; licenseFull?: boolean; hostType?: string; connSubType?: string | null; diskPaths?: string[]; diskMountPaths?: string[]; vcenterDatacenter?: string; vcenterCluster?: string; vcenterHost?: string; status?: string; toolsStatus?: string; toolsRunningStatus?: string } | null>(null)
   const [migTargetConn, setMigTargetConn] = useState('')
   const [migTargetNode, setMigTargetNode] = useState('')
   const [migTargetStorage, setMigTargetStorage] = useState('')
@@ -333,7 +333,7 @@ export default function InventoryDetails({
   const [migStoragesLoading, setMigStoragesLoading] = useState(false)
   const [migStoragesError, setMigStoragesError] = useState<string | null>(null)
   const [migSshfsAvailable, setMigSshfsAvailable] = useState<boolean | null>(null) // null = not checked yet
-  const [vcenterPreflight, setVcenterPreflight] = useState<{ checked: boolean; ok: boolean; installing: boolean; errors: string[]; virtV2vInstalled: boolean; virtioWinInstalled: boolean; nbdkitInstalled: boolean; nbdcopyInstalled: boolean; guestfsToolsInstalled: boolean; ovmfInstalled: boolean; detectedDisks: string[]; tempStorages: { path: string; availableBytes: number; totalBytes: number; filesystem: string }[]; installError?: { hintKey?: '401_enterprise'; output: string } } | null>(null)
+  const [vcenterPreflight, setVcenterPreflight] = useState<{ checked: boolean; ok: boolean; installing: boolean; errors: string[]; virtV2vInstalled: boolean; virtioWinInstalled: boolean; nbdkitInstalled: boolean; nbdcopyInstalled: boolean; guestfsToolsInstalled: boolean; ovmfInstalled: boolean; ntfsCompressionPluginInstalled: boolean; detectedDisks: string[]; tempStorages: { path: string; availableBytes: number; totalBytes: number; filesystem: string }[]; installError?: { hintKey?: '401_enterprise'; output: string } } | null>(null)
   const [migStarting, setMigStarting] = useState(false)
   const [migJobId, setMigJobId] = useState<string | null>(null)
   const [migJob, setMigJob] = useState<any>(null)
@@ -820,7 +820,7 @@ export default function InventoryDetails({
       ? migNodeOptions.filter((o: any) => o.connId === migTargetConn && o.status === 'online').map((o: any) => o.node)
       : [migTargetNode]
     if (nodesToCheck.length === 0) {
-      setVcenterPreflight({ checked: true, ok: false, installing: false, errors: ['No online nodes in the selected cluster'], virtV2vInstalled: false, virtioWinInstalled: false, nbdkitInstalled: false, nbdcopyInstalled: false, guestfsToolsInstalled: false, ovmfInstalled: false, detectedDisks: [], tempStorages: [] })
+      setVcenterPreflight({ checked: true, ok: false, installing: false, errors: ['No online nodes in the selected cluster'], virtV2vInstalled: false, virtioWinInstalled: false, nbdkitInstalled: false, nbdcopyInstalled: false, guestfsToolsInstalled: false, ovmfInstalled: false, ntfsCompressionPluginInstalled: false, detectedDisks: [], tempStorages: [] })
       return
     }
     Promise.all(nodesToCheck.map(async (node: string) => {
@@ -842,6 +842,7 @@ export default function InventoryDetails({
       const allNbdcopy = results.every(r => !!r.nbdcopyInstalled)
       const allGuestfsTools = results.every(r => !!r.guestfsToolsInstalled)
       const allOvmf = results.every(r => !!r.ovmfInstalled)
+      const allNtfsPlugin = results.every(r => !!r.ntfsCompressionPluginInstalled)
       const allVirtioWin = results.every(r => !!r.virtioWinInstalled)
       // tempStorages: when targeting multiple nodes we take the INTERSECTION by
       // path (a temp dir is only useful if it exists on every node the batch
@@ -892,13 +893,14 @@ export default function InventoryDetails({
         nbdcopyInstalled: allNbdcopy,
         guestfsToolsInstalled: allGuestfsTools,
         ovmfInstalled: allOvmf,
+        ntfsCompressionPluginInstalled: allNtfsPlugin,
         detectedDisks,
         tempStorages: aggregatedTempStorages,
       })
       if (detectedDisks.length > 0) {
         setMigDiskPaths(detectedDisks.join('\n'))
       }
-    }).catch(() => setVcenterPreflight({ checked: true, ok: false, installing: false, errors: ['Preflight check failed'], virtV2vInstalled: false, virtioWinInstalled: false, nbdkitInstalled: false, nbdcopyInstalled: false, guestfsToolsInstalled: false, ovmfInstalled: false, detectedDisks: [], tempStorages: [] }))
+    }).catch(() => setVcenterPreflight({ checked: true, ok: false, installing: false, errors: ['Preflight check failed'], virtV2vInstalled: false, virtioWinInstalled: false, nbdkitInstalled: false, nbdcopyInstalled: false, guestfsToolsInstalled: false, ovmfInstalled: false, ntfsCompressionPluginInstalled: false, detectedDisks: [], tempStorages: [] }))
     loadMigStorages(migTargetConn, fetchNode)
     // Fetch classic Linux/OVS bridges (node-scoped) AND SDN VNets (cluster-scoped),
     // merged into one selector list. A migrated NIC accepts a VNet name in its
@@ -4127,7 +4129,7 @@ return vm?.isCluster ?? false
                             vmid: vm.vmid, name: vm.name, connId: vm.connectionId,
                             connName: vm.connectionName, cpu: vm.numCPU, memoryMB: vm.memoryMB,
                             committed: vm.committed, guestOS: vm.guestOS, licenseFull: vm.licenseFull,
-                            hostType: ht, diskPaths: (vm as any).diskPaths,
+                            hostType: ht, diskPaths: (vm as any).diskPaths, diskMountPaths: (vm as any).diskMountPaths,
                             // Connection sub-type: gates warm for an XCP-ng pool
                             // (XAPI yes, Xen Orchestra no) in the migrate dialog.
                             connSubType: vm.connSubType ?? null,

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/InventoryTree.tsx
@@ -59,6 +59,7 @@ import { useTenant } from '@/contexts/TenantContext'
 import { useTaskTracker } from '@/hooks/useTaskTracker'
 import { useMyVdcs } from '@/hooks/useMyVdcs'
 import { readVdcContextCookie } from '@/lib/vdc/contextCookie'
+import { describeVmLoadFailure, describeVmLoadTimeout, externalVmFetchTimeoutMs } from '@/lib/inventory/externalVmFetch'
 import { MigrateVmDialog, CrossClusterMigrateParams } from '@/components/MigrateVmDialog'
 import { CloneVmDialog } from '@/components/hardware/CloneVmDialog'
 import { StatusIcon, NodeIcon, ClusterIcon, getVmIcon } from './components/TreeIcons'
@@ -1675,10 +1676,10 @@ return next
               // each fetch independently and clear its own loading flag when it
               // resolves — the working connections pop their VMs immediately, the
               // broken ones stay spinning until their own timeout hits.
-              const VM_FETCH_TIMEOUT_MS = 15_000
               for (const conn of extConns) {
                 const controller = new AbortController()
-                const timeoutId = setTimeout(() => controller.abort(), VM_FETCH_TIMEOUT_MS)
+                const vmFetchTimeoutMs = externalVmFetchTimeoutMs(conn.type)
+                const timeoutId = setTimeout(() => controller.abort(), vmFetchTimeoutMs)
                 const apiPrefix = conn.type === 'xcpng' ? 'xcpng' : conn.type === 'hyperv' ? 'hyperv' : conn.type === 'nutanix' ? 'nutanix' : 'vmware'
                 ;(async () => {
                   let vms: any[] = []
@@ -1691,11 +1692,11 @@ return next
                       const vmJson = await vmRes.json()
                       vms = Array.isArray(vmJson?.data) ? vmJson.data : (vmJson?.data?.vms || [])
                     } else {
-                      loadError = `HTTP ${vmRes.status}`
+                      loadError = await describeVmLoadFailure(vmRes)
                     }
                   } catch (err: any) {
                     loadError = err?.name === 'AbortError'
-                      ? `timeout after ${VM_FETCH_TIMEOUT_MS / 1000}s`
+                      ? describeVmLoadTimeout(vmFetchTimeoutMs)
                       : err?.message || 'fetch failed'
                   } finally {
                     clearTimeout(timeoutId)

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -962,7 +962,7 @@ describe('migration dialog options', () => {
   const PREFLIGHT_TEMP_TOO_SMALL = {
     checked: true, ok: true, installing: false, errors: [] as string[],
     virtV2vInstalled: true, virtioWinInstalled: true, nbdkitInstalled: true,
-    nbdcopyInstalled: true, guestfsToolsInstalled: true, ovmfInstalled: true,
+    nbdcopyInstalled: true, guestfsToolsInstalled: true, ovmfInstalled: true, ntfsCompressionPluginInstalled: true,
     detectedDisks: [] as string[],
     tempStorages: [{ path: '/tmp', availableBytes: 150 * GIB, totalBytes: 200 * GIB, filesystem: 'ext4' }],
   }

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -258,7 +258,7 @@ export interface InventoryDialogsProps {
   executeBulkAction: () => void
 
   // ESXi / External migration dialog
-  esxiMigrateVm: { vmid: string; name: string; connId: string; connName: string; cpu?: number; memoryMB?: number; committed?: number; guestOS?: string; licenseFull?: boolean; hostType?: string; connSubType?: string | null; diskPaths?: string[]; status?: string; toolsStatus?: string; toolsRunningStatus?: string } | null
+  esxiMigrateVm: { vmid: string; name: string; connId: string; connName: string; cpu?: number; memoryMB?: number; committed?: number; guestOS?: string; licenseFull?: boolean; hostType?: string; connSubType?: string | null; diskPaths?: string[]; diskMountPaths?: string[]; status?: string; toolsStatus?: string; toolsRunningStatus?: string } | null
   setEsxiMigrateVm: (v: any) => void
   migTargetConn: string
   setMigTargetConn: (v: string) => void
@@ -302,7 +302,7 @@ export interface InventoryDialogsProps {
   migStoragesError: string | null
   retryMigStorages: () => void
   migSshfsAvailable: boolean | null
-  vcenterPreflight: { checked: boolean; ok: boolean; installing: boolean; errors: string[]; virtV2vInstalled: boolean; virtioWinInstalled: boolean; nbdkitInstalled: boolean; nbdcopyInstalled: boolean; guestfsToolsInstalled: boolean; ovmfInstalled: boolean; detectedDisks: string[]; tempStorages: { path: string; availableBytes: number; totalBytes: number; filesystem: string }[]; installError?: { hintKey?: '401_enterprise'; output: string } } | null
+  vcenterPreflight: { checked: boolean; ok: boolean; installing: boolean; errors: string[]; virtV2vInstalled: boolean; virtioWinInstalled: boolean; nbdkitInstalled: boolean; nbdcopyInstalled: boolean; guestfsToolsInstalled: boolean; ovmfInstalled: boolean; ntfsCompressionPluginInstalled: boolean; detectedDisks: string[]; tempStorages: { path: string; availableBytes: number; totalBytes: number; filesystem: string }[]; installError?: { hintKey?: '401_enterprise'; output: string } } | null
   setVcenterPreflight: (v: any) => void
   migStarting: boolean
   setMigStarting: (v: boolean) => void
@@ -537,8 +537,9 @@ export default function InventoryDialogs(props: InventoryDialogsProps) {
               whiteSpace: 'pre-wrap',
               wordBreak: 'break-all',
             }}
-          >{`sed -i "s|^deb https://enterprise.proxmox.com|# &|" /etc/apt/sources.list.d/pve-enterprise.list
-echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VERSION_CODENAME) pve-no-subscription" > /etc/apt/sources.list.d/pve-no-subscription.list`}</Box>
+          >{`for f in /etc/apt/sources.list.d/*.sources; do grep -q "enterprise.proxmox.com" "$f" || continue; sed -i "/^Enabled:/d" "$f"; echo "Enabled: false" >> "$f"; done
+sed -i "s|^deb https://enterprise.proxmox.com|# &|" /etc/apt/sources.list.d/*.list 2>/dev/null
+printf 'Types: deb\\nURIs: http://download.proxmox.com/debian/pve\\nSuites: %s\\nComponents: pve-no-subscription\\nSigned-By: /usr/share/keyrings/proxmox-archive-keyring.gpg\\n' "$(. /etc/os-release && echo $VERSION_CODENAME)" > /etc/apt/sources.list.d/pve-no-subscription.sources`}</Box>
         </>
       )}
       <Typography variant="caption" sx={{ opacity: 0.7, display: 'block', mb: 0.5 }}>
@@ -620,6 +621,7 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
         nbdcopyInstalled: results.every((r: any) => !!r.nbdcopyInstalled),
         guestfsToolsInstalled: results.every((r: any) => !!r.guestfsToolsInstalled),
         ovmfInstalled: results.every((r: any) => !!r.ovmfInstalled),
+        ntfsCompressionPluginInstalled: results.every((r: any) => !!r.ntfsCompressionPluginInstalled),
         detectedDisks: firstWithDisks?.detectedDisks || [],
         tempStorages: firstWithStorages?.tempStorages || [],
         installError,
@@ -1027,6 +1029,7 @@ echo "deb http://download.proxmox.com/debian/pve $(. /etc/os-release && echo $VE
             nbdcopyInstalled: results.every((r: any) => !!r.nbdcopyInstalled),
             guestfsToolsInstalled: results.every((r: any) => !!r.guestfsToolsInstalled),
             ovmfInstalled: results.every((r: any) => !!r.ovmfInstalled),
+        ntfsCompressionPluginInstalled: results.every((r: any) => !!r.ntfsCompressionPluginInstalled),
             detectedDisks: [],
             tempStorages: results[0]?.tempStorages || [],
           })
@@ -2843,6 +2846,7 @@ return
                       { label: 'libnbd-bin (nbdcopy)', installed: vcenterPreflight.nbdcopyInstalled, required: true, note: 'virt-v2v disk copy step' },
                       { label: 'guestfs-tools (rhsrvany)', installed: vcenterPreflight.guestfsToolsInstalled, required: true, note: 'Windows firstboot scripts' },
                       { label: 'ovmf', installed: vcenterPreflight.ovmfInstalled, required: true, note: 'UEFI firmware for output metadata' },
+                      { label: 'ntfs-3g system-compression plugin', installed: vcenterPreflight.ntfsCompressionPluginInstalled, required: true, note: 'Windows guests installed with Compact OS' },
                     ]
                     const virtioWinMissing = !vcenterPreflight.virtioWinInstalled
                     const virtioWinRequired = isWindowsGuest
@@ -3082,14 +3086,15 @@ return
                       <Typography variant="caption" sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}>VHDX Disks</Typography>
                       {esxiMigrateVm.diskPaths && esxiMigrateVm.diskPaths.length > 0 ? (
                         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                          {esxiMigrateVm.diskPaths.map((disk: string) => {
+                          {esxiMigrateVm.diskPaths.map((disk: string, diskIdx: number) => {
                             const fileName = disk.split('\\').pop() || disk.split('/').pop() || disk
+                            const mountPath = esxiMigrateVm.diskMountPaths?.[diskIdx] || `/mnt/hyperv/${fileName}`
                             return (
                               <Box key={disk} sx={{ display: 'flex', alignItems: 'center', gap: 1, p: 0.75, borderRadius: 1, bgcolor: 'action.hover' }}>
                                 <i className="ri-checkbox-circle-fill" style={{ fontSize: 16, color: theme.palette.success.main }} />
                                 <Box sx={{ flex: 1, minWidth: 0 }}>
                                   <Typography variant="body2" sx={{ fontFamily: '"JetBrains Mono", monospace', fontSize: 11, wordBreak: 'break-all' }}>
-                                    /mnt/hyperv/{fileName}
+                                    {mountPath}
                                   </Typography>
                                   <Typography variant="caption" sx={{ opacity: 0.4, fontSize: 10 }}>
                                     {disk}
@@ -3370,6 +3375,7 @@ return
                     if (!vcenterPreflight.nbdcopyInstalled) return true
                     if (!vcenterPreflight.guestfsToolsInstalled) return true
                     if (!vcenterPreflight.ovmfInstalled) return true
+                    if (!vcenterPreflight.ntfsCompressionPluginInstalled) return true
                     // virtio-win is required for Windows guests — without it the
                     // VM will likely BSOD with INACCESSIBLE_BOOT_DEVICE.
                     if (isWindowsGuest && !vcenterPreflight.virtioWinInstalled) return true
@@ -4011,6 +4017,7 @@ return
                     { label: 'libnbd-bin (nbdcopy)', installed: vcenterPreflight.nbdcopyInstalled, required: true, note: 'virt-v2v disk copy step' },
                     { label: 'guestfs-tools (rhsrvany)', installed: vcenterPreflight.guestfsToolsInstalled, required: true, note: 'Windows firstboot scripts' },
                     { label: 'ovmf', installed: vcenterPreflight.ovmfInstalled, required: true, note: 'UEFI firmware for output metadata' },
+                      { label: 'ntfs-3g system-compression plugin', installed: vcenterPreflight.ntfsCompressionPluginInstalled, required: true, note: 'Windows guests installed with Compact OS' },
                   ]
                   const virtioWinMissingBulk = !vcenterPreflight.virtioWinInstalled && hasWindowsInBatch
                   const missingAptBulk = aptChecklistBulk.some(d => !d.installed)
@@ -4476,6 +4483,7 @@ return
                       if (!vcenterPreflight.nbdcopyInstalled) return true
                       if (!vcenterPreflight.guestfsToolsInstalled) return true
                       if (!vcenterPreflight.ovmfInstalled) return true
+                    if (!vcenterPreflight.ntfsCompressionPluginInstalled) return true
                       // In bulk, block if batch contains Windows VMs and virtio-win is missing
                       if (!vcenterPreflight.virtioWinInstalled) {
                         const hasWin = (bulkMigHostInfo?.vms || [])

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { deriveHypervDiskPaths } from "./useMigrationOptions"
+
+describe("deriveHypervDiskPaths", () => {
+  it("returns blank for a non-Hyper-V VM", () => {
+    expect(deriveHypervDiskPaths({ hostType: "vmware", diskPaths: ["C:\\VMs\\a.vhdx"] })).toBe("")
+  })
+
+  it("returns blank for Hyper-V without disk paths", () => {
+    expect(deriveHypervDiskPaths({ hostType: "hyperv" })).toBe("")
+  })
+
+  it("joins matching mount paths verbatim", () => {
+    expect(deriveHypervDiskPaths({
+      hostType: "hyperv",
+      diskPaths: ["D:\\HYPERV\\a.vhdx", "D:\\HYPERV\\nested\\b.vhdx"],
+      diskMountPaths: ["/mnt/hyperv/a.vhdx", "/mnt/hyperv/nested/b.vhdx"],
+    })).toBe("/mnt/hyperv/a.vhdx\n/mnt/hyperv/nested/b.vhdx")
+  })
+
+  it("falls back to mounted basenames when mount paths are absent", () => {
+    expect(deriveHypervDiskPaths({
+      hostType: "hyperv",
+      diskPaths: ["C:\\VMs\\a.vhdx", "D:\\VMs\\b.vhd"],
+    })).toBe("/mnt/hyperv/a.vhdx\n/mnt/hyperv/b.vhd")
+  })
+
+  it("falls back when mount and disk path counts differ", () => {
+    expect(deriveHypervDiskPaths({
+      hostType: "hyperv",
+      diskPaths: ["C:\\VMs\\a.vhdx", "C:\\VMs\\b.vhdx"],
+      diskMountPaths: ["/mnt/hyperv/wrong/a.vhdx"],
+    })).toBe("/mnt/hyperv/a.vhdx\n/mnt/hyperv/b.vhdx")
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/hooks/useMigrationOptions.ts
@@ -7,23 +7,27 @@ import { DOWNTIME_BUDGET_DEFAULT_SEC } from '../components/migrationGuards'
  * fields the reset logic needs; InventoryDetails' richer esxiMigrateVm state
  * is structurally assignable to it.
  */
-type MigrationDialogVm = { hostType?: string; diskPaths?: string[] } | null | undefined
+type MigrationDialogVm = { hostType?: string; diskPaths?: string[]; diskMountPaths?: string[] } | null | undefined
 
 /**
- * Hyper-V sources with known VHDX paths get migDiskPaths pre-filled: the
- * Windows paths are mapped onto the /mnt/hyperv/ mount the migration pipeline
- * uses ("C:\VMs\TestVM.vhdx" -> "/mnt/hyperv/TestVM.vhdx"). Every other source
- * starts blank. Derived here, inside the reset, because deriving it in the
- * dialog-open click handler would be wiped by the reset effect running right
- * after (state updates from the handler and the open both commit before the
- * effect fires).
+ * Hyper-V sources with known VHDX paths get migDiskPaths pre-filled with the
+ * paths under the /mnt/hyperv/ mount the migration pipeline uses. The API
+ * computes them relative to the SMB share's local folder (diskMountPaths, see
+ * lib/hyperv/diskPaths.ts); older payloads without that field fall back to the
+ * basename ("C:\VMs\TestVM.vhdx" -> "/mnt/hyperv/TestVM.vhdx"), which the
+ * pipeline then relocates by file name. Every other source starts blank.
+ * Derived here, inside the reset, because deriving it in the dialog-open click
+ * handler would be wiped by the reset effect running right after (state
+ * updates from the handler and the open both commit before the effect fires).
  */
-function deriveHypervDiskPaths(vm: MigrationDialogVm): string {
+export function deriveHypervDiskPaths(vm: MigrationDialogVm): string {
   if (!vm || vm.hostType !== 'hyperv' || !vm.diskPaths?.length) return ''
 
-  return vm.diskPaths
-    .map(p => `/mnt/hyperv/${p.split('\\').pop() || p.split('/').pop() || p}`)
-    .join('\n')
+  const mountPaths = vm.diskMountPaths?.length === vm.diskPaths.length
+    ? vm.diskMountPaths
+    : vm.diskPaths.map(p => `/mnt/hyperv/${p.split('\\').pop() || p.split('/').pop() || p}`)
+
+  return mountPaths.join('\n')
 }
 
 /**

--- a/frontend/src/app/(dashboard)/settings/page.jsx
+++ b/frontend/src/app/(dashboard)/settings/page.jsx
@@ -46,6 +46,7 @@ import { useLicense, Features } from '@/contexts/LicenseContext'
 import { useRBAC } from '@/contexts/RBACContext'
 import EmptyState from '@/components/EmptyState'
 import { CountryFlag } from '@/components/ui/CountryFlag'
+import { interpretConnectionStatusResponse } from '@/components/settings/connectionStatusResult'
 import { findCountry } from '@/lib/utils/countries'
 
 import { isMultiLicenseEnabled } from '@/lib/features'
@@ -202,15 +203,15 @@ function ConnectionStatus({ connection, autoTest = false, onNodesLoaded }) {
         : `/api/v1/connections/${connection.id}/nodes`
 
       const res = await fetch(endpoint)
+      const json = await res.json().catch(() => ({}))
+      const result = interpretConnectionStatusResponse(res, json)
 
-      if (res.ok) {
+      if (result.status === 'ok') {
         setStatus('ok')
         if (onNodesLoaded) onNodesLoaded()
       } else {
-        const json = await res.json().catch(() => ({}))
-
         setStatus('error')
-        setError(json?.error || `HTTP ${res.status}`)
+        setError(result.error)
       }
     } catch (e) {
       setStatus('error')

--- a/frontend/src/app/api/v1/hyperv/[id]/status/route.ts
+++ b/frontend/src/app/api/v1/hyperv/[id]/status/route.ts
@@ -4,6 +4,7 @@ import { getSessionPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { HyperVClient } from "@/lib/hyperv/client"
+import { logHypervFailure } from "@/lib/hyperv/log"
 
 export const runtime = "nodejs"
 
@@ -56,7 +57,7 @@ export async function GET(
         }
       })
     } catch (connErr: any) {
-      const msg = connErr?.message || String(connErr)
+      const msg = logHypervFailure("status probe", conn.name, host, connErr)
 
       if (msg.includes("401") || msg.includes("Unauthorized") || msg.includes("credentials")) {
         return NextResponse.json({

--- a/frontend/src/app/api/v1/hyperv/[id]/vms/[vmid]/route.ts
+++ b/frontend/src/app/api/v1/hyperv/[id]/vms/[vmid]/route.ts
@@ -4,6 +4,7 @@ import { getSessionPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { HyperVClient } from "@/lib/hyperv/client"
+import { withHypervLog } from "@/lib/hyperv/log"
 
 export const runtime = "nodejs"
 
@@ -23,7 +24,7 @@ export async function GET(
     const prisma = await getSessionPrisma()
     const conn = await prisma.connection.findUnique({
       where: { id },
-      select: { id: true, name: true, baseUrl: true, apiTokenEnc: true, insecureTLS: true, type: true },
+      select: { id: true, name: true, baseUrl: true, apiTokenEnc: true, insecureTLS: true, type: true, hypervShareName: true },
     })
 
     if (!conn || conn.type !== 'hyperv') {
@@ -39,7 +40,7 @@ export async function GET(
     const useSSL = conn.insecureTLS ? false : conn.baseUrl.startsWith("https")
 
     const client = new HyperVClient({ host, username, password, useSSL })
-    const vm = await client.getVM(vmid)
+    const vm = await withHypervLog(`VM lookup ${vmid}`, conn.name, host, () => client.getVM(vmid, { shareName: conn.hypervShareName }))
 
     return NextResponse.json({
       data: {
@@ -53,6 +54,7 @@ export async function GET(
         guestOS: `Hyper-V Gen ${vm.generation}`,
         firmware: vm.generation === 2 ? 'efi' : 'bios',
         diskPaths: vm.diskPaths,
+        diskMountPaths: vm.diskMountPaths,
         connectionId: conn.id,
         connectionName: conn.name,
       }

--- a/frontend/src/app/api/v1/hyperv/[id]/vms/route.ts
+++ b/frontend/src/app/api/v1/hyperv/[id]/vms/route.ts
@@ -4,6 +4,7 @@ import { getSessionPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { HyperVClient } from "@/lib/hyperv/client"
+import { withHypervLog } from "@/lib/hyperv/log"
 
 export const runtime = "nodejs"
 
@@ -23,7 +24,7 @@ export async function GET(
     const { id } = await params
     const conn = await prisma.connection.findUnique({
       where: { id },
-      select: { id: true, name: true, baseUrl: true, apiTokenEnc: true, insecureTLS: true, type: true },
+      select: { id: true, name: true, baseUrl: true, apiTokenEnc: true, insecureTLS: true, type: true, hypervShareName: true },
     })
 
     if (!conn || conn.type !== 'hyperv') {
@@ -40,7 +41,7 @@ export async function GET(
     const useSSL = conn.insecureTLS ? false : conn.baseUrl.startsWith("https")
 
     const client = new HyperVClient({ host, username, password, useSSL })
-    const hypervVms = await client.listVMs()
+    const hypervVms = await withHypervLog("VM listing", conn.name, host, () => client.listVMs({ shareName: conn.hypervShareName }))
 
     // Map to the standard format expected by the frontend migration UI
     const vms = hypervVms.map(vm => ({
@@ -52,6 +53,7 @@ export async function GET(
       power_state: vm.state,
       committed: vm.diskSizeBytes || undefined,
       diskPaths: vm.diskPaths,
+      diskMountPaths: vm.diskMountPaths,
       generation: vm.generation,
     }))
 

--- a/frontend/src/app/api/v1/migrations/[id]/retry/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/retry/route.test.ts
@@ -21,6 +21,8 @@ vi.mock("@/lib/tenant", () => ({
   getCurrentTenantId: vi.fn(async () => "default"),
 }))
 vi.mock("@/lib/migration/pipeline", () => ({ runMigrationPipeline: vi.fn() }))
+vi.mock("@/lib/migration/v2v-pipeline", () => ({ runV2vMigrationPipeline: vi.fn() }))
+vi.mock("@/lib/migration/xcpng-pipeline", () => ({ runXcpngMigrationPipeline: vi.fn() }))
 vi.mock("@/lib/migration/warm/warm-pipeline", () => ({ runWarmMigration: vi.fn() }))
 vi.mock("@/lib/migration/warm/xcpng-warm-pipeline", () => ({ runXcpngWarmMigration: vi.fn() }))
 vi.mock("@/lib/migration/orphan-sweep", () => ({ resolveInstanceId: vi.fn(() => "inst-1") }))
@@ -28,10 +30,14 @@ vi.mock("@/lib/migration/orphan-sweep", () => ({ resolveInstanceId: vi.fn(() => 
 import { POST } from "./route"
 import { callRoute, readJson } from "@/__tests__/setup/route-test"
 import { runMigrationPipeline } from "@/lib/migration/pipeline"
+import { runV2vMigrationPipeline } from "@/lib/migration/v2v-pipeline"
+import { runXcpngMigrationPipeline } from "@/lib/migration/xcpng-pipeline"
 import { runWarmMigration } from "@/lib/migration/warm/warm-pipeline"
 import { runXcpngWarmMigration } from "@/lib/migration/warm/xcpng-warm-pipeline"
 
 const cold = runMigrationPipeline as unknown as ReturnType<typeof vi.fn>
+const v2v = runV2vMigrationPipeline as unknown as ReturnType<typeof vi.fn>
+const xcpngCold = runXcpngMigrationPipeline as unknown as ReturnType<typeof vi.fn>
 const warm = runWarmMigration as unknown as ReturnType<typeof vi.fn>
 const xcpngWarm = runXcpngWarmMigration as unknown as ReturnType<typeof vi.fn>
 
@@ -47,6 +53,8 @@ async function runAfters() { for (const cb of h.afterCbs) await cb() }
 beforeEach(() => {
   h.afterCbs.length = 0
   cold.mockReset()
+  v2v.mockReset()
+  xcpngCold.mockReset()
   warm.mockReset()
   xcpngWarm.mockReset()
   h.prisma.migrationJob.findUnique.mockReset()
@@ -89,7 +97,7 @@ describe("POST /api/v1/migrations/[id]/retry", () => {
     expect(await readJson<any>(res)).toEqual({ data: { jobId: "job-2", status: "pending" } })
     expect(h.prisma.connection.findUnique).toHaveBeenCalledWith({
       where: { id: "src" },
-      select: { type: true },
+      select: { type: true, subType: true },
     })
 
     await runAfters()
@@ -128,6 +136,79 @@ describe("POST /api/v1/migrations/[id]/retry", () => {
     await runAfters()
     expect(xcpngWarm).toHaveBeenCalledWith("job-2", job.config, "default")
     expect(warm).not.toHaveBeenCalled()
+    expect(cold).not.toHaveBeenCalled()
+  })
+
+  it("re-dispatches a failed Hyper-V job to the v2v pipeline", async () => {
+    const job = {
+      ...failedJob,
+      config: {
+        sourceType: "hyperv",
+        migrationType: "cold",
+        diskPaths: ["/mnt/hyperv/a/b.vhdx"],
+        sourceVmName: "2025-test",
+      },
+    }
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce(job)
+    h.prisma.connection.findUnique.mockResolvedValueOnce({ type: "hyperv", subType: null })
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(200)
+    await runAfters()
+
+    expect(v2v).toHaveBeenCalledOnce()
+    expect(v2v).toHaveBeenCalledWith("job-2", expect.objectContaining({
+      sourceType: "hyperv",
+      diskPaths: ["/mnt/hyperv/a/b.vhdx"],
+      sourceVmName: "2025-test",
+      migrationType: "cold",
+    }), "default")
+    expect(cold).not.toHaveBeenCalled()
+  })
+
+  it("uses the live connection type for a legacy Hyper-V job", async () => {
+    const job = { ...failedJob, config: { ...failedJob.config, migrationType: "cold" } }
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce(job)
+    h.prisma.connection.findUnique.mockResolvedValueOnce({ type: "hyperv", subType: null })
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(200)
+    await runAfters()
+
+    expect(v2v).toHaveBeenCalledOnce()
+    expect(v2v.mock.calls[0][0]).toBe("job-2")
+    // The rebuilt config must carry the live connection's type too, not the
+    // "vmware" default: the v2v pipeline rejects an unknown source type.
+    expect(v2v.mock.calls[0][1]).toMatchObject({ sourceType: "hyperv", migrationType: "cold" })
+    expect(cold).not.toHaveBeenCalled()
+  })
+
+  it("re-dispatches an XCP-ng cold job to the XCP-ng pipeline", async () => {
+    const job = { ...failedJob, config: { sourceType: "xcpng", migrationType: "cold" } }
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce(job)
+    h.prisma.connection.findUnique.mockResolvedValueOnce({ type: "xcpng", subType: null })
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(200)
+    await runAfters()
+
+    expect(xcpngCold).toHaveBeenCalledWith("job-2", expect.objectContaining({ migrationType: "cold" }), "default")
+    expect(cold).not.toHaveBeenCalled()
+  })
+
+  it("preserves live mode when retrying a vCenter job through v2v", async () => {
+    const job = { ...failedJob, config: { sourceType: "vcenter", migrationType: "live" } }
+    h.prisma.migrationJob.findUnique.mockResolvedValueOnce(job)
+    h.prisma.connection.findUnique.mockResolvedValueOnce({ type: "vmware", subType: "vcenter" })
+
+    const res = await callRoute(POST, { params: { id: "job-1" }, method: "POST" })
+    expect(res.status).toBe(200)
+    await runAfters()
+
+    expect(v2v).toHaveBeenCalledWith("job-2", expect.objectContaining({
+      sourceType: "vcenter",
+      migrationType: "live",
+    }), "default")
     expect(cold).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/app/api/v1/migrations/[id]/retry/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/retry/route.ts
@@ -5,7 +5,10 @@ import { getSessionPrisma, getCurrentTenantId } from "@/lib/tenant"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { authOptions } from "@/lib/auth/config"
 import { runMigrationPipeline } from "@/lib/migration/pipeline"
+import { runV2vMigrationPipeline } from "@/lib/migration/v2v-pipeline"
+import { runXcpngMigrationPipeline } from "@/lib/migration/xcpng-pipeline"
 import { runWarmMigration } from "@/lib/migration/warm/warm-pipeline"
+import { resolveRetryEngine, v2vConfigFromJobConfig } from "@/lib/migration/retry-dispatch"
 import { runXcpngWarmMigration } from "@/lib/migration/warm/xcpng-warm-pipeline"
 import { resolveInstanceId } from "@/lib/migration/orphan-sweep"
 
@@ -67,29 +70,36 @@ export async function POST(
     })
 
     const tenantId = await getCurrentTenantId()
-    // Dispatch the retry to the same engine the original used. Warm jobs must
-    // not fall back to the cold pipeline (it powers off the running source).
-    const isWarm = (job.config as any)?.migrationType === "warm"
-    // Warm has one engine per source hypervisor (SOAP/VDDK for VMware, XAPI/NBD
-    // for XCP-ng). Resolve it from the source connection while the request-scoped
-    // Prisma client is still alive; it may be torn down inside after(). A deleted
-    // connection falls back to the sourceType persisted in the job config, so an
-    // XCP-ng retry is never handed to the VMware engine.
-    let warmSourceType: string | null = null
-    if (isWarm) {
-      const src = await prisma.connection.findUnique({ where: { id: job.sourceConnectionId }, select: { type: true } })
-      warmSourceType = src?.type ?? (job.config as any)?.sourceType ?? null
-    }
+    // Dispatch the retry to the same engine the original used: warm must not
+    // fall back to a cold pipeline (it powers off the running source), and a
+    // Hyper-V / vCenter / Nutanix / XCP-ng job must not be handed to the
+    // direct-ESXi pipeline, which rejects any non-VMware source. The engine
+    // comes from the sourceType persisted in the job config; jobs created
+    // before that field existed fall back to the live source connection.
+    // Resolve it while the request-scoped Prisma client is still alive; it may
+    // be torn down inside after().
+    const jobConfig = (job.config ?? {}) as Record<string, any>
+    const sourceConn = await prisma.connection.findUnique({
+      where: { id: job.sourceConnectionId },
+      select: { type: true, subType: true },
+    })
+    const engine = resolveRetryEngine(jobConfig, sourceConn)
     after(async () => {
-      if (isWarm) {
-        const warmConfig = config as unknown as Parameters<typeof runWarmMigration>[1]
-        if (warmSourceType === "xcpng") {
-          await runXcpngWarmMigration(newJob.id, warmConfig, tenantId)
-        } else {
-          await runWarmMigration(newJob.id, warmConfig, tenantId)
-        }
-      } else {
-        await runMigrationPipeline(newJob.id, config, tenantId)
+      switch (engine) {
+        case "warm-xcpng":
+          await runXcpngWarmMigration(newJob.id, config as unknown as Parameters<typeof runXcpngWarmMigration>[1], tenantId)
+          return
+        case "warm-vmware":
+          await runWarmMigration(newJob.id, config as unknown as Parameters<typeof runWarmMigration>[1], tenantId)
+          return
+        case "v2v":
+          await runV2vMigrationPipeline(newJob.id, v2vConfigFromJobConfig(jobConfig, job, sourceConn), tenantId)
+          return
+        case "xcpng-cold":
+          await runXcpngMigrationPipeline(newJob.id, { ...config, migrationType: "cold" }, tenantId)
+          return
+        default:
+          await runMigrationPipeline(newJob.id, config, tenantId)
       }
     })
 

--- a/frontend/src/app/api/v1/migrations/route.ts
+++ b/frontend/src/app/api/v1/migrations/route.ts
@@ -14,6 +14,7 @@ import { soapLogin, soapLogout, soapGetVmConfig, parseVmConfig } from "@/lib/vmw
 import { decryptSecret } from "@/lib/crypto/secret"
 import { assertStorageName } from "@/lib/ssh/validate"
 import { sanitizeV2vRoot } from "@/lib/migration/v2v-root-select"
+import { persistedV2vInputs } from "@/lib/migration/retry-dispatch"
 
 export const runtime = "nodejs"
 
@@ -187,7 +188,11 @@ export async function POST(req: Request) {
         // Warm-only options (vddkLibdir, downtimeBudgetSec) are persisted here so a
         // retry — which rebuilds the config from job.config — keeps them instead of
         // silently reverting to the defaults.
-        config: { sourceConnectionId, sourceVmId, sourceVmName: body.sourceVmName, targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2, migrationType, transferMode, sourceType: effectiveSourceType, ...(targetVmid !== undefined && { targetVmid }), ...(body.vddkLibdir && { vddkLibdir: body.vddkLibdir }), ...(downtimeBudgetSec !== undefined && { downtimeBudgetSec }), ...(cutoverMode !== undefined && { cutoverMode }) },
+        config: { sourceConnectionId, sourceVmId, sourceVmName: body.sourceVmName, targetConnectionId, targetNode, targetStorage, networkBridge, vlanTag, startAfterMigration, convertDisksToQcow2, migrationType, transferMode, ...(targetVmid !== undefined && { targetVmid }), ...(body.vddkLibdir && { vddkLibdir: body.vddkLibdir }), ...(downtimeBudgetSec !== undefined && { downtimeBudgetSec }), ...(cutoverMode !== undefined && { cutoverMode }),
+          // Source type and virt-v2v inputs (disk paths, vCenter placement, temp
+          // storage, root override): persisted so a retry rebuilds the same job.
+          sourceType: effectiveSourceType,
+          ...persistedV2vInputs(body, v2vRoot) },
         status: "pending",
         currentStep: "pending",
         startedAt: new Date(),

--- a/frontend/src/components/settings/connectionStatusResult.test.ts
+++ b/frontend/src/components/settings/connectionStatusResult.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { interpretConnectionStatusResponse } from "./connectionStatusResult"
+
+describe("interpretConnectionStatusResponse", () => {
+  it("accepts an online connection", () => {
+    expect(
+      interpretConnectionStatusResponse(
+        { ok: true, status: 200 },
+        { data: { status: "online" } },
+      ),
+    ).toEqual({ status: "ok" })
+  })
+
+  it("accepts a PVE nodes response", () => {
+    expect(
+      interpretConnectionStatusResponse(
+        { ok: true, status: 200 },
+        { data: [{ node: "pve-01", status: "online" }] },
+      ),
+    ).toEqual({ status: "ok" })
+  })
+
+  it("surfaces the warning from an authentication error", () => {
+    expect(
+      interpretConnectionStatusResponse(
+        { ok: true, status: 200 },
+        {
+          data: {
+            status: "auth_error",
+            warning: "Invalid credentials or Basic auth not enabled on WinRM",
+          },
+        },
+      ),
+    ).toEqual({
+      status: "error",
+      error: "Invalid credentials or Basic auth not enabled on WinRM",
+    })
+  })
+
+  it("uses a default message for an authentication error without a warning", () => {
+    expect(
+      interpretConnectionStatusResponse(
+        { ok: true, status: 200 },
+        { data: { status: "auth_error" } },
+      ),
+    ).toEqual({ status: "error", error: "Invalid credentials" })
+  })
+
+  it("surfaces the API error for a failed response", () => {
+    expect(
+      interpretConnectionStatusResponse(
+        { ok: false, status: 502 },
+        { error: "Hyper-V host unreachable: fetch failed" },
+      ),
+    ).toEqual({ status: "error", error: "Hyper-V host unreachable: fetch failed" })
+  })
+
+  it("falls back to the HTTP status for a failed response without an error", () => {
+    expect(interpretConnectionStatusResponse({ ok: false, status: 504 }, {})).toEqual({
+      status: "error",
+      error: "HTTP 504",
+    })
+  })
+})

--- a/frontend/src/components/settings/connectionStatusResult.ts
+++ b/frontend/src/components/settings/connectionStatusResult.ts
@@ -1,0 +1,31 @@
+/**
+ * Interpret a connection probe response for the status chip of the
+ * Settings > Connections tables.
+ *
+ * The external hypervisor status routes (`/api/v1/{vmware,xcpng,nutanix,hyperv}/[id]/status`)
+ * answer HTTP 200 with `data.status = 'auth_error'` when the host is reachable
+ * but rejects the credentials. Judging on `res.ok` alone painted those green,
+ * so a Hyper-V connection whose password was wrong showed "Online" in Settings
+ * while the inventory tree said "unreachable".
+ */
+
+export type ConnectionStatusResult =
+  | { status: 'ok' }
+  | { status: 'error'; error: string }
+
+export function interpretConnectionStatusResponse(
+  res: { ok: boolean; status: number },
+  json: any,
+): ConnectionStatusResult {
+  if (!res.ok) {
+    const error = typeof json?.error === 'string' && json.error.trim() ? json.error.trim() : `HTTP ${res.status}`
+    return { status: 'error', error }
+  }
+
+  if (json?.data?.status === 'auth_error') {
+    const warning = typeof json.data.warning === 'string' && json.data.warning.trim()
+    return { status: 'error', error: warning || 'Invalid credentials' }
+  }
+
+  return { status: 'ok' }
+}

--- a/frontend/src/lib/hyperv/client.test.ts
+++ b/frontend/src/lib/hyperv/client.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { executeMock } = vi.hoisted(() => ({ executeMock: vi.fn() }))
+
+vi.mock("./winrm", () => ({
+  WinRMClient: class { execute = executeMock },
+}))
+
+import { HyperVClient } from "./client"
+
+const conn = { host: "hv.example", username: "Administrator", password: "pw" }
+const validVmId = "11111111-2222-3333-4444-555555555555"
+const nestedDisk = "D:\\HYPERV\\2025-test\\2025-test\\Virtual Hard Disks\\2025-test.vhdx"
+
+describe("HyperVClient", () => {
+  beforeEach(() => executeMock.mockReset())
+
+  it("lists VMs and disk files in one command without using Get-VHD", async () => {
+    executeMock.mockResolvedValue('{"SharePath":null,"VMs":[]}')
+    await new HyperVClient(conn).listVMs()
+
+    expect(executeMock).toHaveBeenCalledOnce()
+    const script = executeMock.mock.calls[0][0]
+    expect(script).toContain("Get-VMHardDiskDrive")
+    expect(script).toContain("Get-Item -LiteralPath")
+    expect(script).not.toContain("Get-VHD")
+    expect(script).not.toContain("Get-SmbShare")
+    expect(script).toContain("$sharePath = $null")
+  })
+
+  it("resolves a requested SMB share in the same list command", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({ SharePath: "D:\\HYPERV", VMs: [] }))
+    await new HyperVClient(conn).listVMs({ shareName: "VMs" })
+
+    expect(executeMock).toHaveBeenCalledOnce()
+    expect(executeMock.mock.calls[0][0]).toContain("Get-SmbShare -Name 'VMs'")
+  })
+
+  it("maps the wrapped VM array, sums disks, and derives mount paths", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({
+      SharePath: "D:\\HYPERV",
+      VMs: [
+        {
+          VMId: validVmId, Name: "web-01", State: 2, ProcessorCount: 4,
+          MemoryMB: 8192, DynamicMemoryMaxMB: 16384, Generation: 2,
+          Disks: [
+            { Path: nestedDisk, SizeBytes: 100 },
+            { Path: "E:\\other\\x.vhdx", SizeBytes: 250 },
+          ],
+        },
+        {
+          VMId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", Name: "db-01", State: 3,
+          ProcessorCount: 8, MemoryMB: 16384, DynamicMemoryMaxMB: 32768, Generation: 1,
+          Disks: [{ Path: "D:\\HYPERV\\db\\db.vhdx", SizeBytes: 500 }],
+        },
+      ],
+    }))
+
+    await expect(new HyperVClient(conn).listVMs()).resolves.toEqual([
+      {
+        vmId: validVmId, name: "web-01", state: "Running", cpuCount: 4, memoryMB: 8192,
+        diskSizeBytes: 350, diskPaths: [nestedDisk, "E:\\other\\x.vhdx"],
+        diskMountPaths: [
+          "/mnt/hyperv/2025-test/2025-test/Virtual Hard Disks/2025-test.vhdx",
+          "/mnt/hyperv/x.vhdx",
+        ],
+        generation: 2,
+      },
+      {
+        vmId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", name: "db-01", state: "Off",
+        cpuCount: 8, memoryMB: 16384, diskSizeBytes: 500,
+        diskPaths: ["D:\\HYPERV\\db\\db.vhdx"], diskMountPaths: ["/mnt/hyperv/db/db.vhdx"],
+        generation: 1,
+      },
+    ])
+  })
+
+  it("prefers the startup memory over the dynamic maximum for an off VM", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({
+      SharePath: null,
+      VMs: [{ VMId: "aaaaaaaa-0000-0000-0000-000000000001", Name: "off", State: 3, ProcessorCount: 2,
+        MemoryMB: 0, MemoryStartupMB: 4096, DynamicMemoryMaxMB: 1048576, Generation: 2, Disks: [] }],
+    }))
+
+    const [vm] = await new HyperVClient(conn).listVMs()
+
+    expect(vm.memoryMB).toBe(4096)
+  })
+
+  it("falls back to maximum dynamic memory for an off VM", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({
+      SharePath: null,
+      VMs: { VMId: validVmId, Name: "off-vm", State: 3, ProcessorCount: 2, MemoryMB: 0,
+        DynamicMemoryMaxMB: 4096, Generation: 2, Disks: [] },
+    }))
+
+    const [vm] = await new HyperVClient(conn).listVMs()
+    expect(vm.state).toBe("Off")
+    expect(vm.memoryMB).toBe(4096)
+  })
+
+  it("tolerates a bare VM and a bare disk object", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({
+      SharePath: null,
+      VMs: { VMId: validVmId, Name: "single-disk-vm", State: "Paused", ProcessorCount: 1,
+        MemoryMB: 1024, Generation: 2, Disks: { Path: "C:\\VMs\\missing.vhdx", SizeBytes: 0 } },
+    }))
+
+    const [vm] = await new HyperVClient(conn).listVMs()
+    expect(vm.state).toBe("Paused")
+    expect(vm.diskPaths).toEqual(["C:\\VMs\\missing.vhdx"])
+    expect(vm.diskMountPaths).toEqual(["/mnt/hyperv/missing.vhdx"])
+    expect(vm.diskSizeBytes).toBe(0)
+  })
+
+  it.each(['{"SharePath":null,"VMs":[]}', '{"SharePath":null}'])(
+    "returns an empty list for stdout %j",
+    async stdout => {
+      executeMock.mockResolvedValue(stdout)
+      await expect(new HyperVClient(conn).listVMs()).resolves.toEqual([])
+    },
+  )
+
+  it("rejects a malformed VM ID without executing PowerShell", async () => {
+    await expect(new HyperVClient(conn).getVM("not-a-guid")).rejects.toThrow("Invalid VM ID format: not-a-guid")
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  it("gets one VM by GUID using Get-VHD and maps its share-relative disks", async () => {
+    executeMock.mockResolvedValue(JSON.stringify({
+      SharePath: "D:\\HYPERV", VMId: validVmId, Name: "migration-vm", State: 2,
+      ProcessorCount: 6, MemoryMB: 12288, DynamicMemoryMaxMB: 16384, Generation: 2,
+      Disks: [{ Path: nestedDisk, SizeBytes: 1000 }, { Path: "E:\\other\\x.vhdx", SizeBytes: 2000 }],
+    }))
+
+    const vm = await new HyperVClient(conn).getVM(validVmId, { shareName: "VMs" })
+
+    expect(executeMock).toHaveBeenCalledOnce()
+    const script = executeMock.mock.calls[0][0]
+    expect(script).toContain("Get-VHD")
+    expect(script).toContain("Get-SmbShare -Name 'VMs'")
+    expect(vm).toEqual({
+      vmId: validVmId, name: "migration-vm", state: "Running", cpuCount: 6, memoryMB: 12288,
+      diskSizeBytes: 3000, diskPaths: [nestedDisk, "E:\\other\\x.vhdx"],
+      diskMountPaths: [
+        "/mnt/hyperv/2025-test/2025-test/Virtual Hard Disks/2025-test.vhdx",
+        "/mnt/hyperv/x.vhdx",
+      ],
+      generation: 2,
+    })
+  })
+
+  it("rejects a malformed readiness VM ID without executing PowerShell", async () => {
+    await expect(new HyperVClient(conn).getVmReadiness("not-a-guid")).rejects.toThrow("Invalid VM ID format: not-a-guid")
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [{ State: 3, CheckpointCount: 2 }, { state: "Off", checkpointCount: 2 }],
+    [{ State: 2 }, { state: "Running", checkpointCount: 0 }],
+  ])("gets VM readiness from %j", async (stdout, expected) => {
+    executeMock.mockResolvedValue(JSON.stringify(stdout))
+    await expect(new HyperVClient(conn).getVmReadiness(validVmId)).resolves.toEqual(expected)
+
+    expect(executeMock).toHaveBeenCalledOnce()
+    const script = executeMock.mock.calls[0][0]
+    expect(script).toContain("Get-VMSnapshot")
+    expect(script).toContain(`'${validVmId}'`)
+  })
+})

--- a/frontend/src/lib/hyperv/client.ts
+++ b/frontend/src/lib/hyperv/client.ts
@@ -6,6 +6,7 @@
  */
 
 import { WinRMClient, type WinRMConnection } from "./winrm"
+import { hypervDiskMountPath } from "./diskPaths"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,8 +19,30 @@ export interface HyperVVm {
   cpuCount: number
   memoryMB: number
   diskSizeBytes: number
-  diskPaths: string[]   // VHDX / VHD file paths
+  diskPaths: string[]   // VHDX / VHD file paths (Windows paths on the host)
+  /**
+   * Same disks as seen from the Proxmox node once the connection's SMB share
+   * is mounted at /mnt/hyperv (see lib/hyperv/diskPaths.ts). Relative to the
+   * share's local path when it is known, basename otherwise.
+   */
+  diskMountPaths: string[]
   generation: number    // 1 or 2
+}
+
+export interface HyperVListOptions {
+  /** SMB share name of the connection: its local path is resolved on the host to map disk paths. */
+  shareName?: string | null
+}
+
+/** Facts the offline migration needs before copying a VM's disk files. */
+export interface HyperVVmReadiness {
+  state: string          // Running, Off, Saved, Paused, Other
+  checkpointCount: number
+}
+
+/** Single-quote a value for interpolation inside a PowerShell string literal. */
+function psQuote(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
 }
 
 // ---------------------------------------------------------------------------
@@ -43,96 +66,84 @@ export class HyperVClient {
   /**
    * List all VMs on the Hyper-V host, including disk paths and sizes.
    *
-   * Executes two PowerShell commands:
-   * 1. Get-VM for basic VM info
-   * 2. For each VM, Get-VMHardDiskDrive + Get-VHD for disk details
-   *
-   * The disk info is gathered in a single batched PS call to avoid
-   * N+1 round trips to the host.
+   * ONE PowerShell invocation. Every remote command pays a powershell.exe
+   * start plus the Hyper-V module import (several seconds each on Windows
+   * Server 2019), so the VM list and the disk list are gathered in the same
+   * script. Disk sizes come from the file size on disk (Get-Item), never from
+   * Get-VHD: that cmdlet opens every VHDX and walks its parent chain, which
+   * measured at 13 s for ~20 disks on a customer host and pushed the whole
+   * listing past the inventory's client-side timeout. getVM() keeps Get-VHD
+   * for the single VM about to be migrated, where the exact size matters.
    */
-  async listVMs(): Promise<HyperVVm[]> {
-    // Step 1: Get all VMs with basic info
-    const vmPs = `
-      $vms = Get-VM | Select-Object VMId, Name, State, ProcessorCount,
-        @{N='MemoryMB';E={[math]::Round($_.MemoryAssigned/1MB)}},
-        @{N='DynamicMemoryMaxMB';E={[math]::Round($_.MemoryMaximum/1MB)}},
-        Generation
-      if ($vms -eq $null) { '[]' } else { $vms | ConvertTo-Json -Compress }
-    `.trim()
-
-    const vmRaw = await this.winrm.execute(vmPs)
-    const vmData = this.parseJsonArray(vmRaw)
-
-    if (vmData.length === 0) return []
-
-    // Step 2: Get disk info for all VMs in a single call
-    // Build a PS script that collects disk paths + sizes per VM
-    const diskPs = `
-      $result = @{}
+  async listVMs(options: HyperVListOptions = {}): Promise<HyperVVm[]> {
+    const ps = `
+      ${this.sharePathSnippet(options.shareName)}
+      $out = @()
       foreach ($vm in Get-VM) {
         $disks = @()
-        $hdds = Get-VMHardDiskDrive -VM $vm
-        foreach ($hdd in $hdds) {
+        foreach ($hdd in Get-VMHardDiskDrive -VM $vm) {
           $size = 0
           try {
-            $vhd = Get-VHD -Path $hdd.Path -ErrorAction SilentlyContinue
-            if ($vhd) { $size = $vhd.FileSize }
+            $file = Get-Item -LiteralPath $hdd.Path -ErrorAction Stop
+            $size = $file.Length
           } catch {}
           $disks += @{Path=$hdd.Path; SizeBytes=$size}
         }
-        $result[$vm.VMId.ToString()] = $disks
+        $out += @{
+          VMId = $vm.VMId.ToString()
+          Name = $vm.Name
+          State = [int]$vm.State
+          ProcessorCount = $vm.ProcessorCount
+          MemoryMB = [math]::Round($vm.MemoryAssigned/1MB)
+          MemoryStartupMB = [math]::Round($vm.MemoryStartup/1MB)
+          DynamicMemoryMaxMB = [math]::Round($vm.MemoryMaximum/1MB)
+          Generation = $vm.Generation
+          Disks = $disks
+        }
       }
-      $result | ConvertTo-Json -Compress -Depth 4
+      @{ SharePath = $sharePath; VMs = @($out) } | ConvertTo-Json -Compress -Depth 5
     `.trim()
 
-    let diskMap: Record<string, Array<{ Path: string; SizeBytes: number }>> = {}
-    try {
-      const diskRaw = await this.winrm.execute(diskPs)
-      const parsed = JSON.parse(diskRaw.trim())
-      // PowerShell ConvertTo-Json wraps single-element arrays as objects,
-      // and nested arrays may be objects too. Normalize carefully.
-      diskMap = this.normalizeDiskMap(parsed)
-    } catch {
-      // If disk enumeration fails, we still return VMs without disk info
-      // rather than failing the entire listing
+    const raw = await this.winrm.execute(ps)
+    const data = JSON.parse(raw.trim())
+    const sharePath = typeof data?.SharePath === "string" ? data.SharePath : null
+
+    return this.normalizeArray(data?.VMs).map((vm: any) => this.mapVm(vm, sharePath))
+  }
+
+  /**
+   * Retrieve what decides whether the VM can be migrated offline: it must be
+   * powered off (the disk files are copied as they are) and carry no
+   * checkpoint (the active disk would be a differencing .avhdx whose parent
+   * chain only resolves on the Windows host).
+   */
+  async getVmReadiness(vmId: string): Promise<HyperVVmReadiness> {
+    this.assertVmId(vmId)
+    const ps = `
+      $vm = Get-VM -Id ${psQuote(vmId)}
+      if (-not $vm) { throw "VM not found: ${vmId}" }
+      @{
+        State = [int]$vm.State
+        CheckpointCount = @(Get-VMSnapshot -VM $vm -ErrorAction SilentlyContinue).Count
+      } | ConvertTo-Json -Compress
+    `.trim()
+
+    const raw = await this.winrm.execute(ps)
+    const data = JSON.parse(raw.trim())
+    return {
+      state: this.resolveVmState(data.State),
+      checkpointCount: typeof data.CheckpointCount === "number" ? data.CheckpointCount : 0,
     }
-
-    return vmData.map((vm: any) => {
-      const vmId = vm.VMId?.toString() || ""
-      const diskEntries = diskMap[vmId] || []
-      const diskPaths = diskEntries.map(d => d.Path).filter(Boolean)
-      const diskSizeBytes = diskEntries.reduce((sum, d) => sum + (d.SizeBytes || 0), 0)
-
-      // PowerShell State enum: Running=2, Off=3, Saved=6, Paused=9, etc.
-      // ConvertTo-Json serializes it as an integer, but sometimes as string
-      const state = this.resolveVmState(vm.State)
-
-      // MemoryMB may be 0 if VM is off (MemoryAssigned = 0); fall back to max
-      const memoryMB = (vm.MemoryMB || 0) > 0 ? vm.MemoryMB : (vm.DynamicMemoryMaxMB || 0)
-
-      return {
-        vmId,
-        name: vm.Name || "Unknown",
-        state,
-        cpuCount: vm.ProcessorCount || 0,
-        memoryMB,
-        diskSizeBytes,
-        diskPaths,
-        generation: vm.Generation || 1,
-      }
-    })
   }
 
   /**
    * Get a single VM by its GUID, including disk info.
    */
-  async getVM(vmId: string): Promise<HyperVVm> {
-    // Validate GUID format to prevent injection
-    if (!/^[0-9a-f-]{36}$/i.test(vmId)) {
-      throw new Error(`Invalid VM ID format: ${vmId}`)
-    }
+  async getVM(vmId: string, options: HyperVListOptions = {}): Promise<HyperVVm> {
+    this.assertVmId(vmId)
 
     const ps = `
+      ${this.sharePathSnippet(options.shareName)}
       $vm = Get-VM -Id '${vmId}'
       if (-not $vm) { throw "VM not found: ${vmId}" }
 
@@ -148,11 +159,13 @@ export class HyperVClient {
       }
 
       @{
+        SharePath = $sharePath
         VMId = $vm.VMId.ToString()
         Name = $vm.Name
         State = $vm.State
         ProcessorCount = $vm.ProcessorCount
         MemoryMB = [math]::Round($vm.MemoryAssigned/1MB)
+        MemoryStartupMB = [math]::Round($vm.MemoryStartup/1MB)
         DynamicMemoryMaxMB = [math]::Round($vm.MemoryMaximum/1MB)
         Generation = $vm.Generation
         Disks = $disks
@@ -161,38 +174,61 @@ export class HyperVClient {
 
     const raw = await this.winrm.execute(ps)
     const data = JSON.parse(raw.trim())
+    const sharePath = typeof data?.SharePath === "string" ? data.SharePath : null
 
-    const diskEntries = this.normalizeArray(data.Disks || [])
-    const diskPaths = diskEntries.map((d: any) => d.Path).filter(Boolean)
-    const diskSizeBytes = diskEntries.reduce((sum: number, d: any) => sum + (d.SizeBytes || 0), 0)
-    const memoryMB = (data.MemoryMB || 0) > 0 ? data.MemoryMB : (data.DynamicMemoryMaxMB || 0)
-
-    return {
-      vmId: data.VMId || vmId,
-      name: data.Name || "Unknown",
-      state: this.resolveVmState(data.State),
-      cpuCount: data.ProcessorCount || 0,
-      memoryMB,
-      diskSizeBytes,
-      diskPaths,
-      generation: data.Generation || 1,
-    }
+    return this.mapVm({ ...data, VMId: data.VMId || vmId }, sharePath)
   }
 
   // -----------------------------------------------------------------------
   // Internal helpers
   // -----------------------------------------------------------------------
 
-  /**
-   * Parse JSON that might be a single object (when PS has one result)
-   * or an array. Always returns an array.
-   */
-  private parseJsonArray(raw: string): any[] {
-    const trimmed = raw.trim()
-    if (!trimmed || trimmed === "[]") return []
+  /** Validate GUID format to prevent injection into the PowerShell script. */
+  private assertVmId(vmId: string): void {
+    if (!/^[0-9a-f-]{36}$/i.test(vmId)) {
+      throw new Error(`Invalid VM ID format: ${vmId}`)
+    }
+  }
 
-    const parsed = JSON.parse(trimmed)
-    return Array.isArray(parsed) ? parsed : [parsed]
+  /**
+   * PowerShell prologue setting $sharePath to the local folder behind the
+   * connection's SMB share (null when unknown). Resolved in the same remote
+   * command as the VM query: every extra command costs a powershell.exe start.
+   */
+  private sharePathSnippet(shareName?: string | null): string {
+    if (!shareName) return "$sharePath = $null"
+    return `$sharePath = $null
+      try { $sharePath = (Get-SmbShare -Name ${psQuote(shareName)} -ErrorAction Stop).Path } catch {}`
+  }
+
+  /** Map one VM object of the PowerShell output to HyperVVm. */
+  private mapVm(vm: any, sharePath: string | null): HyperVVm {
+    const vmId = vm?.VMId?.toString() || ""
+    const diskEntries = this.normalizeArray(vm?.Disks || [])
+    const diskPaths: string[] = diskEntries.map((d: any) => d?.Path).filter(Boolean)
+    const diskSizeBytes = diskEntries.reduce(
+      (sum: number, d: any) => sum + (typeof d?.SizeBytes === "number" ? d.SizeBytes : 0),
+      0
+    )
+
+    // MemoryAssigned is 0 while the VM is off. The startup memory is what the
+    // VM gets at boot and what a migration should size; the dynamic maximum
+    // is a ceiling (1 TB by default on Hyper-V) and only a last resort.
+    const memoryMB = (vm?.MemoryMB || 0) > 0
+      ? vm.MemoryMB
+      : (vm?.MemoryStartupMB || 0) > 0 ? vm.MemoryStartupMB : (vm?.DynamicMemoryMaxMB || 0)
+
+    return {
+      vmId,
+      name: vm?.Name || "Unknown",
+      state: this.resolveVmState(vm?.State),
+      cpuCount: vm?.ProcessorCount || 0,
+      memoryMB,
+      diskSizeBytes,
+      diskPaths,
+      diskMountPaths: diskPaths.map(p => hypervDiskMountPath(p, sharePath)),
+      generation: vm?.Generation || 1,
+    }
   }
 
   /**
@@ -201,26 +237,6 @@ export class HyperVClient {
   private normalizeArray(val: any): any[] {
     if (!val) return []
     return Array.isArray(val) ? val : [val]
-  }
-
-  /**
-   * Normalize the disk map from PowerShell.
-   * ConvertTo-Json may serialize single-element arrays as bare objects,
-   * so each value needs normalization.
-   */
-  private normalizeDiskMap(
-    parsed: any
-  ): Record<string, Array<{ Path: string; SizeBytes: number }>> {
-    if (!parsed || typeof parsed !== "object") return {}
-
-    const result: Record<string, Array<{ Path: string; SizeBytes: number }>> = {}
-    for (const [key, val] of Object.entries(parsed)) {
-      result[key] = this.normalizeArray(val).map((d: any) => ({
-        Path: d?.Path || "",
-        SizeBytes: typeof d?.SizeBytes === "number" ? d.SizeBytes : 0,
-      }))
-    }
-    return result
   }
 
   /**

--- a/frontend/src/lib/hyperv/diskPaths.test.ts
+++ b/frontend/src/lib/hyperv/diskPaths.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { HYPERV_MOUNT_ROOT, hypervDiskBasename, hypervDiskMountPath } from "./diskPaths"
+
+const disk = "D:\\HYPERV\\2025-test\\2025-test\\Virtual Hard Disks\\2025-test.vhdx"
+const mounted = "/mnt/hyperv/2025-test/2025-test/Virtual Hard Disks/2025-test.vhdx"
+
+describe("hypervDiskMountPath", () => {
+  it.each([
+    [disk, "D:\\HYPERV", mounted],
+    [disk, "d:\\hyperv", mounted],
+    [disk, "D:\\HYPERV\\", mounted],
+    ["D:/HYPERV/vm/Virtual Hard Disks/vm.vhdx", "D:/HYPERV", "/mnt/hyperv/vm/Virtual Hard Disks/vm.vhdx"],
+  ])("maps %s relative to %s", (windowsPath, sharePath, expected) => {
+    expect(hypervDiskMountPath(windowsPath, sharePath)).toBe(expected)
+  })
+
+  it.each([null, undefined, ""])("uses the basename when the share is %j", sharePath => {
+    expect(hypervDiskMountPath(disk, sharePath)).toBe(`${HYPERV_MOUNT_ROOT}/2025-test.vhdx`)
+  })
+
+  it("uses the basename for a disk outside the share", () => {
+    expect(hypervDiskMountPath("E:\\other\\x.vhdx", "D:\\HYPERV")).toBe("/mnt/hyperv/x.vhdx")
+  })
+
+  it("uses the basename when the disk path equals the share path", () => {
+    expect(hypervDiskMountPath("D:\\HYPERV", "D:\\HYPERV")).toBe("/mnt/hyperv/HYPERV")
+  })
+})
+
+describe("hypervDiskBasename", () => {
+  it.each([
+    ["D:\\VMs\\disk.vhdx", "disk.vhdx"],
+    ["/mnt/hyperv/vm/disk.vhd", "disk.vhd"],
+  ])("extracts the filename from %s", (path, expected) => {
+    expect(hypervDiskBasename(path)).toBe(expected)
+  })
+})

--- a/frontend/src/lib/hyperv/diskPaths.ts
+++ b/frontend/src/lib/hyperv/diskPaths.ts
@@ -1,0 +1,39 @@
+/**
+ * Where a Hyper-V virtual disk lands once the connection's SMB share is
+ * mounted on the Proxmox node (see the CIFS mount in lib/migration/v2v-pipeline.ts).
+ *
+ * Hyper-V keeps each VM's disks under `<store>\<VM>\Virtual Hard Disks\`, so the
+ * file is almost never at the root of the share. Mapping only the basename
+ * (`/mnt/hyperv/<file>.vhdx`) forced users to point the share at that leaf
+ * folder for every VM. With the share's local path (`Get-SmbShare .Path`) the
+ * relative part is kept: `D:\HYPERV\vm\Virtual Hard Disks\vm.vhdx` under a
+ * share on `D:\HYPERV` becomes `/mnt/hyperv/vm/Virtual Hard Disks/vm.vhdx`.
+ */
+
+export const HYPERV_MOUNT_ROOT = "/mnt/hyperv"
+
+function normalizeWindowsPath(p: string): string {
+  return p.replaceAll("/", "\\").replace(/\\+$/, "")
+}
+
+export function hypervDiskBasename(windowsPath: string): string {
+  const parts = windowsPath.split(/[\\/]/).filter(Boolean)
+  return parts.at(-1) || windowsPath
+}
+
+/**
+ * Mount-side path of a disk. Falls back to the basename when the share path is
+ * unknown or the disk lives outside the share (the pipeline then searches the
+ * mount for that file name).
+ */
+export function hypervDiskMountPath(windowsPath: string, shareLocalPath?: string | null): string {
+  const disk = normalizeWindowsPath(windowsPath)
+  const share = shareLocalPath ? normalizeWindowsPath(shareLocalPath) : ""
+
+  if (share && disk.toLowerCase().startsWith(`${share.toLowerCase()}\\`)) {
+    const relative = disk.slice(share.length + 1).split("\\").filter(Boolean).join("/")
+    if (relative) return `${HYPERV_MOUNT_ROOT}/${relative}`
+  }
+
+  return `${HYPERV_MOUNT_ROOT}/${hypervDiskBasename(windowsPath)}`
+}

--- a/frontend/src/lib/hyperv/log.test.ts
+++ b/frontend/src/lib/hyperv/log.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { logHypervFailure, withHypervLog } from "./log"
+
+describe("logHypervFailure", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("logs the error message with the connection and host and returns it", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const msg = logHypervFailure("VM listing", "SRVBACKUP3", "192.168.78.230", new Error("WinRM HTTP 401: "))
+    expect(msg).toBe("WinRM HTTP 401: ")
+    expect(spy).toHaveBeenCalledWith("[hyperv] VM listing failed for SRVBACKUP3 (192.168.78.230): WinRM HTTP 401: ")
+  })
+
+  it("stringifies non-Error values", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    expect(logHypervFailure("status probe", "HV", "10.0.0.1", "socket hang up")).toBe("socket hang up")
+    expect(logHypervFailure("status probe", "HV", "10.0.0.1", { message: "boom" })).toBe("boom")
+  })
+})
+
+describe("withHypervLog", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("returns the result and stays silent on success", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    await expect(withHypervLog("VM listing", "HV", "10.0.0.1", async () => [1, 2])).resolves.toEqual([1, 2])
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it("logs then rethrows the original error", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const boom = new Error("operation timed out")
+    await expect(withHypervLog("VM lookup 42", "HV", "10.0.0.1", async () => { throw boom })).rejects.toBe(boom)
+    expect(spy).toHaveBeenCalledWith("[hyperv] VM lookup 42 failed for HV (10.0.0.1): operation timed out")
+  })
+})

--- a/frontend/src/lib/hyperv/log.ts
+++ b/frontend/src/lib/hyperv/log.ts
@@ -1,0 +1,22 @@
+/**
+ * Server-side trace for Hyper-V calls that fail. The UI only shows a status
+ * chip or a tooltip, so the WinRM fault has to land in the server log for an
+ * "unreachable" report to be diagnosable from `docker compose logs`.
+ */
+
+/** Logs the failure and returns its message, for callers that inspect it. */
+export function logHypervFailure(what: string, connName: string, host: string, err: unknown): string {
+  const msg = (err as any)?.message || String(err)
+  console.error(`[hyperv] ${what} failed for ${connName} (${host}): ${msg}`)
+  return msg
+}
+
+/** Runs a Hyper-V call, logging any failure before rethrowing it untouched. */
+export async function withHypervLog<T>(what: string, connName: string, host: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    logHypervFailure(what, connName, host, err)
+    throw err
+  }
+}

--- a/frontend/src/lib/hyperv/winrm.test.ts
+++ b/frontend/src/lib/hyperv/winrm.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { Agent } from "undici"
 
-import { WinRMClient } from "./winrm"
+import { WinRMClient, cleanPowerShellStderr } from "./winrm"
 
 function agentOptions(agent: object): Record<string, any> {
   const key = Object.getOwnPropertySymbols(agent).find((s) => s.description === "options")!
@@ -39,5 +39,58 @@ describe("WinRMClient HTTP transport", () => {
     const init = (globalThis.fetch as any).mock.calls[0][1]
     expect((globalThis.fetch as any).mock.calls[0][0]).toBe("http://hv.example:5985/wsman")
     expect(init.dispatcher).toBeUndefined()
+  })
+})
+
+describe("WinRMClient receive loop", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const streamDone = (text: string) =>
+    `<s:Envelope><rsp:ReceiveResponse><rsp:Stream Name="stdout" CommandId="c1">${Buffer.from(text).toString("base64")}</rsp:Stream>` +
+    `<rsp:CommandState CommandId="c1" State="http://schemas.microsoft.com/wbem/wsman/1/windows/shell/CommandState/Done"/></rsp:ReceiveResponse></s:Envelope>`
+
+  it("keeps polling after the server's OperationTimeout fault and gives Receive a budget above 60 s", async () => {
+    const timedOut =
+      "<s:Envelope><s:Fault><s:Text>The WS-Management service cannot complete the operation within the time specified in OperationTimeout.</s:Text></s:Fault></s:Envelope>"
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(timedOut, { status: 500 }))
+      .mockResolvedValueOnce(new Response(streamDone("[]"), { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { stdout, stderr } = await (new WinRMClient(conn) as any).receiveOutput("shell-1", "c1")
+
+    expect(stdout).toBe("[]")
+    expect(stderr).toBe("")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1].body).toContain("<wsman:OperationTimeout>PT60S</wsman:OperationTimeout>")
+      expect(call[1].signal).toBeInstanceOf(AbortSignal)
+    }
+  })
+
+  it("still surfaces a real fault from Receive", async () => {
+    const denied = "<s:Envelope><s:Fault><s:Text>Access is denied.</s:Text></s:Fault></s:Envelope>"
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(denied, { status: 500 })))
+
+    await expect((new WinRMClient(conn) as any).receiveOutput("shell-1", "c1")).rejects.toThrow("Access is denied.")
+  })
+})
+
+describe("cleanPowerShellStderr", () => {
+  it("drops CLIXML progress records (module preparation) so they never count as an error", () => {
+    const clixml = `#< CLIXML
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Préparation des modules à la première utilisation.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>`
+    expect(cleanPowerShellStderr(clixml)).toBe("")
+  })
+
+  it("keeps the error strings of a CLIXML stream, decoded", () => {
+    const clixml = `#< CLIXML
+<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><MS><PR N="Record"><AV>x</AV></PR></MS></Obj><S S="Error">Get-VM : The term &apos;Get-VM&apos; is not recognized_x000D__x000A_</S><S S="Error">At line:1 char:1_x000D__x000A_</S></Objs>`
+    expect(cleanPowerShellStderr(clixml)).toBe("Get-VM : The term 'Get-VM' is not recognized\nAt line:1 char:1")
+  })
+
+  it("returns plain-text stderr unchanged", () => {
+    expect(cleanPowerShellStderr("  Access is denied.\n")).toBe("Access is denied.")
   })
 })

--- a/frontend/src/lib/hyperv/winrm.ts
+++ b/frontend/src/lib/hyperv/winrm.ts
@@ -50,6 +50,34 @@ const RECEIVE_ACTION = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/
 const SIGNAL_ACTION  = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/Signal"
 const SIGNAL_TERMINATE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shell/signal/terminate"
 
+/**
+ * WS-Management OperationTimeout sent in every header. A Receive blocks on the
+ * server until the command writes output or this elapses, in which case the
+ * server answers a wsman:TimedOut fault and the client simply asks again.
+ */
+const OPERATION_TIMEOUT_SEC = 60
+
+/**
+ * HTTP budget for a Receive request: it must outlive OperationTimeout, or a
+ * PowerShell script that stays silent for 30 s (Get-VM over a host with many
+ * guests) aborts on our side before the server had a chance to answer.
+ */
+const RECEIVE_TIMEOUT_MS = (OPERATION_TIMEOUT_SEC + 15) * 1000
+
+/**
+ * Overall cap on one command's output wait (two OperationTimeout rounds).
+ * Ordinary listings finish in a few seconds; the inventory's client budget
+ * for Hyper-V (lib/inventory/externalVmFetch.ts) sits above this cap plus the
+ * shell round trips, so the UI never gives up before the route does.
+ */
+export const MAX_RECEIVE_WAIT_MS = 2 * OPERATION_TIMEOUT_SEC * 1000
+
+/** True for the server-side wsman:TimedOut fault (no output yet, command still running). */
+function isOperationTimeoutFault(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err)
+  return /TimedOut|OperationTimeout/i.test(msg)
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -58,6 +86,37 @@ const SIGNAL_TERMINATE = "http://schemas.microsoft.com/wbem/wsman/1/windows/shel
 function encodePSCommand(cmd: string): string {
   const buf = Buffer.from(cmd, "utf16le")
   return buf.toString("base64")
+}
+
+/**
+ * Turn PowerShell's stderr into the text of the real errors only.
+ *
+ * Over WinRM, powershell.exe serialises its error stream as CLIXML
+ * (`#< CLIXML` header followed by an <Objs> document). That stream also
+ * carries progress records ("Preparing modules for first use", pipeline
+ * progress) which are not errors at all, so a command with no stdout and a
+ * module import on a cold host looked like a failure. Keep the <S S="Error">
+ * strings, drop the rest; a plain-text stderr is returned unchanged.
+ */
+export function cleanPowerShellStderr(stderr: string): string {
+  const text = stderr.trim()
+  if (!text.startsWith("#< CLIXML")) return text
+
+  const errors: string[] = []
+  const re = /<S S="Error">([\s\S]*?)<\/S>/g
+  for (const m of text.matchAll(re)) {
+    const decoded = m[1]
+      .replaceAll(/_x000D__x000A_/g, "\n")
+      .replaceAll(/_x000A_/g, "\n")
+      .replaceAll(/&lt;/g, "<")
+      .replaceAll(/&gt;/g, ">")
+      .replaceAll(/&quot;/g, '"')
+      .replaceAll(/&apos;/g, "'")
+      .replaceAll(/&amp;/g, "&")
+      .trim()
+    if (decoded) errors.push(decoded)
+  }
+  return errors.join("\n").trim()
 }
 
 /** Extract the text content of the first XML tag matching a local name. */
@@ -115,13 +174,17 @@ export class WinRMClient {
     const shellId = await this.createShell()
 
     try {
-      const commandId = await this.runCommand(shellId, psCommand)
+      // Progress records would otherwise land on stderr as CLIXML; nobody
+      // watches a progress bar over WinRM, and they cost bandwidth per poll.
+      const script = `$ProgressPreference = 'SilentlyContinue'\n${psCommand}`
+      const commandId = await this.runCommand(shellId, script)
       const { stdout, stderr } = await this.receiveOutput(shellId, commandId)
       await this.signalTerminate(shellId, commandId)
 
-      // If we got nothing on stdout but have stderr, treat as error
-      if (!stdout.trim() && stderr.trim()) {
-        throw new Error(`PowerShell error: ${stderr.trim().slice(0, 2000)}`)
+      // If we got nothing on stdout but a real error on stderr, fail
+      const errorText = cleanPowerShellStderr(stderr)
+      if (!stdout.trim() && errorText) {
+        throw new Error(`PowerShell error: ${errorText.slice(0, 2000)}`)
       }
 
       return stdout
@@ -161,7 +224,7 @@ export class WinRMClient {
         </wsa:ReplyTo>
         <wsa:Action s:mustUnderstand="true">${action}</wsa:Action>
         <wsa:MessageID>${messageId}</wsa:MessageID>
-        <wsman:OperationTimeout>PT60S</wsman:OperationTimeout>
+        <wsman:OperationTimeout>PT${OPERATION_TIMEOUT_SEC}S</wsman:OperationTimeout>
         ${extras}
       </s:Header>`
   }
@@ -236,9 +299,9 @@ export class WinRMClient {
     const stdoutParts: string[] = []
     const stderrParts: string[] = []
 
-    const maxPolls = 60
+    const deadline = Date.now() + MAX_RECEIVE_WAIT_MS
 
-    for (let i = 0; i < maxPolls; i++) {
+    while (Date.now() < deadline) {
       const selectorHeader = `<wsman:SelectorSet><wsman:Selector Name="ShellId">${shellId}</wsman:Selector></wsman:SelectorSet>`
       const header = this.soapHeader(RECEIVE_ACTION, SHELL_URI, selectorHeader)
       const body = `
@@ -246,7 +309,15 @@ export class WinRMClient {
           <rsp:DesiredStream CommandId="${commandId}">stdout stderr</rsp:DesiredStream>
         </rsp:Receive>`
 
-      const xml = await this.post(this.soapEnvelope(header, body))
+      let xml: string
+      try {
+        xml = await this.post(this.soapEnvelope(header, body), RECEIVE_TIMEOUT_MS)
+      } catch (err) {
+        // The server waited OperationTimeout without output: the command is
+        // still running, ask again. Anything else is a real failure.
+        if (isOperationTimeoutFault(err)) continue
+        throw err
+      }
 
       // Extract Stream elements with Name="stdout" or Name="stderr"
       // containing base64-encoded output
@@ -311,7 +382,7 @@ export class WinRMClient {
   // HTTP transport
   // -----------------------------------------------------------------------
 
-  private async post(soapXml: string): Promise<string> {
+  private async post(soapXml: string, timeoutMs: number = this.timeout): Promise<string> {
     const fetchOpts: RequestInit & { dispatcher?: unknown } = {
       method: "POST",
       headers: {
@@ -322,7 +393,7 @@ export class WinRMClient {
         "Accept-Encoding": "identity",
       },
       body: soapXml,
-      signal: AbortSignal.timeout(this.timeout),
+      signal: AbortSignal.timeout(timeoutMs),
     }
 
     // For HTTPS with self-signed certs, disable TLS verification

--- a/frontend/src/lib/inventory/externalVmFetch.test.ts
+++ b/frontend/src/lib/inventory/externalVmFetch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_EXTERNAL_VM_FETCH_TIMEOUT_MS,
+  describeVmLoadFailure,
+  describeVmLoadTimeout,
+  externalVmFetchTimeoutMs,
+} from "./externalVmFetch"
+
+describe("external VM fetch helpers", () => {
+  it("allows a longer timeout for Hyper-V", () => {
+    expect(externalVmFetchTimeoutMs("hyperv")).toBe(150_000)
+  })
+
+  it.each(["vmware", "xcpng", "nutanix", undefined, "unknown"])(
+    "uses the default timeout for %s",
+    (type) => {
+      expect(externalVmFetchTimeoutMs(type)).toBe(DEFAULT_EXTERNAL_VM_FETCH_TIMEOUT_MS)
+      expect(externalVmFetchTimeoutMs(type)).toBe(15_000)
+    },
+  )
+
+  it("includes an API error in the failure description", async () => {
+    const res = new Response(JSON.stringify({ error: "WinRM HTTP 401: Access is denied." }), {
+      status: 500,
+    })
+
+    await expect(describeVmLoadFailure(res)).resolves.toBe(
+      "HTTP 500: WinRM HTTP 401: Access is denied.",
+    )
+  })
+
+  it("falls back to the status for a non-JSON body", async () => {
+    const res = new Response("<html>", { status: 502 })
+
+    await expect(describeVmLoadFailure(res)).resolves.toBe("HTTP 502")
+  })
+
+  it("falls back to the status when JSON has no string error", async () => {
+    const res = new Response(JSON.stringify({ error: null }), { status: 500 })
+
+    await expect(describeVmLoadFailure(res)).resolves.toBe("HTTP 500")
+  })
+
+  it.each([
+    [150_000, "timeout after 150s"],
+    [15_000, "timeout after 15s"],
+  ])("describes a %i ms timeout", (timeoutMs, expected) => {
+    expect(describeVmLoadTimeout(timeoutMs)).toBe(expected)
+  })
+})

--- a/frontend/src/lib/inventory/externalVmFetch.ts
+++ b/frontend/src/lib/inventory/externalVmFetch.ts
@@ -1,0 +1,45 @@
+/**
+ * Client-side budget and error wording for the external hypervisor VM
+ * listings the inventory tree fetches (`/api/v1/<type>/<id>/vms`).
+ *
+ * VMware, XCP-ng and Nutanix answer one REST/SOAP call, so 15 s is plenty.
+ * Hyper-V runs PowerShell over WinRM: powershell.exe start + Hyper-V module
+ * import + Get-VM over every guest. A customer host with ~20 disks needed
+ * 13 s for the cmdlets alone, and the old 15 s budget cut the request off
+ * while the host was answering, showing it as "unreachable". The Hyper-V
+ * budget sits above the WinRM client's cap for one command's output wait
+ * (MAX_RECEIVE_WAIT_MS, 120 s, see lib/hyperv/winrm.ts) plus the shell round
+ * trips, so the UI never gives up while the route is still legitimately
+ * waiting. A dead host still fails fast: the first WinRM request times out
+ * after 30 s.
+ */
+
+export const DEFAULT_EXTERNAL_VM_FETCH_TIMEOUT_MS = 15_000
+
+const TIMEOUT_BY_TYPE: Record<string, number> = {
+  hyperv: 150_000,
+}
+
+export function externalVmFetchTimeoutMs(type: string | undefined): number {
+  return (type && TIMEOUT_BY_TYPE[type]) || DEFAULT_EXTERNAL_VM_FETCH_TIMEOUT_MS
+}
+
+/**
+ * Wording for a failed listing. The routes put the real cause (WinRM fault,
+ * PowerShell error, SOAP fault) in the `error` field of the body; surface it
+ * instead of the bare HTTP status so the tooltip tells the user what to fix.
+ */
+export async function describeVmLoadFailure(res: Response): Promise<string> {
+  let message: string | undefined
+  try {
+    const json = await res.json()
+    if (typeof json?.error === 'string' && json.error.trim()) message = json.error.trim()
+  } catch {
+    // Non-JSON body (proxy page, empty 502): fall back to the status code
+  }
+  return message ? `HTTP ${res.status}: ${message}` : `HTTP ${res.status}`
+}
+
+export function describeVmLoadTimeout(timeoutMs: number): string {
+  return `timeout after ${Math.round(timeoutMs / 1000)}s`
+}

--- a/frontend/src/lib/migration/hyperv-disks.test.ts
+++ b/frontend/src/lib/migration/hyperv-disks.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveHypervDiskPaths } from "./hyperv-disks"
+
+function fakeExec(handler: (command: string) => string | undefined) {
+  return vi.fn(async (command: string) => ({ success: true, output: handler(command) }))
+}
+
+describe("resolveHypervDiskPaths", () => {
+  it("keeps an existing path verbatim without searching", async () => {
+    const requested = "/mnt/hyperv/vm/disk.vhdx"
+    const exec = fakeExec(command => command.startsWith("test -f ") ? "yes\n" : undefined)
+
+    await expect(resolveHypervDiskPaths([requested], exec)).resolves.toEqual({ paths: [requested], notes: [] })
+    expect(exec).toHaveBeenCalledOnce()
+    expect(exec.mock.calls.some(([command]) => command.startsWith("find "))).toBe(false)
+  })
+
+  it("replaces a missing path when exactly one matching file is found", async () => {
+    const requested = "/mnt/hyperv/old/disk.vhdx"
+    const replacement = "/mnt/hyperv/new/disk.vhdx"
+    const exec = fakeExec(command => {
+      if (command.startsWith("test -f ")) return "no"
+      if (command.includes("-iname 'disk.vhdx'")) return `${replacement}\n`
+    })
+
+    const result = await resolveHypervDiskPaths([requested], exec)
+    expect(result.paths).toEqual([replacement])
+    expect(result.notes).toHaveLength(1)
+    expect(result.notes[0]).toContain(requested)
+    expect(result.notes[0]).toContain(replacement)
+  })
+
+  it("rejects when several files have the requested basename", async () => {
+    const exec = fakeExec(command => {
+      if (command.startsWith("test -f ")) return "no"
+      if (command.includes("-iname 'disk.vhdx'")) return "/mnt/hyperv/a/disk.vhdx\n/mnt/hyperv/b/disk.vhdx\n"
+    })
+
+    await expect(resolveHypervDiskPaths(["/mnt/hyperv/missing/disk.vhdx"], exec)).rejects.toThrow("Several files named")
+  })
+
+  it("lists visible inventory when the requested disk cannot be found", async () => {
+    const exec = fakeExec(command => {
+      if (command.startsWith("test -f ")) return "no"
+      if (command.includes("-iname 'missing.vhdx'")) return ""
+      if (command.includes("head -40")) return "/mnt/hyperv/a.vhdx\n/mnt/hyperv/b.vhd\n"
+    })
+
+    await expect(resolveHypervDiskPaths(["/mnt/hyperv/missing.vhdx"], exec)).rejects.toThrow(
+      /Disk file not found[\s\S]*\/mnt\/hyperv\/a\.vhdx[\s\S]*\/mnt\/hyperv\/b\.vhd/,
+    )
+  })
+
+  it("reports when no VHDX or VHD file is visible anywhere", async () => {
+    const exec = fakeExec(command => command.startsWith("test -f ") ? "no" : "")
+    await expect(resolveHypervDiskPaths(["/mnt/hyperv/missing.vhdx"], exec)).rejects.toThrow("No VHDX/VHD file is visible")
+  })
+
+  it("quotes the basename and searches the supplied mount root", async () => {
+    const exec = fakeExec(command => command.startsWith("test -f ") ? "no" : "")
+    await expect(resolveHypervDiskPaths(["/old/a disk.vhdx"], exec, "/mnt/x")).rejects.toThrow()
+
+    const basenameFind = exec.mock.calls.map(([command]) => command).find(command => command.includes("-iname"))
+    // Bare root, not quoted: the orchestrator allowlist matches `find /mnt/hyperv ` by prefix.
+    expect(basenameFind).toContain("find /mnt/x ")
+    expect(basenameFind).toContain("-iname 'a disk.vhdx'")
+  })
+})

--- a/frontend/src/lib/migration/hyperv-disks.ts
+++ b/frontend/src/lib/migration/hyperv-disks.ts
@@ -1,0 +1,88 @@
+/**
+ * Locate a Hyper-V VM's disk files on the mounted SMB share before virt-v2v
+ * runs. The dialog derives `/mnt/hyperv/...` paths from what the host reports,
+ * but the share may point elsewhere than expected (older connections mapped
+ * the basename only, users move disks, shares get re-created). So each path is
+ * checked on the node and, when missing, searched by file name under the
+ * mount. Ambiguity is an error: silently picking one of two same-named VHDX
+ * files would migrate the wrong VM.
+ */
+
+import { HYPERV_MOUNT_ROOT, hypervDiskBasename } from "@/lib/hyperv/diskPaths"
+import { shellEscape } from "@/lib/ssh/exec"
+
+export interface HypervDiskExecResult {
+  success: boolean
+  output?: string
+}
+
+export type HypervDiskExec = (command: string) => Promise<HypervDiskExecResult>
+
+export interface HypervDiskResolution {
+  /** Paths to hand to virt-v2v, same order as the input. */
+  paths: string[]
+  /** One line per path that had to be relocated, for the job log. */
+  notes: string[]
+}
+
+const DISK_GLOB = String.raw`\( -iname "*.vhdx" -o -iname "*.vhd" -o -iname "*.avhdx" \)`
+
+/**
+ * The orchestrator allowlist admits `find /mnt/hyperv ` by prefix, so the
+ * mount root goes on the command line bare when it is a plain path; quoting it
+ * would push every scan onto the ssh2 fallback.
+ */
+function findRoot(mountRoot: string): string {
+  return /^[A-Za-z0-9_./-]+$/.test(mountRoot) ? mountRoot : shellEscape(mountRoot)
+}
+
+function lines(output: string | undefined): string[] {
+  return (output || "").split("\n").map(l => l.trim()).filter(l => l.startsWith("/"))
+}
+
+export async function resolveHypervDiskPaths(
+  requested: string[],
+  exec: HypervDiskExec,
+  mountRoot: string = HYPERV_MOUNT_ROOT,
+): Promise<HypervDiskResolution> {
+  const paths: string[] = []
+  const notes: string[] = []
+
+  for (const requestedPath of requested) {
+    const exists = await exec(`test -f ${shellEscape(requestedPath)} && echo yes || echo no`)
+    if (exists.output?.trim() === "yes") {
+      paths.push(requestedPath)
+      continue
+    }
+
+    const fileName = hypervDiskBasename(requestedPath)
+    const found = await exec(
+      `find ${findRoot(mountRoot)} -type f -iname ${shellEscape(fileName)} 2>/dev/null || true`,
+    )
+    const candidates = lines(found.output)
+
+    if (candidates.length === 1) {
+      paths.push(candidates[0])
+      notes.push(`${requestedPath} not found, using ${candidates[0]}`)
+      continue
+    }
+
+    if (candidates.length > 1) {
+      throw new Error(
+        `Several files named ${fileName} exist on the Hyper-V share (${candidates.join(", ")}). ` +
+        `Enter the exact path of the disk to migrate in the VHDX Disk Paths field.`,
+      )
+    }
+
+    const inventory = await exec(
+      `find ${findRoot(mountRoot)} -type f ${DISK_GLOB} 2>/dev/null | head -40 || true`,
+    )
+    const available = lines(inventory.output)
+    const hint = available.length > 0
+      ? `Disk files visible on the share: ${available.join(", ")}`
+      : `No VHDX/VHD file is visible on the share at all: check that the SMB share exposes the folder holding the VM disks.`
+    throw new Error(`Disk file not found on the Hyper-V share: ${requestedPath} (${fileName} is nowhere under ${mountRoot}). ${hint}`)
+  }
+
+  return { paths, notes }
+}

--- a/frontend/src/lib/migration/ntfs-compression-plugin.test.ts
+++ b/frontend/src/lib/migration/ntfs-compression-plugin.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  NTFS_COMPRESSION_PLUGIN_FILE,
+  NTFS_COMPRESSION_PLUGIN_URL,
+  NTFS_COMPRESSION_SUPERMIN_TARBALL,
+  ntfsCompressionPluginCheckCommand,
+  ntfsCompressionPluginInstallScript,
+} from "./ntfs-compression-plugin"
+
+describe("ntfs-3g system-compression plugin scripts", () => {
+  it("checks both the plugin file and the supermin.d tarball", () => {
+    const cmd = ntfsCompressionPluginCheckCommand()
+    expect(cmd).toContain(`/usr/lib/*/ntfs-3g/${NTFS_COMPRESSION_PLUGIN_FILE}`)
+    expect(cmd).toContain("/usr/lib/*/guestfs/supermin.d")
+    expect(cmd).toContain(NTFS_COMPRESSION_SUPERMIN_TARBALL)
+    expect(cmd).toMatch(/echo yes; else echo no/)
+  })
+
+  it("pins the upstream release and builds against ntfs-3g's own plugin directory", () => {
+    const script = ntfsCompressionPluginInstallScript()
+    expect(NTFS_COMPRESSION_PLUGIN_URL).toMatch(/^https:\/\/github\.com\/ebiggers\/ntfs-3g-system-compression\/archive\/refs\/tags\/v\d+\.\d+\.tar\.gz$/)
+    expect(script).toContain(NTFS_COMPRESSION_PLUGIN_URL)
+    expect(script).toContain("ntfs-3g-dev")
+    expect(script).toContain("strings $(command -v ntfs-3g) | grep ntfs-plugin || true")
+    expect(script).toContain('./configure --libdir="$LIBDIR"')
+  })
+
+  it("is idempotent: skips the build when the plugin exists and the tarball when registered", () => {
+    const script = ntfsCompressionPluginInstallScript()
+    expect(script).toMatch(/^set -eo pipefail; /)
+    // Under pipefail a no-match `ls` would abort the script on the very case it
+    // handles (plugin absent): every exploratory lookup is guarded.
+    expect(script).toContain(`PLUGIN=$( (ls /usr/lib/*/ntfs-3g/${NTFS_COMPRESSION_PLUGIN_FILE} 2>/dev/null || true) | head -1)`)
+    expect(script).toContain("SD=$( (ls -d /usr/lib/*/guestfs/supermin.d 2>/dev/null || true) | head -1)")
+    expect(script).toContain('if [ -z "$PLUGIN" ]; then')
+    expect(script).toContain(`if [ ! -f "$SD/${NTFS_COMPRESSION_SUPERMIN_TARBALL}" ]; then`)
+  })
+
+  it("registers the plugin with supermin and drops the cached appliance", () => {
+    const script = ntfsCompressionPluginInstallScript()
+    expect(script).toContain(`tar czf "$SD/${NTFS_COMPRESSION_SUPERMIN_TARBALL}" -C / "\${PLUGIN#/}"`)
+    expect(script).toContain("rm -rf /var/tmp/.guestfs-*/appliance.d")
+    expect(script).toContain("supermin.d not found")
+    expect(script.trim().endsWith("echo installed")).toBe(true)
+  })
+})

--- a/frontend/src/lib/migration/ntfs-compression-plugin.ts
+++ b/frontend/src/lib/migration/ntfs-compression-plugin.ts
@@ -1,0 +1,82 @@
+/**
+ * ntfs-3g "system compression" plugin for the libguestfs appliance.
+ *
+ * Windows can store its system files with "Compact OS" (WOF system
+ * compression, reparse tag 0x80000017). Windows decides this alone at install
+ * time, so users have it without knowing. ntfs-3g only reads such files with
+ * the ntfs-3g-system-compression plugin: without it every compressed file is
+ * exposed as a dangling symlink ("unsupported reparse tag 0x80000017"),
+ * libguestfs cannot find System32\cmd.exe, inspection returns no operating
+ * system and virt-v2v fails with "No root device found". Fedora and RHEL ship
+ * the plugin (libguestfs-winsupport); Debian, hence Proxmox VE, does not.
+ *
+ * Two steps are needed on the node, both idempotent:
+ *   1. build the plugin from the pinned upstream release and install it in
+ *      ntfs-3g's plugin directory (the directory ntfs-3g was built with);
+ *   2. hand it to supermin through a tarball in libguestfs' supermin.d, since
+ *      the appliance is assembled from installed *packages* and ignores a
+ *      stray file, then drop the cached appliance so it is rebuilt.
+ *
+ * Verified on Proxmox VE 9 (Debian 13, libguestfs 1.54, ntfs-3g 2022.10.3):
+ * a Compact OS Windows Server 2025 goes from "<operatingsystems/>" to a
+ * clean inspection.
+ */
+
+export const NTFS_COMPRESSION_PLUGIN_VERSION = "1.1"
+export const NTFS_COMPRESSION_PLUGIN_URL =
+  `https://github.com/ebiggers/ntfs-3g-system-compression/archive/refs/tags/v${NTFS_COMPRESSION_PLUGIN_VERSION}.tar.gz`
+
+/** Plugin file name, fixed by ntfs-3g: ntfs-plugin-<reparse tag>.so */
+export const NTFS_COMPRESSION_PLUGIN_FILE = "ntfs-plugin-80000017.so"
+export const NTFS_COMPRESSION_SUPERMIN_TARBALL = "zz-ntfs-3g-system-compression.tar.gz"
+
+/**
+ * Shell fragment that prints "yes" when both the plugin and its supermin.d
+ * tarball are in place, "no" otherwise. Used by the preflight check.
+ */
+export function ntfsCompressionPluginCheckCommand(): string {
+  return (
+    `PLUGIN=$(ls /usr/lib/*/ntfs-3g/${NTFS_COMPRESSION_PLUGIN_FILE} 2>/dev/null | head -1); ` +
+    `SD=$(ls -d /usr/lib/*/guestfs/supermin.d 2>/dev/null | head -1); ` +
+    `if [ -n "$PLUGIN" ] && [ -n "$SD" ] && [ -f "$SD/${NTFS_COMPRESSION_SUPERMIN_TARBALL}" ]; then echo yes; else echo no; fi`
+  )
+}
+
+/**
+ * Bash script (to run under `bash -c`, with `set -e` semantics) that builds
+ * and installs the plugin if missing, then registers it with supermin. Safe to
+ * run again: every step checks for its result first.
+ */
+export function ntfsCompressionPluginInstallScript(): string {
+  return (
+    "set -eo pipefail; " +
+    // Exploratory lookups run under `set -eo pipefail`: a no-match ls or grep
+    // must not abort the script, it is the very case the script handles.
+    `PLUGIN=$( (ls /usr/lib/*/ntfs-3g/${NTFS_COMPRESSION_PLUGIN_FILE} 2>/dev/null || true) | head -1); ` +
+    'if [ -z "$PLUGIN" ]; then ' +
+    "  apt-get install -y build-essential pkg-config ntfs-3g-dev autoconf automake libtool curl; " +
+    // ntfs-3g looks for plugins in the directory compiled into its binary
+    // (e.g. /usr/lib/x86_64-linux-gnu/ntfs-3g); the plugin's configure wants
+    // the parent of that directory as --libdir.
+    "  LIBDIR=$( (strings $(command -v ntfs-3g) | grep ntfs-plugin || true) | head -1 | sed 's@/ntfs-3g/.*@@'); " +
+    '  [ -n "$LIBDIR" ] || LIBDIR=/usr/lib/x86_64-linux-gnu; ' +
+    "  TMPDIR=$(mktemp -d); " +
+    '  cd "$TMPDIR"; ' +
+    `  curl -fsSL -o plugin.tar.gz ${NTFS_COMPRESSION_PLUGIN_URL}; ` +
+    "  tar xzf plugin.tar.gz; " +
+    "  cd ntfs-3g-system-compression-*; " +
+    '  autoreconf -i && ./configure --libdir="$LIBDIR" && make && make install; ' +
+    '  cd /; rm -rf "$TMPDIR"; ' +
+    `  PLUGIN="$LIBDIR/ntfs-3g/${NTFS_COMPRESSION_PLUGIN_FILE}"; ` +
+    "fi; " +
+    `SD=$( (ls -d /usr/lib/*/guestfs/supermin.d 2>/dev/null || true) | head -1); ` +
+    '[ -n "$SD" ] || { echo "libguestfs supermin.d not found (is guestfs-tools installed?)" >&2; exit 1; }; ' +
+    `if [ ! -f "$SD/${NTFS_COMPRESSION_SUPERMIN_TARBALL}" ]; then ` +
+    `  tar czf "$SD/${NTFS_COMPRESSION_SUPERMIN_TARBALL}" -C / "\${PLUGIN#/}"; ` +
+    // libguestfs rebuilds the appliance when supermin.d changes; clearing the
+    // cache makes that certain for the next run.
+    "  rm -rf /var/tmp/.guestfs-*/appliance.d; " +
+    "fi; " +
+    "echo installed"
+  )
+}

--- a/frontend/src/lib/migration/retry-dispatch.test.ts
+++ b/frontend/src/lib/migration/retry-dispatch.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+
+import { persistedV2vInputs, resolveRetryEngine, resolveRetrySourceType, v2vConfigFromJobConfig } from "./retry-dispatch"
+
+describe("resolveRetrySourceType", () => {
+  it("prefers the persisted source type", () => {
+    expect(resolveRetrySourceType({ sourceType: "hyperv" }, { type: "vmware", subType: "vcenter" })).toBe("hyperv")
+  })
+
+  it.each([
+    [undefined, { type: "vmware", subType: "vcenter" }, "vcenter"],
+    [undefined, { type: "hyperv" }, "hyperv"],
+    [undefined, undefined, "vmware"],
+  ])("resolves config %j and connection %j to %s", (config, connection, expected) => {
+    expect(resolveRetrySourceType(config, connection)).toBe(expected)
+  })
+})
+
+describe("resolveRetryEngine", () => {
+  it.each([
+    [{ sourceType: "xcpng", migrationType: "warm" }, undefined, "warm-xcpng"],
+    [{ sourceType: "hyperv", migrationType: "warm" }, undefined, "warm-vmware"],
+    [{ sourceType: "hyperv", migrationType: "cold" }, undefined, "v2v"],
+    [{ sourceType: "vcenter", migrationType: "cold" }, undefined, "v2v"],
+    [{ sourceType: "nutanix", migrationType: "cold" }, undefined, "v2v"],
+    [{ sourceType: "xcpng", migrationType: "cold" }, undefined, "xcpng-cold"],
+    [{ sourceType: "vmware", migrationType: "cold" }, undefined, "vmware"],
+    [{ migrationType: "cold" }, null, "vmware"],
+  ])("resolves %j with %j to %s", (config, connection, expected) => {
+    expect(resolveRetryEngine(config, connection)).toBe(expected)
+  })
+})
+
+describe("v2vConfigFromJobConfig", () => {
+  const job = {
+    sourceConnectionId: "job-source",
+    sourceVmId: "job-vm",
+    sourceVmName: "job-name",
+    targetConnectionId: "job-target",
+    targetNode: "job-node",
+    targetStorage: "job-storage",
+  }
+
+  it("copies config fields and preserves live migration only for vCenter", () => {
+    const result = v2vConfigFromJobConfig({
+      sourceType: "vcenter",
+      sourceConnectionId: "config-source",
+      sourceVmId: "config-vm",
+      sourceVmName: "config-name",
+      targetConnectionId: "config-target",
+      targetNode: "config-node",
+      targetStorage: "config-storage",
+      networkBridge: "vmbr1",
+      vlanTag: 42,
+      startAfterMigration: true,
+      convertDisksToQcow2: true,
+      diskPaths: ["/mnt/hyperv/a.vhdx"],
+      tempStorage: "/scratch",
+      vcenterDatacenter: "dc",
+      vcenterCluster: "cluster",
+      vcenterHost: "host",
+      targetVmid: 123,
+      v2vRoot: "/dev/sda2",
+      migrationType: "live",
+    }, job)
+
+    expect(result).toEqual({
+      sourceConnectionId: "config-source",
+      sourceVmId: "config-vm",
+      sourceVmName: "config-name",
+      sourceType: "vcenter",
+      targetConnectionId: "config-target",
+      targetNode: "config-node",
+      targetStorage: "config-storage",
+      networkBridge: "vmbr1",
+      vlanTag: 42,
+      startAfterMigration: true,
+      convertDisksToQcow2: true,
+      vcenterDatacenter: "dc",
+      vcenterCluster: "cluster",
+      vcenterHost: "host",
+      diskPaths: ["/mnt/hyperv/a.vhdx"],
+      tempStorage: "/scratch",
+      migrationType: "live",
+      targetVmid: 123,
+      v2vRoot: "/dev/sda2",
+    })
+  })
+
+  it("falls back to job columns and forces Hyper-V live config to cold", () => {
+    const result = v2vConfigFromJobConfig({ sourceType: "hyperv", migrationType: "live" }, job)
+
+    expect(result).toMatchObject({
+      sourceConnectionId: "job-source",
+      sourceVmId: "job-vm",
+      sourceVmName: "job-name",
+      targetConnectionId: "job-target",
+      targetNode: "job-node",
+      targetStorage: "job-storage",
+      sourceType: "hyperv",
+      migrationType: "cold",
+    })
+    expect(result).not.toHaveProperty("targetVmid")
+    expect(result).not.toHaveProperty("v2vRoot")
+  })
+
+  it("takes the source type from the live connection for a legacy job without sourceType", () => {
+    const result = v2vConfigFromJobConfig({ migrationType: "cold" }, job, { type: "hyperv", subType: null })
+    expect(result.sourceType).toBe("hyperv")
+
+    const vcenter = v2vConfigFromJobConfig({ migrationType: "live" }, job, { type: "vmware", subType: "vcenter" })
+    expect(vcenter).toMatchObject({ sourceType: "vcenter", migrationType: "live" })
+  })
+})
+
+describe("persistedV2vInputs", () => {
+  it("returns nothing for a body without virt-v2v inputs", () => {
+    expect(persistedV2vInputs({}, undefined)).toEqual({})
+  })
+
+  it("keeps every provided input", () => {
+    expect(persistedV2vInputs({
+      diskPaths: ["/mnt/hyperv/Win2025/Virtual Hard Disks/Win2025.vhdx"],
+      tempStorage: "/var/lib/vz",
+      vcenterDatacenter: "DC1",
+      vcenterCluster: "Prod",
+      vcenterHost: "esx1.lab",
+    }, "/dev/sda3")).toEqual({
+      diskPaths: ["/mnt/hyperv/Win2025/Virtual Hard Disks/Win2025.vhdx"],
+      tempStorage: "/var/lib/vz",
+      vcenterDatacenter: "DC1",
+      vcenterCluster: "Prod",
+      vcenterHost: "esx1.lab",
+      v2vRoot: "/dev/sda3",
+    })
+  })
+
+  it("drops empty disk path lists, non-arrays and blank strings", () => {
+    expect(persistedV2vInputs({ diskPaths: [], tempStorage: "", vcenterDatacenter: null, vcenterCluster: undefined, vcenterHost: 0 }, undefined)).toEqual({})
+    expect(persistedV2vInputs({ diskPaths: "not-a-list" }, undefined)).toEqual({})
+  })
+
+  it("keeps an explicit empty root override but not an absent one", () => {
+    expect(persistedV2vInputs({}, "")).toEqual({ v2vRoot: "" })
+    expect(persistedV2vInputs({ tempStorage: "/tmp" }, undefined)).toEqual({ tempStorage: "/tmp" })
+  })
+})

--- a/frontend/src/lib/migration/retry-dispatch.ts
+++ b/frontend/src/lib/migration/retry-dispatch.ts
@@ -1,0 +1,100 @@
+/**
+ * Which engine a retried migration job goes back to.
+ *
+ * The create route (/api/v1/migrations) picks the engine from the source
+ * connection type and the migration mode; the retry route used to send every
+ * non-warm job to the direct-ESXi pipeline, which fails on anything else with
+ * "ESXi connection not found" (Hyper-V, vCenter, Nutanix and offline XCP-ng
+ * jobs could not be retried). The engine is now derived from the sourceType
+ * persisted in the job config, with the live connection as a fallback for
+ * jobs created before that field existed.
+ */
+
+import type { V2vMigrationConfig } from "./v2v-pipeline"
+
+export type RetryEngine = "warm-vmware" | "warm-xcpng" | "v2v" | "xcpng-cold" | "vmware"
+
+export interface RetrySourceConnection {
+  type: string
+  subType?: string | null
+}
+
+/** Effective source type, same rule as the create route (vmware + vcenter subType => vcenter). */
+export function resolveRetrySourceType(
+  config: Record<string, any> | null | undefined,
+  sourceConn: RetrySourceConnection | null | undefined,
+): string {
+  const persisted = typeof config?.sourceType === "string" ? config.sourceType : null
+  if (persisted) return persisted
+  if (!sourceConn) return "vmware"
+  if (sourceConn.type === "vmware" && sourceConn.subType === "vcenter") return "vcenter"
+  return sourceConn.type
+}
+
+export function resolveRetryEngine(
+  config: Record<string, any> | null | undefined,
+  sourceConn: RetrySourceConnection | null | undefined,
+): RetryEngine {
+  const sourceType = resolveRetrySourceType(config, sourceConn)
+  const isWarm = config?.migrationType === "warm"
+
+  if (isWarm) return sourceType === "xcpng" ? "warm-xcpng" : "warm-vmware"
+  if (sourceType === "vcenter" || sourceType === "hyperv" || sourceType === "nutanix") return "v2v"
+  if (sourceType === "xcpng") return "xcpng-cold"
+  return "vmware"
+}
+
+/**
+ * Rebuild the virt-v2v pipeline config from a persisted job config. Mirrors
+ * the object the create route hands to runV2vMigrationPipeline.
+ */
+export function v2vConfigFromJobConfig(
+  config: Record<string, any>,
+  job: { sourceConnectionId: string; sourceVmId: string; sourceVmName: string | null; targetConnectionId: string; targetNode: string; targetStorage: string },
+  sourceConn: RetrySourceConnection | null | undefined = null,
+): V2vMigrationConfig {
+  // Same resolution as the engine choice: a job saved before sourceType was
+  // persisted must not fall back to "vmware" here while the engine was picked
+  // from the live connection.
+  const sourceType = resolveRetrySourceType(config, sourceConn) as V2vMigrationConfig["sourceType"]
+  const migrationType: "cold" | "live" = sourceType === "vcenter" && config.migrationType === "live" ? "live" : "cold"
+
+  return {
+    sourceConnectionId: config.sourceConnectionId || job.sourceConnectionId,
+    sourceVmId: config.sourceVmId || job.sourceVmId,
+    sourceVmName: config.sourceVmName || job.sourceVmName || "",
+    sourceType,
+    targetConnectionId: config.targetConnectionId || job.targetConnectionId,
+    targetNode: config.targetNode || job.targetNode,
+    targetStorage: config.targetStorage || job.targetStorage,
+    networkBridge: config.networkBridge || "",
+    vlanTag: config.vlanTag,
+    startAfterMigration: !!config.startAfterMigration,
+    convertDisksToQcow2: !!config.convertDisksToQcow2,
+    vcenterDatacenter: config.vcenterDatacenter,
+    vcenterCluster: config.vcenterCluster,
+    vcenterHost: config.vcenterHost,
+    diskPaths: Array.isArray(config.diskPaths) ? config.diskPaths : undefined,
+    tempStorage: config.tempStorage,
+    migrationType,
+    ...(config.targetVmid !== undefined && { targetVmid: config.targetVmid }),
+    ...(config.v2vRoot !== undefined && { v2vRoot: config.v2vRoot }),
+  }
+}
+
+/**
+ * virt-v2v inputs the migration dialog sends (Hyper-V / Nutanix disk paths,
+ * vCenter placement, temporary storage, root override). Persisted in
+ * `job.config` so a retry rebuilds the same job instead of falling back to the
+ * ESXi defaults. Empty values are dropped so the stored config stays small.
+ */
+export function persistedV2vInputs(body: Record<string, any>, v2vRoot: string | undefined): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  if (Array.isArray(body.diskPaths) && body.diskPaths.length > 0) out.diskPaths = body.diskPaths
+  if (body.tempStorage) out.tempStorage = body.tempStorage
+  if (body.vcenterDatacenter) out.vcenterDatacenter = body.vcenterDatacenter
+  if (body.vcenterCluster) out.vcenterCluster = body.vcenterCluster
+  if (body.vcenterHost) out.vcenterHost = body.vcenterHost
+  if (v2vRoot !== undefined) out.v2vRoot = v2vRoot
+  return out
+}

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -23,6 +23,9 @@ import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
 import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+import { HyperVClient } from "@/lib/hyperv/client"
+import { resolveHypervDiskPaths } from "./hyperv-disks"
+import { ntfsCompressionPluginCheckCommand, ntfsCompressionPluginInstallScript } from "./ntfs-compression-plugin"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
 import { parseV2vXml, buildPveCreateParams } from "./v2vConfigMapper"
@@ -1404,6 +1407,32 @@ export async function runV2vMigrationPipeline(
     }
     await appendLog(jobId, "virt-v2v is available on target node", "success")
 
+    // Windows guests installed with "Compact OS" store their system files as
+    // WOF reparse points; libguestfs only sees them through the ntfs-3g
+    // system-compression plugin, which Debian does not ship. Nodes prepared
+    // before this check existed lack it, so make sure of it here rather than
+    // fail half an hour later with "No root device found".
+    const ntfsPluginCheck = await executeSSH(config.targetConnectionId, nodeIp, ntfsCompressionPluginCheckCommand())
+    if (!ntfsPluginCheck.output?.trim().endsWith("yes")) {
+      await appendLog(jobId, "Installing the ntfs-3g system-compression plugin for libguestfs (Compact OS Windows guests)...")
+      const pluginInstall = await executeSSH(
+        config.targetConnectionId,
+        nodeIp,
+        `bash -c ${shellEscape(ntfsCompressionPluginInstallScript())}`,
+        10 * 60 * 1000,
+      )
+      if (pluginInstall.success) {
+        await appendLog(jobId, "ntfs-3g system-compression plugin installed", "success")
+      } else {
+        await appendLog(
+          jobId,
+          `Could not install the ntfs-3g system-compression plugin (${(pluginInstall.error || pluginInstall.output || "unknown error").trim().slice(0, 300)}). ` +
+          `A Windows guest using Compact OS will not be recognised; run 'compact /compactos:never' in the guest or install the plugin manually.`,
+          "warn",
+        )
+      }
+    }
+
     // Probe virt-v2v capability for --block-driver (introduced in 2.2.0).
     // Debian 12 Bookworm (PVE 8 base) ships virt-v2v 2.0.x which lacks this flag.
     const blockDriverProbe = await executeSSH(
@@ -1471,7 +1500,7 @@ export async function runV2vMigrationPipeline(
     if (config.sourceType === "hyperv") {
       const sourceConn = await prisma.connection.findUnique({
         where: { id: config.sourceConnectionId },
-        select: { baseUrl: true, apiTokenEnc: true, hypervShareName: true },
+        select: { baseUrl: true, apiTokenEnc: true, hypervShareName: true, insecureTLS: true },
       })
       if (sourceConn?.apiTokenEnc) {
         const creds = decryptSecret(sourceConn.apiTokenEnc)
@@ -1480,6 +1509,41 @@ export async function runV2vMigrationPipeline(
         const smbPass = colonIdx > 0 ? creds.substring(colonIdx + 1) : creds
         const smbHost = (sourceConn.baseUrl || "").replace(/^https?:\/\//, "").replace(/:\d+\/?$/, "").replace(/\/.*$/, "")
         const shareName = (sourceConn as any).hypervShareName || "VMs"
+
+        // The offline path copies the disk files as they are: the VM must be
+        // powered off and carry no checkpoint (the active disk would be a
+        // differencing .avhdx whose parent chain only resolves on Windows).
+        // Without this gate virt-v2v inspects for half a minute and ends on
+        // "No root device found", which says nothing about the actual cause.
+        await appendLog(jobId, "Checking source VM state on the Hyper-V host...")
+        try {
+          const hyperv = new HyperVClient({
+            host: smbHost,
+            username: smbUser,
+            password: smbPass,
+            useSSL: sourceConn.insecureTLS ? false : (sourceConn.baseUrl || "").startsWith("https"),
+          })
+          const readiness = await hyperv.getVmReadiness(config.sourceVmId)
+          if (readiness.state !== "Off") {
+            throw new Error(
+              `Hyper-V VM "${config.sourceVmName || config.sourceVmId}" is ${readiness.state}. ` +
+              `Offline migration copies the virtual disk files, so the VM must be powered off first (Stop-VM).`,
+            )
+          }
+          if (readiness.checkpointCount > 0) {
+            throw new Error(
+              `Hyper-V VM "${config.sourceVmName || config.sourceVmId}" has ${readiness.checkpointCount} checkpoint(s). ` +
+              `Delete them (Remove-VMSnapshot merges the .avhdx chain into the base disk) before migrating.`,
+            )
+          }
+          await appendLog(jobId, "Source VM is powered off with no checkpoint", "success")
+        } catch (probeErr: any) {
+          const msg = probeErr?.message || String(probeErr)
+          // Our own verdicts above are final; a failed probe (WinRM down) only warns,
+          // the disk copy may still succeed and virt-v2v reports the rest.
+          if (msg.startsWith("Hyper-V VM ")) throw probeErr
+          await appendLog(jobId, `Could not verify the source VM state over WinRM: ${msg}`, "warn")
+        }
 
         // Check if already mounted
         const mountCheck = await executeSSH(config.targetConnectionId, nodeIp, "mountpoint -q /mnt/hyperv && echo mounted || echo not_mounted")
@@ -1490,7 +1554,7 @@ export async function runV2vMigrationPipeline(
           const cifsCheck = await executeSSH(config.targetConnectionId, nodeIp, "which mount.cifs")
           if (!cifsCheck.success || !cifsCheck.output?.trim()) {
             await appendLog(jobId, "Installing cifs-utils...")
-            await executeSSH(config.targetConnectionId, nodeIp, "apt-get update -qq && apt-get install -y cifs-utils")
+            await executeSSH(config.targetConnectionId, nodeIp, "apt-get update -qq || true; apt-get install -y cifs-utils")
           }
 
           // Mount the share
@@ -1503,6 +1567,19 @@ export async function runV2vMigrationPipeline(
           await appendLog(jobId, "Hyper-V SMB share mounted at /mnt/hyperv", "success")
         } else {
           await appendLog(jobId, "Hyper-V SMB share already mounted at /mnt/hyperv")
+        }
+
+        // Locate the configured disk files on the mounted share. The dialog
+        // derives these from the host's paths; a share rooted elsewhere, or a
+        // job created before relative paths were mapped, still resolves by
+        // file name as long as it is unambiguous.
+        if (config.diskPaths && config.diskPaths.length > 0) {
+          const resolution = await resolveHypervDiskPaths(
+            config.diskPaths,
+            (cmd) => executeSSH(config.targetConnectionId, nodeIp, cmd),
+          )
+          for (const note of resolution.notes) await appendLog(jobId, note, "warn")
+          config.diskPaths = resolution.paths
         }
 
         // Auto-detect disk paths if not provided
@@ -1958,7 +2035,9 @@ export async function runV2vMigrationPipeline(
         const install = await executeSSH(
           config.targetConnectionId,
           nodeIp,
-          "apt-get update -qq && apt-get install -y nbdkit libnbd-bin",
+          // `|| true`: the enterprise-repo 401 of an unsubscribed node must not
+          // block a package that lives in Debian main.
+          "apt-get update -qq || true; apt-get install -y nbdkit libnbd-bin",
         )
         if (!install.success) {
           throw new Error(

--- a/frontend/src/lib/migration/v2v-preflight.ts
+++ b/frontend/src/lib/migration/v2v-preflight.ts
@@ -1,6 +1,7 @@
 import { executeSSH, shellEscape, type SSHResult } from "@/lib/ssh/exec"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { getNodeIp } from "@/lib/ssh/node-ip"
+import { ntfsCompressionPluginCheckCommand, ntfsCompressionPluginInstallScript } from "./ntfs-compression-plugin"
 
 export interface TempStorageOption {
   path: string
@@ -41,6 +42,13 @@ export interface PreflightResult {
    * point cost-wise) with "cannot find firmware for UEFI guests".
    */
   ovmfInstalled: boolean
+  /**
+   * ntfs-3g system-compression plugin present on the node AND registered in
+   * libguestfs' supermin.d (see lib/migration/ntfs-compression-plugin.ts).
+   * Without it a Windows guest installed with "Compact OS" is not recognised
+   * by libguestfs and virt-v2v fails with "No root device found".
+   */
+  ntfsCompressionPluginInstalled: boolean
   diskSpaceAvailableBytes: number
   diskSpaceRequired: number
   diskSpaceSufficient: boolean
@@ -67,6 +75,7 @@ export async function runV2vPreflight(
   const result: PreflightResult = {
     ssh: false,
     virtioWinInstalled: false,
+    ntfsCompressionPluginInstalled: false,
     virtV2vInstalled: false,
     pvInstalled: false,
     nbdkitInstalled: false,
@@ -93,7 +102,7 @@ export async function runV2vPreflight(
   result.ssh = true
 
   // 2-4: Run remaining checks in parallel
-  const [v2vCheck, pvCheck, dfCheck, virtioWinCheck, ntfsFixCheck, virtCustomizeCheck, nbdkitCheck, nbdcopyCheck, guestfsCheck, ovmfCheck] = await Promise.all([
+  const [v2vCheck, pvCheck, dfCheck, virtioWinCheck, ntfsFixCheck, virtCustomizeCheck, nbdkitCheck, nbdcopyCheck, guestfsCheck, ovmfCheck, ntfsPluginCheck] = await Promise.all([
     executeSSH(targetConnectionId, nodeIp, "which virt-v2v"),
     executeSSH(targetConnectionId, nodeIp, "which pv"),
     executeSSH(targetConnectionId, nodeIp, "df -B1 /tmp | tail -1 | awk '{print $4}'"),
@@ -106,6 +115,8 @@ export async function runV2vPreflight(
     executeSSH(targetConnectionId, nodeIp, "test -f /usr/share/virt-tools/rhsrvany.exe -o -f /usr/share/virt-tools/pvvxsvc.exe && echo yes || echo no"),
     // OVMF firmware: required for UEFI guests at "Creating output metadata"
     executeSSH(targetConnectionId, nodeIp, "test -f /usr/share/OVMF/OVMF_CODE_4M.fd -o -f /usr/share/OVMF/OVMF_CODE.fd && echo yes || echo no"),
+    // ntfs-3g system-compression plugin: Windows "Compact OS" guests are invisible to libguestfs without it
+    executeSSH(targetConnectionId, nodeIp, ntfsCompressionPluginCheckCommand()),
   ])
 
   // 2. Check virt-v2v installed
@@ -150,6 +161,13 @@ export async function runV2vPreflight(
     result.ovmfInstalled = true
   } else {
     errors.push("ovmf is not installed (required for UEFI guest migration — fails after disk copy with 'cannot find firmware for UEFI guests')")
+  }
+
+  // 3e. Check the ntfs-3g system-compression plugin (Compact OS Windows guests)
+  if (ntfsPluginCheck.success && ntfsPluginCheck.output?.trim().endsWith('yes')) {
+    result.ntfsCompressionPluginInstalled = true
+  } else {
+    errors.push("ntfs-3g system-compression plugin is not installed (Windows guests using Compact OS fail with 'No root device found')")
   }
 
   // 4. Check virtio-win drivers
@@ -282,6 +300,14 @@ const MINGW_SRVANY_RPM_URL =
  * ntfsfix + qemu-nbd (for NTFS dirty flag recovery) are installed lazily in
  * the pipeline only when a Windows NTFS error is actually hit.
  */
+/**
+ * Budget for the package installation. The default executeSSH budget is 30 s,
+ * which the orchestrator-rejected `bash -c` wrapper then inherits on the ssh2
+ * fallback: apt alone needs longer than that on a cold node, and building the
+ * ntfs-3g plugin adds a compile step. Twenty minutes covers a slow mirror.
+ */
+export const INSTALL_V2V_PACKAGES_TIMEOUT_MS = 20 * 60 * 1000
+
 export async function installV2vPackages(
   targetConnectionId: string,
   targetNode: string
@@ -296,7 +322,11 @@ export async function installV2vPackages(
   const script =
     // pipefail so a failing rpm2cpio can't be masked by a successful cpio
     "set -eo pipefail; " +
-    "apt-get update -qq; " +
+    // `|| true`: a node pointed at enterprise.proxmox.com without a
+    // subscription fails `apt-get update` with a 401 (exit 100) although every
+    // package below comes from the Debian repositories, which refreshed fine.
+    // The real gate stays `apt-get install`, which still fails loudly.
+    "apt-get update -qq || true; " +
     "apt-get install -y virt-v2v pv nbdkit libnbd-bin guestfs-tools ovmf rpm2cpio cpio wget; " +
     "if [ ! -f /usr/share/virt-tools/rhsrvany.exe ] && [ ! -f /usr/share/virt-tools/pvvxsvc.exe ]; then " +
     "  TMPDIR=$(mktemp -d); " +
@@ -306,11 +336,14 @@ export async function installV2vPackages(
     "  mkdir -p /usr/share/virt-tools; " +
     "  cp ./usr/i686-w64-mingw32/sys-root/mingw/bin/*.exe /usr/share/virt-tools/; " +
     "  cd /; rm -rf \"$TMPDIR\"; " +
-    "fi"
+    "fi; " +
+    // Compact OS support for libguestfs: plugin built from the pinned upstream
+    // release and registered with supermin (idempotent, see the module).
+    ntfsCompressionPluginInstallScript()
 
   // shellEscape wraps in single quotes — critical here so the remote shell
   // doesn't expand $(mktemp -d) / $TMPDIR before bash -c receives the script.
-  return executeSSH(targetConnectionId, nodeIp, `bash -c ${shellEscape(script)}`)
+  return executeSSH(targetConnectionId, nodeIp, `bash -c ${shellEscape(script)}`, INSTALL_V2V_PACKAGES_TIMEOUT_MS)
 }
 
 const VIRTIO_WIN_URL = "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"


### PR DESCRIPTION
## Summary

Follow-up to a Hyper-V evaluation (Windows Server 2019 host with a couple of dozen VMs, Windows Server 2025 guests, Proxmox VE 9.2): the connection showed as unreachable right after being added, and the migrations that could be started failed before or during the virt-v2v conversion. Every cause was reproduced on a lab Hyper-V host and fixed here.

## Inventory and connection status

- The VM listing is a single PowerShell call. Disk sizes come from `Get-Item` instead of `Get-VHD`, which opened every VHDX and alone took 13 s on the reported host, on top of a fresh PowerShell per WinRM round trip.
- The WinRM transport keeps receiving past the operation timeout instead of treating it as a failure, with a 120 s ceiling; the inventory tree waits up to 150 s for Hyper-V and keeps 15 s for the REST-based sources.
- Wrong credentials no longer show a green "Online" chip: the `auth_error` status the routes return is now red, and the tree tooltip shows the server's error message instead of `HTTP 500`. Hyper-V faults are logged server-side so an "unreachable" report can be diagnosed from the container logs.

## Migration

- Disk paths were flattened to their basename and looked up at the root of the SMB share. The host now reports the share's local path (`Get-SmbShare`), paths stay relative to it, and the pipeline resolves them on the node: `test -f`, then `find` by name, with an explicit error when several files match.
- **Retry** sent every failed job to the ESXi pipeline. The engine is now chosen from the persisted source type, and the create route persists the virt-v2v inputs (disk paths, temporary storage, vCenter placement, root override) so a retry rebuilds the same job.
- virt-v2v ended with `No root device found` on Windows guests installed with **Compact OS**: libguestfs cannot read WOF-compressed system files without the `ntfs-3g` system-compression plugin, which Debian does not package. The preflight now builds the plugin from the pinned upstream release, installs it and registers it with supermin; the pipeline installs it on the fly when a node lacks it, and shows it as a required item in the dialog. Windows decides on its own whether an installation is Compact, so affected guests are not identifiable from the outside.
- The pipeline refuses a source VM that is running or has checkpoints before starting the conversion, with a message that says what to do.

## Package installation

- **Install missing packages** ran with the default 30 s SSH budget, so any installation longer than that failed and left the node half-prepared. It now has a 20 minute budget.
- A failing `apt-get update` (the 401 an unsubscribed node gets from the enterprise repository) no longer aborts installations whose packages all come from the Debian repositories; only a failing `apt-get install` is reported. The repository hint shown on failure now handles the deb822 `.sources` files of Proxmox VE 9 as well as the older `.list` files.
- The orchestrator's SSH command allowlist gains the matching prefixes in a separate change. Until it is deployed the commands run through the direct SSH fallback, as before.

## Verification

- Lab: Windows Server 2022 Hyper-V host, Windows Server 2025 guest made Compact with `compact /compactos:always`. Before: `virt-inspector` returned no operating system, exactly as reported. After: end-to-end migration from the dialog on a Proxmox VE 9 node, virt-v2v conversion in 49 s, VM booted to the Windows lock screen.
- 144 unit tests across 18 files (WinRM transport, Hyper-V client, disk path derivation and resolution, retry dispatch, external VM fetch budgets, connection status, plugin script, preflight and retry routes), ESLint clean, new-code coverage measured at 86% with the Sonar formula (lines and conditions).
- User documentation updated separately (Hyper-V connection requirements, Compact OS note, package installation without a subscription).
