### PR TITLE
fix(pbs): align the PBS integration with the 4.x API contract

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsS3EndpointsTab.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/tabs/pbs/PbsS3EndpointsTab.tsx
@@ -24,6 +24,8 @@ interface PbsS3EndpointsTabProps {
 }
 
 type PbsS3Endpoint = {
+  // PBS nomme l'entree `id` ; `name` reste tolere pour les reponses anciennes.
+  id?: string
   name?: string
   endpoint?: string
   region?: string
@@ -171,10 +173,10 @@ export default function PbsS3EndpointsTab({ pbsId }: PbsS3EndpointsTabProps) {
                 {endpoints.map((ep, idx) => {
                   const accessKey = String(ep['access-key-id'] || ep['access-key'] || '')
                   return (
-                    <TableRow key={ep.name || `s3-${idx}`} hover>
+                    <TableRow key={ep.id || ep.name || `s3-${idx}`} hover>
                       <TableCell sx={{ fontSize: 12 }}>
                         <Typography variant="caption" sx={{ fontWeight: 600 }}>
-                          {ep.name || '—'}
+                          {ep.id || ep.name || '—'}
                         </Typography>
                       </TableCell>
                       <TableCell sx={{ fontSize: 12 }}>

--- a/frontend/src/app/api/v1/pbs/[id]/access/users/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/access/users/route.ts
@@ -22,7 +22,10 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> |
 
     const conn = await getPbsConnectionById(id)
 
-    const users = await pbsFetch<any[]>(conn, "/access/users")
+    // Sans `include_tokens`, PBS ne renvoie que les utilisateurs : leurs
+    // jetons d'API manquent et l'onglet les affiche comme absents. Le nom du
+    // parametre porte bien un souligne, pas un tiret.
+    const users = await pbsFetch<any[]>(conn, "/access/users?include_tokens=1")
 
     return NextResponse.json({ data: Array.isArray(users) ? users : [] })
   } catch (e: any) {

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/jobsGuard.test.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/jobsGuard.test.ts
@@ -63,10 +63,11 @@ function mockPbsData() {
     }
     if (path === "/admin/verify") return []
     if (path === "/config/tape-backup-job") return []
-    if (path.startsWith("/admin/datastore/") && path.endsWith("/prune-job")) {
-      if (path.includes("store1")) return [{ id: "prune-store1", ns: "ns-a" }]
-      if (path.includes("store2")) return [{ id: "prune-store2", ns: "" }]
-      return []
+    if (path === "/admin/prune") {
+      return [
+        { id: "prune-store1", store: "store1", ns: "ns-a" },
+        { id: "prune-store2", store: "store2", ns: "" },
+      ]
     }
     if (path.startsWith("/admin/datastore/") && path.endsWith("/gc")) {
       if (path.includes("store1")) return { schedule: "daily" }
@@ -110,6 +111,25 @@ describe("GET /api/v1/pbs/[id]/jobs — access verdict", () => {
       expect.arrayContaining(["sync1", "sync2", "sync3", "prune-store1", "prune-store2", "gc-store1", "gc-store2"])
     )
     expect(body.data.datastores).toEqual(["store1", "store2"])
+  })
+
+  it("admin: a /admin/prune failure leaves the other job types listed", async () => {
+    assertVdcPbsAccessMock.mockResolvedValue({ kind: "admin" })
+    const base = pbsFetchMock.getMockImplementation()!
+
+    pbsFetchMock.mockImplementation(async (conn: any, path: string) => {
+      if (path === "/admin/prune") throw new Error("PBS 403 /admin/prune")
+
+      return base(conn, path)
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET as any, { params: { id: "pbs-1" } })
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.jobs.prune).toEqual([])
+    expect(body.data.jobs.sync.map((j: any) => j.id)).toEqual(["sync1", "sync2", "sync3"])
   })
 
   it("iaas tenant: only jobs whose (datastore, namespace) is in the union ∩ narrowed scope are returned", async () => {

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/prune/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/prune/[jobId]/route.ts
@@ -1,124 +1,24 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import {
+  deletePbsJobConfig,
+  updatePbsJobConfig,
+  type PbsJobRouteContext,
+} from "@/lib/proxmox/pbsJobConfig"
+import { PRUNE_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string; jobId: string }>
-}
 
 /**
  * PUT /api/v1/pbs/[id]/jobs/prune/[jobId]
  * Met à jour un Prune Job
- * Note: jobId format attendu: "datastore:jobid" ou on utilise le store du body
  */
-export async function PUT(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-    const body = await req.json()
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_EDIT, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    // Le store est nécessaire pour l'endpoint
-    const store = body.store || body.datastore
-
-    if (!store) {
-      return NextResponse.json({ error: "Datastore is required" }, { status: 400 })
-    }
-
-    const params: Record<string, any> = {}
-
-    if (body.ns !== undefined) params.ns = body.ns || null
-    if (body.schedule !== undefined) params.schedule = body.schedule || null
-    if (body.comment !== undefined) params.comment = body.comment || null
-    if (body.disable !== undefined) params.disable = body.disable
-
-    // Retention settings
-    if (body.keepLast !== undefined) params['keep-last'] = body.keepLast || null
-    if (body.keepHourly !== undefined) params['keep-hourly'] = body.keepHourly || null
-    if (body.keepDaily !== undefined) params['keep-daily'] = body.keepDaily || null
-    if (body.keepWeekly !== undefined) params['keep-weekly'] = body.keepWeekly || null
-    if (body.keepMonthly !== undefined) params['keep-monthly'] = body.keepMonthly || null
-    if (body.keepYearly !== undefined) params['keep-yearly'] = body.keepYearly || null
-
-    const result = await pbsFetch<any>(
-      conn, 
-      `/admin/datastore/${encodeURIComponent(store)}/prune-job/${encodeURIComponent(jobId)}`, 
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(params)
-      }
-    )
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Prune job updated successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-prune-jobs] PUT Error:", String(e?.message || e).replace(/[\r\n]/g, ''))
-
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function PUT(req: Request, ctx: PbsJobRouteContext) {
+  return updatePbsJobConfig(req, ctx, PRUNE_JOB)
 }
 
 /**
  * DELETE /api/v1/pbs/[id]/jobs/prune/[jobId]
  * Supprime un Prune Job
- * Note: Nécessite le store dans les query params
  */
-export async function DELETE(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-    const { searchParams } = new URL(req.url)
-    const store = searchParams.get('store')
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    if (!store) {
-      return NextResponse.json({ error: "Store parameter is required" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_DELETE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    await pbsFetch<any>(
-      conn, 
-      `/admin/datastore/${encodeURIComponent(store)}/prune-job/${encodeURIComponent(jobId)}`, 
-      {
-        method: 'DELETE'
-      }
-    )
-
-    return NextResponse.json({ 
-      message: 'Prune job deleted successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-prune-jobs] DELETE Error:", String(e?.message || e).replace(/[\r\n]/g, ''))
-
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function DELETE(req: Request, ctx: PbsJobRouteContext) {
+  return deletePbsJobConfig(req, ctx, PRUNE_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/prune/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/prune/route.ts
@@ -1,78 +1,12 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { createPbsJobConfig, type PbsJobCollectionContext } from "@/lib/proxmox/pbsJobConfig"
+import { PRUNE_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string }>
-}
 
 /**
  * POST /api/v1/pbs/[id]/jobs/prune
  * Crée un nouveau Prune Job sur PBS
  */
-export async function POST(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id } = await ctx.params
-    const body = await req.json()
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing PBS connection ID" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_CREATE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    if (!body.id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 })
-    }
-
-    if (!body.store) {
-      return NextResponse.json({ error: "Datastore is required" }, { status: 400 })
-    }
-
-    const params: Record<string, any> = {
-      id: body.id,
-      store: body.store,
-    }
-
-    if (body.ns) params.ns = body.ns
-    if (body.schedule) params.schedule = body.schedule
-    if (body.comment) params.comment = body.comment
-    if (body.maxDepth !== undefined) params['max-depth'] = body.maxDepth
-
-    // Retention settings
-    if (body.keepLast !== undefined && body.keepLast > 0) params['keep-last'] = body.keepLast
-    if (body.keepHourly !== undefined && body.keepHourly > 0) params['keep-hourly'] = body.keepHourly
-    if (body.keepDaily !== undefined && body.keepDaily > 0) params['keep-daily'] = body.keepDaily
-    if (body.keepWeekly !== undefined && body.keepWeekly > 0) params['keep-weekly'] = body.keepWeekly
-    if (body.keepMonthly !== undefined && body.keepMonthly > 0) params['keep-monthly'] = body.keepMonthly
-    if (body.keepYearly !== undefined && body.keepYearly > 0) params['keep-yearly'] = body.keepYearly
-
-    // PBS uses the datastore-specific endpoint for prune jobs
-    const result = await pbsFetch<any>(conn, `/admin/datastore/${encodeURIComponent(body.store)}/prune-job`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Prune job created successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-prune-jobs] POST Error:", String(e?.message || e).replace(/[\r\n]/g, ''))
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function POST(req: Request, ctx: PbsJobCollectionContext) {
+  return createPbsJobConfig(req, ctx, PRUNE_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/route.ts
@@ -72,11 +72,12 @@ export async function GET(req: Request, ctx: RouteContext) {
       ? await getPbsConnectionById(id)
       : await getPbsConnectionByIdUnscoped(id)
 
-    // Récupérer les datastores d'abord (nécessaire pour prune et GC jobs).
+    // Récupérer les datastores d'abord (nécessaire pour les GC jobs).
     // For a scoped tenant, narrow to their authorised datastores up-front so
-    // prune-job/gc calls are never even made against a datastore they have
-    // no binding on (and the returned `datastores` list never leaks names
-    // of datastores outside their scope).
+    // gc calls are never even made against a datastore they have no binding
+    // on (and the returned `datastores` list never leaks names of datastores
+    // outside their scope). Prune jobs come from the PBS-wide /admin/prune
+    // and are narrowed by the (datastore, namespace) check further down.
     const datastores = await pbsFetch<any[]>(conn, "/admin/datastore").catch(() => [])
     let datastoreNames = (datastores || []).map(ds => ds.store || ds.name).filter(Boolean)
     if (allowedDatastores) {
@@ -84,12 +85,16 @@ export async function GET(req: Request, ctx: RouteContext) {
     }
 
     // Récupérer tous les types de jobs en parallèle
-    const [syncJobs, verifyJobs] = await Promise.all([
+    const [syncJobs, verifyJobs, rawPruneJobs] = await Promise.all([
       // Sync Jobs
       pbsFetch<any[]>(conn, "/admin/sync").catch(() => []),
 
       // Verify Jobs
       pbsFetch<any[]>(conn, "/admin/verify").catch(() => []),
+
+      // Prune Jobs — endpoint global comme sync et verify, et non un appel par
+      // datastore : /admin/datastore/{store}/prune-job n'existe pas cote PBS.
+      pbsFetch<any[]>(conn, "/admin/prune").catch(() => []),
     ])
 
     // Tape Backup Jobs - essayer plusieurs endpoints selon la version PBS
@@ -113,18 +118,11 @@ export async function GET(req: Request, ctx: RouteContext) {
       }
     }
 
-    // Récupérer les prune jobs et GC config pour chaque datastore
-    const pruneJobsPromises = datastoreNames.map(async (store) => {
-      try {
-        const pruneJobs = await pbsFetch<any[]>(conn, `/admin/datastore/${encodeURIComponent(store)}/prune-job`)
+    // Le prune job porte son datastore dans `store` ; on l'expose sous
+    // `datastore` comme le reste de la route.
+    const pruneJobs = (rawPruneJobs || []).map(job => ({ ...job, datastore: job.store }))
 
-        
-return (pruneJobs || []).map(job => ({ ...job, datastore: store }))
-      } catch {
-        return []
-      }
-    })
-
+    // Récupérer la GC config pour chaque datastore
     const gcConfigPromises = datastoreNames.map(async (store) => {
       try {
         const gcStatus = await pbsFetch<any>(conn, `/admin/datastore/${encodeURIComponent(store)}/gc`)
@@ -136,11 +134,7 @@ return { datastore: store, ...gcStatus }
       }
     })
 
-    const pruneJobsArrays = await Promise.all(pruneJobsPromises)
     const gcConfigs = (await Promise.all(gcConfigPromises)).filter(Boolean)
-
-    // Flatten prune jobs
-    const pruneJobs = pruneJobsArrays.flat()
 
     // Formater les Sync Jobs — /admin/sync is NOT datastore-scoped (returns
     // jobs across the whole PBS), so it needs an explicit (store, ns) check.
@@ -196,8 +190,8 @@ return { datastore: store, ...gcStatus }
       _raw: job
     }))
 
-    // Formater les Prune Jobs — fetched per (already datastore-narrowed)
-    // store, but each store can hold namespaces outside the tenant's scope.
+    // Formater les Prune Jobs — /admin/prune is PBS-wide, so the (datastore,
+    // namespace) check is what narrows a scoped tenant here.
     const formattedPruneJobs = pruneJobs.filter((job: any) => inScope(job.datastore, job.ns || '')).map((job: any) => ({
       id: job.id,
       type: 'prune',

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/sync/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/sync/[jobId]/route.ts
@@ -1,98 +1,24 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import {
+  deletePbsJobConfig,
+  updatePbsJobConfig,
+  type PbsJobRouteContext,
+} from "@/lib/proxmox/pbsJobConfig"
+import { SYNC_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string; jobId: string }>
-}
 
 /**
  * PUT /api/v1/pbs/[id]/jobs/sync/[jobId]
  * Met à jour un Sync Job
  */
-export async function PUT(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-    const body = await req.json()
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_EDIT, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    const params: Record<string, any> = {}
-
-    if (body.store) params.store = body.store
-    if (body.remote) params.remote = body.remote
-    if (body.remoteStore) params['remote-store'] = body.remoteStore
-    if (body.ns !== undefined) params.ns = body.ns || null
-    if (body.remoteNs !== undefined) params['remote-ns'] = body.remoteNs || null
-    if (body.schedule !== undefined) params.schedule = body.schedule || null
-    if (body.comment !== undefined) params.comment = body.comment || null
-    if (body.removeVanished !== undefined) params['remove-vanished'] = body.removeVanished
-    if (body.disable !== undefined) params.disable = body.disable
-
-    const result = await pbsFetch<any>(conn, `/admin/sync/${encodeURIComponent(jobId)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Sync job updated successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-sync-jobs] PUT Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function PUT(req: Request, ctx: PbsJobRouteContext) {
+  return updatePbsJobConfig(req, ctx, SYNC_JOB)
 }
 
 /**
  * DELETE /api/v1/pbs/[id]/jobs/sync/[jobId]
  * Supprime un Sync Job
  */
-export async function DELETE(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_DELETE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    await pbsFetch<any>(conn, `/admin/sync/${encodeURIComponent(jobId)}`, {
-      method: 'DELETE'
-    })
-
-    return NextResponse.json({ 
-      message: 'Sync job deleted successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-sync-jobs] DELETE Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function DELETE(req: Request, ctx: PbsJobRouteContext) {
+  return deletePbsJobConfig(req, ctx, SYNC_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/sync/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/sync/route.ts
@@ -1,83 +1,12 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { createPbsJobConfig, type PbsJobCollectionContext } from "@/lib/proxmox/pbsJobConfig"
+import { SYNC_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string }>
-}
 
 /**
  * POST /api/v1/pbs/[id]/jobs/sync
  * Crée un nouveau Sync Job sur PBS
  */
-export async function POST(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id } = await ctx.params
-    const body = await req.json()
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing PBS connection ID" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_CREATE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    // Validation
-    if (!body.id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 })
-    }
-
-    if (!body.store) {
-      return NextResponse.json({ error: "Datastore is required" }, { status: 400 })
-    }
-
-    if (!body.remote) {
-      return NextResponse.json({ error: "Remote is required" }, { status: 400 })
-    }
-
-    if (!body.remoteStore) {
-      return NextResponse.json({ error: "Remote datastore is required" }, { status: 400 })
-    }
-
-    // Build params for PBS API
-    const params: Record<string, any> = {
-      id: body.id,
-      store: body.store,
-      remote: body.remote,
-      'remote-store': body.remoteStore,
-    }
-
-    if (body.ns) params.ns = body.ns
-    if (body.remoteNs) params['remote-ns'] = body.remoteNs
-    if (body.schedule) params.schedule = body.schedule
-    if (body.comment) params.comment = body.comment
-    if (body.removeVanished) params['remove-vanished'] = true
-    if (body.maxDepth !== undefined) params['max-depth'] = body.maxDepth
-
-    const result = await pbsFetch<any>(conn, "/admin/sync", {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Sync job created successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-sync-jobs] POST Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function POST(req: Request, ctx: PbsJobCollectionContext) {
+  return createPbsJobConfig(req, ctx, SYNC_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/tape/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/tape/[jobId]/route.ts
@@ -1,99 +1,24 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import {
+  deletePbsJobConfig,
+  updatePbsJobConfig,
+  type PbsJobRouteContext,
+} from "@/lib/proxmox/pbsJobConfig"
+import { TAPE_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string; jobId: string }>
-}
 
 /**
  * PUT /api/v1/pbs/[id]/jobs/tape/[jobId]
  * Met à jour un Tape Backup Job
  */
-export async function PUT(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-    const body = await req.json()
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_EDIT, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    const params: Record<string, any> = {}
-
-    if (body.store) params.store = body.store
-    if (body.pool) params.pool = body.pool
-    if (body.drive) params.drive = body.drive
-    if (body.ns !== undefined) params.ns = body.ns || null
-    if (body.schedule !== undefined) params.schedule = body.schedule || null
-    if (body.comment !== undefined) params.comment = body.comment || null
-    if (body.ejectMedia !== undefined) params['eject-media'] = body.ejectMedia
-    if (body.exportMediaSet !== undefined) params['export-media-set'] = body.exportMediaSet
-    if (body.latestOnly !== undefined) params['latest-only'] = body.latestOnly
-    if (body.disable !== undefined) params.disable = body.disable
-
-    const result = await pbsFetch<any>(conn, `/config/tape-backup-job/${encodeURIComponent(jobId)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Tape backup job updated successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-tape-jobs] PUT Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function PUT(req: Request, ctx: PbsJobRouteContext) {
+  return updatePbsJobConfig(req, ctx, TAPE_JOB)
 }
 
 /**
  * DELETE /api/v1/pbs/[id]/jobs/tape/[jobId]
  * Supprime un Tape Backup Job
  */
-export async function DELETE(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_DELETE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    await pbsFetch<any>(conn, `/config/tape-backup-job/${encodeURIComponent(jobId)}`, {
-      method: 'DELETE'
-    })
-
-    return NextResponse.json({ 
-      message: 'Tape backup job deleted successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-tape-jobs] DELETE Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function DELETE(req: Request, ctx: PbsJobRouteContext) {
+  return deletePbsJobConfig(req, ctx, TAPE_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/tape/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/tape/route.ts
@@ -1,84 +1,12 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { createPbsJobConfig, type PbsJobCollectionContext } from "@/lib/proxmox/pbsJobConfig"
+import { TAPE_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string }>
-}
 
 /**
  * POST /api/v1/pbs/[id]/jobs/tape
  * Crée un nouveau Tape Backup Job sur PBS
  */
-export async function POST(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id } = await ctx.params
-    const body = await req.json()
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing PBS connection ID" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_CREATE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    // Validation
-    if (!body.id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 })
-    }
-
-    if (!body.store) {
-      return NextResponse.json({ error: "Datastore is required" }, { status: 400 })
-    }
-
-    if (!body.pool) {
-      return NextResponse.json({ error: "Media Pool is required" }, { status: 400 })
-    }
-
-    if (!body.drive) {
-      return NextResponse.json({ error: "Drive is required" }, { status: 400 })
-    }
-
-    const params: Record<string, any> = {
-      id: body.id,
-      store: body.store,
-      pool: body.pool,
-      drive: body.drive,
-    }
-
-    if (body.ns) params.ns = body.ns
-    if (body.schedule) params.schedule = body.schedule
-    if (body.comment) params.comment = body.comment
-    if (body.ejectMedia) params['eject-media'] = true
-    if (body.exportMediaSet) params['export-media-set'] = true
-    if (body.latestOnly) params['latest-only'] = true
-    if (body.notifyUser) params['notify-user'] = body.notifyUser
-    if (body.maxDepth !== undefined) params['max-depth'] = body.maxDepth
-
-    const result = await pbsFetch<any>(conn, "/config/tape-backup-job", {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Tape backup job created successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-tape-jobs] POST Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function POST(req: Request, ctx: PbsJobCollectionContext) {
+  return createPbsJobConfig(req, ctx, TAPE_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/verify/[jobId]/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/verify/[jobId]/route.ts
@@ -1,96 +1,24 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import {
+  deletePbsJobConfig,
+  updatePbsJobConfig,
+  type PbsJobRouteContext,
+} from "@/lib/proxmox/pbsJobConfig"
+import { VERIFY_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string; jobId: string }>
-}
 
 /**
  * PUT /api/v1/pbs/[id]/jobs/verify/[jobId]
  * Met à jour un Verify Job
  */
-export async function PUT(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-    const body = await req.json()
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_EDIT, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    const params: Record<string, any> = {}
-
-    if (body.store) params.store = body.store
-    if (body.ns !== undefined) params.ns = body.ns || null
-    if (body.schedule !== undefined) params.schedule = body.schedule || null
-    if (body.comment !== undefined) params.comment = body.comment || null
-    if (body.ignoreVerified !== undefined) params['ignore-verified'] = body.ignoreVerified
-    if (body.outdatedAfter !== undefined) params['outdated-after'] = body.outdatedAfter
-    if (body.disable !== undefined) params.disable = body.disable
-
-    const result = await pbsFetch<any>(conn, `/admin/verify/${encodeURIComponent(jobId)}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Verify job updated successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-verify-jobs] PUT Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function PUT(req: Request, ctx: PbsJobRouteContext) {
+  return updatePbsJobConfig(req, ctx, VERIFY_JOB)
 }
 
 /**
  * DELETE /api/v1/pbs/[id]/jobs/verify/[jobId]
  * Supprime un Verify Job
  */
-export async function DELETE(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id, jobId } = await ctx.params
-
-    if (!id || !jobId) {
-      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_DELETE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    await pbsFetch<any>(conn, `/admin/verify/${encodeURIComponent(jobId)}`, {
-      method: 'DELETE'
-    })
-
-    return NextResponse.json({ 
-      message: 'Verify job deleted successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-verify-jobs] DELETE Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function DELETE(req: Request, ctx: PbsJobRouteContext) {
+  return deletePbsJobConfig(req, ctx, VERIFY_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/jobs/verify/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/jobs/verify/route.ts
@@ -1,71 +1,12 @@
-import { NextResponse } from "next/server"
-
-import { demoResponse } from "@/lib/demo/demo-api"
-import { pbsFetch } from "@/lib/proxmox/pbs-client"
-import { getPbsConnectionById } from "@/lib/connections/getConnection"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { createPbsJobConfig, type PbsJobCollectionContext } from "@/lib/proxmox/pbsJobConfig"
+import { VERIFY_JOB } from "@/lib/proxmox/pbsJobSpecs"
 
 export const runtime = "nodejs"
-
-type RouteContext = {
-  params: Promise<{ id: string }>
-}
 
 /**
  * POST /api/v1/pbs/[id]/jobs/verify
  * Crée un nouveau Verify Job sur PBS
  */
-export async function POST(req: Request, ctx: RouteContext) {
-  const demo = demoResponse(req)
-  if (demo) return demo
-
-  try {
-    const { id } = await ctx.params
-    const body = await req.json()
-
-    if (!id) {
-      return NextResponse.json({ error: "Missing PBS connection ID" }, { status: 400 })
-    }
-
-    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_CREATE, "pbs", id)
-
-    if (denied) return denied
-
-    const conn = await getPbsConnectionById(id)
-
-    if (!body.id) {
-      return NextResponse.json({ error: "Job ID is required" }, { status: 400 })
-    }
-
-    if (!body.store) {
-      return NextResponse.json({ error: "Datastore is required" }, { status: 400 })
-    }
-
-    const params: Record<string, any> = {
-      id: body.id,
-      store: body.store,
-    }
-
-    if (body.ns) params.ns = body.ns
-    if (body.schedule) params.schedule = body.schedule
-    if (body.comment) params.comment = body.comment
-    if (body.ignoreVerified !== undefined) params['ignore-verified'] = body.ignoreVerified
-    if (body.outdatedAfter) params['outdated-after'] = body.outdatedAfter
-    if (body.maxDepth !== undefined) params['max-depth'] = body.maxDepth
-
-    const result = await pbsFetch<any>(conn, "/admin/verify", {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params)
-    })
-
-    return NextResponse.json({ 
-      data: result,
-      message: 'Verify job created successfully'
-    })
-  } catch (e: any) {
-    console.error("[pbs-verify-jobs] POST Error:", e)
-    
-return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
-  }
+export async function POST(req: Request, ctx: PbsJobCollectionContext) {
+  return createPbsJobConfig(req, ctx, VERIFY_JOB)
 }

--- a/frontend/src/app/api/v1/pbs/[id]/pbs4Compat.test.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/pbs4Compat.test.ts
@@ -1,0 +1,361 @@
+/**
+ * ui#817 — compatibilité de l'API PBS 4.x.
+ *
+ * Ces tests épinglent ce que ProxCenter envoie réellement à PBS, sur les
+ * points où le schéma PBS avait été mal lu :
+ *
+ * - `notify`/`quiet`/`enabled` sont des booléens JSON, un 0/1 est rejeté ;
+ * - modifier un dépôt APT est un POST, le PUT du même chemin sert à en ajouter ;
+ * - lister les jetons d'API exige `include_tokens` (souligné, pas tiret) ;
+ * - la CRUD des jobs sync/verify/prune vit sous /config, /admin ne fait que
+ *   lister et déclencher ;
+ * - un prune job n'est plus adressé par datastore ;
+ * - vider un champ dans un `PUT /config/*` passe par le tableau `delete`, PBS
+ *   refusant un `null` sur une propriété typée.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { callRoute } from "@/__tests__/setup/route-test"
+
+const { checkPermissionMock, getPbsConnectionByIdMock, pbsFetchMock } = vi.hoisted(() => ({
+  checkPermissionMock: vi.fn(),
+  getPbsConnectionByIdMock: vi.fn(),
+  pbsFetchMock: vi.fn(),
+}))
+
+vi.mock("@/lib/demo/demo-api", () => ({ demoResponse: () => null }))
+
+vi.mock("@/lib/proxmox/pbs-client", () => ({
+  pbsFetch: (...a: any[]) => pbsFetchMock(...a),
+}))
+
+vi.mock("@/lib/connections/getConnection", () => ({
+  getPbsConnectionById: (...a: any[]) => getPbsConnectionByIdMock(...a),
+  getPbsConnectionByIdUnscoped: (...a: any[]) => getPbsConnectionByIdMock(...a),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  PERMISSIONS: {
+    NODE_MANAGE: "node.manage",
+    BACKUP_VIEW: "backup.view",
+    BACKUP_JOB_CREATE: "backup.job.create",
+    BACKUP_JOB_EDIT: "backup.job.edit",
+    BACKUP_JOB_DELETE: "backup.job.delete",
+  },
+}))
+
+const CONN = { id: "pbs-1", baseUrl: "https://pbs.local:8007" }
+
+/** Dernier appel pbsFetch, décomposé en (path, method, body JSON). */
+function lastCall(): { path: string; method: string; body: any } {
+  const call = pbsFetchMock.mock.calls.at(-1)
+
+  if (!call) throw new Error("pbsFetch was never called")
+
+  const [, path, init] = call
+
+  return {
+    path,
+    method: String(init?.method || "GET").toUpperCase(),
+    body: init?.body ? JSON.parse(init.body) : undefined,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getPbsConnectionByIdMock.mockResolvedValue(CONN)
+  pbsFetchMock.mockResolvedValue([])
+})
+
+describe("PBS 4.x — types de paramètres", () => {
+  it("le rafraîchissement APT envoie notify/quiet en booléens", async () => {
+    const { POST } = await import("./updates/refresh/route")
+    const res = await callRoute(POST as any, { params: { id: "pbs-1" }, method: "POST" })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/nodes/localhost/apt/update")
+    expect(method).toBe("POST")
+    expect(body).toEqual({ notify: false, quiet: true })
+  })
+
+  it("l'activation d'un dépôt est un POST avec un enabled booléen", async () => {
+    const { POST } = await import("./repositories/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { op: "toggle", path: "/etc/apt/sources.list", index: 0, enabled: true, digest: "d1" },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/nodes/localhost/apt/repositories")
+    expect(method).toBe("POST")
+    expect(body).toEqual({
+      path: "/etc/apt/sources.list",
+      index: 0,
+      enabled: true,
+      digest: "d1",
+    })
+  })
+
+  it("l'ajout d'un dépôt reste un PUT porté par handle", async () => {
+    const { POST } = await import("./repositories/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { op: "add", handle: "no-subscription" },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/nodes/localhost/apt/repositories")
+    expect(method).toBe("PUT")
+    expect(body).toEqual({ handle: "no-subscription" })
+  })
+})
+
+describe("PBS 4.x — jetons d'API", () => {
+  it("liste les utilisateurs avec include_tokens", async () => {
+    pbsFetchMock.mockResolvedValue([{ userid: "root@pam", tokens: [{ tokenid: "pxc" }] }])
+
+    const { GET } = await import("./access/users/route")
+    const res = await callRoute(GET as any, { params: { id: "pbs-1" } })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/access/users?include_tokens=1")
+
+    const payload = await res.json()
+
+    expect(payload.data[0].tokens).toEqual([{ tokenid: "pxc" }])
+  })
+})
+
+describe("PBS 4.x — CRUD des jobs sous /config", () => {
+  it("crée un sync job sur /config/sync", async () => {
+    const { POST } = await import("./jobs/sync/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { id: "s1", store: "ds1", remote: "r1", remoteStore: "rds1", removeVanished: 1 },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/config/sync")
+    expect(method).toBe("POST")
+    expect(body["remote-store"]).toBe("rds1")
+    expect(body["remove-vanished"]).toBe(true)
+  })
+
+  it("met à jour un sync job sur /config/sync/{id} et efface via delete", async () => {
+    const { PUT } = await import("./jobs/sync/[jobId]/route")
+    const res = await callRoute(PUT as any, {
+      params: { id: "pbs-1", jobId: "s1" },
+      method: "PUT",
+      body: { schedule: "daily", ns: "", comment: "", disable: 0 },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/config/sync/s1")
+    expect(method).toBe("PUT")
+    expect(body.schedule).toBe("daily")
+    expect(body.disable).toBe(false)
+    expect(body.delete).toEqual(expect.arrayContaining(["ns", "comment"]))
+    expect(body).not.toHaveProperty("ns")
+    expect(JSON.stringify(body)).not.toContain("null")
+  })
+
+  it("supprime un sync job sur /config/sync/{id}", async () => {
+    const { DELETE } = await import("./jobs/sync/[jobId]/route")
+    const res = await callRoute(DELETE as any, {
+      params: { id: "pbs-1", jobId: "s1" },
+      method: "DELETE",
+    })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/config/sync/s1")
+    expect(lastCall().method).toBe("DELETE")
+  })
+
+  it("crée un verify job sur /config/verify avec ignore-verified booléen", async () => {
+    const { POST } = await import("./jobs/verify/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { id: "v1", store: "ds1", ignoreVerified: 1, outdatedAfter: "30" },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, body } = lastCall()
+
+    expect(path).toBe("/config/verify")
+    expect(body["ignore-verified"]).toBe(true)
+    expect(body["outdated-after"]).toBe(30)
+  })
+
+  it("met à jour un verify job sur /config/verify/{id}", async () => {
+    const { PUT } = await import("./jobs/verify/[jobId]/route")
+    const res = await callRoute(PUT as any, {
+      params: { id: "pbs-1", jobId: "v1" },
+      method: "PUT",
+      body: { ns: null, schedule: "hourly" },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, body } = lastCall()
+
+    expect(path).toBe("/config/verify/v1")
+    expect(body.delete).toEqual(["ns"])
+    expect(body.schedule).toBe("hourly")
+  })
+})
+
+describe("PBS 4.x — prune jobs hors du datastore", () => {
+  it("crée un prune job sur /config/prune", async () => {
+    const { POST } = await import("./jobs/prune/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { id: "p1", store: "ds1", schedule: "daily", keepLast: 3, keepDaily: 0 },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/config/prune")
+    expect(method).toBe("POST")
+    expect(body).toMatchObject({ id: "p1", store: "ds1", schedule: "daily", "keep-last": 3 })
+    expect(body).not.toHaveProperty("keep-daily")
+  })
+
+  it("refuse une création de prune job sans schedule (obligatoire côté PBS)", async () => {
+    const { POST } = await import("./jobs/prune/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { id: "p1", store: "ds1" },
+    })
+
+    expect(res.status).toBe(400)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("met à jour un prune job par son seul id, une rétention à 0 étant effacée", async () => {
+    const { PUT } = await import("./jobs/prune/[jobId]/route")
+    const res = await callRoute(PUT as any, {
+      params: { id: "pbs-1", jobId: "p1" },
+      method: "PUT",
+      body: { keepLast: 5, keepDaily: 0, comment: "nightly" },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/config/prune/p1")
+    expect(method).toBe("PUT")
+    expect(body["keep-last"]).toBe(5)
+    expect(body.comment).toBe("nightly")
+    expect(body.delete).toEqual(["keep-daily"])
+  })
+
+  it("supprime un verify job sur /config/verify/{id}", async () => {
+    const { DELETE } = await import("./jobs/verify/[jobId]/route")
+    const res = await callRoute(DELETE as any, {
+      params: { id: "pbs-1", jobId: "v1" },
+      method: "DELETE",
+    })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/config/verify/v1")
+    expect(lastCall().method).toBe("DELETE")
+  })
+
+  it("crée un tape backup job sur /config/tape-backup-job", async () => {
+    const { POST } = await import("./jobs/tape/route")
+    const res = await callRoute(POST as any, {
+      params: { id: "pbs-1" },
+      body: { id: "t1", store: "ds1", pool: "pool1", drive: "drive0", ejectMedia: 1 },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, method, body } = lastCall()
+
+    expect(path).toBe("/config/tape-backup-job")
+    expect(method).toBe("POST")
+    expect(body).toMatchObject({ id: "t1", pool: "pool1", drive: "drive0", "eject-media": true })
+  })
+
+  it("supprime un tape backup job sur /config/tape-backup-job/{id}", async () => {
+    const { DELETE } = await import("./jobs/tape/[jobId]/route")
+    const res = await callRoute(DELETE as any, {
+      params: { id: "pbs-1", jobId: "t1" },
+      method: "DELETE",
+    })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/config/tape-backup-job/t1")
+  })
+
+  it("supprime un prune job sans exiger le datastore", async () => {
+    const { DELETE } = await import("./jobs/prune/[jobId]/route")
+    const res = await callRoute(DELETE as any, {
+      params: { id: "pbs-1", jobId: "p1" },
+      method: "DELETE",
+    })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/config/prune/p1")
+    expect(lastCall().method).toBe("DELETE")
+  })
+})
+
+describe("PBS 4.x — tape backup jobs", () => {
+  it("efface via delete et n'envoie pas de disable (absent du schema PBS)", async () => {
+    const { PUT } = await import("./jobs/tape/[jobId]/route")
+    const res = await callRoute(PUT as any, {
+      params: { id: "pbs-1", jobId: "t1" },
+      method: "PUT",
+      body: { ns: "", comment: "", ejectMedia: 1, disable: true },
+    })
+
+    expect(res.status).toBe(200)
+
+    const { path, body } = lastCall()
+
+    expect(path).toBe("/config/tape-backup-job/t1")
+    expect(body["eject-media"]).toBe(true)
+    expect(body.delete).toEqual(expect.arrayContaining(["ns", "comment"]))
+    expect(body).not.toHaveProperty("disable")
+    expect(JSON.stringify(body)).not.toContain("null")
+  })
+})
+
+describe("PBS 4.x — clients S3", () => {
+  it("lit la configuration S3 sur /config/s3", async () => {
+    pbsFetchMock.mockResolvedValue([{ id: "minio", endpoint: "s3.local" }])
+
+    const { GET } = await import("./s3-endpoints/route")
+    const res = await callRoute(GET as any, { params: { id: "pbs-1" } })
+
+    expect(res.status).toBe(200)
+    expect(lastCall().path).toBe("/config/s3")
+
+    const payload = await res.json()
+
+    expect(payload.data).toEqual([{ id: "minio", endpoint: "s3.local" }])
+    expect(payload.notSupported).toBeUndefined()
+  })
+})

--- a/frontend/src/app/api/v1/pbs/[id]/repositories/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/repositories/route.ts
@@ -75,15 +75,18 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       const payload: Record<string, any> = {
         path,
         index,
-        enabled: enabled ? 1 : 0,
+        // Schema PBS : `enabled` est un booleen, un 0/1 est rejete.
+        enabled,
       }
 
       if (typeof digest === "string" && digest.length > 0) {
         payload.digest = digest
       }
 
+      // Cote PBS, changer un depot existant est un POST (`change_repository`) ;
+      // le PUT du meme chemin est reserve a l'ajout d'un depot (`add_repository`).
       await pbsFetch(conn, "/nodes/localhost/apt/repositories", {
-        method: "PUT",
+        method: "POST",
         body: JSON.stringify(payload),
       })
 
@@ -103,6 +106,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       payload.digest = digest
     }
 
+    // `add_repository` cote PBS : PUT sur le meme chemin.
     await pbsFetch(conn, "/nodes/localhost/apt/repositories", {
       method: "PUT",
       body: JSON.stringify(payload),

--- a/frontend/src/app/api/v1/pbs/[id]/s3-endpoints/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/s3-endpoints/route.ts
@@ -23,7 +23,10 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> |
     const conn = await getPbsConnectionById(id)
 
     try {
-      const endpoints = await pbsFetch<any[]>(conn, "/config/s3-endpoint")
+      // PBS expose la configuration des clients S3 sous /config/s3 ;
+      // /config/s3-endpoint n'existe pas et repondait 404, donc l'onglet
+      // affichait « non supporte » sur un PBS 4 qui les gere pourtant.
+      const endpoints = await pbsFetch<any[]>(conn, "/config/s3")
 
       return NextResponse.json({ data: Array.isArray(endpoints) ? endpoints : [] })
     } catch (inner: any) {

--- a/frontend/src/app/api/v1/pbs/[id]/updates/refresh/route.ts
+++ b/frontend/src/app/api/v1/pbs/[id]/updates/refresh/route.ts
@@ -25,9 +25,11 @@ export async function POST(
 
     const conn = await getPbsConnectionById(id)
 
+    // PBS attend de vrais booleens JSON pour `notify`/`quiet` : un 0/1 est
+    // rejete par le schema (« Expected boolean value. »).
     const upid = await pbsFetch<string>(conn, "/nodes/localhost/apt/update", {
       method: "POST",
-      body: JSON.stringify({ notify: 0, quiet: 1 }),
+      body: JSON.stringify({ notify: false, quiet: true }),
     })
 
     return NextResponse.json({ data: { upid } })

--- a/frontend/src/lib/proxmox/pbsConfigUpdate.test.ts
+++ b/frontend/src/lib/proxmox/pbsConfigUpdate.test.ts
@@ -1,0 +1,89 @@
+/**
+ * ui#817 — PBS refuse un `null` sur une propriété typée : effacer un champ
+ * dans un `PUT /config/*` passe par le tableau `delete`. Ces tests épinglent
+ * la convention du constructeur et des normalisateurs de champ.
+ */
+import { describe, expect, it } from "vitest"
+
+import {
+  optionalBoolean,
+  optionalNumber,
+  optionalPositiveNumber,
+  pbsConfigUpdate,
+} from "./pbsConfigUpdate"
+
+describe("pbsConfigUpdate", () => {
+  it("ne transmet pas un champ laissé à undefined", () => {
+    const update = pbsConfigUpdate()
+
+    update.set("ns", undefined)
+
+    expect(update.build()).toEqual({})
+  })
+
+  it("met un null et une chaîne vide dans delete, jamais dans le corps", () => {
+    const update = pbsConfigUpdate()
+
+    update.set("ns", "")
+    update.set("comment", null)
+
+    const body = update.build()
+
+    expect(body).toEqual({ delete: ["ns", "comment"] })
+    expect(JSON.stringify(body)).not.toContain("null")
+  })
+
+  it("conserve false et 0, qui sont des valeurs et non des effacements", () => {
+    const update = pbsConfigUpdate()
+
+    update.set("disable", false)
+    update.set("max-depth", 0)
+
+    expect(update.build()).toEqual({ disable: false, "max-depth": 0 })
+  })
+
+  it("mélange les champs transmis et les champs effacés", () => {
+    const update = pbsConfigUpdate()
+
+    update.set("schedule", "daily")
+    update.set("ns", "")
+
+    expect(update.build()).toEqual({ schedule: "daily", delete: ["ns"] })
+  })
+
+  it("rend un objet neuf à chaque build", () => {
+    const update = pbsConfigUpdate()
+
+    update.set("schedule", "daily")
+
+    expect(update.build()).not.toBe(update.build())
+    expect(update.build()).toEqual(update.build())
+  })
+})
+
+describe("normalisateurs de champ", () => {
+  it("optionalBoolean laisse passer undefined et convertit le reste", () => {
+    expect(optionalBoolean(undefined)).toBeUndefined()
+    expect(optionalBoolean(1)).toBe(true)
+    expect(optionalBoolean(0)).toBe(false)
+    expect(optionalBoolean(true)).toBe(true)
+    expect(optionalBoolean(null)).toBe(false)
+  })
+
+  it("optionalNumber distingue non transmis, effacement et valeur", () => {
+    expect(optionalNumber(undefined)).toBeUndefined()
+    expect(optionalNumber(null)).toBeNull()
+    expect(optionalNumber("")).toBeNull()
+    expect(optionalNumber("30")).toBe(30)
+    expect(optionalNumber(0)).toBe(0)
+  })
+
+  it("optionalPositiveNumber efface une rétention à zéro ou négative", () => {
+    expect(optionalPositiveNumber(undefined)).toBeUndefined()
+    expect(optionalPositiveNumber(null)).toBeNull()
+    expect(optionalPositiveNumber("")).toBeNull()
+    expect(optionalPositiveNumber(0)).toBeNull()
+    expect(optionalPositiveNumber(-2)).toBeNull()
+    expect(optionalPositiveNumber("7")).toBe(7)
+  })
+})

--- a/frontend/src/lib/proxmox/pbsConfigUpdate.ts
+++ b/frontend/src/lib/proxmox/pbsConfigUpdate.ts
@@ -1,0 +1,73 @@
+// src/lib/proxmox/pbsConfigUpdate.ts
+
+/**
+ * Construit le corps d'un `PUT /config/*` de PBS.
+ *
+ * PBS verifie chaque propriete contre son schema sans jamais ignorer les
+ * `null` : envoyer `{ ns: null }` pour vider un champ echoue en
+ * « parameter verification failed: 'ns': Expected string value. ». Le seul
+ * moyen d'effacer une propriete est de la nommer dans le tableau `delete`.
+ *
+ * Convention de `set()` :
+ * - `undefined` : le client n'a pas transmis le champ, on n'y touche pas ;
+ * - `null` ou chaine vide : le client veut l'effacer, on le met dans `delete` ;
+ * - toute autre valeur (`false` et `0` compris) : on l'envoie telle quelle.
+ */
+export type PbsConfigUpdate = {
+  set: (key: string, value: unknown) => void
+  build: () => Record<string, unknown>
+}
+
+export function pbsConfigUpdate(): PbsConfigUpdate {
+  const params: Record<string, unknown> = {}
+  const remove: string[] = []
+
+  return {
+    set(key, value) {
+      if (value === undefined) return
+
+      if (value === null || value === "") {
+        remove.push(key)
+
+        return
+      }
+
+      params[key] = value
+    },
+    build() {
+      return remove.length > 0 ? { ...params, delete: remove } : { ...params }
+    },
+  }
+}
+
+/**
+ * Normalise un booleen optionnel pour `set()` : `undefined` reste
+ * `undefined` (champ non transmis), tout le reste devient un vrai booleen,
+ * PBS refusant un 0/1 dans un corps JSON.
+ */
+export function optionalBoolean(value: unknown): boolean | undefined {
+  return value === undefined ? undefined : Boolean(value)
+}
+
+/**
+ * Normalise un entier optionnel pour `set()` : `undefined` reste `undefined`,
+ * un `null` ou une chaine vide demande l'effacement, le reste est converti.
+ */
+export function optionalNumber(value: unknown): number | null | undefined {
+  if (value === undefined) return undefined
+  if (value === null || value === "") return null
+
+  return Number(value)
+}
+
+/**
+ * Variante pour les compteurs de retention : PBS n'accepte pas de `keep-*` a
+ * zero, un 0 ou un negatif vaut donc « efface la regle ».
+ */
+export function optionalPositiveNumber(value: unknown): number | null | undefined {
+  const parsed = optionalNumber(value)
+
+  if (parsed === undefined || parsed === null) return parsed
+
+  return parsed > 0 ? parsed : null
+}

--- a/frontend/src/lib/proxmox/pbsJobConfig.test.ts
+++ b/frontend/src/lib/proxmox/pbsJobConfig.test.ts
@@ -1,0 +1,316 @@
+/**
+ * ui#817 — le squelette partagé des routes de configuration d'un job PBS.
+ * Les quatre familles (sync, verify, prune, tape) portaient chacune leur copie
+ * de ce chemin ; il n'existe plus qu'ici, donc ses branches (mode démo, params
+ * manquants, refus RBAC, erreur PBS) sont vérifiées une seule fois.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { demoResponseMock, checkPermissionMock, getPbsConnectionByIdMock, pbsFetchMock } = vi.hoisted(
+  () => ({
+    demoResponseMock: vi.fn(),
+    checkPermissionMock: vi.fn(),
+    getPbsConnectionByIdMock: vi.fn(),
+    pbsFetchMock: vi.fn(),
+  })
+)
+
+vi.mock("@/lib/demo/demo-api", () => ({ demoResponse: (...a: any[]) => demoResponseMock(...a) }))
+
+vi.mock("@/lib/proxmox/pbs-client", () => ({ pbsFetch: (...a: any[]) => pbsFetchMock(...a) }))
+
+vi.mock("@/lib/connections/getConnection", () => ({
+  getPbsConnectionById: (...a: any[]) => getPbsConnectionByIdMock(...a),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  PERMISSIONS: {
+    BACKUP_JOB_CREATE: "backup.job.create",
+    BACKUP_JOB_EDIT: "backup.job.edit",
+    BACKUP_JOB_DELETE: "backup.job.delete",
+  },
+}))
+
+import { createPbsJobConfig, deletePbsJobConfig, updatePbsJobConfig } from "./pbsJobConfig"
+import { PbsJobRequestError, type PbsJobSpec } from "./pbsJobSpecs"
+
+const SPEC: PbsJobSpec = {
+  configPath: "/config/demo",
+  label: "Demo job",
+  logTag: "pbs-demo-jobs",
+  buildCreate: (body: any) => {
+    if (!body.id) throw new PbsJobRequestError("Job ID is required")
+
+    return { id: body.id }
+  },
+  buildUpdate: (body: any) => ({ schedule: body.schedule }),
+}
+
+const CONN = { id: "pbs-1", baseUrl: "https://pbs.local:8007" }
+
+function ctx(params: { id?: string; jobId?: string }) {
+  return { params: Promise.resolve(params as { id: string; jobId: string }) }
+}
+
+function jsonRequest(body: unknown = {}) {
+  return new Request("http://test.local/_", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, "error").mockImplementation(() => {})
+  demoResponseMock.mockReturnValue(null)
+  checkPermissionMock.mockResolvedValue(null)
+  getPbsConnectionByIdMock.mockResolvedValue(CONN)
+  pbsFetchMock.mockResolvedValue({ ok: true })
+})
+
+describe("createPbsJobConfig", () => {
+  it("poste le corps de creation sur la collection du spec", async () => {
+    const res = await createPbsJobConfig(
+      jsonRequest({ id: "j1" }),
+      { params: Promise.resolve({ id: "pbs-1" }) },
+      SPEC
+    )
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      data: { ok: true },
+      message: "Demo job created successfully",
+    })
+
+    const [, path, init] = pbsFetchMock.mock.calls[0]
+
+    expect(path).toBe("/config/demo")
+    expect(init.method).toBe("POST")
+    expect(JSON.parse(init.body)).toEqual({ id: "j1" })
+  })
+
+  it("traduit un requis manquant en 400 portant le message du spec", async () => {
+    const res = await createPbsJobConfig(
+      jsonRequest({}),
+      { params: Promise.resolve({ id: "pbs-1" }) },
+      SPEC
+    )
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Job ID is required" })
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+    expect(console.error).not.toHaveBeenCalled()
+  })
+
+  it("rend la réponse du mode démo sans toucher à PBS", async () => {
+    demoResponseMock.mockReturnValue(new Response("demo", { status: 200 }))
+
+    const res = await createPbsJobConfig(
+      jsonRequest({ id: "j1" }),
+      { params: Promise.resolve({ id: "pbs-1" }) },
+      SPEC
+    )
+
+    await expect(res.text()).resolves.toBe("demo")
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 400 quand l'id de connexion manque", async () => {
+    const res = await createPbsJobConfig(
+      jsonRequest({ id: "j1" }),
+      { params: Promise.resolve({} as { id: string }) },
+      SPEC
+    )
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Missing PBS connection ID" })
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it("relaie le refus RBAC de création", async () => {
+    checkPermissionMock.mockResolvedValue(new Response(null, { status: 403 }))
+
+    const res = await createPbsJobConfig(
+      jsonRequest({ id: "j1" }),
+      { params: Promise.resolve({ id: "pbs-1" }) },
+      SPEC
+    )
+
+    expect(res.status).toBe(403)
+    expect(checkPermissionMock).toHaveBeenCalledWith("backup.job.create", "pbs", "pbs-1")
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 500 quand PBS refuse la création", async () => {
+    pbsFetchMock.mockRejectedValue(new Error("PBS 400 /config/demo:\nbad param"))
+
+    const res = await createPbsJobConfig(
+      jsonRequest({ id: "j1" }),
+      { params: Promise.resolve({ id: "pbs-1" }) },
+      SPEC
+    )
+
+    expect(res.status).toBe(500)
+    expect(console.error).toHaveBeenCalledWith(
+      "[pbs-demo-jobs] POST Error:",
+      "PBS 400 /config/demo:bad param"
+    )
+  })
+})
+
+describe("updatePbsJobConfig", () => {
+  it("envoie le PUT sur la collection du spec, id du job encodé", async () => {
+    const res = await updatePbsJobConfig(
+      jsonRequest({ schedule: "daily" }),
+      ctx({ id: "pbs-1", jobId: "job/one" }),
+      SPEC
+    )
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      data: { ok: true },
+      message: "Demo job updated successfully",
+    })
+
+    const [, path, init] = pbsFetchMock.mock.calls[0]
+
+    expect(path).toBe("/config/demo/job%2Fone")
+    expect(init.method).toBe("PUT")
+    expect(JSON.parse(init.body)).toEqual({ schedule: "daily" })
+  })
+
+  it("rend la réponse du mode démo sans toucher à PBS", async () => {
+    demoResponseMock.mockReturnValue(new Response("demo", { status: 200 }))
+
+    const res = await updatePbsJobConfig(jsonRequest(), ctx({ id: "pbs-1", jobId: "j1" }), SPEC)
+
+    await expect(res.text()).resolves.toBe("demo")
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 400 quand l'id du job manque", async () => {
+    const res = await updatePbsJobConfig(jsonRequest(), ctx({ id: "pbs-1" }), SPEC)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: "Missing parameters" })
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 400 quand l'id de connexion manque", async () => {
+    const res = await updatePbsJobConfig(jsonRequest(), ctx({ jobId: "j1" }), SPEC)
+
+    expect(res.status).toBe(400)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("relaie le refus RBAC tel quel", async () => {
+    checkPermissionMock.mockResolvedValue(new Response(null, { status: 403 }))
+
+    const res = await updatePbsJobConfig(jsonRequest(), ctx({ id: "pbs-1", jobId: "j1" }), SPEC)
+
+    expect(res.status).toBe(403)
+    expect(checkPermissionMock).toHaveBeenCalledWith("backup.job.edit", "pbs", "pbs-1")
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 500 avec le message PBS, et le journal tient sur une ligne", async () => {
+    pbsFetchMock.mockRejectedValue(new Error("PBS 400 /config/demo:\nbad param"))
+
+    const res = await updatePbsJobConfig(jsonRequest(), ctx({ id: "pbs-1", jobId: "j1" }), SPEC)
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: "PBS 400 /config/demo:\nbad param",
+    })
+    expect(console.error).toHaveBeenCalledWith(
+      "[pbs-demo-jobs] PUT Error:",
+      "PBS 400 /config/demo:bad param"
+    )
+  })
+
+  it("répond 500 sur un corps illisible", async () => {
+    const bad = new Request("http://test.local/_", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{",
+    })
+
+    const res = await updatePbsJobConfig(bad, ctx({ id: "pbs-1", jobId: "j1" }), SPEC)
+
+    expect(res.status).toBe(500)
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("deletePbsJobConfig", () => {
+  it("envoie le DELETE sur l'entrée, sans corps", async () => {
+    const res = await deletePbsJobConfig(
+      new Request("http://test.local/_", { method: "DELETE" }),
+      ctx({ id: "pbs-1", jobId: "j1" }),
+      SPEC
+    )
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ message: "Demo job deleted successfully" })
+
+    const [, path, init] = pbsFetchMock.mock.calls[0]
+
+    expect(path).toBe("/config/demo/j1")
+    expect(init).toEqual({ method: "DELETE" })
+  })
+
+  it("rend la réponse du mode démo sans toucher à PBS", async () => {
+    demoResponseMock.mockReturnValue(new Response("demo", { status: 200 }))
+
+    const res = await deletePbsJobConfig(
+      new Request("http://test.local/_", { method: "DELETE" }),
+      ctx({ id: "pbs-1", jobId: "j1" }),
+      SPEC
+    )
+
+    await expect(res.text()).resolves.toBe("demo")
+    expect(pbsFetchMock).not.toHaveBeenCalled()
+  })
+
+  it("répond 400 sur des params incomplets", async () => {
+    const res = await deletePbsJobConfig(
+      new Request("http://test.local/_", { method: "DELETE" }),
+      ctx({ id: "pbs-1" }),
+      SPEC
+    )
+
+    expect(res.status).toBe(400)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+  })
+
+  it("relaie le refus RBAC avec la permission de suppression", async () => {
+    checkPermissionMock.mockResolvedValue(new Response(null, { status: 403 }))
+
+    const res = await deletePbsJobConfig(
+      new Request("http://test.local/_", { method: "DELETE" }),
+      ctx({ id: "pbs-1", jobId: "j1" }),
+      SPEC
+    )
+
+    expect(res.status).toBe(403)
+    expect(checkPermissionMock).toHaveBeenCalledWith("backup.job.delete", "pbs", "pbs-1")
+  })
+
+  it("répond 500 quand PBS refuse la suppression", async () => {
+    pbsFetchMock.mockRejectedValue(new Error("PBS 404 /config/demo/j1"))
+
+    const res = await deletePbsJobConfig(
+      new Request("http://test.local/_", { method: "DELETE" }),
+      ctx({ id: "pbs-1", jobId: "j1" }),
+      SPEC
+    )
+
+    expect(res.status).toBe(500)
+    expect(console.error).toHaveBeenCalledWith(
+      "[pbs-demo-jobs] DELETE Error:",
+      "PBS 404 /config/demo/j1"
+    )
+  })
+})

--- a/frontend/src/lib/proxmox/pbsJobConfig.ts
+++ b/frontend/src/lib/proxmox/pbsJobConfig.ts
@@ -1,0 +1,140 @@
+// src/lib/proxmox/pbsJobConfig.ts
+import { NextResponse } from "next/server"
+
+import { demoResponse } from "@/lib/demo/demo-api"
+import { pbsFetch } from "@/lib/proxmox/pbs-client"
+import { getPbsConnectionById } from "@/lib/connections/getConnection"
+import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { PbsJobRequestError, type PbsJobSpec } from "@/lib/proxmox/pbsJobSpecs"
+
+/**
+ * Squelette commun aux routes d'un job PBS adresse par son id. Les quatre
+ * families (sync, verify, prune, tape backup) partageaient mot pour mot le
+ * mode demo, la lecture des params, le controle RBAC, l'ouverture de la
+ * connexion, l'appel PBS et le journal d'erreur : ce chemin n'est desormais
+ * ecrit et teste qu'une fois, chaque route n'apportant que son
+ * [[PbsJobSpec]].
+ */
+export type PbsJobRouteContext = {
+  params: Promise<{ id: string; jobId: string }>
+}
+
+export type PbsJobCollectionContext = {
+  params: Promise<{ id: string }>
+}
+
+/** Message d'erreur reduit a une seule ligne avant d'entrer dans le journal. */
+function logLine(e: unknown): string {
+  return String((e as any)?.message || e).replace(/[\r\n]/g, "")
+}
+
+function itemPath(spec: PbsJobSpec, jobId: string): string {
+  return `${spec.configPath}/${encodeURIComponent(jobId)}`
+}
+
+export async function createPbsJobConfig(
+  req: Request,
+  ctx: PbsJobCollectionContext,
+  spec: PbsJobSpec
+): Promise<Response> {
+  const demo = demoResponse(req)
+  if (demo) return demo
+
+  try {
+    const { id } = await ctx.params
+    const body = await req.json()
+
+    if (!id) {
+      return NextResponse.json({ error: "Missing PBS connection ID" }, { status: 400 })
+    }
+
+    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_CREATE, "pbs", id)
+
+    if (denied) return denied
+
+    const conn = await getPbsConnectionById(id)
+
+    const result = await pbsFetch<any>(conn, spec.configPath, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(spec.buildCreate(body)),
+    })
+
+    return NextResponse.json({ data: result, message: `${spec.label} created successfully` })
+  } catch (e: any) {
+    if (e instanceof PbsJobRequestError) {
+      return NextResponse.json({ error: e.message }, { status: 400 })
+    }
+
+    console.error(`[${spec.logTag}] POST Error:`, logLine(e))
+
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}
+
+export async function updatePbsJobConfig(
+  req: Request,
+  ctx: PbsJobRouteContext,
+  spec: PbsJobSpec
+): Promise<Response> {
+  const demo = demoResponse(req)
+  if (demo) return demo
+
+  try {
+    const { id, jobId } = await ctx.params
+    const body = await req.json()
+
+    if (!id || !jobId) {
+      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
+    }
+
+    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_EDIT, "pbs", id)
+
+    if (denied) return denied
+
+    const conn = await getPbsConnectionById(id)
+
+    const result = await pbsFetch<any>(conn, itemPath(spec, jobId), {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(spec.buildUpdate(body)),
+    })
+
+    return NextResponse.json({ data: result, message: `${spec.label} updated successfully` })
+  } catch (e: any) {
+    console.error(`[${spec.logTag}] PUT Error:`, logLine(e))
+
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}
+
+export async function deletePbsJobConfig(
+  req: Request,
+  ctx: PbsJobRouteContext,
+  spec: PbsJobSpec
+): Promise<Response> {
+  const demo = demoResponse(req)
+  if (demo) return demo
+
+  try {
+    const { id, jobId } = await ctx.params
+
+    if (!id || !jobId) {
+      return NextResponse.json({ error: "Missing parameters" }, { status: 400 })
+    }
+
+    const denied = await checkPermission(PERMISSIONS.BACKUP_JOB_DELETE, "pbs", id)
+
+    if (denied) return denied
+
+    const conn = await getPbsConnectionById(id)
+
+    await pbsFetch<any>(conn, itemPath(spec, jobId), { method: "DELETE" })
+
+    return NextResponse.json({ message: `${spec.label} deleted successfully` })
+  } catch (e: any) {
+    console.error(`[${spec.logTag}] DELETE Error:`, logLine(e))
+
+    return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })
+  }
+}

--- a/frontend/src/lib/proxmox/pbsJobSpecs.test.ts
+++ b/frontend/src/lib/proxmox/pbsJobSpecs.test.ts
@@ -1,0 +1,270 @@
+/**
+ * ui#817 — les quatre descriptions de job PBS. Ce sont des fonctions pures :
+ * elles traduisent le corps reçu de l'UI en corps PBS, et c'est là que vivent
+ * les règles de type du schéma 4.x (booléens réels, entiers, champs
+ * obligatoires non effaçables, rétention à zéro).
+ */
+import { describe, expect, it } from "vitest"
+
+import { PbsJobRequestError, PRUNE_JOB, SYNC_JOB, TAPE_JOB, VERIFY_JOB } from "./pbsJobSpecs"
+
+/** Corps de création minimal accepté par chaque famille. */
+const MINIMAL_CREATE: Array<[typeof SYNC_JOB, Record<string, unknown>]> = [
+  [SYNC_JOB, { id: "j1", store: "ds1", remote: "r1", remoteStore: "rds1" }],
+  [VERIFY_JOB, { id: "j1", store: "ds1" }],
+  [PRUNE_JOB, { id: "j1", store: "ds1", schedule: "daily" }],
+  [TAPE_JOB, { id: "j1", store: "ds1", pool: "pool1", drive: "drive0" }],
+]
+
+describe("création : champs obligatoires", () => {
+  for (const [spec, minimal] of MINIMAL_CREATE) {
+    it(`${spec.label} : le corps minimal passe et porte l'id`, () => {
+      expect(spec.buildCreate(minimal)).toMatchObject({ id: "j1", store: "ds1" })
+    })
+
+    for (const missing of Object.keys(minimal)) {
+      it(`${spec.label} : refuse un corps sans ${missing}`, () => {
+        const body = { ...minimal, [missing]: undefined }
+
+        expect(() => spec.buildCreate(body)).toThrow(PbsJobRequestError)
+        expect(() => spec.buildCreate(body)).toThrow(/is required$/)
+      })
+    }
+
+    it(`${spec.label} : ns, comment et max-depth ne partent que renseignés`, () => {
+      expect(spec.buildCreate({ ...minimal, ns: "", comment: "" })).not.toHaveProperty("ns")
+      expect(spec.buildCreate({ ...minimal, ns: "team", comment: "c", maxDepth: "2" })).toMatchObject(
+        { ns: "team", comment: "c", "max-depth": 2 }
+      )
+    })
+  }
+})
+
+describe("création : champs propres à chaque famille", () => {
+  it("SYNC_JOB mappe remote-store, remote-ns et remove-vanished", () => {
+    expect(
+      SYNC_JOB.buildCreate({
+        id: "j1",
+        store: "ds1",
+        remote: "r1",
+        remoteStore: "rds1",
+        remoteNs: "team",
+        schedule: "daily",
+        removeVanished: 1,
+      })
+    ).toEqual({
+      id: "j1",
+      store: "ds1",
+      remote: "r1",
+      "remote-store": "rds1",
+      "remote-ns": "team",
+      schedule: "daily",
+      "remove-vanished": true,
+    })
+  })
+
+  it("VERIFY_JOB convertit ignore-verified et outdated-after", () => {
+    expect(
+      VERIFY_JOB.buildCreate({ id: "j1", store: "ds1", ignoreVerified: 0, outdatedAfter: "30" })
+    ).toEqual({ id: "j1", store: "ds1", "ignore-verified": false, "outdated-after": 30 })
+  })
+
+  it("PRUNE_JOB ne garde que les rétentions strictement positives", () => {
+    const params = PRUNE_JOB.buildCreate({
+      id: "j1",
+      store: "ds1",
+      schedule: "daily",
+      keepLast: 3,
+      keepHourly: 0,
+      keepDaily: "7",
+      keepWeekly: null,
+      keepYearly: -1,
+      disable: 1,
+    })
+
+    expect(params).toEqual({
+      id: "j1",
+      store: "ds1",
+      schedule: "daily",
+      disable: true,
+      "keep-last": 3,
+      "keep-daily": 7,
+    })
+  })
+
+  it("TAPE_JOB ne transmet ses drapeaux que lorsqu'ils sont vrais", () => {
+    const minimal = { id: "j1", store: "ds1", pool: "pool1", drive: "drive0" }
+
+    expect(TAPE_JOB.buildCreate({ ...minimal, ejectMedia: 0, latestOnly: false })).toEqual(minimal)
+    expect(
+      TAPE_JOB.buildCreate({
+        ...minimal,
+        notifyUser: "root@pam",
+        ejectMedia: true,
+        exportMediaSet: 1,
+        latestOnly: "yes",
+      })
+    ).toMatchObject({
+      "notify-user": "root@pam",
+      "eject-media": true,
+      "export-media-set": true,
+      "latest-only": true,
+    })
+  })
+})
+
+describe("collections /config des quatre jobs", () => {
+  it("pointe la collection et le libellé de chaque famille", () => {
+    expect([SYNC_JOB.configPath, SYNC_JOB.label]).toEqual(["/config/sync", "Sync job"])
+    expect([VERIFY_JOB.configPath, VERIFY_JOB.label]).toEqual(["/config/verify", "Verify job"])
+    expect([PRUNE_JOB.configPath, PRUNE_JOB.label]).toEqual(["/config/prune", "Prune job"])
+    expect([TAPE_JOB.configPath, TAPE_JOB.label]).toEqual([
+      "/config/tape-backup-job",
+      "Tape backup job",
+    ])
+  })
+})
+
+describe("champs partagés", () => {
+  for (const spec of [SYNC_JOB, VERIFY_JOB, PRUNE_JOB, TAPE_JOB]) {
+    it(`${spec.label} : un corps vide ne transmet rien`, () => {
+      expect(spec.buildUpdate({})).toEqual({})
+    })
+
+    it(`${spec.label} : ns et comment vides passent par delete`, () => {
+      const body = spec.buildUpdate({ ns: "", comment: "" })
+
+      expect(body.delete).toEqual(expect.arrayContaining(["ns", "comment"]))
+      expect(JSON.stringify(body)).not.toContain("null")
+    })
+
+    it(`${spec.label} : max-depth arrive en entier`, () => {
+      expect(spec.buildUpdate({ maxDepth: "3" })).toMatchObject({ "max-depth": 3 })
+    })
+
+    it(`${spec.label} : un store vide ne supprime pas le champ obligatoire`, () => {
+      const body = spec.buildUpdate({ store: "" })
+
+      expect(body).not.toHaveProperty("store")
+      expect(body.delete ?? []).not.toContain("store")
+    })
+  }
+})
+
+describe("SYNC_JOB", () => {
+  it("mappe les noms PBS et convertit remove-vanished en booléen", () => {
+    expect(
+      SYNC_JOB.buildUpdate({
+        store: "ds1",
+        remote: "r1",
+        remoteStore: "rds1",
+        remoteNs: "team-a",
+        schedule: "daily",
+        removeVanished: 1,
+        disable: 0,
+      })
+    ).toEqual({
+      store: "ds1",
+      remote: "r1",
+      "remote-store": "rds1",
+      "remote-ns": "team-a",
+      schedule: "daily",
+      "remove-vanished": true,
+      disable: false,
+    })
+  })
+
+  it("efface un schedule et un remote-ns vidés", () => {
+    const body = SYNC_JOB.buildUpdate({ schedule: "", remoteNs: "" })
+
+    expect(body.delete).toEqual(expect.arrayContaining(["remote-ns", "schedule"]))
+  })
+
+  it("ne supprime pas remote-store, obligatoire côté PBS", () => {
+    const body = SYNC_JOB.buildUpdate({ remoteStore: "", remote: "" })
+
+    expect(body.delete ?? []).not.toContain("remote-store")
+    expect(body.delete ?? []).not.toContain("remote")
+  })
+})
+
+describe("VERIFY_JOB", () => {
+  it("convertit ignore-verified en booléen et outdated-after en entier", () => {
+    expect(
+      VERIFY_JOB.buildUpdate({ store: "ds1", ignoreVerified: 1, outdatedAfter: "30" })
+    ).toEqual({ store: "ds1", "ignore-verified": true, "outdated-after": 30 })
+  })
+
+  it("efface outdated-after vidé", () => {
+    expect(VERIFY_JOB.buildUpdate({ outdatedAfter: "" }).delete).toEqual(["outdated-after"])
+  })
+})
+
+describe("PRUNE_JOB", () => {
+  it("accepte datastore comme alias de store", () => {
+    expect(PRUNE_JOB.buildUpdate({ datastore: "ds1" })).toMatchObject({ store: "ds1" })
+    expect(PRUNE_JOB.buildUpdate({ store: "ds1", datastore: "ds2" })).toMatchObject({
+      store: "ds1",
+    })
+  })
+
+  it("garde une rétention positive et efface celle à zéro", () => {
+    const body = PRUNE_JOB.buildUpdate({
+      keepLast: 5,
+      keepHourly: 0,
+      keepDaily: "7",
+      keepWeekly: null,
+      keepMonthly: "",
+      keepYearly: 2,
+    })
+
+    expect(body).toMatchObject({ "keep-last": 5, "keep-daily": 7, "keep-yearly": 2 })
+    expect(body.delete).toEqual(
+      expect.arrayContaining(["keep-hourly", "keep-weekly", "keep-monthly"])
+    )
+    expect(JSON.stringify(body)).not.toContain("null")
+  })
+
+  it("ne supprime pas un schedule vidé, il est obligatoire", () => {
+    const body = PRUNE_JOB.buildUpdate({ schedule: "" })
+
+    expect(body).not.toHaveProperty("schedule")
+    expect(body.delete ?? []).not.toContain("schedule")
+  })
+})
+
+describe("TAPE_JOB", () => {
+  it("convertit ses trois drapeaux en booléens", () => {
+    expect(
+      TAPE_JOB.buildUpdate({
+        pool: "pool1",
+        drive: "drive0",
+        notifyUser: "root@pam",
+        ejectMedia: 1,
+        exportMediaSet: 0,
+        latestOnly: true,
+      })
+    ).toEqual({
+      pool: "pool1",
+      drive: "drive0",
+      "notify-user": "root@pam",
+      "eject-media": true,
+      "export-media-set": false,
+      "latest-only": true,
+    })
+  })
+
+  it("n'envoie jamais disable, absent du schéma d'un tape backup job", () => {
+    const body = TAPE_JOB.buildUpdate({ disable: true })
+
+    expect(body).not.toHaveProperty("disable")
+    expect(body.delete ?? []).not.toContain("disable")
+  })
+
+  it("ne supprime ni pool ni drive vidés, ils sont obligatoires", () => {
+    const body = TAPE_JOB.buildUpdate({ pool: "", drive: "" })
+
+    expect(body.delete ?? []).not.toContain("pool")
+    expect(body.delete ?? []).not.toContain("drive")
+  })
+})

--- a/frontend/src/lib/proxmox/pbsJobSpecs.ts
+++ b/frontend/src/lib/proxmox/pbsJobSpecs.ts
@@ -1,0 +1,245 @@
+// src/lib/proxmox/pbsJobSpecs.ts
+
+import {
+  optionalBoolean,
+  optionalNumber,
+  optionalPositiveNumber,
+  pbsConfigUpdate,
+  type PbsConfigUpdate,
+} from "@/lib/proxmox/pbsConfigUpdate"
+
+/**
+ * Ce qui distingue les quatre jobs PBS (sync, verify, prune, tape backup) :
+ * leur collection `/config/*`, leur libelle, et la traduction du corps recu de
+ * l'UI vers les proprietes de PBS. Le squelette de route qui consomme ces
+ * descriptions vit dans `pbsJobConfig.ts` ; ici tout est pur et testable sans
+ * Next ni RBAC.
+ */
+export type PbsJobSpec = {
+  /** Collection PBS de la configuration, par exemple `/config/verify`. */
+  configPath: string
+  /** Libelle des messages de reponse, par exemple `Verify job`. */
+  label: string
+  /** Etiquette du journal serveur, par exemple `pbs-verify-jobs`. */
+  logTag: string
+  /** Corps de creation. Leve [[PbsJobRequestError]] si un requis manque. */
+  buildCreate: (body: any) => Record<string, unknown>
+  /** Corps de modification, tableau `delete` compris. */
+  buildUpdate: (body: any) => Record<string, unknown>
+}
+
+/** Corps de requete invalide : la route la traduit en 400. */
+export class PbsJobRequestError extends Error {}
+
+function requireField(value: unknown, message: string): void {
+  if (!value) throw new PbsJobRequestError(message)
+}
+
+/**
+ * Champs optionnels communs aux quatre creations : transmis seulement s'ils
+ * sont renseignes, PBS appliquant ses propres defauts sinon.
+ */
+function setSharedCreateFields(params: Record<string, unknown>, body: any): void {
+  if (body.ns) params.ns = body.ns
+  if (body.comment) params.comment = body.comment
+  if (body.maxDepth !== undefined) params["max-depth"] = Number(body.maxDepth)
+}
+
+/**
+ * Champs communs aux quatre modifications, avec la meme semantique partout :
+ * un vide efface (`ns` vide = namespace racine), un `undefined` ne touche a rien.
+ */
+function setSharedUpdateFields(update: PbsConfigUpdate, body: any): void {
+  update.set("ns", body.ns)
+  update.set("comment", body.comment)
+  update.set("max-depth", optionalNumber(body.maxDepth))
+}
+
+/** Regles de retention d'un prune job : nom PBS, nom recu de l'UI. */
+const PRUNE_KEEP_FIELDS: Array<[string, string]> = [
+  ["keep-last", "keepLast"],
+  ["keep-hourly", "keepHourly"],
+  ["keep-daily", "keepDaily"],
+  ["keep-weekly", "keepWeekly"],
+  ["keep-monthly", "keepMonthly"],
+  ["keep-yearly", "keepYearly"],
+]
+
+export const SYNC_JOB: PbsJobSpec = {
+  configPath: "/config/sync",
+  label: "Sync job",
+  logTag: "pbs-sync-jobs",
+  buildCreate(body) {
+    requireField(body.id, "Job ID is required")
+    requireField(body.store, "Datastore is required")
+    requireField(body.remote, "Remote is required")
+    requireField(body.remoteStore, "Remote datastore is required")
+
+    const params: Record<string, unknown> = {
+      id: body.id,
+      store: body.store,
+      remote: body.remote,
+      "remote-store": body.remoteStore,
+    }
+
+    if (body.remoteNs) params["remote-ns"] = body.remoteNs
+    if (body.schedule) params.schedule = body.schedule
+    if (body.removeVanished !== undefined) {
+      params["remove-vanished"] = Boolean(body.removeVanished)
+    }
+
+    setSharedCreateFields(params, body)
+
+    return params
+  },
+  buildUpdate(body) {
+    const update = pbsConfigUpdate()
+
+    // `store` et `remote-store` sont obligatoires cote PBS : une valeur vide
+    // se traduit par « ne pas toucher », jamais par un effacement.
+    update.set("store", body.store || undefined)
+    update.set("remote", body.remote || undefined)
+    update.set("remote-store", body.remoteStore || undefined)
+    update.set("remote-ns", body.remoteNs)
+    update.set("schedule", body.schedule)
+    update.set("remove-vanished", optionalBoolean(body.removeVanished))
+    update.set("disable", optionalBoolean(body.disable))
+    setSharedUpdateFields(update, body)
+
+    return update.build()
+  },
+}
+
+export const VERIFY_JOB: PbsJobSpec = {
+  configPath: "/config/verify",
+  label: "Verify job",
+  logTag: "pbs-verify-jobs",
+  buildCreate(body) {
+    requireField(body.id, "Job ID is required")
+    requireField(body.store, "Datastore is required")
+
+    const params: Record<string, unknown> = { id: body.id, store: body.store }
+
+    if (body.schedule) params.schedule = body.schedule
+    if (body.ignoreVerified !== undefined) {
+      params["ignore-verified"] = Boolean(body.ignoreVerified)
+    }
+
+    if (body.outdatedAfter) params["outdated-after"] = Number(body.outdatedAfter)
+
+    setSharedCreateFields(params, body)
+
+    return params
+  },
+  buildUpdate(body) {
+    const update = pbsConfigUpdate()
+
+    // `store` est obligatoire cote PBS : une valeur vide vaut « ne pas toucher ».
+    update.set("store", body.store || undefined)
+    update.set("schedule", body.schedule)
+    update.set("ignore-verified", optionalBoolean(body.ignoreVerified))
+    update.set("outdated-after", optionalNumber(body.outdatedAfter))
+    update.set("disable", optionalBoolean(body.disable))
+    setSharedUpdateFields(update, body)
+
+    return update.build()
+  },
+}
+
+export const PRUNE_JOB: PbsJobSpec = {
+  configPath: "/config/prune",
+  label: "Prune job",
+  logTag: "pbs-prune-jobs",
+  buildCreate(body) {
+    requireField(body.id, "Job ID is required")
+    requireField(body.store, "Datastore is required")
+
+    // `schedule` n'est pas optionnel dans le schema d'un prune job PBS.
+    requireField(body.schedule, "Schedule is required")
+
+    const params: Record<string, unknown> = {
+      id: body.id,
+      store: body.store,
+      schedule: body.schedule,
+    }
+
+    if (body.disable !== undefined) params.disable = Boolean(body.disable)
+
+    for (const [pbsKey, bodyKey] of PRUNE_KEEP_FIELDS) {
+      const keep = optionalPositiveNumber(body[bodyKey])
+
+      if (keep) params[pbsKey] = keep
+    }
+
+    setSharedCreateFields(params, body)
+
+    return params
+  },
+  buildUpdate(body) {
+    const update = pbsConfigUpdate()
+
+    // `store` et `schedule` sont obligatoires cote PBS : une valeur vide vaut
+    // « ne pas toucher », jamais un effacement.
+    update.set("store", body.store || body.datastore || undefined)
+    update.set("schedule", body.schedule || undefined)
+    update.set("disable", optionalBoolean(body.disable))
+    setSharedUpdateFields(update, body)
+
+    // Retention : un 0 ou un vide efface la regle via le tableau `delete`,
+    // PBS refusant un `null` sur une propriete entiere.
+    for (const [pbsKey, bodyKey] of PRUNE_KEEP_FIELDS) {
+      update.set(pbsKey, optionalPositiveNumber(body[bodyKey]))
+    }
+
+    return update.build()
+  },
+}
+
+export const TAPE_JOB: PbsJobSpec = {
+  configPath: "/config/tape-backup-job",
+  label: "Tape backup job",
+  logTag: "pbs-tape-jobs",
+  buildCreate(body) {
+    requireField(body.id, "Job ID is required")
+    requireField(body.store, "Datastore is required")
+    requireField(body.pool, "Media Pool is required")
+    requireField(body.drive, "Drive is required")
+
+    const params: Record<string, unknown> = {
+      id: body.id,
+      store: body.store,
+      pool: body.pool,
+      drive: body.drive,
+    }
+
+    if (body.schedule) params.schedule = body.schedule
+    if (body.notifyUser) params["notify-user"] = body.notifyUser
+    if (body.ejectMedia) params["eject-media"] = true
+    if (body.exportMediaSet) params["export-media-set"] = true
+    if (body.latestOnly) params["latest-only"] = true
+
+    setSharedCreateFields(params, body)
+
+    return params
+  },
+  buildUpdate(body) {
+    const update = pbsConfigUpdate()
+
+    // `store`, `pool` et `drive` sont obligatoires cote PBS : une valeur vide
+    // vaut « ne pas toucher », jamais un effacement.
+    update.set("store", body.store || undefined)
+    update.set("pool", body.pool || undefined)
+    update.set("drive", body.drive || undefined)
+    update.set("schedule", body.schedule)
+    update.set("notify-user", body.notifyUser)
+    update.set("eject-media", optionalBoolean(body.ejectMedia))
+    update.set("export-media-set", optionalBoolean(body.exportMediaSet))
+    update.set("latest-only", optionalBoolean(body.latestOnly))
+    setSharedUpdateFields(update, body)
+
+    // Un tape backup job n'a pas de propriete `disable` dans le schema PBS :
+    // l'envoyer declenche « schema does not allow additional properties ».
+
+    return update.build()
+  },
+}


### PR DESCRIPTION
Closes #817.

Several Proxmox Backup Server calls did not match the PBS 4.x API contract. Two of them surfaced as an outright error or an empty screen, the rest were silent. Every point below was verified against the published PBS 4.x schema (the api-viewer `apiSchema`) and the PBS source, and the sweep that produced them compared *every* PBS call in the codebase against that schema rather than only the reported ones.

### Parameter types

The APT database refresh sent `notify` and `quiet` as `0`/`1`, and the repository toggle sent `enabled` the same way. PBS verifies a JSON body against the schema without coercing anything, so an integer where a boolean is declared fails with `parameter verification failed: 'notify': Expected boolean value.` A `0`/`1` is only accepted in a query string, never in a JSON body.

### Repository toggle used the wrong method

PBS maps `POST /nodes/{node}/apt/repositories` to `change_repository` (`path`, `index`, `enabled`) and `PUT` on the same path to `add_repository` (`handle`). The toggle used `PUT`, so fixing the boolean alone would not have been enough: it was also sending a payload the endpoint it reached does not accept. Adding a repository stays on `PUT`.

### API tokens were never listed

`/access/users` only returns tokens when asked for them, so the Access Control tab always reported that none were configured. The parameter is `include_tokens`, with an underscore rather than a hyphen, which the schema, the PBS source and the PBS web UI all agree on.

### Job configuration moved off /admin

`/admin/sync`, `/admin/verify` and `/admin/prune` only expose the listing with status and the `POST /{id}/run` action. Create, update and delete now go through `/config/sync`, `/config/verify` and `/config/prune`.

A prune job is addressed by its id alone: `/admin/datastore/{store}/prune-job` does not exist at all, which is also why the job list never showed a single prune job (it was polling that path once per datastore). The listing now reads the PBS-wide `/admin/prune`, and the tenant scoping stays enforced by the same `(datastore, namespace)` check the sync and verify listings already used. `schedule` is mandatory when creating a prune job, and deleting one no longer needs the datastore.

### Clearing a field needs the delete array

PBS hands the JSON body straight to schema verification and never strips nulls, so a `PUT` sending `{"ns": null}` to clear a field failed with `'ns': Expected string value.` The new `pbsConfigUpdate` helper names the field in the `delete` array instead. It covers the sync, verify, prune and tape job updates, and it leaves required properties (`store`, `remote-store`, `pool`, `drive`, `schedule`) untouched when the caller sends an empty value rather than trying to delete them. A tape backup job has no `disable` property in the schema and no longer receives one.

### S3 clients

They live under `/config/s3`, not `/config/s3-endpoint`, and each entry carries an `id` rather than a `name`. The tab therefore reported them as unsupported on a PBS 4 that does handle them.

### One handler instead of four copies

The eight job routes (create, update, delete for sync, verify, prune and tape) carried four near-identical copies of the same skeleton: demo mode, params, RBAC check, connection, PBS call, error log. That is precisely why every type fix above had to be written four times over, and why one of the four had already drifted (only the prune route sanitised its log line). The skeleton now lives in `lib/proxmox/pbsJobConfig.ts`, and each family contributes only its collection path and its field mapping through `lib/proxmox/pbsJobSpecs.ts`. Route files went from 105-125 lines down to 12-24.

Behaviour is unchanged: the same request bodies, the same status codes, the same response messages. The route-level tests written before the extraction still pass untouched, which is what pins that.

### Tests

`frontend/src/app/api/v1/pbs/[id]/pbs4Compat.test.ts` pins the path, the method and the exact body sent to PBS for each fix above, including that no `null` ever reaches a `PUT` body. `pbsJobSpecs.test.ts` covers the field mappings as pure functions (required fields, boolean coercion, retention at zero, the empty-value-is-not-a-delete rule), `pbsJobConfig.test.ts` covers the shared handler branches once (demo passthrough, missing params, RBAC refusal, PBS error), and `pbsConfigUpdate.test.ts` covers the delete-array convention. The existing job-scoping test was updated for the new prune listing endpoint and still asserts the same tenant isolation.

### Recipe

Verified against a PBS 4.2 lab server. The four screens to exercise are Updates (refresh the package database), Repositories (toggle a repository, then reload to confirm it held server-side), Access Control (API Tokens tab) and S3 Endpoints. The `/api/v1/pbs/[id]/jobs*` routes have no UI caller yet, so the job fixes are covered by the tests and by checking `data.stats.byType.prune` on the job listing.
