### PR TITLE
fix(ha): tell a cut orchestrator response apart from a dead one

### DIFF
--- a/frontend/src/app/api/v1/ha/cluster/route.ts
+++ b/frontend/src/app/api/v1/ha/cluster/route.ts
@@ -1,12 +1,8 @@
-import { NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
+import { proxyHaJson } from '@/lib/orchestrator/haProxy'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
 
 export async function GET() {
   // No license guard: cluster status stays readable when the option expired
@@ -14,14 +10,5 @@ export async function GET() {
   const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
   if (perm) return perm
 
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/cluster`, {
-      headers: orchestratorHeaders(),
-      cache: 'no-store',
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
+  return proxyHaJson('/ha/cluster')
 }

--- a/frontend/src/app/api/v1/ha/config/route.test.ts
+++ b/frontend/src/app/api/v1/ha/config/route.test.ts
@@ -122,6 +122,14 @@ describe('PUT /api/v1/ha/config', () => {
     )
   })
 
+  it('rejects an unreadable body with 400 instead of blaming the orchestrator', async () => {
+    const { PUT } = await import('./route')
+    const res = await callRoute(PUT as any, { method: 'PUT', body: 'not json at all' })
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('forwards orchestrator errors', async () => {
     fetchMock.mockResolvedValue({
       ok: false,

--- a/frontend/src/app/api/v1/ha/config/route.ts
+++ b/frontend/src/app/api/v1/ha/config/route.ts
@@ -1,14 +1,9 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
+import { proxyHaJson } from '@/lib/orchestrator/haProxy'
+import { haOperationWithBody } from '@/lib/orchestrator/haRoute'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
 
 export async function GET() {
   // No license guard: HA config stays readable when the option expired
@@ -16,34 +11,7 @@ export async function GET() {
   const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
   if (perm) return perm
 
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/config`, {
-      headers: orchestratorHeaders(),
-      cache: 'no-store',
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
+  return proxyHaJson('/ha/config')
 }
 
-export async function PUT(request: NextRequest) {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const body = await request.json()
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/config`, {
-      method: 'PUT',
-      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+export const PUT = haOperationWithBody('/ha/config', 'PUT')

--- a/frontend/src/app/api/v1/ha/deploy/route.test.ts
+++ b/frontend/src/app/api/v1/ha/deploy/route.test.ts
@@ -115,4 +115,19 @@ describe('GET /api/v1/ha/deploy/status', () => {
 
     expect(res.status).toBe(200)
   })
+
+  it('reports a stream cut mid-flight as 504, not as an unavailable orchestrator (#803)', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' }),
+      })
+    )
+
+    const { GET } = await import('./status/route')
+    const res = await callRoute(GET as any)
+    const data = (await readJson(res)) as { error: string }
+
+    expect(res.status).toBe(504)
+    expect(data.error).toContain('closed the connection')
+  })
 })

--- a/frontend/src/app/api/v1/ha/deploy/route.ts
+++ b/frontend/src/app/api/v1/ha/deploy/route.ts
@@ -1,32 +1,19 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { proxyHaJson } from '@/lib/orchestrator/haProxy'
+import { haWriteGuard } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
 export async function POST(request: NextRequest) {
-  const guard = await requireFeature(Features.HA)
+  const guard = await haWriteGuard()
   if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
 
-  try {
-    let body: Record<string, unknown> = {}
-    try { body = await request.json() } catch { /* empty body is OK for retry */ }
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/deploy`, {
-      method: 'POST',
-      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
+  // Not haOperationWithBody: an empty body is legitimate here, it is how the
+  // wizard retries a deployment.
+  let body: Record<string, unknown> = {}
+  try { body = await request.json() } catch { /* empty body is OK for retry */ }
+
+  return proxyHaJson('/ha/deploy', { method: 'POST', body })
 }

--- a/frontend/src/app/api/v1/ha/deploy/status/route.ts
+++ b/frontend/src/app/api/v1/ha/deploy/status/route.ts
@@ -1,21 +1,18 @@
+import { orchestratorBaseUrl, orchestratorFailure } from '@/lib/orchestrator/haProxy'
+import { haWriteGuard } from '@/lib/orchestrator/haRoute'
 import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
 export async function GET() {
-  const guard = await requireFeature(Features.HA)
+  const guard = await haWriteGuard()
   if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
 
+  // Not proxyHaJson: this one streams the orchestrator's SSE body straight
+  // through instead of parsing it.
   try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/deploy/status`, {
+    const res = await fetch(`${orchestratorBaseUrl()}/api/v1/ha/deploy/status`, {
       headers: orchestratorHeaders(),
     })
 
@@ -34,9 +31,11 @@ export async function GET() {
         'X-Accel-Buffering': 'no',
       },
     })
-  } catch {
-    return new Response(JSON.stringify({ error: 'Orchestrator unavailable' }), {
-      status: 503,
+  } catch (cause) {
+    const failure = orchestratorFailure(cause)
+
+    return new Response(JSON.stringify({ error: failure.error }), {
+      status: failure.status,
       headers: { 'Content-Type': 'application/json' },
     })
   }

--- a/frontend/src/app/api/v1/ha/maintenance/[node]/route.ts
+++ b/frontend/src/app/api/v1/ha/maintenance/[node]/route.ts
@@ -1,14 +1,8 @@
-import { NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { proxyHaJson } from '@/lib/orchestrator/haProxy'
+import { haWriteGuard } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
 
 // Entering and leaving maintenance are the same proxied call under two verbs;
 // keep them on one path so the guards can never drift apart.
@@ -16,22 +10,12 @@ async function proxyMaintenance(
   method: 'POST' | 'DELETE',
   params: Promise<{ node: string }>
 ) {
-  const guard = await requireFeature(Features.HA)
+  const guard = await haWriteGuard()
   if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
 
   const { node } = await params
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/maintenance/${encodeURIComponent(node)}`, {
-      method,
-      headers: orchestratorHeaders(),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
+
+  return proxyHaJson(`/ha/maintenance/${encodeURIComponent(node)}`, { method })
 }
 
 export async function POST(

--- a/frontend/src/app/api/v1/ha/ops/route.test.ts
+++ b/frontend/src/app/api/v1/ha/ops/route.test.ts
@@ -39,6 +39,41 @@ describe('POST /api/v1/ha/switchover', () => {
       expect.objectContaining({ method: 'POST' })
     )
   })
+
+  it('rejects an unreadable body with 400 instead of blaming the orchestrator', async () => {
+    const { POST } = await import('../switchover/route')
+    const res = await callRoute(POST as any, { method: 'POST', body: 'not json at all' })
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('PUT /api/v1/ha/sync-mode', () => {
+  it('forwards the requested sync mode', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true }),
+    })
+
+    const { PUT } = await import('../sync-mode/route')
+    const res = await callRoute(PUT as any, { method: 'PUT', body: { mode: 'synchronous_mode_strict' } })
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/ha/sync-mode'),
+      expect.objectContaining({ method: 'PUT', body: '{"mode":"synchronous_mode_strict"}' })
+    )
+  })
+
+  it('rejects an unreadable body with 400 instead of blaming the orchestrator', async () => {
+    const { PUT } = await import('../sync-mode/route')
+    const res = await callRoute(PUT as any, { method: 'PUT', body: 'not json at all' })
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
 })
 
 describe('POST /api/v1/ha/pause', () => {

--- a/frontend/src/app/api/v1/ha/pause/route.ts
+++ b/frontend/src/app/api/v1/ha/pause/route.ts
@@ -1,29 +1,6 @@
-import { NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { haOperation } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
-export async function POST() {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/pause`, {
-      method: 'POST',
-      headers: orchestratorHeaders(),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+export const POST = haOperation('/ha/pause', 'POST')

--- a/frontend/src/app/api/v1/ha/reinit/[node]/route.ts
+++ b/frontend/src/app/api/v1/ha/reinit/[node]/route.ts
@@ -1,33 +1,18 @@
-import { NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { proxyHaJson } from '@/lib/orchestrator/haProxy'
+import { haWriteGuard } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
-
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
 
 export async function POST(
   _request: Request,
   { params }: { params: Promise<{ node: string }> }
 ) {
-  const guard = await requireFeature(Features.HA)
+  const guard = await haWriteGuard()
   if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
 
   const { node } = await params
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/reinit/${encodeURIComponent(node)}`, {
-      method: 'POST',
-      headers: orchestratorHeaders(),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
+
+  // Reinit polls Patroni for up to 5 minutes on the orchestrator side.
+  return proxyHaJson(`/ha/reinit/${encodeURIComponent(node)}`, { method: 'POST' })
 }

--- a/frontend/src/app/api/v1/ha/resume/route.ts
+++ b/frontend/src/app/api/v1/ha/resume/route.ts
@@ -1,29 +1,6 @@
-import { NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { haOperation } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
-export async function POST() {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/resume`, {
-      method: 'POST',
-      headers: orchestratorHeaders(),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+export const POST = haOperation('/ha/resume', 'POST')

--- a/frontend/src/app/api/v1/ha/switchover/route.ts
+++ b/frontend/src/app/api/v1/ha/switchover/route.ts
@@ -1,31 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { haOperationWithBody } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
-export async function POST(request: NextRequest) {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const body = await request.json()
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/switchover`, {
-      method: 'POST',
-      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+export const POST = haOperationWithBody('/ha/switchover', 'POST')

--- a/frontend/src/app/api/v1/ha/sync-mode/route.ts
+++ b/frontend/src/app/api/v1/ha/sync-mode/route.ts
@@ -1,31 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { haOperationWithBody } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
-export async function PUT(req: NextRequest) {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const body = await req.json()
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/sync-mode`, {
-      method: 'PUT',
-      headers: { ...orchestratorHeaders(), 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+export const PUT = haOperationWithBody('/ha/sync-mode', 'PUT')

--- a/frontend/src/app/api/v1/ha/validate/route.test.ts
+++ b/frontend/src/app/api/v1/ha/validate/route.test.ts
@@ -64,4 +64,32 @@ describe('POST /api/v1/ha/validate', () => {
 
     expect(res.status).toBe(503)
   })
+
+  it('rejects an unreadable body with 400 instead of blaming the orchestrator', async () => {
+    const { POST } = await import('./route')
+    const res = await callRoute(POST as any, { method: 'POST', body: 'not json at all' })
+
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  // #803: the preflight budgets 150s, the Go http.Server used to cut the
+  // response at api.write_timeout (30s). The socket dies with the same
+  // `TypeError: fetch failed` as a refused connection, and the wizard told the
+  // operator the orchestrator was down while it was still probing nodes.
+  it('reports a response cut mid-flight as 504, not as an unavailable orchestrator', async () => {
+    fetchMock.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' }),
+      })
+    )
+
+    const { POST } = await import('./route')
+    const res = await callRoute(POST as any, { body: {} })
+    const data = (await readJson(res)) as { error: string }
+
+    expect(res.status).toBe(504)
+    expect(data.error).toContain('closed the connection')
+    expect(data.error).not.toContain('unavailable')
+  })
 })

--- a/frontend/src/app/api/v1/ha/validate/route.ts
+++ b/frontend/src/app/api/v1/ha/validate/route.ts
@@ -1,31 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server'
-
-import { orchestratorHeaders } from '@/lib/orchestrator/headers'
-import { requireFeature } from '@/lib/auth/requireEnterprise'
-import { Features } from '@/lib/license/features'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { haOperationWithBody } from '@/lib/orchestrator/haRoute'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
 
-const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
-
-export async function POST(request: NextRequest) {
-  const guard = await requireFeature(Features.HA)
-  if (guard) return guard
-  const perm = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
-  if (perm) return perm
-
-  try {
-    const body = await request.json()
-    const res = await fetch(`${ORCHESTRATOR_URL}/api/v1/ha/validate`, {
-      method: 'POST',
-      headers: orchestratorHeaders({ 'Content-Type': 'application/json' }),
-      body: JSON.stringify(body),
-    })
-    const data = await res.json()
-    return NextResponse.json(data, { status: res.status })
-  } catch {
-    return NextResponse.json({ error: 'Orchestrator unavailable' }, { status: 503 })
-  }
-}
+// The preflight budgets 150s (45s per node) and legitimately runs far longer
+// than a normal API call: it opens an SSH session per node and probes the TCP
+// matrix between all three. It must never be reported as an unreachable
+// orchestrator just because it took its time (#803).
+export const POST = haOperationWithBody('/ha/validate', 'POST')

--- a/frontend/src/lib/orchestrator/haProxy.test.ts
+++ b/frontend/src/lib/orchestrator/haProxy.test.ts
@@ -1,0 +1,180 @@
+import net from 'node:net'
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { orchestratorFailure, proxyHaJson } from './haProxy'
+
+vi.mock('./headers', () => ({
+  orchestratorHeaders: (extra: Record<string, string> = {}) => ({ 'X-API-Key': 'test', ...extra }),
+}))
+
+const undiciError = (message: string, code: string) =>
+  Object.assign(new TypeError(message), {
+    cause: Object.assign(new Error('simulated'), { code }),
+  })
+
+describe('orchestratorFailure', () => {
+  it('reports an orchestrator that is not listening as 503 unavailable', () => {
+    expect(orchestratorFailure(undiciError('fetch failed', 'ECONNREFUSED'))).toEqual({
+      status: 503,
+      error: 'Orchestrator unavailable',
+    })
+  })
+
+  it('keeps 503 for an unknown failure, including an error without a cause', () => {
+    expect(orchestratorFailure(new Error('ECONNREFUSED')).status).toBe(503)
+    expect(orchestratorFailure(undefined).status).toBe(503)
+    expect(orchestratorFailure(undiciError('fetch failed', 'ENOTFOUND')).status).toBe(503)
+  })
+
+  it.each([
+    ['UND_ERR_SOCKET', 'fetch failed'],
+    ['ECONNRESET', 'fetch failed'],
+    ['UND_ERR_HEADERS_TIMEOUT', 'fetch failed'],
+    ['UND_ERR_BODY_TIMEOUT', 'terminated'],
+  ])('reports a cut exchange (%s) as 504, not as an unavailable orchestrator', (code, message) => {
+    const failure = orchestratorFailure(undiciError(message, code))
+
+    expect(failure.status).toBe(504)
+    expect(failure.error).toContain('closed the connection')
+  })
+
+  it('reports a cut that happened after the headers (undici "terminated") as 504', () => {
+    expect(orchestratorFailure(new TypeError('terminated')).status).toBe(504)
+  })
+
+  it('reports an aborted request as 504', () => {
+    expect(orchestratorFailure(Object.assign(new Error('x'), { name: 'AbortError' })).status).toBe(504)
+  })
+})
+
+// These two run against the real runtime fetch, on real sockets: the whole
+// point of the fix is that Node reports "nothing is listening" and "the peer
+// hung up mid-request" with the SAME `TypeError: fetch failed`, and only
+// `cause.code` separates them. A hand-built error object cannot prove that.
+describe('proxyHaJson against real sockets', () => {
+  const originalUrl = process.env.ORCHESTRATOR_URL
+
+  afterEach(() => {
+    if (originalUrl === undefined) delete process.env.ORCHESTRATOR_URL
+    else process.env.ORCHESTRATOR_URL = originalUrl
+  })
+
+  it('answers 504 when the orchestrator closes the socket without answering (#803)', async () => {
+    // Exactly what the Go http.Server does when api.write_timeout expires
+    // while the HA preflight is still probing nodes.
+    const server = net.createServer(sock => {
+      sock.on('data', () => sock.end())
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', () => resolve()))
+    const { port } = server.address() as net.AddressInfo
+    process.env.ORCHESTRATOR_URL = `http://127.0.0.1:${port}`
+
+    try {
+      const res = await proxyHaJson('/ha/validate', { method: 'POST', body: { nodes: [] } })
+      const body = await res.json()
+
+      expect(res.status).toBe(504)
+      expect(body.error).toContain('closed the connection')
+      expect(body.error).not.toContain('unavailable')
+    } finally {
+      await new Promise(resolve => server.close(resolve))
+    }
+  })
+
+  it('answers 503 when nothing is listening at all', async () => {
+    const probe = net.createServer()
+    await new Promise<void>(resolve => probe.listen(0, '127.0.0.1', () => resolve()))
+    const { port } = probe.address() as net.AddressInfo
+    await new Promise(resolve => probe.close(resolve))
+    process.env.ORCHESTRATOR_URL = `http://127.0.0.1:${port}`
+
+    const res = await proxyHaJson('/ha/cluster')
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body).toEqual({ error: 'Orchestrator unavailable' })
+  })
+})
+
+describe('proxyHaJson forwarding', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch') as any
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  const upstream = (status: number, json: unknown) =>
+    fetchSpy.mockResolvedValue({ ok: status < 400, status, json: async () => json } as any)
+
+  it('hands the orchestrator payload and status back untouched', async () => {
+    upstream(200, { results: [{ ip: '192.0.2.101' }] })
+
+    const res = await proxyHaJson('/ha/validate', { method: 'POST', body: { vip: '192.0.2.100' } })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ results: [{ ip: '192.0.2.101' }] })
+  })
+
+  it('forwards an upstream error status instead of flattening it', async () => {
+    upstream(409, { error: 'deployment already running' })
+
+    const res = await proxyHaJson('/ha/deploy', { method: 'POST', body: {} })
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'deployment already running' })
+  })
+
+  it('sends the API key, and a Content-Type only when there is a body', async () => {
+    upstream(200, {})
+    await proxyHaJson('/ha/pause', { method: 'POST' })
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      expect.stringContaining('/api/v1/ha/pause'),
+      expect.objectContaining({ method: 'POST', body: undefined, headers: { 'X-API-Key': 'test' } })
+    )
+
+    upstream(200, {})
+    await proxyHaJson('/ha/sync-mode', { method: 'PUT', body: { mode: 'off' } })
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      expect.stringContaining('/api/v1/ha/sync-mode'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: '{"mode":"off"}',
+        headers: { 'X-API-Key': 'test', 'Content-Type': 'application/json' },
+      })
+    )
+  })
+
+  it('keeps an upstream error status when the error body is not JSON either', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON')
+      },
+    } as any)
+
+    const res = await proxyHaJson('/ha/cluster')
+
+    expect(res.status).toBe(500)
+  })
+
+  it('does not blame the orchestrator for a malformed body it did send', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON')
+      },
+    } as any)
+
+    const res = await proxyHaJson('/ha/cluster')
+
+    expect(res.status).toBe(502)
+    expect((await res.json()).error).toContain('malformed')
+  })
+})

--- a/frontend/src/lib/orchestrator/haProxy.ts
+++ b/frontend/src/lib/orchestrator/haProxy.ts
@@ -1,0 +1,111 @@
+// src/lib/orchestrator/haProxy.ts
+//
+// Shared proxy for the /api/v1/ha/* routes. They all do the same thing:
+// forward one call to the orchestrator and hand its JSON back untouched. What
+// is worth centralising is the error path.
+//
+// Every one of these routes used to answer `503 Orchestrator unavailable` from
+// a blind `catch`, including when the orchestrator was perfectly alive and had
+// merely cut the response mid-flight once api.write_timeout expired. Operators
+// then went hunting for a dead orchestrator that was in fact still working
+// (#803: an HA preflight spanning three PVE clusters spends 3s per silently
+// DROPped TCP probe and crossed the 30s server write deadline).
+
+import { NextResponse } from 'next/server'
+
+import { orchestratorHeaders } from './headers'
+
+// Node/undici `cause.code` values meaning "the orchestrator was reached, then
+// the exchange was cut or timed out". Measured on Node 26: a peer closing the
+// socket mid-request surfaces as `TypeError: fetch failed` with
+// `cause.code === 'UND_ERR_SOCKET'`, which is the SAME top-level message a
+// refused connection produces (`cause.code === 'ECONNREFUSED'`). Only
+// `cause.code` tells the two apart, which is why the old blind catch could
+// not.
+const CUT_SHORT_CODES = new Set([
+  'UND_ERR_SOCKET', // other side closed, or reset
+  'ECONNRESET',
+  'UND_ERR_HEADERS_TIMEOUT', // undici caps at 300s; HA reinit polls Patroni up to 5min
+  'UND_ERR_BODY_TIMEOUT',
+])
+
+export interface OrchestratorFailure {
+  status: number
+  error: string
+}
+
+/**
+ * Classify a failed `fetch` toward the orchestrator. Anything that is not
+ * provably a cut or a timeout keeps the historical
+ * `503 Orchestrator unavailable`, so a genuinely down orchestrator still reads
+ * the same way it always did.
+ */
+export function orchestratorFailure(cause: unknown): OrchestratorFailure {
+  const err = cause as { name?: string; message?: string; cause?: { code?: string } } | null
+  const code = err?.cause?.code
+
+  if (err?.name === 'AbortError') {
+    return { status: 504, error: 'Orchestrator request aborted before an answer came back' }
+  }
+
+  // `terminated` is what undici reports when the cut happens after the
+  // response headers, mid-body.
+  if ((code && CUT_SHORT_CODES.has(code)) || err?.message === 'terminated') {
+    return {
+      status: 504,
+      error:
+        'The orchestrator closed the connection before answering. The operation may still be running on the orchestrator, check its logs.',
+    }
+  }
+
+  return { status: 503, error: 'Orchestrator unavailable' }
+}
+
+export function orchestratorBaseUrl(): string {
+  return process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
+}
+
+export interface HaProxyOptions {
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
+  /** Serialised as JSON. Omit entirely for the body-less operations, which
+   *  must not carry a Content-Type either. */
+  body?: unknown
+}
+
+/**
+ * Forward one HA call to the orchestrator and return its response verbatim,
+ * status included, so an upstream 400/409 payload reaches the wizard instead
+ * of being flattened into a generic error.
+ */
+export async function proxyHaJson(path: string, opts: HaProxyOptions = {}): Promise<NextResponse> {
+  const { method = 'GET', body } = opts
+
+  let res: Response
+
+  try {
+    res = await fetch(`${orchestratorBaseUrl()}/api/v1${path}`, {
+      method,
+      headers:
+        body === undefined
+          ? orchestratorHeaders()
+          : orchestratorHeaders({ 'Content-Type': 'application/json' }),
+      body: body === undefined ? undefined : JSON.stringify(body),
+      cache: 'no-store',
+    })
+  } catch (cause) {
+    const failure = orchestratorFailure(cause)
+
+    return NextResponse.json({ error: failure.error }, { status: failure.status })
+  }
+
+  // The orchestrator answered. A body that is not JSON is a failure of its
+  // own and must not be reported as an unreachable orchestrator either.
+  try {
+    return NextResponse.json(await res.json(), { status: res.status })
+  } catch {
+    return NextResponse.json(
+      { error: `Orchestrator returned a malformed response (HTTP ${res.status})` },
+      { status: res.status >= 400 ? res.status : 502 }
+    )
+  }
+}

--- a/frontend/src/lib/orchestrator/haRoute.test.ts
+++ b/frontend/src/lib/orchestrator/haRoute.test.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server'
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { callRoute } from '@/__tests__/setup/route-test'
+
+import { haOperation, haOperationWithBody, haWriteGuard } from './haRoute'
+
+const requireFeature = vi.fn()
+const checkPermission = vi.fn()
+
+vi.mock('@/lib/auth/requireEnterprise', () => ({
+  requireFeature: (...args: unknown[]) => requireFeature(...args),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermission(...args),
+  PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' },
+}))
+
+vi.mock('./headers', () => ({
+  orchestratorHeaders: (extra: Record<string, string> = {}) => ({ 'X-API-Key': 'test', ...extra }),
+}))
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  requireFeature.mockResolvedValue(null)
+  checkPermission.mockResolvedValue(null)
+  fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ ok: true }) })
+})
+
+describe('haWriteGuard', () => {
+  it('lets a licensed admin through', async () => {
+    await expect(haWriteGuard()).resolves.toBeNull()
+    expect(requireFeature).toHaveBeenCalledWith('control_plane_ha')
+    expect(checkPermission).toHaveBeenCalledWith('admin.settings')
+  })
+
+  it('returns the licence rejection without asking for the permission', async () => {
+    const rejection = NextResponse.json({ error: 'Feature not licensed' }, { status: 403 })
+    requireFeature.mockResolvedValue(rejection)
+
+    await expect(haWriteGuard()).resolves.toBe(rejection)
+    expect(checkPermission).not.toHaveBeenCalled()
+  })
+
+  it('returns the permission rejection', async () => {
+    const rejection = NextResponse.json({ error: 'Permission denied' }, { status: 403 })
+    checkPermission.mockResolvedValue(rejection)
+
+    await expect(haWriteGuard()).resolves.toBe(rejection)
+  })
+})
+
+describe('haOperation', () => {
+  it('proxies the call once the guards pass', async () => {
+    const res = await haOperation('/ha/pause', 'POST')()
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/ha/pause',
+      expect.objectContaining({ method: 'POST', body: undefined })
+    )
+  })
+
+  it('stops at a failed guard without reaching the orchestrator', async () => {
+    checkPermission.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }))
+
+    const res = await haOperation('/ha/pause', 'POST')()
+
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('haOperationWithBody', () => {
+  it('forwards the parsed body upstream', async () => {
+    const res = await callRoute(haOperationWithBody('/ha/switchover', 'POST'), {
+      body: { candidate: 'proxcenter-2' },
+    })
+
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/ha/switchover',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ candidate: 'proxcenter-2' }) })
+    )
+  })
+
+  it('answers 400 on an unreadable body instead of blaming the orchestrator', async () => {
+    const res = await callRoute(haOperationWithBody('/ha/switchover', 'POST'), {
+      method: 'POST',
+      body: 'not json at all',
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'Invalid JSON body' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('stops at a failed guard without reading the body', async () => {
+    requireFeature.mockResolvedValue(NextResponse.json({ error: 'nope' }, { status: 403 }))
+
+    const res = await callRoute(haOperationWithBody('/ha/sync-mode', 'PUT'), {
+      method: 'PUT',
+      body: { mode: 'availability' },
+    })
+
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/orchestrator/haRoute.ts
+++ b/frontend/src/lib/orchestrator/haRoute.ts
@@ -1,0 +1,61 @@
+// src/lib/orchestrator/haRoute.ts
+//
+// Route-level plumbing shared by the /api/v1/ha/* handlers. haProxy.ts owns
+// the conversation with the orchestrator; this owns what surrounds it, namely
+// the guards and the request body, so the eleven routes cannot drift apart on
+// either.
+
+import { NextRequest, NextResponse } from 'next/server'
+
+import { proxyHaJson } from './haProxy'
+import { requireFeature } from '@/lib/auth/requireEnterprise'
+import { Features } from '@/lib/license/features'
+import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+
+/**
+ * The two guards every HA write shares: the HA capability, then
+ * admin.settings. Returns the rejection to hand back, or null to proceed.
+ *
+ * The read-only routes (GET /ha/cluster, GET /ha/config) deliberately skip the
+ * capability gate and call checkPermission on their own: a lapsed option must
+ * never blind the operator of a running cluster (spec v5 D2).
+ */
+export async function haWriteGuard(): Promise<NextResponse | null> {
+  const guard = await requireFeature(Features.HA)
+  if (guard) return guard
+
+  return checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+}
+
+type WriteMethod = 'POST' | 'PUT' | 'DELETE'
+
+/** Handler for a guarded HA operation that carries no request body. */
+export function haOperation(path: string, method: WriteMethod) {
+  return async function handler(): Promise<NextResponse> {
+    const guard = await haWriteGuard()
+    if (guard) return guard
+
+    return proxyHaJson(path, { method })
+  }
+}
+
+/**
+ * Handler for a guarded HA operation that forwards its JSON body upstream. An
+ * unreadable body is the caller's fault and answers 400, where the historical
+ * blind catch used to blame the orchestrator with a 503.
+ */
+export function haOperationWithBody(path: string, method: WriteMethod) {
+  return async function handler(request: NextRequest): Promise<NextResponse> {
+    const guard = await haWriteGuard()
+    if (guard) return guard
+
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    return proxyHaJson(path, { method, body })
+  }
+}


### PR DESCRIPTION
## The defect

Every `/api/v1/ha/*` route wrapped its orchestrator call in a blind `catch` that answered `503 Orchestrator unavailable`. On Node 26 a refused connection and a response cut in mid-flight both surface as the same `TypeError: fetch failed`, and only `error.cause.code` separates them: `ECONNREFUSED` for nothing listening, `UND_ERR_SOCKET` for a socket the peer closed. The blind catch could not tell them apart, so an orchestrator that was alive and had already done the work was reported as down.

That is exactly what an HA preflight spanning three PVE clusters produces. It legitimately runs past the orchestrator's write deadline, its response is cut at write time, and the operator gets 30 seconds of waiting followed by "Orchestrator unavailable" for a healthy orchestrator, with the verdict naming the blocked ports lost along with the response. Reported in #803.

## The change

The eleven HA routes now share two helpers. `haProxy.ts` forwards the call and classifies the failure, `haRoute.ts` owns what surrounds it (the licence and permission guards, the JSON body), so the routes cannot drift apart on either and the repetitive ones collapse to a single exported handler. On the failure path:

- a cut or timed out exchange (`UND_ERR_SOCKET`, `ECONNRESET`, `UND_ERR_HEADERS_TIMEOUT`, `UND_ERR_BODY_TIMEOUT`, a mid-body `terminated`, an abort) answers `504` with "The orchestrator closed the connection before answering. The operation may still be running on the orchestrator, check its logs.";
- everything else keeps the historical `503 Orchestrator unavailable`, so a genuinely dead orchestrator reads exactly as it always did;
- the orchestrator's own status and payload are forwarded verbatim, so a `400` or `409` reaches the wizard instead of being flattened into a generic error;
- an unreadable request body answers `400 Invalid JSON body` instead of accusing the orchestrator.

The write deadline that causes the cut is lifted by a separate backend change, already merged on its side. This PR is what turns the remaining failure modes into something an operator can act on.

## Verification

Measured end to end with the orchestrator's write timeout lowered to 5s and a preflight on three unreachable IPs, so the response is genuinely cut:

| frontend | orchestrator | result |
| --- | --- | --- |
| this branch | patched | **200** with the full verdict, 20.2s |
| this branch | unpatched | **504** with the new message, 20.4s |
| `main` | unpatched | **503 Orchestrator unavailable**, 21.3s |

Guard rail, orchestrator stopped entirely: `GET /api/v1/ha/cluster` answers `503 Orchestrator unavailable` in 0.25s, identical on `main` and on this branch. A refused connection must never drift into the new 504, and it does not.

Non regression sweep over nine HA routes against a live orchestrator with no HA config: statuses and payloads identical between `main` and this branch, except `POST /ha/switchover` with an unreadable body, which now answers `400 Invalid JSON body` rather than blaming the orchestrator. The UI always sends `{candidate}`, so no real caller is affected.

In the browser, the HA tab mounts with no console error and the wizard reaches the validation step. Against an unpatched orchestrator it shows the new message with a Retry button; against a patched one it shows the verdict table (SSH, Docker, Compose, PG compatible, cross pings, VIP availability), which is the diagnosis #803 was throwing away.

## Tests

`haProxy.test.ts` adds 15 cases, two of them driving real `net` sockets so the classification is checked against the runtime rather than against hand-built error objects. The #803 path is covered on the validate and deploy routes, and the sync-mode route, which had no test at all, now has one.

Part of #803. The other half of that report, DRS metrics coming back empty when the elected leader is not the VIP holder, is a distinct problem and is not addressed here.
