### PR TITLE
feat(rolling-update): live progress, apt output and approval controls in the wizard and Task Center

### DIFF
--- a/frontend/src/app/api/v1/orchestrator/jobs/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/jobs/route.ts
@@ -142,10 +142,11 @@ export async function GET(req: Request) {
 
         // Transform rolling updates to job format
         for (const ru of rollingUpdates) {
-          // Map rolling update status to job status
+          // Map rolling update status to job status. cancelled is kept as
+          // is: the page counts it as terminal and the Failed filter already
+          // matches it, so the operator sees what actually happened.
           let jobStatus = ru.status
           if (ru.status === "completed") jobStatus = "success"
-          if (ru.status === "cancelled") jobStatus = "failed"
 
           // Calculate progress
           const progress = ru.total_nodes > 0 
@@ -173,6 +174,9 @@ export async function GET(req: Request) {
               totalNodes: ru.total_nodes,
               completedNodes: ru.completed_nodes,
               currentNode: ru.current_node,
+              // Node waiting for the operator when the run is paused for a
+              // manual approval; drives the Approve action.
+              pendingApproval: ru.pending_approval || null,
               nodeStatuses: ru.node_statuses,
               error: ru.error,
             }

--- a/frontend/src/components/ConfirmCloseDialog.tsx
+++ b/frontend/src/components/ConfirmCloseDialog.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+
+import { useTranslations } from 'next-intl'
+
+interface ConfirmCloseDialogProps {
+  open: boolean
+  title: string
+  message: string
+  /** Label of the button that goes ahead with the close. */
+  confirmLabel: string
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * Themed replacement for the native window.confirm() that the update dialogs
+ * used before letting the operator close them mid-run. Stacks above the
+ * parent dialog; the parent stays open until onConfirm.
+ */
+export default function ConfirmCloseDialog({ open, title, message, confirmLabel, onConfirm, onCancel }: ConfirmCloseDialogProps) {
+  const t = useTranslations()
+
+  return (
+    <Dialog open={open} onClose={onCancel} maxWidth='xs' fullWidth aria-labelledby='confirm-close-title'>
+      <DialogTitle id='confirm-close-title'>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onCancel} autoFocus>
+          {t('common.cancel')}
+        </Button>
+        <Button onClick={onConfirm} variant='contained' color='warning'>
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/NodeUpdateDialog.tsx
+++ b/frontend/src/components/NodeUpdateDialog.tsx
@@ -33,6 +33,7 @@ import {
   Typography,
 } from '@mui/material'
 
+import ConfirmCloseDialog from '@/components/ConfirmCloseDialog'
 import { NodeInfo, formatMemory } from '@/components/hardware/utils'
 import { computeRepoIssues, type RepoIssue } from '@/lib/proxmox/aptRepositories'
 
@@ -596,12 +597,20 @@ export default function NodeUpdateDialog({
     setRestartVmsInProgress(false)
   }, [shutdownVms, connBaseUrl, nodeName])
 
+  // Closing while the upgrade runs asks first (themed dialog, not the
+  // browser's confirm box); finishClose does the actual reset.
+  const [confirmCloseOpen, setConfirmCloseOpen] = useState(false)
+
   const handleClose = () => {
     if (upgradeStatus === 'RUNNING') {
-      if (!window.confirm(t('updates.confirmCloseWhileRunning'))) {
-        return
-      }
+      setConfirmCloseOpen(true)
+      return
     }
+    finishClose()
+  }
+
+  const finishClose = () => {
+    setConfirmCloseOpen(false)
 
     if (pollingRef.current) {
       clearInterval(pollingRef.current)
@@ -1523,6 +1532,15 @@ export default function NodeUpdateDialog({
           </Button>
         )}
       </DialogActions>
+
+      <ConfirmCloseDialog
+        open={confirmCloseOpen}
+        title={t('updates.upgradeInProgress')}
+        message={t('updates.confirmCloseWhileRunning')}
+        confirmLabel={t('common.close')}
+        onConfirm={finishClose}
+        onCancel={() => setConfirmCloseOpen(false)}
+      />
     </Dialog>
   )
 }

--- a/frontend/src/components/RollingUpdateWizard.progress.test.tsx
+++ b/frontend/src/components/RollingUpdateWizard.progress.test.tsx
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, waitFor } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import RollingUpdateWizard from './RollingUpdateWizard'
+
+afterEach(cleanup)
+
+const baseRun = {
+  id: 'ru-1',
+  connection_id: 'conn-1',
+  status: 'running',
+  config: {},
+  total_nodes: 3,
+  completed_nodes: 0,
+  current_node: 'pve1',
+  node_statuses: [],
+  logs: [],
+  created_at: '2026-08-28T12:00:00.000Z'
+}
+
+function renderMonitor(run: Record<string, unknown>, ...handlers: Parameters<typeof server.use>) {
+  server.use(
+    http.get('*/api/v1/connections/conn-1', () => HttpResponse.json({ data: { sshEnabled: true } })),
+    http.get('*/api/v1/orchestrator/rolling-updates/ru-1', () => HttpResponse.json({ data: run })),
+    ...handlers
+  )
+
+  renderWithProviders(
+    <RollingUpdateWizard
+      open
+      onClose={vi.fn()}
+      connectionId='conn-1'
+      nodes={[]}
+      nodeUpdates={{}}
+      resumeRollingUpdateId='ru-1'
+    />
+  )
+}
+
+describe('RollingUpdateWizard progress monitoring', () => {
+  it('shows approval feedback and posts approval for the pending node', async () => {
+    let approveCalls = 0
+    const run = {
+      ...baseRun,
+      status: 'paused',
+      completed_nodes: 1,
+      current_node: 'pve2',
+      pending_approval: 'pve2',
+      node_statuses: [
+        { node_name: 'pve1', status: 'completed', reboot_required: false, did_reboot: false },
+        { node_name: 'pve2', status: 'pending', reboot_required: false, did_reboot: false },
+        { node_name: 'pve3', status: 'pending', reboot_required: false, did_reboot: false }
+      ]
+    }
+
+    renderMonitor(
+      run,
+      http.post('*/api/v1/orchestrator/rolling-updates/ru-1/approve', () => {
+        approveCalls += 1
+        return HttpResponse.json({ data: { status: 'approved' } })
+      })
+    )
+
+    expect(await screen.findByText('Awaiting approval')).toBeInTheDocument()
+    expect(await screen.findByText(
+      'The run is paused and waits for your approval before updating pve2. Approve to continue, or cancel to stop here.'
+    )).toBeInTheDocument()
+    const approveButton = await screen.findByRole('button', { name: /Approve pve2/ })
+    expect(screen.queryByRole('button', { name: /^Resume$/ })).not.toBeInTheDocument()
+
+    await userEvent.click(approveButton)
+
+    await waitFor(() => expect(approveCalls).toBe(1))
+  })
+
+  it('offers resume rather than approval for a paused run without a pending node', async () => {
+    renderMonitor({
+      ...baseRun,
+      status: 'paused',
+      node_statuses: [
+        { node_name: 'pve1', status: 'updating', reboot_required: false, did_reboot: false }
+      ]
+    })
+
+    expect(await screen.findByRole('button', { name: /^Resume$/ })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Approve/ })).not.toBeInTheDocument()
+  })
+
+  it('shows package-level progress while the current node is updating', async () => {
+    renderMonitor({
+      ...baseRun,
+      status: 'running',
+      current_node: 'pve1',
+      node_statuses: [
+        {
+          node_name: 'pve1',
+          status: 'updating',
+          reboot_required: false,
+          did_reboot: false,
+          package_progress: { phase: 'configure', done: 56, total: 245 }
+        }
+      ]
+    })
+
+    expect(await screen.findByText(/^In progress: pve1 • Configuring packages 56\/245$/)).toBeInTheDocument()
+    const progressbar = await screen.findByRole('progressbar', { name: 'Progress: 0 / 3 nodes' })
+    const value = Number(progressbar.getAttribute('aria-valuenow'))
+
+    expect(value).toBeGreaterThan(0)
+    expect(value).toBeLessThan(100)
+  })
+
+  it('opens failed-node output and keeps completed-node output collapsed', async () => {
+    const failedOutput = 'Err:2 https://enterprise.proxmox.com/debian/pve trixie InRelease\n  401  Unauthorized\nE: Failed to fetch ... 401 Unauthorized'
+
+    renderMonitor({
+      ...baseRun,
+      status: 'failed',
+      error: 'Failed on node pve1: apt update failed: ...',
+      completed_nodes: 1,
+      node_statuses: [
+        {
+          node_name: 'pve1',
+          status: 'failed',
+          reboot_required: false,
+          did_reboot: false,
+          error: 'apt update failed',
+          update_output: failedOutput
+        },
+        {
+          node_name: 'pve2',
+          status: 'completed',
+          reboot_required: false,
+          did_reboot: false,
+          update_output: 'Setting up pve-manager ...'
+        }
+      ]
+    })
+
+    expect(await screen.findByText(/Failed on node pve1: apt update failed/)).toBeInTheDocument()
+    expect(screen.getByTestId('rolling-update-output-pve1').textContent).toContain('401  Unauthorized')
+    const showCompletedOutput = await screen.findByRole('button', { name: 'Show apt output' })
+    expect(screen.queryByTestId('rolling-update-output-pve2')).not.toBeInTheDocument()
+
+    await userEvent.click(showCompletedOutput)
+
+    expect(screen.getByTestId('rolling-update-output-pve2')).toHaveTextContent('Setting up pve-manager ...')
+  })
+})

--- a/frontend/src/components/RollingUpdateWizard.tsx
+++ b/frontend/src/components/RollingUpdateWizard.tsx
@@ -2,6 +2,16 @@
 
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
+
+import ConfirmCloseDialog from '@/components/ConfirmCloseDialog'
+import NodeUpdateOutput from '@/components/rolling/NodeUpdateOutput'
+import {
+  isAwaitingApproval,
+  packageProgressLabel,
+  runProgressPercent,
+  shouldExpandOutput,
+  type PackageProgress
+} from '@/lib/rolling/updateProgress'
 import { formatBytes } from '@/utils/format'
 import {
   Alert,
@@ -265,6 +275,8 @@ interface RollingUpdate {
   total_nodes: number
   completed_nodes: number
   current_node: string
+  /** Node waiting to be approved when require_manual_approval is set; the run is then `paused`. */
+  pending_approval?: string
   node_statuses: Array<{
     node_name: string
     status: string
@@ -275,6 +287,10 @@ interface RollingUpdate {
     did_reboot: boolean
     version_before?: string
     version_after?: string
+    /** Full apt output of the node, also present when the upgrade failed. */
+    update_output?: string
+    /** Position inside the package upgrade while the node is `updating`. */
+    package_progress?: PackageProgress | null
   }>
   logs: Array<{
     timestamp: string
@@ -359,6 +375,9 @@ export default function RollingUpdateWizard({
   const [rollingUpdate, setRollingUpdate] = useState<RollingUpdate | null>(null)
   const [executionError, setExecutionError] = useState<string | null>(null)
   const [pollingInterval, setPollingInterval] = useState<NodeJS.Timeout | null>(null)
+  // Closing while a run is live asks first; the native confirm() it replaced
+  // rendered as a bare browser box over the themed dialog.
+  const [confirmCloseOpen, setConfirmCloseOpen] = useState(false)
   
   // Initialize node order from nodes — place connectedNode last
   useEffect(() => {
@@ -618,8 +637,10 @@ export default function RollingUpdateWizard({
     }
   }, [connectionId, config, nodeOrder, excludedNodes])
   
-  // Pause/Resume/Cancel actions
-  const executeAction = useCallback(async (action: 'pause' | 'resume' | 'cancel') => {
+  // Pause/Resume/Cancel/Approve actions. `approve` is what a run paused with
+  // pending_approval wants: Resume happened to work because the orchestrator
+  // maps both to the same signal, but nothing told the operator so.
+  const executeAction = useCallback(async (action: 'pause' | 'resume' | 'cancel' | 'approve') => {
     if (!rollingUpdate) return
     
     try {
@@ -644,6 +665,20 @@ export default function RollingUpdateWizard({
     return mins > 0 ? `~${hours}h ${mins}min` : `~${hours}h`
   }
   
+  // Proxmox logo with its status dot next to a node name in the monitor. The
+  // wizard has no PVE node list when opened from the tasks menu, so the dot
+  // follows the run phase: offline while the node reboots, maintenance while
+  // it sits in HA maintenance, the real PVE status (or online) otherwise.
+  const nodeIconFor = (ns: { node_name: string; status: string }) => {
+    if (ns.status === 'rebooting' || ns.status === 'waiting_return') {
+      return <NodeIcon status="offline" size={18} />
+    }
+    if (['entering_maintenance', 'migrating_vms', 'updating', 'verifying_health', 'exiting_maintenance'].includes(ns.status)) {
+      return <NodeIcon status="online" maintenance="maintenance" size={18} />
+    }
+    return <NodeIcon status={nodes.find(n => n.node === ns.node_name)?.status || 'online'} size={18} />
+  }
+
   // Get node status icon
   const getNodeStatusIcon = (status: string) => {
     switch (status) {
@@ -652,26 +687,34 @@ export default function RollingUpdateWizard({
       case 'failed':
         return <ErrorIcon sx={{ color: 'error.main' }} />
       case 'running':
+      case 'entering_maintenance':
       case 'migrating_vms':
       case 'updating':
       case 'rebooting':
+      case 'waiting_return':
+      case 'verifying_health':
+      case 'exiting_maintenance':
         return <CircularProgress size={20} />
       case 'pending':
+      case 'skipped':
         return <InfoIcon sx={{ color: 'text.secondary' }} />
       default:
         return <WarningIcon sx={{ color: 'warning.main' }} />
     }
   }
   
-  // Handle close
+  // Handle close: a live run asks for confirmation first, finishClose does the work.
   const handleClose = () => {
     if (rollingUpdate && ['running', 'paused'].includes(rollingUpdate.status)) {
-      // Confirm before closing during execution
-      if (!window.confirm(t('updates.confirmCloseWhileRunning'))) {
-        return
-      }
+      setConfirmCloseOpen(true)
+      return
     }
-    
+    finishClose()
+  }
+
+  const finishClose = () => {
+    setConfirmCloseOpen(false)
+
     if (pollingInterval) {
       clearInterval(pollingInterval)
       setPollingInterval(null)
@@ -721,11 +764,12 @@ export default function RollingUpdateWizard({
         {rollingUpdate && (
           <Chip 
             size="small" 
-            label={rollingUpdate.status}
+            label={isAwaitingApproval(rollingUpdate) ? t('updates.awaitingApproval') : rollingUpdate.status}
             color={
               rollingUpdate.status === 'completed' ? 'success' :
               rollingUpdate.status === 'failed' ? 'error' :
               rollingUpdate.status === 'running' ? 'primary' :
+              isAwaitingApproval(rollingUpdate) ? 'info' :
               rollingUpdate.status === 'paused' ? 'warning' :
               'default'
             }
@@ -881,9 +925,12 @@ export default function RollingUpdateWizard({
 
                       return (
                         <Box key={nodeName} sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                          <Typography variant="body2" sx={{ minWidth: 100, fontWeight: 600, fontSize: 13 }}>
-                            {nodeName}
-                          </Typography>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 100 }}>
+                            <NodeIcon status={nodes.find(n => n.node === nodeName)?.status} size={18} />
+                            <Typography variant="body2" sx={{ fontWeight: 600, fontSize: 13 }}>
+                              {nodeName}
+                            </Typography>
+                          </Box>
 
                           <FormControl size="small" sx={{ minWidth: 240 }}>
                             <Select
@@ -1409,22 +1456,38 @@ export default function RollingUpdateWizard({
         {/* Step 2: Execution */}
         {activeStep === 2 && rollingUpdate && (
           <Stack spacing={3}>
-            {/* Progress */}
-            <Box>
-              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                <Typography variant="body2">
-                  {t('updates.progressNodes', { completed: rollingUpdate.completed_nodes, total: rollingUpdate.total_nodes })}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {rollingUpdate.current_node && t('updates.inProgressNode', { node: rollingUpdate.current_node })}
-                </Typography>
-              </Box>
-              <LinearProgress 
-                variant="determinate" 
-                value={(rollingUpdate.completed_nodes / rollingUpdate.total_nodes) * 100}
-                sx={{ height: 8, borderRadius: 1 }}
-              />
-            </Box>
+            {/* Progress: advances inside the current node (its step, then apt's own
+                position) instead of jumping by a whole node at a time. */}
+            {(() => {
+              const current = rollingUpdate.node_statuses?.find(ns => ns.node_name === rollingUpdate.current_node)
+              const pkg = packageProgressLabel(current?.package_progress)
+
+              return (
+                <Box>
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                    <Typography variant="body2">
+                      {t('updates.progressNodes', { completed: rollingUpdate.completed_nodes, total: rollingUpdate.total_nodes })}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {rollingUpdate.current_node && t('updates.inProgressNode', { node: rollingUpdate.current_node })}
+                      {pkg && ` • ${t(pkg.key as any, pkg.values)}`}
+                    </Typography>
+                  </Box>
+                  <LinearProgress 
+                    variant="determinate" 
+                    value={runProgressPercent(rollingUpdate)}
+                    aria-label={t('updates.progressNodes', { completed: rollingUpdate.completed_nodes, total: rollingUpdate.total_nodes })}
+                    sx={{ height: 8, borderRadius: 1 }}
+                  />
+                </Box>
+              )
+            })()}
+
+            {isAwaitingApproval(rollingUpdate) && (
+              <Alert severity="info" icon={<PauseIcon />}>
+                {t('updates.approvalBanner', { node: rollingUpdate.pending_approval })}
+              </Alert>
+            )}
             
             {/* Node statuses */}
             {rollingUpdate.node_statuses && rollingUpdate.node_statuses.length > 0 && (
@@ -1434,28 +1497,42 @@ export default function RollingUpdateWizard({
                     {t('updates.nodeStatuses')}
                   </Typography>
                   <List dense>
-                    {rollingUpdate.node_statuses.map((ns) => (
-                    <ListItem key={ns.node_name}>
-                      <ListItemIcon sx={{ minWidth: 40 }}>
-                        {getNodeStatusIcon(ns.status)}
-                      </ListItemIcon>
-                      <ListItemText 
-                        primary={ns.node_name}
-                        secondary={
-                          <>
-                            {ns.status}
-                            {ns.version_before && ns.version_after && 
-                              ` • ${ns.version_before} → ${ns.version_after}`}
-                            {ns.did_reboot && ` • ${t('updates.rebooted')}`}
-                          </>
-                        }
-                      />
-                      {ns.error && (
-                        <Chip size="small" label={t('updates.errorChip')} color="error" />
-                      )}
-                    </ListItem>
-                  ))}
-                </List>
+                    {rollingUpdate.node_statuses.map((ns) => {
+                      const pkg = ns.status === 'updating' ? packageProgressLabel(ns.package_progress) : null
+
+                      return (
+                        <React.Fragment key={ns.node_name}>
+                          <ListItem>
+                            <ListItemIcon sx={{ minWidth: 40 }}>
+                              {getNodeStatusIcon(ns.status)}
+                            </ListItemIcon>
+                            <ListItemText 
+                              primary={
+                                <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+                                  {nodeIconFor(ns)}
+                                  {ns.node_name}
+                                </Box>
+                              }
+                              secondary={
+                                <>
+                                  {ns.status}
+                                  {pkg && ` • ${t(pkg.key as any, pkg.values)}`}
+                                  {ns.version_before && ns.version_after && 
+                                    ` • ${ns.version_before} → ${ns.version_after}`}
+                                  {ns.did_reboot && ` • ${t('updates.rebooted')}`}
+                                  {ns.error && <Typography component="span" variant="inherit" color="error"> • {ns.error}</Typography>}
+                                </>
+                              }
+                            />
+                            {ns.error && (
+                              <Chip size="small" label={t('updates.errorChip')} color="error" />
+                            )}
+                          </ListItem>
+                          <NodeUpdateOutput nodeName={ns.node_name} output={ns.update_output} defaultExpanded={shouldExpandOutput(ns)} />
+                        </React.Fragment>
+                      )
+                    })}
+                  </List>
               </CardContent>
             </Card>
             )}
@@ -1534,23 +1611,31 @@ export default function RollingUpdateWizard({
                   </Typography>
                   <List dense>
                     {rollingUpdate.node_statuses.map((ns) => (
-                      <ListItem key={ns.node_name}>
-                        <ListItemIcon sx={{ minWidth: 40 }}>
-                          {getNodeStatusIcon(ns.status)}
-                        </ListItemIcon>
-                        <ListItemText 
-                          primary={ns.node_name}
-                          secondary={
-                            <>
-                              {ns.version_before && ns.version_after && (
-                                <>{ns.version_before} → {ns.version_after}</>
-                              )}
-                              {ns.did_reboot && ` • ${t('updates.rebooted')}`}
-                              {ns.error && <Typography component="span" color="error"> • {ns.error}</Typography>}
-                            </>
-                          }
-                        />
-                      </ListItem>
+                      <React.Fragment key={ns.node_name}>
+                        <ListItem>
+                          <ListItemIcon sx={{ minWidth: 40 }}>
+                            {getNodeStatusIcon(ns.status)}
+                          </ListItemIcon>
+                          <ListItemText 
+                            primary={
+                              <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+                                {nodeIconFor(ns)}
+                                {ns.node_name}
+                              </Box>
+                            }
+                            secondary={
+                              <>
+                                {ns.version_before && ns.version_after && (
+                                  <>{ns.version_before} → {ns.version_after}</>
+                                )}
+                                {ns.did_reboot && ` • ${t('updates.rebooted')}`}
+                                {ns.error && <Typography component="span" color="error"> • {ns.error}</Typography>}
+                              </>
+                            }
+                          />
+                        </ListItem>
+                        <NodeUpdateOutput nodeName={ns.node_name} output={ns.update_output} defaultExpanded={shouldExpandOutput(ns)} />
+                      </React.Fragment>
                     ))}
                   </List>
                 </CardContent>
@@ -1628,13 +1713,24 @@ export default function RollingUpdateWizard({
             )}
             {rollingUpdate.status === 'paused' && (
               <>
-                <Button
-                  onClick={() => executeAction('resume')}
-                  variant="contained"
-                  startIcon={<PlayArrowIcon />}
-                >
-                  {t('updates.resume')}
-                </Button>
+                {isAwaitingApproval(rollingUpdate) ? (
+                  <Button
+                    onClick={() => executeAction('approve')}
+                    variant="contained"
+                    color="success"
+                    startIcon={<CheckCircleIcon sx={{ fontSize: 18 }} />}
+                  >
+                    {t('updates.approveNode', { node: rollingUpdate.pending_approval })}
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={() => executeAction('resume')}
+                    variant="contained"
+                    startIcon={<PlayArrowIcon />}
+                  >
+                    {t('updates.resume')}
+                  </Button>
+                )}
                 <Button
                   onClick={() => executeAction('cancel')}
                   color="error"
@@ -1653,6 +1749,15 @@ export default function RollingUpdateWizard({
           </Button>
         )}
       </DialogActions>
+
+      <ConfirmCloseDialog
+        open={confirmCloseOpen}
+        title={t('updates.upgradeInProgress')}
+        message={t('updates.confirmCloseWhileRunning')}
+        confirmLabel={t('common.close')}
+        onConfirm={finishClose}
+        onCancel={() => setConfirmCloseOpen(false)}
+      />
     </Dialog>
   )
 }

--- a/frontend/src/components/rolling/NodeUpdateOutput.test.tsx
+++ b/frontend/src/components/rolling/NodeUpdateOutput.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
+
+import NodeUpdateOutput from './NodeUpdateOutput'
+
+afterEach(cleanup)
+
+describe('NodeUpdateOutput', () => {
+  it.each([
+    ['empty', ''],
+    ['undefined', undefined]
+  ])('renders nothing when output is %s', (_label, output) => {
+    const { container } = renderWithProviders(<NodeUpdateOutput nodeName='pve1' output={output} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('is collapsed by default', () => {
+    renderWithProviders(<NodeUpdateOutput nodeName='pve1' output='Setting up pve-manager ...' />)
+
+    expect(screen.getByRole('button', { name: 'Show apt output' })).toBeInTheDocument()
+    expect(screen.queryByTestId('rolling-update-output-pve1')).not.toBeInTheDocument()
+  })
+
+  it('reveals the output when clicked', async () => {
+    renderWithProviders(<NodeUpdateOutput nodeName='pve1' output='Setting up pve-manager ...' />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show apt output' }))
+
+    expect(screen.getByTestId('rolling-update-output-pve1')).toHaveTextContent('Setting up pve-manager ...')
+    expect(screen.getByRole('button', { name: 'Hide apt output' })).toBeInTheDocument()
+  })
+
+  it('renders expanded when requested initially', () => {
+    renderWithProviders(
+      <NodeUpdateOutput nodeName='pve1' output='Setting up pve-manager ...' defaultExpanded />
+    )
+
+    expect(screen.getByTestId('rolling-update-output-pve1')).toHaveTextContent('Setting up pve-manager ...')
+  })
+
+  it('opens when defaultExpanded changes after mount', async () => {
+    const { rerender } = renderWithProviders(
+      <NodeUpdateOutput nodeName='pve1' output='Setting up pve-manager ...' defaultExpanded={false} />
+    )
+
+    rerender(<NodeUpdateOutput nodeName='pve1' output='Setting up pve-manager ...' defaultExpanded />)
+
+    expect(await screen.findByTestId('rolling-update-output-pve1')).toHaveTextContent('Setting up pve-manager ...')
+  })
+})

--- a/frontend/src/components/rolling/NodeUpdateOutput.tsx
+++ b/frontend/src/components/rolling/NodeUpdateOutput.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+
+import { useTranslations } from 'next-intl'
+
+interface NodeUpdateOutputProps {
+  /** Raw apt output captured by the orchestrator for one node. */
+  output?: string | null
+  /** Open the panel on first render (a failed node). */
+  defaultExpanded?: boolean
+  nodeName: string
+}
+
+/**
+ * Collapsible apt output of one node of a rolling update. The orchestrator
+ * already persisted and served `update_output`; the wizard never read it, so a
+ * run that died on `exit status 100` showed nothing while the 401 on the
+ * enterprise repository was sitting in this field (ui#814).
+ */
+export default function NodeUpdateOutput({ output, defaultExpanded = false, nodeName }: NodeUpdateOutputProps) {
+  const t = useTranslations()
+  const [expanded, setExpanded] = useState(defaultExpanded)
+
+  // A node that fails after the panel mounted must open too.
+  useEffect(() => {
+    if (defaultExpanded) setExpanded(true)
+  }, [defaultExpanded])
+
+  if (!output) return null
+
+  const panelId = `rolling-update-output-${nodeName}`
+
+  return (
+    <Box sx={{ pl: 5, pr: 2, pb: 1 }}>
+      <Button
+        size='small'
+        onClick={() => setExpanded(v => !v)}
+        aria-expanded={expanded}
+        aria-controls={panelId}
+        startIcon={<i className={expanded ? 'ri-arrow-up-s-line' : 'ri-arrow-down-s-line'} style={{ fontSize: 18 }} />}
+      >
+        {expanded ? t('updates.hideUpdateOutput') : t('updates.showUpdateOutput')}
+      </Button>
+      {expanded && (
+        <Box
+          id={panelId}
+          component='pre'
+          data-testid={panelId}
+          sx={{
+            m: 0,
+            mt: 0.5,
+            p: 1,
+            maxHeight: 240,
+            overflow: 'auto',
+            bgcolor: 'background.default',
+            borderRadius: 1,
+            fontFamily: 'monospace',
+            fontSize: 11,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all'
+          }}
+        >
+          {output}
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/frontend/src/components/tasks/JobDetailDialog.jsx
+++ b/frontend/src/components/tasks/JobDetailDialog.jsx
@@ -285,6 +285,17 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
                   {t('jobsPage.resume')}
                 </Button>
               )}
+              {actions.includes('approve') && (
+                <Button
+                  size="small"
+                  variant="contained"
+                  color="success"
+                  startIcon={<PlayArrowIcon />}
+                  onClick={() => onAction(job, 'approve')}
+                >
+                  {t('updates.approveNode', { node: job.metadata?.pendingApproval })}
+                </Button>
+              )}
               {actions.includes('cancel') && (
                 <Button
                   size="small"
@@ -420,7 +431,7 @@ export default function JobDetailDialog({ open, onClose, job, onAction, actionEr
                     {logError ? `${t('jobsPage.noLogs')} (${logError})` : t('jobsPage.noLogs')}
                   </Typography>
                 ) : (
-                  logs.slice(-100).map(normalizeLog).map((log, i) => (
+                  logs.slice(-1000).map(normalizeLog).map((log, i) => (
                     <Box
                       key={i}
                       sx={{

--- a/frontend/src/contexts/RBACContext.jsx
+++ b/frontend/src/contexts/RBACContext.jsx
@@ -27,6 +27,12 @@ const RBACContext = createContext({
 
 export function RBACProvider({ children }) {
   const { data: session, status } = useSession()
+
+  // Reload permissions when the user changes, not when the session object is
+  // re-created: SessionProvider refetches /api/auth/session every 60 s and on
+  // every window focus, and each refetch used to drag a full
+  // /api/v1/rbac/effective round trip behind it.
+  const userId = session?.user?.id ?? session?.user?.email ?? null
   const [permissions, setPermissions] = useState([])
   const [roles, setRoles] = useState([])
   const [isAdmin, setIsAdmin] = useState(false)
@@ -36,7 +42,7 @@ export function RBACProvider({ children }) {
 
   // Charger les permissions de l'utilisateur
   const loadPermissions = useCallback(async () => {
-    if (status !== 'authenticated' || !session?.user) {
+    if (status !== 'authenticated' || !userId) {
       setPermissions([])
       setRoles([])
       setIsAdmin(false)
@@ -63,7 +69,7 @@ return
     } finally {
       setLoading(false)
     }
-  }, [session, status])
+  }, [userId, status])
 
   useEffect(() => {
     loadPermissions()

--- a/frontend/src/lib/rolling/updateProgress.test.ts
+++ b/frontend/src/lib/rolling/updateProgress.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isAwaitingApproval,
+  nodeStepFraction,
+  packageFraction,
+  packageProgressLabel,
+  runProgressPercent,
+  shouldExpandOutput
+} from './updateProgress'
+
+describe('nodeStepFraction', () => {
+  it.each([
+    ['pending', 0],
+    ['entering_maintenance', 1 / 8],
+    ['updating', 3 / 8],
+    ['completed', 1],
+    ['skipped', 1],
+    ['failed', 1],
+    ['unknown', 0]
+  ])('returns the expected fraction for %s', (status, expected) => {
+    expect(nodeStepFraction({ status })).toBe(expected)
+  })
+
+  it('includes package progress while a node is updating', () => {
+    const fraction = nodeStepFraction({
+      status: 'updating',
+      package_progress: { phase: 'configure', done: 56, total: 245 }
+    })
+
+    expect(fraction).toBeGreaterThan(3 / 8)
+    expect(fraction).toBeLessThan(4 / 8)
+  })
+})
+
+describe('packageFraction', () => {
+  it('returns zero without progress or while waiting for the apt lock', () => {
+    expect(packageFraction()).toBe(0)
+    expect(packageFraction({ phase: 'waiting_lock', done: 12, total: 0 })).toBe(0)
+  })
+
+  it('positions progress within each counted package phase', () => {
+    expect(packageFraction({ phase: 'download', done: 1, total: 2 })).toBe(1 / 6)
+    expect(packageFraction({ phase: 'unpack', done: 1, total: 2 })).toBe(1 / 2)
+    expect(packageFraction({ phase: 'configure', done: 1, total: 2 })).toBe(5 / 6)
+  })
+
+  it('returns one for the done phase', () => {
+    expect(packageFraction({ phase: 'done', done: 245, total: 245 })).toBe(1)
+  })
+
+  it('uses the phase start when total is zero', () => {
+    expect(packageFraction({ phase: 'download', done: 56, total: 0 })).toBe(0)
+    expect(packageFraction({ phase: 'unpack', done: 56, total: 0 })).toBe(1 / 3)
+    expect(packageFraction({ phase: 'configure', done: 56, total: 0 })).toBe(2 / 3)
+  })
+})
+
+describe('runProgressPercent', () => {
+  it('returns zero when there are no nodes', () => {
+    expect(runProgressPercent({ total_nodes: 0, completed_nodes: 0 })).toBe(0)
+  })
+
+  it('falls back to completed nodes when node statuses are missing', () => {
+    expect(runProgressPercent({ total_nodes: 4, completed_nodes: 1 })).toBe(25)
+  })
+
+  it('sums the individual node fractions when statuses are available', () => {
+    const percent = runProgressPercent({
+      total_nodes: 3,
+      completed_nodes: 1,
+      node_statuses: [
+        { status: 'completed' },
+        { status: 'updating' },
+        { status: 'pending' }
+      ]
+    })
+
+    expect(percent).toBeCloseTo(100 * (1 + 0.375) / 3)
+  })
+
+  it('clamps progress to 100 when more statuses are returned than total nodes', () => {
+    expect(runProgressPercent({
+      total_nodes: 1,
+      completed_nodes: 1,
+      node_statuses: [{ status: 'completed' }, { status: 'completed' }]
+    })).toBe(100)
+  })
+})
+
+describe('packageProgressLabel', () => {
+  it('returns null without progress', () => {
+    expect(packageProgressLabel()).toBeNull()
+  })
+
+  it.each([
+    ['waiting_lock', 'updates.pkgWaitingLock', { seconds: 56 }],
+    ['download', 'updates.pkgDownloading', { count: '56/245' }],
+    ['unpack', 'updates.pkgUnpacking', { count: '56/245' }],
+    ['configure', 'updates.pkgConfiguring', { count: '56/245' }],
+    ['done', 'updates.pkgDone', { count: 56 }]
+  ])('maps %s to its translation key and values', (phase, key, values) => {
+    expect(packageProgressLabel({ phase, done: 56, total: 245 })).toEqual({ key, values })
+  })
+
+  it('formats the count without a denominator when total is zero', () => {
+    expect(packageProgressLabel({ phase: 'configure', done: 56, total: 0 })).toEqual({
+      key: 'updates.pkgConfiguring',
+      values: { count: '56' }
+    })
+  })
+})
+
+describe('isAwaitingApproval', () => {
+  it.each([
+    [{ status: 'paused', pending_approval: 'pve2' }, true],
+    [{ status: 'paused', pending_approval: '' }, false],
+    [{ status: 'paused' }, false],
+    [{ status: 'running', pending_approval: 'pve2' }, false]
+  ])('returns $expected for $0', (run, expected) => {
+    expect(isAwaitingApproval(run)).toBe(expected)
+  })
+})
+
+describe('shouldExpandOutput', () => {
+  it.each([
+    [{ status: 'failed', update_output: 'apt failed' }, true],
+    [{ status: 'failed', update_output: '' }, false],
+    [{ status: 'failed' }, false],
+    [{ status: 'completed', update_output: 'apt output' }, false]
+  ])('returns $expected for $0', (node, expected) => {
+    expect(shouldExpandOutput(node)).toBe(expected)
+  })
+})

--- a/frontend/src/lib/rolling/updateProgress.ts
+++ b/frontend/src/lib/rolling/updateProgress.ts
@@ -1,0 +1,127 @@
+/**
+ * Progress helpers for the rolling update monitor (ui#814).
+ *
+ * The orchestrator reports a status per node and, while apt runs, a
+ * `package_progress` object derived from apt's own output. The wizard used to
+ * count whole nodes only, so the bar stayed at 0 / 3 for the ten minutes a
+ * package upgrade takes. These helpers turn both signals into one fraction.
+ */
+
+/** Node statuses in execution order; the index is the node's step. */
+export const NODE_STEPS = [
+  'pending',
+  'entering_maintenance',
+  'migrating_vms',
+  'updating',
+  'rebooting',
+  'waiting_return',
+  'verifying_health',
+  'exiting_maintenance',
+  'completed'
+] as const
+
+export type PackagePhase = 'waiting_lock' | 'download' | 'unpack' | 'configure' | 'done'
+
+export interface PackageProgress {
+  phase: PackagePhase | string
+  done: number
+  total: number
+  updated_at?: string
+}
+
+export interface NodeProgressLike {
+  node_name?: string
+  status: string
+  package_progress?: PackageProgress | null
+  update_output?: string | null
+}
+
+export interface RunProgressLike {
+  status?: string
+  total_nodes: number
+  completed_nodes: number
+  pending_approval?: string | null
+  node_statuses?: NodeProgressLike[] | null
+}
+
+/** The three apt phases that count packages, in order. */
+const PACKAGE_PHASES = ['download', 'unpack', 'configure']
+
+/** 0..1 position of apt inside the `updating` step. */
+export function packageFraction(progress?: PackageProgress | null): number {
+  if (!progress) return 0
+  if (progress.phase === 'done') return 1
+
+  const phaseIndex = PACKAGE_PHASES.indexOf(progress.phase)
+
+  if (phaseIndex < 0) return 0
+  const inPhase = progress.total > 0 ? Math.min(progress.done / progress.total, 1) : 0
+
+  return (phaseIndex + inPhase) / PACKAGE_PHASES.length
+}
+
+/** 0..1 position of a node inside its own steps; finished nodes count as 1. */
+export function nodeStepFraction(node: NodeProgressLike): number {
+  if (node.status === 'completed' || node.status === 'skipped' || node.status === 'failed') return 1
+
+  const index = NODE_STEPS.indexOf(node.status as (typeof NODE_STEPS)[number])
+
+  if (index <= 0) return 0
+
+  const within = node.status === 'updating' ? packageFraction(node.package_progress) : 0
+
+  return (index + within) / (NODE_STEPS.length - 1)
+}
+
+/** 0..100 value for the run's progress bar. */
+export function runProgressPercent(run: RunProgressLike): number {
+  if (!run.total_nodes || run.total_nodes <= 0) return 0
+
+  const nodes = run.node_statuses
+
+  if (!nodes || nodes.length === 0) {
+    return clampPercent((run.completed_nodes / run.total_nodes) * 100)
+  }
+
+  const sum = nodes.reduce((acc, node) => acc + nodeStepFraction(node), 0)
+
+  return clampPercent((sum / run.total_nodes) * 100)
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+
+  return Math.max(0, Math.min(100, value))
+}
+
+/** i18n key and values describing apt's position for a node, or null when apt is not running. */
+export function packageProgressLabel(progress?: PackageProgress | null): { key: string; values: Record<string, string | number> } | null {
+  if (!progress) return null
+
+  const count = progress.total > 0 ? `${progress.done}/${progress.total}` : `${progress.done}`
+
+  switch (progress.phase) {
+    case 'waiting_lock':
+      return { key: 'updates.pkgWaitingLock', values: { seconds: progress.done } }
+    case 'download':
+      return { key: 'updates.pkgDownloading', values: { count } }
+    case 'unpack':
+      return { key: 'updates.pkgUnpacking', values: { count } }
+    case 'configure':
+      return { key: 'updates.pkgConfiguring', values: { count } }
+    case 'done':
+      return { key: 'updates.pkgDone', values: { count: progress.done } }
+    default:
+      return null
+  }
+}
+
+/** A paused run that names a node in `pending_approval` wants an approval, not a resume. */
+export function isAwaitingApproval(run: Pick<RunProgressLike, 'status' | 'pending_approval'>): boolean {
+  return run.status === 'paused' && !!run.pending_approval
+}
+
+/** The apt output of a failed node is the only place its cause is stated: open it by default. */
+export function shouldExpandOutput(node: Pick<NodeProgressLike, 'status' | 'update_output'>): boolean {
+  return node.status === 'failed' && !!node.update_output
+}

--- a/frontend/src/lib/tasks/jobActions.test.ts
+++ b/frontend/src/lib/tasks/jobActions.test.ts
@@ -68,6 +68,10 @@ describe("jobActions", () => {
   it("offers pause/cancel on a running rolling update and resume/cancel when paused", () => {
     expect(jobActions({ id: "ru-1", type: "rolling_update", status: "running" })).toEqual(["pause", "cancel"])
     expect(jobActions({ id: "ru-1", type: "rolling_update", status: "paused" })).toEqual(["resume", "cancel"])
+    // Paused for a manual approval: the operator approves, they do not resume.
+    expect(
+      jobActions({ id: "ru-1", type: "rolling_update", status: "paused", metadata: { pendingApproval: "pve2" } }),
+    ).toEqual(["approve", "cancel"])
     expect(jobActions({ id: "ru-1", type: "rolling_update", status: "success" })).toEqual([])
   })
 
@@ -90,6 +94,9 @@ describe("jobActionUrl", () => {
   it("keeps rolling updates on the orchestrator route", () => {
     expect(jobActionUrl({ id: "ru-1", type: "rolling_update" }, "pause")).toBe(
       "/api/v1/orchestrator/rolling-updates/ru-1/pause",
+    )
+    expect(jobActionUrl({ id: "ru-1", type: "rolling_update" }, "approve")).toBe(
+      "/api/v1/orchestrator/rolling-updates/ru-1/approve",
     )
     expect(jobActionUrl({ id: "ru-1", type: "rolling_update" }, "cancel")).toBe(
       "/api/v1/orchestrator/rolling-updates/ru-1/cancel",

--- a/frontend/src/lib/tasks/jobActions.ts
+++ b/frontend/src/lib/tasks/jobActions.ts
@@ -17,7 +17,7 @@ export type JobLike = {
   metadata?: Record<string, any> | null
 } | null | undefined
 
-export type JobAction = 'pause' | 'resume' | 'cancel'
+export type JobAction = 'pause' | 'resume' | 'approve' | 'cancel'
 
 /** `UPID:pve1:0000ABCD:...` -> `pve1`. */
 function upidNode(upid: string): string | null {
@@ -73,7 +73,10 @@ export function jobActions(job: JobLike): JobAction[] {
 
   if (job.type === 'rolling_update') {
     if (job.status === 'running') return ['pause', 'cancel']
-    if (job.status === 'paused') return ['resume', 'cancel']
+    // A run paused for a manual approval wants an approval, not a resume:
+    // the orchestrator's approve action releases the gate without lifting
+    // an operator pause, resume would do both.
+    if (job.status === 'paused') return [job.metadata?.pendingApproval ? 'approve' : 'resume', 'cancel']
 
     return []
   }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -6451,7 +6451,17 @@
     "restartLocalVmsDescription": "VMs neu starten, die vor dem Update heruntergefahren wurden.",
     "restartLocalVmsBtn": "VMs neustarten",
     "restartingLocalVms": "VMs werden neugestartet...",
-    "localVmsRestarted": "All Lokal VMs restarted erfolgreich."
+    "localVmsRestarted": "All Lokal VMs restarted erfolgreich.",
+    "awaitingApproval": "Warten auf Genehmigung",
+    "approvalBanner": "Der Vorgang ist pausiert und wartet auf Ihre Genehmigung, bevor {node} aktualisiert wird. Genehmigen Sie, um fortzufahren, oder brechen Sie ab, um hier zu stoppen.",
+    "approveNode": "{node} genehmigen",
+    "showUpdateOutput": "apt-Ausgabe anzeigen",
+    "hideUpdateOutput": "apt-Ausgabe ausblenden",
+    "pkgWaitingLock": "Warten auf die apt-Sperre ({seconds} s)",
+    "pkgDownloading": "Pakete werden heruntergeladen: {count}",
+    "pkgUnpacking": "Pakete werden entpackt: {count}",
+    "pkgConfiguring": "Pakete werden konfiguriert: {count}",
+    "pkgDone": "{count} Paket(e) konfiguriert"
   },
   "replication": {
     "title": "Replikation",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -6506,7 +6506,17 @@
     "restartLocalVmsDescription": "Restart VMs that were shut down before the update.",
     "restartLocalVmsBtn": "Restart VMs",
     "restartingLocalVms": "Restarting VMs...",
-    "localVmsRestarted": "All local VMs restarted successfully."
+    "localVmsRestarted": "All local VMs restarted successfully.",
+    "awaitingApproval": "Awaiting approval",
+    "approvalBanner": "The run is paused and waits for your approval before updating {node}. Approve to continue, or cancel to stop here.",
+    "approveNode": "Approve {node}",
+    "showUpdateOutput": "Show apt output",
+    "hideUpdateOutput": "Hide apt output",
+    "pkgWaitingLock": "Waiting for the apt lock ({seconds}s)",
+    "pkgDownloading": "Downloading packages {count}",
+    "pkgUnpacking": "Unpacking packages {count}",
+    "pkgConfiguring": "Configuring packages {count}",
+    "pkgDone": "{count} package(s) configured"
   },
   "replication": {
     "title": "Replication",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -6506,7 +6506,17 @@
     "restartLocalVmsDescription": "Reiniciar VMs que se apagaron antes de la actualización.",
     "restartLocalVmsBtn": "Reiniciar VMs",
     "restartingLocalVms": "Reiniciando VMs...",
-    "localVmsRestarted": "Todas las VMs locales se reiniciaron correctamente."
+    "localVmsRestarted": "Todas las VMs locales se reiniciaron correctamente.",
+    "awaitingApproval": "En espera de aprobación",
+    "approvalBanner": "La ejecución está en pausa y espera su aprobación antes de actualizar {node}. Apruebe para continuar o cancele para detenerla aquí.",
+    "approveNode": "Aprobar {node}",
+    "showUpdateOutput": "Mostrar salida de apt",
+    "hideUpdateOutput": "Ocultar salida de apt",
+    "pkgWaitingLock": "Esperando el bloqueo de apt ({seconds} s)",
+    "pkgDownloading": "Descargando paquetes {count}",
+    "pkgUnpacking": "Desempaquetando paquetes {count}",
+    "pkgConfiguring": "Configurando paquetes {count}",
+    "pkgDone": "{count} paquete(s) configurado(s)"
   },
   "replication": {
     "title": "Replicación",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -6501,7 +6501,17 @@
     "restartLocalVmsDescription": "Redémarrer les VMs éteintes avant la mise à jour.",
     "restartLocalVmsBtn": "Redémarrer les VMs",
     "restartingLocalVms": "Redémarrage des VMs...",
-    "localVmsRestarted": "Toutes les VMs locales ont été redémarrées avec succès."
+    "localVmsRestarted": "Toutes les VMs locales ont été redémarrées avec succès.",
+    "awaitingApproval": "En attente d'approbation",
+    "approvalBanner": "L'exécution est suspendue et attend votre approbation avant la mise à jour de {node}. Approuvez pour continuer ou annulez pour vous arrêter ici.",
+    "approveNode": "Approuver {node}",
+    "showUpdateOutput": "Afficher la sortie apt",
+    "hideUpdateOutput": "Masquer la sortie apt",
+    "pkgWaitingLock": "En attente du verrou apt ({seconds} s)",
+    "pkgDownloading": "Téléchargement des paquets {count}",
+    "pkgUnpacking": "Décompression des paquets {count}",
+    "pkgConfiguring": "Configuration des paquets {count}",
+    "pkgDone": "{count} paquet(s) configuré(s)"
   },
   "replication": {
     "title": "Réplication",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -6506,7 +6506,17 @@
     "restartLocalVmsDescription": "업데이트 전에 종료된 VM을 재시작합니다.",
     "restartLocalVmsBtn": "VM 재시작",
     "restartingLocalVms": "VM 재시작 중...",
-    "localVmsRestarted": "모든 로컬 VM이 성공적으로 재시작되었습니다."
+    "localVmsRestarted": "모든 로컬 VM이 성공적으로 재시작되었습니다.",
+    "awaitingApproval": "승인 대기 중",
+    "approvalBanner": "실행이 일시 중지되었으며 {node} 업데이트 전에 승인을 기다리고 있습니다. 계속하려면 승인하고 여기서 중지하려면 취소하세요.",
+    "approveNode": "{node} 승인",
+    "showUpdateOutput": "apt 출력 표시",
+    "hideUpdateOutput": "apt 출력 숨기기",
+    "pkgWaitingLock": "apt 잠금 대기 중 ({seconds}초)",
+    "pkgDownloading": "패키지 다운로드 중 {count}",
+    "pkgUnpacking": "패키지 압축 해제 중 {count}",
+    "pkgConfiguring": "패키지 구성 중 {count}",
+    "pkgDone": "패키지 {count}개 구성 완료"
   },
   "replication": {
     "title": "복제",

--- a/frontend/src/messages/rollingUpdateProgressMessages.test.ts
+++ b/frontend/src/messages/rollingUpdateProgressMessages.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+const PROGRESS_KEYS = [
+  'awaitingApproval',
+  'approvalBanner',
+  'approveNode',
+  'showUpdateOutput',
+  'hideUpdateOutput',
+  'pkgWaitingLock',
+  'pkgDownloading',
+  'pkgUnpacking',
+  'pkgConfiguring',
+  'pkgDone'
+]
+
+const PLACEHOLDERS_BY_KEY: Record<string, string> = {
+  approvalBanner: '{node}',
+  approveNode: '{node}',
+  pkgWaitingLock: '{seconds}',
+  pkgDownloading: '{count}',
+  pkgUnpacking: '{count}',
+  pkgConfiguring: '{count}',
+  pkgDone: '{count}'
+}
+
+describe('rolling update progress messages, i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} declares every rolling update progress message as a non-empty string`, () => {
+      for (const key of PROGRESS_KEYS) {
+        const value = messages?.updates?.[key]
+        expect(value, `${locale}: updates.${key}`).toBeTypeOf('string')
+        expect(value.trim(), `${locale}: updates.${key}`).not.toBe('')
+      }
+    })
+
+    it(`${locale} preserves every rolling update progress placeholder`, () => {
+      for (const [key, placeholder] of Object.entries(PLACEHOLDERS_BY_KEY)) {
+        expect(messages?.updates?.[key], `${locale}: updates.${key}`).toContain(placeholder)
+      }
+    })
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -6453,7 +6453,17 @@
     "restartLocalVmsDescription": "重启更新前已关闭的虚拟机。",
     "restartLocalVmsBtn": "重启虚拟机",
     "restartingLocalVms": "正在重启虚拟机...",
-    "localVmsRestarted": "所有本地虚拟机已成功重启。"
+    "localVmsRestarted": "所有本地虚拟机已成功重启。",
+    "awaitingApproval": "等待批准",
+    "approvalBanner": "运行已暂停，正在等待您的批准，然后再更新 {node}。批准以继续，或取消以在此停止。",
+    "approveNode": "批准 {node}",
+    "showUpdateOutput": "显示 apt 输出",
+    "hideUpdateOutput": "隐藏 apt 输出",
+    "pkgWaitingLock": "正在等待 apt 锁（{seconds} 秒）",
+    "pkgDownloading": "正在下载软件包 {count}",
+    "pkgUnpacking": "正在解包软件包 {count}",
+    "pkgConfiguring": "正在配置软件包 {count}",
+    "pkgDone": "已配置 {count} 个软件包"
   },
   "replication": {
     "title": "复制",


### PR DESCRIPTION
## Problem

During a rolling update the wizard went silent for the whole package upgrade of a node: the progress bar counted whole nodes and stayed at `0 / 3` for eight minutes, the node tile only read `updating`, and the apt output the orchestrator already collected and served as `update_output` was never displayed. On a failed run that meant `apt update failed: Process exited with status 100` and nothing else, while the actual cause, a 401 on the enterprise repository, was in that field the whole time. Manual approval had no affordance either: the footer offered Pause, Resume and Cancel, and the operator had to guess that Resume was the approval (#814).

## Changes

**Progress**
- `src/lib/rolling/updateProgress.ts`: the bar value is the sum of per node fractions over the ordered node statuses, with apt's own position inside `updating` taken from the `package_progress` the orchestrator now publishes. The header and the node tile name the phase: `Configuring packages 56/245`, `Downloading packages 186/243`, `Waiting for the apt lock (45s)`.

**apt output**
- `NodeUpdateOutput`: a collapsible panel per node in the execution and completed views, opened automatically when the node failed. The orchestrator now persists `update_output` on failure too, so the cause of a failed upgrade is on screen.

**Approval**
- A run paused for a manual approval shows an `Awaiting approval` chip, a banner naming the node and an `Approve <node>` button calling the `approve` action; a plain pause keeps Resume. The Task Center's detail dialog offers the same action from `metadata.pendingApproval`.

**Wizard polish found during the recette**
- Node names carry the Proxmox icon and its status dot in the SSH addresses block, the node statuses and the summary (offline while rebooting, maintenance while in HA maintenance, the PVE status otherwise).
- `entering_maintenance`, `waiting_return`, `verifying_health` and `exiting_maintenance` show the spinner instead of a warning triangle; `skipped` is informational.
- Closing the wizard or the node update dialog during a run asks through a themed `ConfirmCloseDialog` instead of `window.confirm`.

**Task Center**
- Cancelled runs keep the `cancelled` status instead of being mapped to failed, the detail dialog shows up to 1000 log lines, and the list follows the orchestrator's history endpoint, so finished runs stay listed with their full log.

**Aside**
- `RBACContext` reloads permissions when the user id or the auth status changes rather than on every `session` object refetch: each `/api/auth/session` poll (60 s, window focus) used to trigger a full `/api/v1/rbac/effective` round trip.

## Notes

- Requires the matching orchestrator change (streamed apt progress, `package_progress`, `pending_approval`, `approve`, history endpoint); the UI degrades gracefully without it (no phase label, Resume instead of Approve).
- i18n: 10 new `updates.*` keys in the 6 catalogs, with a parity test.

## Verification

- `vitest`: 5 new or extended files, 88 tests (progress helpers, output panel, wizard in monitor mode with msw, message parity, job actions), plus the existing wizard, Task Center and job detail suites.
- `tsc --noEmit`: no error in the touched files (the 75 remaining are pre-existing in test files).
- Lab: a 3 node rolling update followed live in the wizard, 243 + 254 packages, output panels, and the finished run visible in the Task Center with its log.

Closes #814
