### PR TITLE
fix(rbac): inventory views hidden for assignments inheriting the role scope (#842)

### DIFF
--- a/frontend/src/hooks/useRBACScopeProfile.test.ts
+++ b/frontend/src/hooks/useRBACScopeProfile.test.ts
@@ -26,6 +26,8 @@ vi.mock("@/contexts/TenantContext", () => ({
   useTenant: () => mockUseTenant(),
 }))
 
+import { useRBACScopeProfile } from "./useRBACScopeProfile"
+
 const ALL_VIEWS = ["tree", "vms", "hosts", "pools", "tags", "favorites", "templates"]
 
 function makeRbac(overrides: Partial<{ roles: any[]; scopeTypes: string[]; isAdmin: boolean; loading: boolean }> = {}) {
@@ -46,8 +48,10 @@ function makeTenant(overrides: Partial<{ currentTenant: any; loading: boolean }>
   }
 }
 
-async function run() {
-  const { useRBACScopeProfile } = await import("./useRBACScopeProfile")
+// A custom-hook-shaped wrapper so react-hooks/rules-of-hooks accepts the
+// call: useMemo is mocked above, so this runs synchronously without a render
+// tree. vi.mock is hoisted, so the static import below already sees the mocks.
+function useProfileUnderTest() {
   return useRBACScopeProfile()
 }
 
@@ -56,11 +60,11 @@ describe("useRBACScopeProfile", () => {
     vi.clearAllMocks()
   })
 
-  it("admin → every view, default tree", async () => {
+  it("admin → every view, default tree", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tree")
     expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
@@ -70,100 +74,120 @@ describe("useRBACScopeProfile", () => {
   // follows the role's default scope, which is "global" when the role has
   // none. /rbac/effective already resolves that into scope_types; the raw
   // role row still says "inherit" and must not drive the view profile.
-  it("inherit assignment resolved to global → every view, default tree", async () => {
+  it("inherit assignment resolved to global → every view, default tree", () => {
     mockUseRBAC.mockReturnValue(makeRbac({
       roles: [{ id: "role_custom", name: "Ops", scope_type: "inherit", scope_target: null }],
       scopeTypes: ["global"],
     }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tree")
     expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
   })
 
-  it("inherit assignment resolved to a pool default scope → pools view, default pools", async () => {
+  it("inherit assignment resolved to a pool default scope → pools view, default pools", () => {
     mockUseRBAC.mockReturnValue(makeRbac({
       roles: [{ id: "role_custom", name: "Ops", scope_type: "inherit", scope_target: null }],
       scopeTypes: ["pool"],
     }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("pools")
     expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "templates", "vms"])
   })
 
-  it("direct connection grant without any role → every view, default tree", async () => {
+  it("direct connection grant without any role → every view, default tree", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ roles: [], scopeTypes: ["connection"] }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tree")
     expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
   })
 
-  it("tag-only → tags + safe views, default tags", async () => {
+  it("tag-only → tags + safe views, default tags", () => {
     mockUseRBAC.mockReturnValue(makeRbac({
       roles: [{ id: "role_custom", scope_type: "tag", scope_target: "prod" }],
       scopeTypes: ["tag"],
     }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tags")
     expect([...result.allowedViewModes].sort()).toEqual(["favorites", "tags", "templates", "vms"])
   })
 
-  it("tag + pool → both views, default tags", async () => {
+  it("tag + pool → both views, default tags", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["tag", "pool"] }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tags")
     expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "tags", "templates", "vms"])
   })
 
-  it("no scope at all → minimal views, default vms", async () => {
-    mockUseRBAC.mockReturnValue(makeRbac())
+  it("scopeTypes not yet an array (context default) → minimal views, default vms", () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: undefined as any }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("vms")
     expect([...result.allowedViewModes].sort()).toEqual(["favorites", "templates", "vms"])
   })
 
-  it("vDC tenant hides tree and hosts even with a global scope", async () => {
+  it("vDC tenant with a tag scope keeps tags as the default view", () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["tag"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ currentTenant: { id: "t-acme", operatingModel: "vdc" } }))
+
+    const result = useProfileUnderTest()
+
+    expect(result.defaultViewMode).toBe("tags")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "tags", "templates", "vms"])
+  })
+
+  it("no scope at all → minimal views, default vms", () => {
+    mockUseRBAC.mockReturnValue(makeRbac())
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = useProfileUnderTest()
+
+    expect(result.defaultViewMode).toBe("vms")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "templates", "vms"])
+  })
+
+  it("vDC tenant hides tree and hosts even with a global scope", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["global"] }))
     mockUseTenant.mockReturnValue(makeTenant({ currentTenant: { id: "t-acme", operatingModel: "vdc" } }))
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("vms")
     expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "tags", "templates", "vms"])
   })
 
-  it("MSP tenant keeps tree and hosts", async () => {
+  it("MSP tenant keeps tree and hosts", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["connection"] }))
     mockUseTenant.mockReturnValue(makeTenant({ currentTenant: { id: "t-msp", operatingModel: "msp" } }))
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.defaultViewMode).toBe("tree")
     expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
   })
 
-  it("returns loading=true with every view while RBAC is loading", async () => {
+  it("returns loading=true with every view while RBAC is loading", () => {
     mockUseRBAC.mockReturnValue(makeRbac({ loading: true }))
     mockUseTenant.mockReturnValue(makeTenant())
 
-    const result = await run()
+    const result = useProfileUnderTest()
 
     expect(result.loading).toBe(true)
     expect(result.defaultViewMode).toBe("tree")

--- a/frontend/src/hooks/useRBACScopeProfile.test.ts
+++ b/frontend/src/hooks/useRBACScopeProfile.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for useRBACScopeProfile.
+ *
+ * Environment: node (no jsdom, no @testing-library/react).
+ * Strategy: mock the two context hooks and mock React.useMemo to invoke the
+ * factory synchronously so the hook can be called as a plain function.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+vi.mock("react", async (orig) => {
+  const actual = await orig<typeof import("react")>()
+  return {
+    ...actual,
+    useMemo: (factory: () => any, _deps?: any[]) => factory(),
+  }
+})
+
+const mockUseRBAC = vi.fn()
+const mockUseTenant = vi.fn()
+
+vi.mock("@/contexts/RBACContext", () => ({
+  useRBAC: () => mockUseRBAC(),
+}))
+
+vi.mock("@/contexts/TenantContext", () => ({
+  useTenant: () => mockUseTenant(),
+}))
+
+const ALL_VIEWS = ["tree", "vms", "hosts", "pools", "tags", "favorites", "templates"]
+
+function makeRbac(overrides: Partial<{ roles: any[]; scopeTypes: string[]; isAdmin: boolean; loading: boolean }> = {}) {
+  return {
+    roles: [],
+    scopeTypes: [],
+    isAdmin: false,
+    loading: false,
+    ...overrides,
+  }
+}
+
+function makeTenant(overrides: Partial<{ currentTenant: any; loading: boolean }> = {}) {
+  return {
+    currentTenant: { id: "default", operatingModel: "provider" },
+    loading: false,
+    ...overrides,
+  }
+}
+
+async function run() {
+  const { useRBACScopeProfile } = await import("./useRBACScopeProfile")
+  return useRBACScopeProfile()
+}
+
+describe("useRBACScopeProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("admin → every view, default tree", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ isAdmin: true }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tree")
+    expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
+  })
+
+  // Issue #842: an assignment whose scope_type is the "inherit" sentinel
+  // follows the role's default scope, which is "global" when the role has
+  // none. /rbac/effective already resolves that into scope_types; the raw
+  // role row still says "inherit" and must not drive the view profile.
+  it("inherit assignment resolved to global → every view, default tree", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({
+      roles: [{ id: "role_custom", name: "Ops", scope_type: "inherit", scope_target: null }],
+      scopeTypes: ["global"],
+    }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tree")
+    expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
+  })
+
+  it("inherit assignment resolved to a pool default scope → pools view, default pools", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({
+      roles: [{ id: "role_custom", name: "Ops", scope_type: "inherit", scope_target: null }],
+      scopeTypes: ["pool"],
+    }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("pools")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "templates", "vms"])
+  })
+
+  it("direct connection grant without any role → every view, default tree", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ roles: [], scopeTypes: ["connection"] }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tree")
+    expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
+  })
+
+  it("tag-only → tags + safe views, default tags", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({
+      roles: [{ id: "role_custom", scope_type: "tag", scope_target: "prod" }],
+      scopeTypes: ["tag"],
+    }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tags")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "tags", "templates", "vms"])
+  })
+
+  it("tag + pool → both views, default tags", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["tag", "pool"] }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tags")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "tags", "templates", "vms"])
+  })
+
+  it("no scope at all → minimal views, default vms", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac())
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("vms")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "templates", "vms"])
+  })
+
+  it("vDC tenant hides tree and hosts even with a global scope", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["global"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ currentTenant: { id: "t-acme", operatingModel: "vdc" } }))
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("vms")
+    expect([...result.allowedViewModes].sort()).toEqual(["favorites", "pools", "tags", "templates", "vms"])
+  })
+
+  it("MSP tenant keeps tree and hosts", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ scopeTypes: ["connection"] }))
+    mockUseTenant.mockReturnValue(makeTenant({ currentTenant: { id: "t-msp", operatingModel: "msp" } }))
+
+    const result = await run()
+
+    expect(result.defaultViewMode).toBe("tree")
+    expect([...result.allowedViewModes].sort()).toEqual([...ALL_VIEWS].sort())
+  })
+
+  it("returns loading=true with every view while RBAC is loading", async () => {
+    mockUseRBAC.mockReturnValue(makeRbac({ loading: true }))
+    mockUseTenant.mockReturnValue(makeTenant())
+
+    const result = await run()
+
+    expect(result.loading).toBe(true)
+    expect(result.defaultViewMode).toBe("tree")
+  })
+})

--- a/frontend/src/hooks/useRBACScopeProfile.ts
+++ b/frontend/src/hooks/useRBACScopeProfile.ts
@@ -28,19 +28,19 @@ type ScopeProfile = {
 }
 
 /**
- * Analyzes the user's RBAC roles to determine which inventory view modes
- * are appropriate, and which one should be the default.
+ * Analyzes the user's effective RBAC scopes to determine which inventory
+ * view modes are appropriate, and which one should be the default.
  *
  * - Admin or infra-scoped → all views, default "tree"
- * - Tag-only → tags, vms, favorites, templates — default "tags"
- * - Pool-only → pools, vms, favorites, templates — default "pools"
- * - Tag + pool → tags, pools, vms, favorites, templates — default "tags"
- * - VM-only → vms, favorites, templates — default "vms"
+ * - Tag-only → tags, vms, favorites, templates, default "tags"
+ * - Pool-only → pools, vms, favorites, templates, default "pools"
+ * - Tag + pool → tags, pools, vms, favorites, templates, default "tags"
+ * - VM-only → vms, favorites, templates, default "vms"
  * - Mixed infra + non-infra → all views, default "tree"
- * - No roles → vms, favorites, templates — default "vms"
+ * - No scope → vms, favorites, templates, default "vms"
  */
 export function useRBACScopeProfile(): ScopeProfile {
-  const { roles, isAdmin, loading } = useRBAC()
+  const { scopeTypes: effectiveScopeTypes, isAdmin, loading } = useRBAC()
   const { currentTenant, loading: tenantLoading } = useTenant()
   // Tenants other than the provider get the cloud-style abstraction:
   // nodes / hosts / clusters are an implementation detail and never appear
@@ -81,12 +81,17 @@ export function useRBACScopeProfile(): ScopeProfile {
       })
     }
 
-    // Collect unique scope types from user's roles
+    // Use the aggregated scope_types from /rbac/effective: an assignment
+    // whose scope_type is the "inherit" sentinel is resolved there into the
+    // role's default scopes ("global" when the role has none), and direct
+    // permission grants are folded in too. Reading the raw roles[].scope_type
+    // left "inherit" unmatched and pushed the user to the minimal profile
+    // (issue #842).
     const scopeTypes = new Set<string>(
-      roles.map((r: any) => r.scope_type).filter(Boolean)
+      (Array.isArray(effectiveScopeTypes) ? effectiveScopeTypes : []).filter(Boolean),
     )
 
-    // No roles at all → minimal view
+    // No scope at all → minimal view
     if (scopeTypes.size === 0) {
       return restrict({
         defaultViewMode: 'vms' as ViewMode,
@@ -128,5 +133,5 @@ export function useRBACScopeProfile(): ScopeProfile {
       allowedViewModes: allowed,
       loading: false,
     })
-  }, [roles, isAdmin, loading, hideInfra])
+  }, [effectiveScopeTypes, isAdmin, loading, hideInfra])
 }


### PR DESCRIPTION
## What

An assignment whose scope is set to "Default" carries the `inherit` sentinel and follows the role's default scopes, or `global` when the role defines none. The server already resolved that everywhere: `loadUserGrants` expands it before matching, and `/api/v1/rbac/effective` returns the resolved `scope_types`, so permissions and data were correct. One client consumer did not: `useRBACScopeProfile`, which decides which inventory views a user gets, still read the raw `roles[].scope_type`. `"inherit"` fell into neither the infra bucket (`global` / `connection` / `node`) nor the tag or pool ones, so the inventory dropped to the minimal profile with only the VMs, favorites and templates views, no tree, hosts, pools or tags. Switching the assignment to an explicit Global scope bypassed the sentinel, which is why that workaround appeared to fix it.

The hook now reads the aggregated `scope_types` from the RBAC context, the same source `useWidgetVisibility` already used with a comment explaining why. Two side effects, both intended: a user whose only grant is a direct permission (no role) gets the views matching that grant, and a role whose default scope is a pool or a tag gives its inheriting users the pools or tags view, since the resolved scope is what drives the profile.

`useRBACScopeProfile.test.ts` is new, on the same pattern as `useWidgetVisibility.test.ts`: ten cases covering inherit resolved to global, inherit resolved to a pool, a direct connection grant, tag-only, tag + pool, no scope, the vDC and MSP tenant restrictions and the loading state. The two inherit cases were red before the change.

## Why

Reported in #842 on 1.4.9: a user assigned to a role with the Default scope could not see the pools or the folders in the inventory, while the same user with the scope set to Global on the assignment could. The report's screenshot shows the three-button toolbar the minimal profile renders.

## Testing

Reproduced and validated in the browser on a lab with two PVE 9.2 clusters: a custom role with no default scope, a user assigned with the Default scope. Before the change the toolbar had three views; after it the seven views are present with the tree open by default and both clusters listed. Setting a pool default scope on the same role and reloading gives the VMs, pools, favorites and templates views with pools selected. The super admin view is unchanged, and an explicit Global assignment now behaves exactly like Default on a role without default scope.

`vitest src/hooks/` passes (51 tests, 7 files).
