### PR TITLE
release: v1.4.9

### DIFF
--- a/RELEASE_NOTES_v1.4.9.md
+++ b/RELEASE_NOTES_v1.4.9.md
@@ -1,0 +1,71 @@
+# ProxCenter v1.4.9
+
+**The API reference inside the product, warm migration from XCP-ng, rolling updates you can watch and approve, PBS 4 compatibility, and one HA leader at a time.**
+
+## Rolling updates
+
+- **Live apt progress per node**, with the apt output on screen when a step fails.
+- **Explicit manual approval** of each node, from the wizard or the Task Center, and cancel honoured while paused.
+- **The parallel migrations setting is honoured**, and evacuated guests are spread by projected load and affinity rules.
+- **Finished runs stay in the Task Center** with their full log, and a cancelled run reads cancelled.
+- **The Ceph wait only holds on real recovery**, not on our own `noout` flag or unrelated warnings.
+- **Nodes are reached on their management address**, never on a Corosync or Ceph network.
+- **Repository preflight reads the Proxmox fields correctly**, and the enterprise-without-free-alternative check fires at last.
+- **A 2 GB disk floor replaces the check that failed a 14 GB root with 4.8 GB free.**
+- **Tooltips on every wizard parameter**, health tiles, and a sudoers warning about `NOPASSWD: ALL`.
+
+## Migration
+
+- **XCP-ng direct pool connections (XAPI)** alongside Xen Orchestra, and **warm migration from XCP-ng with CBT over NBD**.
+- **XCP-ng Live mode is removed**: it never worked. Offline downloads survive a slow SSH poll and retry three times.
+- **Hyper-V: inventory in one PowerShell call**, wrong credentials shown as an authentication error, disk paths on SMB shares resolved, retry on the right engine.
+- **Compact OS Windows guests convert**: the `ntfs-3g` system-compression plugin is installed by the preflight.
+- **Hyper-V and Nutanix guests keep their source CPU count and memory** instead of 1 vCPU and 2 GB.
+- **Cold migrations to file storage write the disk once**: the converted image is adopted in place, temporary space drops from 2x to 1x.
+- **Warm node preparation says it needs Proxmox VE 9** instead of dumping an apt transcript.
+- **Install missing packages gets a 20 minute budget**, and a 401 on the enterprise repository no longer aborts Debian packages.
+
+## Consoles
+
+- **Fullscreen and scaling controls** on VNC and SPICE, remembered per console kind.
+- **VM power actions in the SPICE console**: start, shutdown, stop, pause, with automatic reconnect.
+- **Send-key menu and clipboard text on noVNC**, and keystrokes typed into a guest are no longer logged to the browser console.
+
+## High availability and DRS
+
+- **One orchestrator leader at a time**: the lock is taken on the Postgres primary only, and the pool refuses a hot standby (no more SQLSTATE 25006).
+- **The DRS page is populated from any node**, metrics and recommendations are routed to the leader through a new `/api/v1/leader` probe.
+- **A long HA preflight returns its verdict** instead of a false "Orchestrator unavailable", and a cut response is told apart from a dead orchestrator.
+- **DRS migrations stranded at running after an orchestrator restart are settled automatically**, and the task footer shows the real percentage instead of 50 %.
+
+## Site Recovery
+
+- **A replication job continues past a failing VM** and lands in a new Partially synced status, with the failed VMs named.
+- **A replicated VM carrying a Proxmox snapshot syncs again** instead of failing on `rbd: File exists`.
+- **Alerts and reports know the partial status**, and the failure alert no longer flaps during a rerun.
+
+## Backups and PBS
+
+- **PBS 4.x compatibility**: package refresh, repository toggle, API token listing, S3 endpoints and prune jobs all work again.
+
+## Network and notifications
+
+- **Configuring sFlow succeeds**, reports per-node results, and is re-applied after a node reboot.
+- **Flows are attributed by guest MAC** on SDN topologies.
+- **Commas work in the default recipients field**, and a list saved glued by the semicolon workaround is repaired.
+
+## Interface and API
+
+- **The public API reference is rendered inside the product**, under Settings, with Try-it on your own instance.
+- **Tooltips stay reachable on disabled buttons**, so the reason a button is unavailable is readable.
+- **The storage overview table fills the page.**
+
+## Dependencies
+
+Twenty-five Dependabot updates batched, including undici 8 pinned to HTTP/1.1, cron-parser 5, dagre 3, react-resizable 4 and `@types/node` 26. New dependency: `@scalar/api-reference-react` for the API reference page.
+
+## Upgrading
+
+Pull the images. One schema migration ships with this release, applied by the frontend entrypoint at first boot: the XCP-ng connection sub-type, backfilled to Xen Orchestra for existing connections.
+
+**HA clusters:** the DRS leader routing needs a new HAProxy frontend and the `ORCHESTRATOR_LEADER_URL` variable on each node, which an image pull does not add. Nothing breaks without them; the two edits are in the [HA documentation](https://docs.proxcenter.io/operations/ha-prerequisites).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,55 @@
-/root/saas/proxcenter-frontend/frontend/.env.example
+# ProxCenter Frontend Environment Configuration
+# Copy this file to .env and fill in your values
+
+# Database (Postgres)
+# ProxCenter speaks Postgres only since the SQLite cutover. Point this at
+# your Postgres instance — the bundled docker-compose stack provisions one
+# automatically.
+DATABASE_URL="postgresql://proxcenter:change-me@localhost:5432/proxcenter?schema=public"
+
+# Application Secret (generate a strong random string)
+APP_SECRET="your-app-secret-here"
+
+# NextAuth Configuration
+NEXTAUTH_SECRET="your-nextauth-secret-here"
+NEXTAUTH_URL="http://localhost:3000"
+
+# Session timeouts, in seconds. The database session row is authoritative —
+# it is what actually revokes a session — and the session cookie's own
+# lifetime is derived from SESSION_ABSOLUTE_TIMEOUT so it can never outlive
+# that row.
+# SESSION_IDLE_TIMEOUT: time without activity before a session expires. Default: 43200 (12 hours)
+# SESSION_ABSOLUTE_TIMEOUT: max session lifetime regardless of activity. Default: 604800 (7 days)
+# SESSION_IDLE_TIMEOUT="43200"
+# SESSION_ABSOLUTE_TIMEOUT="604800"
+
+# Shared secret for the first-run setup endpoint, which is reachable without
+# authentication for as long as no account exists. The setup request must then
+# carry the same value in its x-setup-token header. Unset keeps the historical
+# behaviour, so a local dev instance needs nothing here.
+# PROXCENTER_SETUP_TOKEN=""
+
+# Orchestrator Backend URL
+ORCHESTRATOR_URL="http://localhost:8080"
+
+# Shared secret used by ws-proxy.js to call /api/internal/console/consume
+# (VM/CT console handshake). Auto-generated on first launch by
+# scripts/ensure-internal-token.js (npm start / npm run dev) or by
+# docker-entrypoint.sh in the official image, so most deployments never
+# need to set this manually. Override only if you run the Next.js process
+# and ws-proxy.js on separate hosts.
+# INTERNAL_API_TOKEN="generate-with: openssl rand -hex 32"
+
+# Optional: AI Integration (Ollama)
+# OLLAMA_URL="http://localhost:11434"
+# OLLAMA_MODEL="llama3.1:8b"
+
+# Proxmox API request budgets, in milliseconds.
+# PVE_TIMEOUT_MS: default budget for a single Proxmox API call. Sized for the
+# endpoints ProxCenter polls most often. Default: 8000
+# PVE_SLOW_READ_TIMEOUT_MS: budget for reads where Proxmox enumerates every
+# configured backend before answering, such as the storage listing behind the
+# migration dialog. Raise this when a datacenter declares many PBS storages and
+# "pvesh get /nodes/NODE/storage" is measurably slow. Default: 30000
+# PVE_TIMEOUT_MS="8000"
+# PVE_SLOW_READ_TIMEOUT_MS="30000"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "proxcenter",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "proxcenter",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "hasInstallScript": true,
       "license": "Commercial",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proxcenter",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "license": "Commercial",
   "private": true,
   "scripts": {

--- a/frontend/src/data/changelog.json
+++ b/frontend/src/data/changelog.json
@@ -1,5 +1,40 @@
 [
   {
+    "version": "1.4.9",
+    "title": "In-app API reference, warm migration from XCP-ng and rolling update enhancements",
+    "items": [
+      { "type": "new", "text": "Rolling updates show live apt progress per node, with the apt output on screen when a step fails" },
+      { "type": "new", "text": "Rolling updates can require an explicit approval before each node, from the wizard or the Task Center" },
+      { "type": "fix", "text": "Rolling updates honour the parallel migrations setting and spread evacuated guests by projected load and affinity rules" },
+      { "type": "improved", "text": "Finished rolling updates stay in the Task Center with their full log, and a cancelled run reads cancelled" },
+      { "type": "fix", "text": "Rolling updates reach nodes on their management address and no longer wait on Ceph for our own noout flag or unrelated warnings" },
+      { "type": "fix", "text": "The node update preflight reads the Proxmox repository fields correctly, so the enterprise-without-free-alternative check finally fires" },
+      { "type": "new", "text": "XCP-ng pools can be connected directly through XAPI, next to Xen Orchestra" },
+      { "type": "new", "text": "Warm migration from XCP-ng with CBT: full copy of a live snapshot, then delta passes over NBD until the cutover" },
+      { "type": "breaking", "text": "XCP-ng Live mode is removed, it never worked. Use Offline or Warm" },
+      { "type": "fix", "text": "XCP-ng offline downloads survive a slow SSH poll and retry three times instead of deleting the partial file" },
+      { "type": "fix", "text": "Hyper-V: inventory in a single PowerShell call, wrong credentials shown as an authentication error, SMB disk paths resolved, retry on the right engine" },
+      { "type": "new", "text": "Windows guests installed with Compact OS convert: the ntfs-3g system-compression plugin is installed by the preflight" },
+      { "type": "fix", "text": "Hyper-V and Nutanix guests keep their source CPU count and memory instead of 1 vCPU and 2 GB" },
+      { "type": "improved", "text": "Cold migrations to file storage write the converted disk once and need half the temporary space" },
+      { "type": "fix", "text": "Warm node preparation states that it needs Proxmox VE 9 instead of dumping an apt transcript" },
+      { "type": "new", "text": "Consoles: fullscreen and scaling controls on VNC and SPICE, remembered per console kind" },
+      { "type": "new", "text": "SPICE console: start, shutdown, stop and pause the VM from the toolbar, with automatic reconnect" },
+      { "type": "fix", "text": "noVNC no longer logs the keystrokes typed into a guest to the browser console" },
+      { "type": "fix", "text": "HA: a single orchestrator leader at a time, elected on the Postgres primary only, and no more read-only transaction errors on a hot standby" },
+      { "type": "fix", "text": "HA: the DRS page is populated from any node, metrics and recommendations are routed to the leader" },
+      { "type": "fix", "text": "HA: a long preflight returns its verdict instead of a false Orchestrator unavailable" },
+      { "type": "fix", "text": "DRS migrations left running after an orchestrator restart are settled automatically, and the task footer shows their real progress instead of 50 %" },
+      { "type": "new", "text": "Site Recovery: a replication job continues past a failing VM and reports a Partially synced status with the failed VMs named" },
+      { "type": "fix", "text": "Site Recovery: a replicated VM carrying a Proxmox snapshot syncs again instead of failing on rbd File exists" },
+      { "type": "fix", "text": "PBS 4.x: package refresh, repository toggle, API token listing, S3 endpoints and prune jobs work again" },
+      { "type": "fix", "text": "Network Flows: configuring sFlow succeeds, reports per-node results and is re-applied after a node reboot; flows are attributed by guest MAC" },
+      { "type": "fix", "text": "Commas work in the default notification recipients, and a list saved glued by the semicolon workaround is repaired" },
+      { "type": "new", "text": "The public API reference is rendered inside the product, under Settings, with Try-it on your own instance" },
+      { "type": "fix", "text": "Tooltips stay reachable on disabled buttons, so the reason a button is unavailable is readable" }
+    ]
+  },
+  {
     "version": "1.4.8",
     "title": "vDC storage policies, tenant VLAN networks and a complete Task Center",
     "items": [


### PR DESCRIPTION
Release v1.4.9.

- `RELEASE_NOTES_v1.4.9.md`, read by the release job at the tagged SHA. One line per bullet, 4.9 KB.
- `frontend/src/data/changelog.json`: the 1.4.9 What's New entry, 29 items, at the head of the array.
- `frontend/package.json` and `package-lock.json`: 1.4.8 to 1.4.9.
- `frontend/.env.example`: restored. Since #781 the file was committed as a symlink pointing to itself, so the documented example environment file had disappeared from the repository.

Scope since v1.4.8: 33 commits, 19 functional pull requests (#781 to #830) and the Dependabot batches. One schema migration ships (`20260826000000_xcpng_connection_subtype`). One new environment variable, `ORCHESTRATOR_LEADER_URL`, wired in `docker-compose.ha.yml` and falling back to `ORCHESTRATOR_URL` elsewhere; the release notes carry the manual step for HA clusters deployed before this release.

The orchestrator is tagged first, then this repository.