### PR TITLE
Migration: keep the source CPU count and memory for Hyper-V and Nutanix guests

### DIFF
--- a/frontend/src/lib/migration/source-sizing.test.ts
+++ b/frontend/src/lib/migration/source-sizing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { applySourceSizing, hypervSourceSizing, nutanixSourceSizing } from "./source-sizing"
+
+describe("hypervSourceSizing", () => {
+  it("keeps the processor count and startup memory of the source VM", () => {
+    expect(hypervSourceSizing({ cpuCount: 1, memoryMB: 4096 })).toEqual({ source: "Hyper-V", cores: 1, memoryMB: 4096 })
+  })
+
+  it("returns null when the host reported nothing usable", () => {
+    expect(hypervSourceSizing({ cpuCount: 0, memoryMB: 0 })).toBeNull()
+    expect(hypervSourceSizing(undefined)).toBeNull()
+    expect(hypervSourceSizing({ cpuCount: Number.NaN, memoryMB: -1 })).toBeNull()
+  })
+
+  it("keeps a partial report", () => {
+    expect(hypervSourceSizing({ cpuCount: 4 })).toEqual({ source: "Hyper-V", cores: 4, memoryMB: 0 })
+    expect(hypervSourceSizing({ memoryMB: 8192.4 })).toEqual({ source: "Hyper-V", cores: 0, memoryMB: 8192 })
+  })
+})
+
+describe("nutanixSourceSizing", () => {
+  it("uses the flattened vCPU count and memory_size_mib", () => {
+    expect(nutanixSourceSizing({ numCpus: 8, memoryMB: 16384 })).toEqual({ source: "Nutanix", cores: 8, memoryMB: 16384 })
+    expect(nutanixSourceSizing(null)).toBeNull()
+  })
+})
+
+describe("applySourceSizing", () => {
+  it("replaces the virt-v2v placeholders and describes the change", () => {
+    const vmConfig = { cores: 1, memory: 2048 }
+    const line = applySourceSizing(vmConfig, { source: "Hyper-V", cores: 2, memoryMB: 4096 })
+    expect(vmConfig).toEqual({ cores: 2, memory: 4096 })
+    expect(line).toBe("Overriding virt-v2v defaults with Hyper-V source values: cores 1->2, memory 2048MB->4096MB")
+  })
+
+  it("leaves untouched what the source did not report", () => {
+    const vmConfig = { cores: 1, memory: 2048 }
+    expect(applySourceSizing(vmConfig, { source: "Nutanix", cores: 0, memoryMB: 8192 })).toContain("cores 1->1, memory 2048MB->8192MB")
+    expect(vmConfig).toEqual({ cores: 1, memory: 8192 })
+  })
+})

--- a/frontend/src/lib/migration/source-sizing.ts
+++ b/frontend/src/lib/migration/source-sizing.ts
@@ -1,0 +1,56 @@
+/**
+ * Sizing of the source VM for the virt-v2v `-i disk` paths (Hyper-V, Nutanix).
+ *
+ * In that mode virt-v2v only sees the disk image, so the libvirt XML it writes
+ * carries placeholder hardware (1 vCPU, 2 GB of RAM). The vCenter path already
+ * overrides those from the SOAP inspection; this module does the same with
+ * what the Hyper-V host (WinRM) or Prism Central reports, so the Proxmox VM
+ * matches the source instead of needing a manual fixup after every migration.
+ */
+
+export interface SourceSizing {
+  /** Human label for the job log. */
+  source: "Hyper-V" | "Nutanix"
+  /** vCPUs, 0 when the source did not report them. */
+  cores: number
+  /** Memory in MiB, 0 when the source did not report it. */
+  memoryMB: number
+}
+
+function positive(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.round(value) : 0
+}
+
+function build(source: SourceSizing["source"], cores: unknown, memoryMB: unknown): SourceSizing | null {
+  const sizing = { source, cores: positive(cores), memoryMB: positive(memoryMB) }
+
+  return sizing.cores === 0 && sizing.memoryMB === 0 ? null : sizing
+}
+
+/** Hyper-V reports ProcessorCount and the startup memory of a powered-off VM. */
+export function hypervSourceSizing(vm: { cpuCount?: number; memoryMB?: number } | null | undefined): SourceSizing | null {
+  return build("Hyper-V", vm?.cpuCount, vm?.memoryMB)
+}
+
+/** Prism Central reports sockets x vCPUs per socket (flattened) and memory_size_mib. */
+export function nutanixSourceSizing(vm: { numCpus?: number; memoryMB?: number } | null | undefined): SourceSizing | null {
+  return build("Nutanix", vm?.numCpus, vm?.memoryMB)
+}
+
+/**
+ * Applies the source sizing to the VM config parsed from the virt-v2v XML,
+ * leaving untouched whatever the source did not report, and returns the log
+ * line describing the change.
+ */
+export function applySourceSizing(vmConfig: { cores: number; memory: number }, sizing: SourceSizing): string {
+  const cores = sizing.cores || vmConfig.cores
+  const memory = sizing.memoryMB || vmConfig.memory
+  const line =
+    `Overriding virt-v2v defaults with ${sizing.source} source values: ` +
+    `cores ${vmConfig.cores}->${cores}, memory ${vmConfig.memory}MB->${memory}MB`
+
+  vmConfig.cores = cores
+  vmConfig.memory = memory
+
+  return line
+}

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -25,6 +25,7 @@ import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import { HyperVClient } from "@/lib/hyperv/client"
 import { resolveHypervDiskPaths } from "./hyperv-disks"
+import { applySourceSizing, hypervSourceSizing, nutanixSourceSizing, type SourceSizing } from "./source-sizing"
 import { ntfsCompressionPluginCheckCommand, ntfsCompressionPluginInstallScript } from "./ntfs-compression-plugin"
 import { getNodeIp } from "@/lib/ssh/node-ip"
 import { parseV2vLine, calculateOverallProgress } from "./v2v-progress"
@@ -1309,6 +1310,32 @@ async function processV2vOutput(jobId: string, output: string, progressOffset: n
   }
 }
 
+/** Prism Central client built from the stored source connection credentials. */
+async function nutanixClientForConnection(prisma: ReturnType<typeof getTenantPrisma>, sourceConnectionId: string) {
+  const sourceConn = await prisma.connection.findUnique({
+    where: { id: sourceConnectionId },
+    select: { baseUrl: true, apiTokenEnc: true, insecureTLS: true },
+  })
+  if (!sourceConn?.apiTokenEnc) {
+    throw new Error("Nutanix source connection credentials not found")
+  }
+
+  const creds = decryptSecret(sourceConn.apiTokenEnc)
+  const colonIdx = creds.indexOf(":")
+  const ntxUser = colonIdx > 0 ? creds.substring(0, colonIdx) : "admin"
+  const ntxPass = colonIdx > 0 ? creds.substring(colonIdx + 1) : creds
+
+  const { NutanixClient } = await import("@/lib/nutanix/client")
+  const ntxClient = new NutanixClient({
+    baseUrl: sourceConn.baseUrl,
+    username: ntxUser,
+    password: ntxPass,
+    insecureTLS: sourceConn.insecureTLS,
+  })
+
+  return { ntxClient, insecureTLS: sourceConn.insecureTLS }
+}
+
 /**
  * Main virt-v2v migration pipeline
  */
@@ -1378,6 +1405,9 @@ export async function runV2vMigrationPipeline(
   // We capture the parsed source config at vSAN detection time and use it later
   // in Phase 5 to override the sparse defaults virt-v2v would otherwise emit.
   let sourceVmwareConfig: EsxiVmConfig | null = null
+  // Same gap for the other -i disk sources: the Hyper-V host (WinRM) or Prism
+  // Central knows the real CPU count and memory, virt-v2v writes 1 vCPU / 2 GB.
+  let sourceSizing: SourceSizing | null = null
   // Live migration state. When migrationType=="live" and the source VM is
   // powered on, we snapshot before the NFC export so transfer happens while
   // the VM keeps serving traffic, then power off + remove the snapshot right
@@ -1537,6 +1567,11 @@ export async function runV2vMigrationPipeline(
             )
           }
           await appendLog(jobId, "Source VM is powered off with no checkpoint", "success")
+          try {
+            sourceSizing = hypervSourceSizing(await hyperv.getVM(config.sourceVmId))
+          } catch (sizingErr: any) {
+            await appendLog(jobId, `Could not read the source VM sizing over WinRM: ${sizingErr?.message || String(sizingErr)}`, "warn")
+          }
         } catch (probeErr: any) {
           const msg = probeErr?.message || String(probeErr)
           // Our own verdicts above are final; a failed probe (WinRM down) only warns,
@@ -1821,31 +1856,24 @@ export async function runV2vMigrationPipeline(
 
     if (isCancelled(jobId)) throw new Error("Migration cancelled")
 
+    // ── PHASE 2.4: Nutanix source sizing ──
+    // Read once from Prism Central whatever the disk path: virt-v2v -i disk has
+    // no metadata, and without this every Nutanix VM lands with 1 vCPU / 2 GB.
+    if (config.sourceType === "nutanix") {
+      try {
+        const { ntxClient } = await nutanixClientForConnection(prisma, config.sourceConnectionId)
+        sourceSizing = nutanixSourceSizing(await ntxClient.getVM(config.sourceVmId))
+      } catch (sizingErr: any) {
+        await appendLog(jobId, `Could not read the source VM sizing from Prism Central: ${sizingErr?.message || String(sizingErr)}`, "warn")
+      }
+    }
+
     // ── PHASE 2.5: Nutanix disk download ──
     // If sourceType is nutanix and no diskPaths provided, download disks from Prism API
     if (config.sourceType === "nutanix" && (!config.diskPaths || config.diskPaths.length === 0)) {
       await appendLog(jobId, "Downloading disks from Nutanix Prism Central...")
 
-      const sourceConn = await prisma.connection.findUnique({
-        where: { id: config.sourceConnectionId },
-        select: { baseUrl: true, apiTokenEnc: true, insecureTLS: true },
-      })
-      if (!sourceConn?.apiTokenEnc) {
-        throw new Error("Nutanix source connection credentials not found")
-      }
-
-      const creds = decryptSecret(sourceConn.apiTokenEnc)
-      const colonIdx = creds.indexOf(":")
-      const ntxUser = colonIdx > 0 ? creds.substring(0, colonIdx) : "admin"
-      const ntxPass = colonIdx > 0 ? creds.substring(colonIdx + 1) : creds
-
-      const { NutanixClient } = await import("@/lib/nutanix/client")
-      const ntxClient = new NutanixClient({
-        baseUrl: sourceConn.baseUrl,
-        username: ntxUser,
-        password: ntxPass,
-        insecureTLS: sourceConn.insecureTLS,
-      })
+      const { ntxClient, insecureTLS } = await nutanixClientForConnection(prisma, config.sourceConnectionId)
 
       // List disks for this VM
       const disks = await ntxClient.listDisks(config.sourceVmId)
@@ -1887,7 +1915,7 @@ export async function runV2vMigrationPipeline(
         const downloadUrl = ntxClient.getDiskDownloadUrl(imageUuid)
         const authHeader = ntxClient.getAuthHeader()
         const diskPath = `${downloadDir}/disk-${i}.raw`
-        const insecureFlag = sourceConn.insecureTLS ? "-k" : ""
+        const insecureFlag = insecureTLS ? "-k" : ""
 
         // Launch curl in background via nohup
         // Credentials stored in a curl config file (chmod 600), deleted after download
@@ -1896,7 +1924,7 @@ export async function runV2vMigrationPipeline(
         await appendLog(jobId, `Downloading disk ${i} to ${diskPath} (${(disk.sizeBytes / 1073741824).toFixed(1)} GB)...`)
 
         // Write curl config file with auth header (restricted permissions)
-        const cfgContent = `header = "Authorization: ${authHeader}"\noutput = "${diskPath}"\nurl = "${downloadUrl}"\nsilent\n${sourceConn.insecureTLS ? "insecure" : ""}`
+        const cfgContent = `header = "Authorization: ${authHeader}"\noutput = "${diskPath}"\nurl = "${downloadUrl}"\nsilent\n${insecureTLS ? "insecure" : ""}`
         const writeCfg = await executeSSH(config.targetConnectionId, nodeIp,
           `printf '%s' ${shellEscape(cfgContent)} > ${shellEscape(curlCfg)} && chmod 600 ${shellEscape(curlCfg)}`)
         if (!writeCfg.success) {
@@ -2713,6 +2741,8 @@ export async function runV2vMigrationPipeline(
             mac: n.macAddress || undefined,
           }))
         }
+      } else if (sourceSizing) {
+        await appendLog(jobId, applySourceSizing(vmConfig, sourceSizing), "info")
       }
 
       createParams = buildPveCreateParams(vmConfig, targetVmid, config.networkBridge, config.vlanTag)


### PR DESCRIPTION
## Summary

Follow-up to #813. A Hyper-V VM with 4 GB of RAM migrated fine but landed on Proxmox with `memory: 2048` and `cores: 1`. virt-v2v runs in `-i disk` mode for Hyper-V and Nutanix sources, so the libvirt XML it writes carries placeholder hardware (1 vCPU, 2 GB), and only the vCenter path overrode those values from its SOAP inspection. Every Hyper-V or Nutanix migration therefore needed a manual sizing fixup.

## Change

- New `lib/migration/source-sizing.ts`: derives the source sizing from what the Hyper-V host reports (`ProcessorCount`, startup memory of the powered-off VM) or from Prism Central (`num_sockets` x `num_vcpus_per_socket`, `memory_size_mib`), and applies it to the VM config parsed from the virt-v2v XML, leaving untouched whatever the source did not report. Fully unit-tested.
- Pipeline: the Hyper-V sizing is read over WinRM right after the power-state and checkpoint check; the Nutanix sizing is read from Prism Central before the download phase, whether disk paths were supplied or not. Both are applied when the Proxmox VM is created, in the same place as the vCenter override, with a log line showing the change. A failed read only warns and the conversion goes on.
- The Prism Central client construction is shared between the sizing read and the existing download phase.

## Verification

- Lab: the Windows Server 2025 guest from #813 (Hyper-V, 1 vCPU, 4 GB) migrated end to end; the job log shows `Overriding virt-v2v defaults with Hyper-V source values: cores 1->1, memory 2048MB->4096MB` and the created VM has `memory: 4096`.
- 33 unit tests (source sizing, pipeline integration, import path, root gate), ESLint clean.
- User documentation updated separately (Configure stage).
