### PR TITLE
fix(task-center): publish the real progress of a running DRS migration

### DIFF
--- a/frontend/src/app/api/v1/orchestrator/jobs/jobsScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/jobsScope.test.ts
@@ -344,3 +344,130 @@ describe("GET /api/v1/orchestrator/jobs — tenant scoping", () => {
     expect(ids).not.toContain("ru-none")
   })
 })
+
+/**
+ * #818: a DRS migration used to be published with a constant 50% progress
+ * whenever its status was "running". Combined with an orchestrator-side row
+ * that nothing reconciled, that displayed finished migrations as "In progress,
+ * 50%" forever in the shared task footer and the Task Center.
+ *
+ * These live in this file rather than a new one on purpose: they need the exact
+ * same harness (fetch, prisma, tenant scope and RBAC mocks) as the scoping
+ * tests above, and duplicating it would be the worse trade.
+ */
+describe("GET /api/v1/orchestrator/jobs — DRS migration progress", () => {
+  const asProvider = () => {
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
+  }
+
+  const isProgressUrl = (url: string) => url.includes("/drs/migrations/") && url.endsWith("/progress")
+
+  const drsFetch = (migrations: any[], progress: (url: string) => any) => async (url: string) => {
+    if (isProgressUrl(url)) return progress(url)
+    if (url.includes("/drs/migrations")) return { ok: true, json: async () => ({ data: migrations }) }
+    return { ok: true, json: async () => ({ data: [] }) }
+  }
+
+  const runningMigration = (over: Record<string, any> = {}) => ({
+    id: "dm-run",
+    connection_id: "c1",
+    vmid: 100,
+    vm_name: "vm1",
+    source_node: "node12",
+    target_node: "node11",
+    status: "running",
+    started_at: "2026-01-01T00:00:00Z",
+    ...over,
+  })
+
+  const drsJobs = (body: any) => body.data.filter((j: any) => j.type === "drs")
+
+  it("publishes the real PVE progress of a running migration, never a constant 50", async () => {
+    asProvider()
+    fetchMock.mockImplementation(drsFetch(
+      [runningMigration()],
+      async () => ({ ok: true, json: async () => ({ progress: 37, status: "running" }) }),
+    ))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+
+    const job = drsJobs(body).find((j: any) => j.id === "dm-run")
+    expect(job.status).toBe("running")
+    expect(job.progress).toBe(37)
+  })
+
+  it("leaves the progress unknown (0, an indeterminate bar) when the lookup fails", async () => {
+    asProvider()
+    fetchMock.mockImplementation(drsFetch(
+      [runningMigration()],
+      async () => ({ ok: false, json: async () => ({}) }),
+    ))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+
+    expect(drsJobs(body).find((j: any) => j.id === "dm-run").progress).toBe(0)
+  })
+
+  it("never asks for the progress of a migration that already ended", async () => {
+    asProvider()
+    fetchMock.mockImplementation(drsFetch(
+      [
+        runningMigration({ id: "dm-done", status: "completed", completed_at: "2026-01-01T00:10:00Z" }),
+        runningMigration({ id: "dm-ko", status: "failed", error: "timeout" }),
+      ],
+      async () => ({ ok: true, json: async () => ({ progress: 42 }) }),
+    ))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+
+    expect(fetchMock.mock.calls.filter(([url]: any[]) => isProgressUrl(url))).toHaveLength(0)
+    expect(drsJobs(body).find((j: any) => j.id === "dm-done").progress).toBe(100)
+    expect(drsJobs(body).find((j: any) => j.id === "dm-ko").progress).toBe(0)
+  })
+
+  it("bounds the fan-out: this route is polled from every page by the task footer", async () => {
+    asProvider()
+    const many = Array.from({ length: 12 }, (_, i) => runningMigration({ id: `dm-${i}`, vmid: 100 + i }))
+    fetchMock.mockImplementation(drsFetch(
+      many,
+      async () => ({ ok: true, json: async () => ({ progress: 12 }) }),
+    ))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+
+    const lookups = fetchMock.mock.calls.filter(([url]: any[]) => isProgressUrl(url))
+    expect(lookups.length).toBeGreaterThan(0)
+    expect(lookups.length).toBeLessThanOrEqual(8)
+    // Every row is still listed, the ones past the cap simply carry no
+    // progress rather than being dropped.
+    expect(drsJobs(body)).toHaveLength(12)
+  })
+
+  it("does not ask for the progress of a migration outside the caller's perimeter", async () => {
+    getCurrentTenantIdMock.mockResolvedValue("tenant-a")
+    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
+    getInfraMock.mockResolvedValue({ kind: "iaas", vdcScope: { connectionIds: new Set(["c1"]) } })
+
+    fetchMock.mockImplementation(drsFetch(
+      [runningMigration({ id: "dm-foreign", connection_id: "c2" })],
+      async () => ({ ok: true, json: async () => ({ progress: 88 }) }),
+    ))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { method: "GET" })
+    const body = await res.json()
+
+    expect(fetchMock.mock.calls.filter(([url]: any[]) => isProgressUrl(url))).toHaveLength(0)
+    expect(body.data.map((j: any) => j.id)).not.toContain("dm-foreign")
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -12,6 +12,17 @@ export const runtime = "nodejs"
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || "http://localhost:8080"
 
+/**
+ * How many DRS migrations may be asked for their real progress in one poll.
+ *
+ * The Task Center and the shared task footer both hit this route, the footer
+ * from every page, so the fan-out has to stay bounded: a fleet-wide rebalance
+ * must not turn one poll into dozens of orchestrator round trips. Rows beyond
+ * the cap keep an unknown progress, which the footer renders as an
+ * indeterminate bar.
+ */
+const MAX_DRS_PROGRESS_LOOKUPS = 8
+
 /** Extract hostname from a baseUrl like "https://pve1.example.com:8006" */
 function extractHostname(baseUrl: string): string {
   try {
@@ -184,6 +195,42 @@ export async function GET(req: Request) {
         const drsData = await drsRes.json()
         const migrations: any[] = Array.isArray(drsData) ? drsData : (drsData?.data || [])
 
+        // Real progress for the migrations still in flight (#818).
+        //
+        // The list endpoint carries no progress field, so this route used to
+        // publish a constant 50% for every running row. A migration whose
+        // orchestrator-side monitor goroutine died therefore stayed "In
+        // progress, 50%" for good, which is what the reporter saw. The
+        // per-migration progress endpoint has the real percentage, read from
+        // the PVE task, and asking it also gives the orchestrator its chance
+        // to self-heal a row whose task has in fact finished.
+        //
+        // Only running rows the caller will actually be shown are asked (the
+        // connection maps are already restricted to its perimeter), never more than
+        // MAX_DRS_PROGRESS_LOOKUPS of them. A lookup that fails leaves the
+        // progress unknown rather than inventing one.
+        const drsProgress = new Map<string, number>()
+        const inFlight = migrations
+          .filter((m: any) => m?.id && m.status === "running"
+            && (connById.has(m.connection_id) || connByName.has(m.connection_id)))
+          .slice(0, MAX_DRS_PROGRESS_LOOKUPS)
+
+        await Promise.all(inFlight.map(async (m: any) => {
+          try {
+            const progRes = await fetch(`${ORCHESTRATOR_URL}/api/v1/drs/migrations/${m.id}/progress`, {
+              headers: orchestratorHeaders({ "Content-Type": "application/json" }),
+            })
+            if (!progRes.ok) return
+
+            const prog = await progRes.json()
+            if (typeof prog?.progress === "number" && Number.isFinite(prog.progress)) {
+              drsProgress.set(m.id, Math.max(0, Math.min(100, Math.round(prog.progress))))
+            }
+          } catch {
+            // Leave the row without a progress value.
+          }
+        }))
+
         for (let i = 0; i < migrations.length; i++) {
           const m = migrations[i]
           let jobStatus = m.status
@@ -197,7 +244,7 @@ export async function GET(req: Request) {
             name: `DRS Migration - ${vmLabel}`,
             type: "drs",
             status: jobStatus,
-            progress: jobStatus === "success" ? 100 : jobStatus === "running" ? 50 : 0,
+            progress: jobStatus === "success" ? 100 : (drsProgress.get(m.id) ?? 0),
             startedAt: m.started_at,
             endedAt: m.completed_at,
             createdAt: m.started_at,

--- a/frontend/src/components/automation/drs/AffinityRulesManager.tsx
+++ b/frontend/src/components/automation/drs/AffinityRulesManager.tsx
@@ -376,7 +376,7 @@ export default function AffinityRulesManager({
                   <TableCell width={60}>{t('common.active')}</TableCell>
                   <TableCell>{t('common.name')}</TableCell>
                   <TableCell width={130}>{t('common.type')}</TableCell>
-                  <TableCell>Guests</TableCell>
+                  <TableCell>{t('inventory.guests')}</TableCell>
                   <TableCell>{t('inventory.nodes')}</TableCell>
                   <TableCell width={80}>{t('common.source')}</TableCell>
                   <TableCell width={130} align="right">{t('common.actions')}</TableCell>

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -58,6 +58,7 @@
     "none": "Keine",
     "all": "Alle",
     "type": "Typ",
+    "source": "Quelle",
     "description": "Beschreibung",
     "date": "Datum",
     "details": "Details",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -41,6 +41,7 @@
     "name": "Name",
     "description": "Description",
     "type": "Type",
+    "source": "Source",
     "date": "Date",
     "size": "Size",
     "notes": "Notes",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -41,6 +41,7 @@
     "name": "Nombre",
     "description": "Descripción",
     "type": "Tipo",
+    "source": "Origen",
     "date": "Fecha",
     "size": "Tamaño",
     "notes": "Notas",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -41,6 +41,7 @@
     "name": "Nom",
     "description": "Description",
     "type": "Type",
+    "source": "Source",
     "date": "Date",
     "size": "Taille",
     "notes": "Notes",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -41,6 +41,7 @@
     "name": "이름",
     "description": "설명",
     "type": "유형",
+    "source": "출처",
     "date": "날짜",
     "size": "크기",
     "notes": "메모",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -41,6 +41,7 @@
     "name": "名称",
     "description": "描述",
     "type": "类型",
+    "source": "来源",
     "date": "日期",
     "size": "大小",
     "notes": "备注",


### PR DESCRIPTION
## Problem

Reported in #818: several DRS migrations stay in the shared task footer at 50% "In progress" while no migration is running in Proxmox VE, and reloading the page changes nothing.

Two independent defects add up to that.

The progress number is invented here. The orchestrator's DRS migration list carries no progress field at all, so this route substituted a constant for every row whose status was `running`:

```ts
progress: jobStatus === "success" ? 100 : jobStatus === "running" ? 50 : 0,
```

Every DRS migration in flight therefore reads 50%, in the footer and in the Task Center, whatever its real state. The real percentage does exist, on a per-migration endpoint the footer never called.

The status itself was never reconciled orchestrator-side, which is the other half and is fixed by a separate orchestrator change, already pushed. Until now a row whose monitoring goroutine died with its process stayed `running` for good, and the footer read those rows as they are, hence the 50% that no reload could clear.

## Fix

Reads the real percentage from `/drs/migrations/{id}/progress`, then publishes it instead of the constant.

Bounded on purpose, because the footer polls this route from every page:

- only rows whose status is `running` are asked, so a quiet cluster costs nothing;
- only rows inside the caller's perimeter, reusing the connection maps this route already builds, so no lookup is spent on a job the caller will not be shown;
- at most eight lookups per poll, so a fleet-wide rebalance cannot turn one footer poll into dozens of round trips. Rows past the cap are still listed, they simply carry no progress.

A lookup that fails leaves the progress unknown rather than inventing a number. The footer already renders that as an indeterminate bar (`variant={task.progress > 0 ? 'determinate' : 'indeterminate'}`), which is the honest rendering for a migration whose percentage we could not read. Asking also gives the orchestrator its chance to self-heal a row whose Proxmox task has in fact ended.

The Site Recovery rows a few lines below use the same constant. Left alone deliberately: their payload offers no honest progress source either, and replacing one made-up number with another would widen this PR without adding truth.

## Also in here

`common.source` was missing from all six message catalogs, the default locale included, so the DRS affinity rules table threw `MISSING_MESSAGE: Could not resolve 'common.source' in messages for locale 'en'` on every render. Added to the six, next to the other column labels. Found while testing this fix on the DRS page.

The `Guests` column header of that same table was hardcoded English while the cell right next to it already used `t('inventory.nodes')`. It now uses the existing `inventory.guests` key, which is present in all six catalogs.

## Verification

`jobsScope.test.ts` grows five cases pinning the new behaviour: the real percentage is published, a failed lookup leaves it unknown rather than 50, a migration that already ended is never asked, the fan-out stays bounded with twelve rows in flight, and a row outside the caller's perimeter is neither asked nor listed. Fourteen tests green in that file, the nine pre-existing scoping cases included, and the whole `src/messages` suite green at 196 tests. Both suites were checked by mutation (restoring the hardcoded 50, then reverting) to prove they bite. ESLint clean on the changed files.

Closes #818
