### PR TITLE
feat(site-recovery): render the partially synced replication job status

### DIFF
--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -299,6 +299,7 @@ export async function GET(req: Request) {
           if (rj.status === "synced") jobStatus = "success"
           else if (rj.status === "syncing") jobStatus = "running"
           else if (rj.status === "error") jobStatus = "failed"
+          else if (rj.status === "partial") jobStatus = "failed" // one or more VMs in error, see error_message
           // paused and pending stay as-is
 
           const vmLabel = (rj.vm_names || []).length > 0

--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -6,6 +6,7 @@ import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraSc
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
 import { orchestratorHeaders } from "@/lib/orchestrator/headers"
 import { TERMINAL_STATUSES, sourceTypeLabel } from "@/lib/tasks/sharedTask"
+import { replicationJobStatus } from "@/lib/tasks/replicationJobStatus"
 
 export const runtime = "nodejs"
 
@@ -294,13 +295,8 @@ export async function GET(req: Request) {
         const replJobs: any[] = Array.isArray(replData) ? replData : (replData?.data || [])
 
         for (const rj of replJobs) {
-          // Map replication status → unified job status
-          let jobStatus = rj.status
-          if (rj.status === "synced") jobStatus = "success"
-          else if (rj.status === "syncing") jobStatus = "running"
-          else if (rj.status === "error") jobStatus = "failed"
-          else if (rj.status === "partial") jobStatus = "failed" // one or more VMs in error, see error_message
-          // paused and pending stay as-is
+          // Map replication status → unified job status (paused and pending stay as-is)
+          const jobStatus = replicationJobStatus(rj.status)
 
           const vmLabel = (rj.vm_names || []).length > 0
             ? rj.vm_names.slice(0, 3).join(", ") + (rj.vm_names.length > 3 ? ` +${rj.vm_names.length - 3}` : "")

--- a/frontend/src/components/automation/site-recovery/DashboardTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.test.tsx
@@ -40,6 +40,7 @@ function health(overrides: Partial<ReplicationHealthStatus> = {}): ReplicationHe
       error: 0,
       paused: 0,
       no_match: 0,
+      partial: 0,
     },
     ...overrides,
   }
@@ -68,11 +69,44 @@ describe('DashboardTab job status distribution', () => {
         error: 0,
         paused: 0,
         no_match: 2,
+        partial: 0,
       },
     }))
 
     const label = screen.getByText(/No matching VMs/)
     expect(label).toHaveTextContent('No matching VMs: 2')
+  })
+
+  it('renders the partially synced segment and count', () => {
+    renderDashboard(health({
+      job_summary: {
+        synced: 1,
+        syncing: 0,
+        pending: 0,
+        error: 0,
+        paused: 0,
+        no_match: 0,
+        partial: 1,
+      },
+    }))
+
+    expect(screen.getByText(/Partially synced/)).toHaveTextContent('Partially synced: 1')
+  })
+
+  it('treats a missing partial count (older orchestrator) as zero', () => {
+    renderDashboard(health({
+      job_summary: {
+        synced: 1,
+        syncing: 0,
+        pending: 0,
+        error: 0,
+        paused: 0,
+        no_match: 0,
+      } as any,
+    }))
+
+    expect(screen.getByText(/Synced/)).toHaveTextContent('Synced: 1')
+    expect(screen.queryByText(/Partially synced/)).not.toBeInTheDocument()
   })
 
   it('treats a missing no_match count as zero', () => {

--- a/frontend/src/components/automation/site-recovery/DashboardTab.tsx
+++ b/frontend/src/components/automation/site-recovery/DashboardTab.tsx
@@ -151,7 +151,8 @@ const RPOGauge = ({ compliance, t }: { compliance: number; t: any }) => {
 const JobStatusDistribution = ({ summary, t }: { summary: JobStatusSummary; t: any }) => {
   const theme = useTheme()
   const noMatch = summary.no_match || 0
-  const total = summary.synced + summary.syncing + summary.pending + summary.error + summary.paused + noMatch
+  const partial = summary.partial || 0
+  const total = summary.synced + summary.syncing + summary.pending + summary.error + summary.paused + noMatch + partial
 
   const segments = [
     { key: 'synced', count: summary.synced, color: theme.palette.success.main, label: t('siteRecovery.status.synced') },
@@ -159,7 +160,8 @@ const JobStatusDistribution = ({ summary, t }: { summary: JobStatusSummary; t: a
     { key: 'pending', count: summary.pending, color: theme.palette.warning.main, label: t('siteRecovery.status.pending') },
     { key: 'error', count: summary.error, color: theme.palette.error.main, label: t('siteRecovery.status.error') },
     { key: 'paused', count: summary.paused, color: theme.palette.text.disabled, label: t('siteRecovery.status.paused') },
-    { key: 'no_match', count: noMatch, color: theme.palette.warning.dark, label: t('siteRecovery.status.noMatch') }
+    { key: 'no_match', count: noMatch, color: theme.palette.warning.dark, label: t('siteRecovery.status.noMatch') },
+    { key: 'partial', count: partial, color: theme.palette.warning.light, label: t('siteRecovery.status.partial') }
   ].filter(s => s.count > 0)
 
   if (total === 0) return null
@@ -921,7 +923,7 @@ export default function DashboardTab({ health, loading, jobs, connections, vmNam
   }, [health])
 
   const jobSummary = useMemo(() => health?.job_summary || {
-    synced: 0, syncing: 0, pending: 0, error: 0, paused: 0, no_match: 0
+    synced: 0, syncing: 0, pending: 0, error: 0, paused: 0, no_match: 0, partial: 0
   }, [health])
 
   if (loading) {

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.test.tsx
@@ -71,6 +71,15 @@ describe('EmergencyDRTab: job status chip', () => {
     expect(screen.queryByText('no_match')).not.toBeInTheDocument()
   })
 
+  it('renders a translated warning chip for a partial job instead of the raw value', () => {
+    renderTab([job({ status: 'partial' })])
+
+    const chip = screen.getByText('Partially synced').closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorWarning')
+    expect(screen.queryByText('partial')).not.toBeInTheDocument()
+  })
+
   it('keeps the existing raw labels for the other statuses', () => {
     renderTab([job({ status: 'synced' })])
 

--- a/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
+++ b/frontend/src/components/automation/site-recovery/EmergencyDRTab.tsx
@@ -178,9 +178,10 @@ export default function EmergencyDRTab({
 
   const statusChip = (status: string) => {
     const colorMap: Record<string, 'success' | 'warning' | 'error' | 'default' | 'info'> = {
-      synced: 'success', syncing: 'info', paused: 'warning', error: 'error', pending: 'default', no_match: 'warning',
+      synced: 'success', syncing: 'info', paused: 'warning', error: 'error', pending: 'default', no_match: 'warning', partial: 'warning',
     }
-    const label = status === 'no_match' ? t('status.noMatch') : status
+    const labelMap: Record<string, string> = { no_match: t('status.noMatch'), partial: t('status.partial') }
+    const label = labelMap[status] ?? status
     return <Chip size="small" label={label} color={colorMap[status] || 'default'} sx={{ textTransform: 'capitalize' }} />
   }
 

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.test.tsx
@@ -160,3 +160,42 @@ describe('ProtectionTab: no matching VMs status (issue #687)', () => {
     expect(screen.queryByText('201 - pending-vm')).not.toBeInTheDocument()
   })
 })
+
+describe('ProtectionTab: partially synced status', () => {
+  // A job where some VMs synced and one failed (for instance a VM whose
+  // Proxmox snapshot broke the mirror snapshot) is "partial": the healthy
+  // VMs are protected, the job stays scheduled, and the card must say so
+  // instead of showing a bare error or a raw status string.
+  it('shows the "Partially synced" warning chip for a partial job', () => {
+    renderTab([job({ status: 'partial', error_message: '1 of 6 VMs failed: VM 279: failed to create snapshot' })])
+
+    const chipLabel = screen.getByText('Partially synced')
+    const chip = chipLabel.closest('.MuiChip-root')
+    expect(chip).toBeInTheDocument()
+    expect(chip).toHaveClass('MuiChip-colorWarning')
+    expect(chip?.querySelector('.ri-error-warning-line')).toBeInTheDocument()
+    expect(screen.queryByText('partial')).not.toBeInTheDocument()
+  })
+
+  it('offers partial in the status filter and filters the job list to partial jobs', async () => {
+    renderTab([
+      job({ id: 'job-partial', status: 'partial', vm_ids: [279], vm_names: ['git-ia'] }),
+      job({ id: 'job-synced', status: 'synced', vm_ids: [221], vm_names: ['sarbacane'] }),
+    ])
+
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    await userEvent.click(await screen.findByRole('option', { name: 'Partially synced' }))
+
+    expect(screen.getByText('279 - git-ia')).toBeInTheDocument()
+    expect(screen.queryByText('221 - sarbacane')).not.toBeInTheDocument()
+  })
+
+  it('shows the failure summary as a warning in the drawer of a partial job', async () => {
+    renderTab([job({ status: 'partial', error_message: '1 of 6 VMs failed: VM 279: failed to create snapshot' })])
+
+    await openDrawer('100 - web-01')
+
+    const alert = await screen.findByText('1 of 6 VMs failed: VM 279: failed to create snapshot')
+    expect(alert.closest('.MuiAlert-root')).toHaveClass('MuiAlert-colorWarning')
+  })
+})

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -74,7 +74,8 @@ const StatusChip = ({ status, t }: { status: ReplicationJobStatus; t: any }) => 
     paused: { label: t('siteRecovery.status.paused'), color: 'default' },
     pending: { label: t('siteRecovery.status.pending'), color: 'warning' },
     failed_over: { label: t('siteRecovery.jobs.failedOver'), color: 'warning', icon: 'ri-shield-star-line' },
-    no_match: { label: t('siteRecovery.status.noMatch'), color: 'warning', icon: 'ri-price-tag-3-line' }
+    no_match: { label: t('siteRecovery.status.noMatch'), color: 'warning', icon: 'ri-price-tag-3-line' },
+    partial: { label: t('siteRecovery.status.partial'), color: 'warning', icon: 'ri-error-warning-line' }
   }
 
   const c = config[status] || config.paused
@@ -594,6 +595,7 @@ export default function ProtectionTab({
               <MenuItem value='paused'>{t('siteRecovery.status.paused')}</MenuItem>
               <MenuItem value='error'>{t('siteRecovery.status.error')}</MenuItem>
               <MenuItem value='no_match'>{t('siteRecovery.status.noMatch')}</MenuItem>
+              <MenuItem value='partial'>{t('siteRecovery.status.partial')}</MenuItem>
             </Select>
             {(q || statusFilter !== 'all') && (
               <Button size='small' onClick={() => { setQ(''); setStatusFilter('all') }} startIcon={<i className='ri-close-line' />}>
@@ -723,8 +725,8 @@ export default function ProtectionTab({
                 </Button>
               </Box>
 
-              {selected.status === 'error' && selected.error_message && (
-                <Alert severity='error' sx={{ mb: 2 }} icon={<i className='ri-error-warning-line' />}>{selected.error_message}</Alert>
+              {(selected.status === 'error' || selected.status === 'partial') && selected.error_message && (
+                <Alert severity={selected.status === 'partial' ? 'warning' : 'error'} sx={{ mb: 2 }} icon={<i className='ri-error-warning-line' />}>{selected.error_message}</Alert>
               )}
 
               <Box sx={{ p: 2, borderRadius: 1, bgcolor: 'action.hover', mb: 2, textAlign: 'center' }}>

--- a/frontend/src/lib/orchestrator/site-recovery.types.ts
+++ b/frontend/src/lib/orchestrator/site-recovery.types.ts
@@ -6,7 +6,7 @@ import type { ScheduleSpec } from '@/components/automation/site-recovery/schedul
 // Replication Jobs
 // ============================================
 
-export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending' | 'failed_over' | 'no_match'
+export type ReplicationJobStatus = 'synced' | 'syncing' | 'error' | 'paused' | 'pending' | 'failed_over' | 'no_match' | 'partial'
 
 export interface BandwidthWindow {
   days: number[]          // 0=Sun, 1=Mon, …, 6=Sat
@@ -266,6 +266,7 @@ export interface JobStatusSummary {
   error: number
   paused: number
   no_match: number
+  partial: number
 }
 
 export interface ReplicationHealthStatus {

--- a/frontend/src/lib/tasks/replicationJobStatus.test.ts
+++ b/frontend/src/lib/tasks/replicationJobStatus.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { replicationJobStatus } from './replicationJobStatus'
+
+describe('replicationJobStatus', () => {
+  it('maps the terminal statuses to the unified success / failed values', () => {
+    expect(replicationJobStatus('synced')).toBe('success')
+    expect(replicationJobStatus('error')).toBe('failed')
+  })
+
+  it('reports a partially synced job as failed so the taskbar does not show it as running forever', () => {
+    expect(replicationJobStatus('partial')).toBe('failed')
+  })
+
+  it('keeps syncing as running and passes the other statuses through', () => {
+    expect(replicationJobStatus('syncing')).toBe('running')
+    expect(replicationJobStatus('paused')).toBe('paused')
+    expect(replicationJobStatus('pending')).toBe('pending')
+    expect(replicationJobStatus('no_match')).toBe('no_match')
+  })
+})

--- a/frontend/src/lib/tasks/replicationJobStatus.ts
+++ b/frontend/src/lib/tasks/replicationJobStatus.ts
@@ -1,0 +1,16 @@
+/**
+ * Maps a Site Recovery replication job status to the unified job status of
+ * the Task Center feed, which only renders success / running / failed plus the
+ * pass-through values (paused, pending, no_match, failed_over).
+ *
+ * "partial" (some VMs synced, at least one in error, the job stays scheduled)
+ * surfaces as failed: the taskbar rows know nothing else than success, failed
+ * and running, and anything else would spin forever as a running task.
+ */
+export function replicationJobStatus(status: string): string {
+  if (status === 'synced') return 'success'
+  if (status === 'syncing') return 'running'
+  if (status === 'error' || status === 'partial') return 'failed'
+
+  return status
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4154,7 +4154,8 @@
       "error": "Fehler",
       "paused": "Pausiert",
       "pending": "Ausstehend",
-      "noMatch": "Keine passenden VMs"
+      "noMatch": "Keine passenden VMs",
+      "partial": "Teilweise synchronisiert"
     },
     "planStatus": {
       "ready": "Bereit",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4177,7 +4177,8 @@
       "error": "Error",
       "paused": "Paused",
       "pending": "Pending",
-      "noMatch": "No matching VMs"
+      "noMatch": "No matching VMs",
+      "partial": "Partially synced"
     },
     "planStatus": {
       "ready": "Ready",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4177,7 +4177,8 @@
       "error": "Error",
       "paused": "En pausa",
       "pending": "Pendiente",
-      "noMatch": "Sin VMs coincidentes"
+      "noMatch": "Sin VMs coincidentes",
+      "partial": "Parcialmente sincronizado"
     },
     "planStatus": {
       "ready": "Listo",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4177,7 +4177,8 @@
       "error": "Erreur",
       "paused": "En pause",
       "pending": "En attente",
-      "noMatch": "Aucune VM correspondante"
+      "noMatch": "Aucune VM correspondante",
+      "partial": "Partiellement synchronisé"
     },
     "planStatus": {
       "ready": "Prêt",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4177,7 +4177,8 @@
       "error": "오류",
       "paused": "일시 중지됨",
       "pending": "대기 중",
-      "noMatch": "일치하는 VM 없음"
+      "noMatch": "일치하는 VM 없음",
+      "partial": "부분 동기화"
     },
     "planStatus": {
       "ready": "준비됨",

--- a/frontend/src/messages/siteRecoveryPartialMessages.test.ts
+++ b/frontend/src/messages/siteRecoveryPartialMessages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+const requiredKeys = ['siteRecovery.status.partial']
+
+function get(messages: any, path: string): unknown {
+  return path.split('.').reduce((node, key) => (node ? node[key] : undefined), messages)
+}
+
+describe('Site Recovery partial i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} declares every Site Recovery partial key`, () => {
+      for (const key of requiredKeys) {
+        expect(get(messages, key), `${locale}: ${key}`).toBeTypeOf('string')
+      }
+    })
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4153,7 +4153,8 @@
       "error": "错误",
       "paused": "已暂停",
       "pending": "等待中",
-      "noMatch": "无匹配的虚拟机"
+      "noMatch": "无匹配的虚拟机",
+      "partial": "部分同步"
     },
     "planStatus": {
       "ready": "就绪",


### PR DESCRIPTION
## Context

A Site Recovery replication job used to stop at the first failing VM (typically a VM carrying a Proxmox snapshot, whose mirror snapshot failed with `rbd: failed to create snapshot: (17) File exists`), leaving every other VM of the job unprotected. The orchestrator side is fixed separately: disk discovery ignores the `[snapshot]` sections of the VM config, the job carries on after a failing VM, and a run where some VMs synced and some failed now ends in a new job status, `partial`, that stays on its schedule.

## What this PR does

Renders the `partial` status everywhere a replication job status is shown:

- `ReplicationJobStatus` and `JobStatusSummary` types gain `partial`.
- Protection tab: warning chip "Partially synced" (`ri-error-warning-line`), a `partial` entry in the status filter, and the job drawer shows `error_message` (the per-VM failure summary) as a warning alert instead of only for `error` jobs.
- Emergency DR tab: translated warning chip instead of the raw status string.
- Dashboard: a "Partially synced" segment in the job status distribution; a missing `partial` count from an older orchestrator is treated as zero, like `no_match`.
- Unified jobs feed (`/api/v1/orchestrator/jobs`): `partial` maps to `failed`, since the taskbar rows only know success / failed / running and anything else would spin forever.
- `siteRecovery.status.partial` in the six served locales, with a parity test.

## Tests

New cases in `ProtectionTab.test.tsx` (chip, filter, drawer alert), `EmergencyDRTab.test.tsx` (chip), `DashboardTab.test.tsx` (segment, missing count) and `siteRecoveryPartialMessages.test.ts`. The touched suites pass (75 tests), ESLint reports no error on the changed files, and `tsc` stays at the `main` baseline.
