### PR TITLE
fix(ha): route DRS metrics and recommendations to the leader orchestrator

### DIFF
--- a/config/ha/haproxy.cfg
+++ b/config/ha/haproxy.cfg
@@ -20,3 +20,23 @@ backend pg_backend
     server proxcenter-1 PEER1_IP:5432 check port 8008
     server proxcenter-2 PEER2_IP:5432 check port 8008
     server proxcenter-3 PEER3_IP:5432 check port 8008
+
+# Leader proxy: forwards DRS metrics/recommendations traffic to whichever
+# orchestrator currently holds leadership. Exactly one node answers 200 on
+# /api/v1/leader, so the frontend's ORCHESTRATOR_LEADER_URL always reaches the
+# node whose in-memory DRS state is populated, regardless of which node holds
+# the VIP (ui#803, defect 2). Uses /api/v1/leader, never /health (keepalived
+# tracks /health).
+frontend orch_leader_frontend
+    bind 127.0.0.1:8081
+    default_backend orch_leader_backend
+
+backend orch_leader_backend
+    option httpchk GET /api/v1/leader
+    http-check expect status 200
+
+    default-server inter 1s fall 2 rise 1 on-marked-down shutdown-sessions
+
+    server proxcenter-1 PEER1_IP:8080 check
+    server proxcenter-2 PEER2_IP:8080 check
+    server proxcenter-3 PEER3_IP:8080 check

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -97,6 +97,9 @@ services:
       NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
       APP_SECRET: ${APP_SECRET}
       ORCHESTRATOR_URL: http://127.0.0.1:8080
+      # DRS metrics/recommendations go through HAProxy to the leader orchestrator
+      # (ui#803, defect 2); everything else stays on the local orchestrator above.
+      ORCHESTRATOR_LEADER_URL: http://127.0.0.1:8081
       ORCHESTRATOR_API_KEY: ${ORCHESTRATOR_API_KEY}
       PROXCENTER_REPORTING_URL: http://127.0.0.1:5000
       PG_POOL_MAX: ${PG_POOL_MAX:-}

--- a/frontend/src/lib/orchestrator/client.test.ts
+++ b/frontend/src/lib/orchestrator/client.test.ts
@@ -321,3 +321,44 @@ describe('parseOrchestratorError', () => {
     expect(parseOrchestratorError(error)).toEqual({ status: 503, message: 'Orchestrator error 503' })
   })
 })
+
+describe('leader routing (ui#803 defect 2)', () => {
+  const ORIG = process.env.ORCHESTRATOR_LEADER_URL
+
+  afterEach(() => {
+    if (ORIG === undefined) delete process.env.ORCHESTRATOR_LEADER_URL
+    else process.env.ORCHESTRATOR_LEADER_URL = ORIG
+    vi.resetModules()
+  })
+
+  async function fetchPathWithLeaderUrl(path: string, leaderUrl?: string) {
+    if (leaderUrl === undefined) delete process.env.ORCHESTRATOR_LEADER_URL
+    else process.env.ORCHESTRATOR_LEADER_URL = leaderUrl
+    vi.resetModules()
+    const localFetch = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', localFetch)
+    const { orchestratorFetch } = await import('./client')
+    await orchestratorFetch(path)
+    return localFetch.mock.calls[0][0] as string
+  }
+
+  it('routes /metrics and /drs to the leader URL when set', async () => {
+    const leader = 'http://127.0.0.1:8081'
+    expect(await fetchPathWithLeaderUrl('/metrics', leader)).toBe(`${leader}/api/v1/metrics`)
+    expect(await fetchPathWithLeaderUrl('/metrics/abc/history', leader)).toBe(`${leader}/api/v1/metrics/abc/history`)
+    expect(await fetchPathWithLeaderUrl('/drs/status', leader)).toBe(`${leader}/api/v1/drs/status`)
+    expect(await fetchPathWithLeaderUrl('/drs/recommendations?validate=true', leader)).toBe(`${leader}/api/v1/drs/recommendations?validate=true`)
+  })
+
+  it('keeps non-leader endpoints on the local orchestrator', async () => {
+    const leader = 'http://127.0.0.1:8081'
+    expect(await fetchPathWithLeaderUrl('/health', leader)).toBe('http://localhost:8080/api/v1/health')
+    expect(await fetchPathWithLeaderUrl('/rolling-updates', leader)).toBe('http://localhost:8080/api/v1/rolling-updates')
+    expect(await fetchPathWithLeaderUrl('/rules', leader)).toBe('http://localhost:8080/api/v1/rules')
+    expect(await fetchPathWithLeaderUrl('/ha/cluster', leader)).toBe('http://localhost:8080/api/v1/ha/cluster')
+  })
+
+  it('falls back to the local orchestrator for /drs when no leader URL is set (non-HA)', async () => {
+    expect(await fetchPathWithLeaderUrl('/drs/status', undefined)).toBe('http://localhost:8080/api/v1/drs/status')
+  })
+})

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -2,7 +2,21 @@
 // Client pour communiquer avec le backend Go d'orchestration
 
 const ORCHESTRATOR_URL = process.env.ORCHESTRATOR_URL || 'http://localhost:8080'
+// DRS metrics and recommendations live in the memory of the single leader
+// orchestrator. In HA, ORCHESTRATOR_LEADER_URL points at an HAProxy frontend
+// that forwards to whichever node currently holds leadership, so the DRS page
+// is populated no matter which node serves the request (e.g. the VIP holder is
+// not always the leader — ui#803, defect 2). Outside HA it is unset and falls
+// back to the local orchestrator, so behaviour is unchanged.
+const ORCHESTRATOR_LEADER_URL = process.env.ORCHESTRATOR_LEADER_URL || ORCHESTRATOR_URL
 const ORCHESTRATOR_API_KEY = process.env.ORCHESTRATOR_API_KEY || ''
+
+// Leader-only endpoints: DRS (/drs/*) and metrics (/metrics/*) read or act on
+// state that only the leader holds. Everything else stays on the local
+// orchestrator (ORCHESTRATOR_URL).
+function orchestratorBaseUrlForPath(path: string): string {
+  return /^\/(metrics|drs)(\/|$|\?)/.test(path) ? ORCHESTRATOR_LEADER_URL : ORCHESTRATOR_URL
+}
 
 export interface OrchestratorRequestOptions {
   method?: 'GET' | 'POST' | 'PUT' | 'DELETE'
@@ -19,7 +33,7 @@ export async function orchestratorFetch<T>(
 ): Promise<T> {
   const { method = 'GET', body, timeout = 30000 } = options
 
-  const url = `${ORCHESTRATOR_URL}/api/v1${path}`
+  const url = `${orchestratorBaseUrlForPath(path)}/api/v1${path}`
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary

In an HA cluster the DRS metrics and recommendations are held in the memory of the single leader orchestrator. The DRS page therefore showed "No cluster connected" whenever the node serving the request was not the leader, most visibly on the node holding the VIP when leadership had moved elsewhere (ui#803). The cluster was healthy the whole time; the page was simply asking a follower.

## Change

`orchestratorFetch` now selects its base URL by path: `/metrics` and `/drs` requests go to `ORCHESTRATOR_LEADER_URL`, while every other endpoint keeps using the local orchestrator. In HA that variable points at an HAProxy frontend that forwards to whichever orchestrator currently holds leadership, so the DRS view is populated no matter which node answers. Outside HA the variable is unset and falls back to `ORCHESTRATOR_URL`, leaving single-node behaviour unchanged. The routing is centralised in `orchestratorFetch`, so DRS reads and actions (approve, execute, evaluate) all reach the leader, which is where that state lives.

The HA config files gain the matching piece: a leader proxy on `127.0.0.1:8081` that health-checks the orchestrator's leader probe, and `ORCHESTRATOR_LEADER_URL` on the frontend service. The backend half (the leader probe and the generated HAProxy/compose templates) is a separate change, already merged.

## Testing

`client.test.ts` covers the routing: `/metrics` and `/drs` go to the leader URL, other paths and the non-HA fallback stay local (30 tests pass). Validated end to end on a 3-node HA lab: logged into the frontend through the VIP while the VIP holder was a follower, and the DRS metrics endpoint returned the populated cluster where the old path returned nothing.

Part of #803.
