### PR TITLE
fix(site-recovery): interval schedule mode, real retention window caption, snapshot inventory errors and filters (#709)

### DIFF
--- a/frontend/src/app/api/v1/orchestrator/replication/snapshots/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/snapshots/route.test.ts
@@ -1,0 +1,164 @@
+// The GET handler used to answer [] on any failure. At scale the snapshot
+// inventory times out routinely, so the operator was told they had no
+// snapshots when the orchestrator had merely timed out. The cluster_id and
+// vmid filters were also unreachable because the handler took no request,
+// so every screen paid for a cluster-wide inventory.
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { callRoute, readJson, deniedPermissionResponse } from '@/__tests__/setup/route-test'
+
+const listMirrorSnapshotsMock = vi.fn()
+const deleteMirrorSnapshotsMock = vi.fn()
+const checkPermissionMock = vi.fn()
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    listMirrorSnapshots: (...args: unknown[]) => listMirrorSnapshotsMock(...args),
+    deleteMirrorSnapshots: (...args: unknown[]) => deleteMirrorSnapshotsMock(...args),
+  }),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...args: unknown[]) => checkPermissionMock(...args),
+  PERMISSIONS: {
+    AUTOMATION_VIEW: 'automation.view',
+    AUTOMATION_MANAGE: 'automation.manage',
+  },
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>(['conn-a', 'conn-b'])),
+}))
+
+import { GET, POST } from './route'
+
+// The handlers are typed on NextRequest (GET reads request.nextUrl); callRoute
+// builds a plain Request, so wrap it into a NextRequest before handing it over.
+type Handler = (req: NextRequest) => Promise<Response>
+const asNextRequest = (handler: Handler) => (req: Request) => handler(new NextRequest(req))
+const getRoute = asNextRequest(GET)
+const postRoute = asNextRequest(POST)
+
+const fakeSnapshots = [
+  { cluster_id: 'conn-a', snapshot: 's1' },
+  { cluster_id: 'conn-zzz', snapshot: 's2' },
+  { snapshot: 's3' },
+]
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  listMirrorSnapshotsMock.mockReset().mockResolvedValue({ data: fakeSnapshots })
+  deleteMirrorSnapshotsMock.mockReset().mockResolvedValue({ data: { deleted: [], failed: [] } })
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
+})
+
+describe('GET /api/v1/orchestrator/replication/snapshots', () => {
+  it('returns the tenant-scoped snapshots passthrough on 200', async () => {
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual([
+      { cluster_id: 'conn-a', snapshot: 's1' },
+      { snapshot: 's3' },
+    ])
+    expect(listMirrorSnapshotsMock).toHaveBeenCalledWith({ clusterId: undefined, vmid: undefined })
+  })
+
+  it('forwards the cluster_id and vmid filters to the orchestrator', async () => {
+    const res = await callRoute(getRoute, { searchParams: { cluster_id: 'conn-a', vmid: '100' } })
+    expect(res.status).toBe(200)
+    expect(listMirrorSnapshotsMock).toHaveBeenCalledWith({ clusterId: 'conn-a', vmid: 100 })
+  })
+
+  it('drops a non numeric vmid instead of forwarding it', async () => {
+    const res = await callRoute(getRoute, { searchParams: { vmid: 'abc' } })
+    expect(res.status).toBe(200)
+    expect(listMirrorSnapshotsMock).toHaveBeenCalledWith({ clusterId: undefined, vmid: undefined })
+  })
+
+  it('returns an empty array when the orchestrator data is not an array', async () => {
+    listMirrorSnapshotsMock.mockResolvedValue({ data: null })
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual([])
+  })
+
+  it('returns denied response when permission check fails', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(403)
+    expect(listMirrorSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a 502 without logging when the orchestrator is unavailable', async () => {
+    const err: any = new Error('Orchestrator unavailable')
+    err.code = 'ORCHESTRATOR_UNAVAILABLE'
+    listMirrorSnapshotsMock.mockRejectedValue(err)
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(502)
+    expect(await readJson(res)).toEqual({ error: 'Orchestrator unavailable' })
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns a 502 with the error message and logs on an unexpected failure', async () => {
+    listMirrorSnapshotsMock.mockRejectedValue(new Error('boom'))
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(502)
+    expect(await readJson(res)).toEqual({ error: 'boom' })
+    expect(consoleErrorSpy).toHaveBeenCalled()
+  })
+
+  it('returns a 502 with a generic message when the failure has no message', async () => {
+    listMirrorSnapshotsMock.mockRejectedValue({})
+    const res = await callRoute(getRoute)
+    expect(res.status).toBe(502)
+    expect(await readJson(res)).toEqual({ error: 'Failed to list snapshots' })
+  })
+})
+
+describe('POST /api/v1/orchestrator/replication/snapshots', () => {
+  const ownedItem = { cluster_id: 'conn-a', pool: 'rbd', image: 'vm-100-disk-0', snapshot: 's1' }
+  const foreignItem = { cluster_id: 'conn-zzz', pool: 'rbd', image: 'vm-200-disk-0', snapshot: 's2' }
+
+  it('returns 400 when items is empty', async () => {
+    const res = await callRoute(postRoute, { body: { items: [] } })
+    expect(res.status).toBe(400)
+    expect(await readJson(res)).toEqual({ error: 'items is required' })
+    expect(deleteMirrorSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty result without calling the orchestrator when every item is foreign', async () => {
+    const res = await callRoute(postRoute, { body: { items: [foreignItem] } })
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual({ deleted: [], failed: [] })
+    expect(deleteMirrorSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('forwards only the tenant-owned items and returns the orchestrator response', async () => {
+    const result = { deleted: [ownedItem], failed: [] }
+    deleteMirrorSnapshotsMock.mockResolvedValue({ data: result })
+    const res = await callRoute(postRoute, { body: { items: [ownedItem, foreignItem] } })
+    expect(res.status).toBe(200)
+    expect(await readJson(res)).toEqual(result)
+    expect(deleteMirrorSnapshotsMock).toHaveBeenCalledWith([ownedItem])
+  })
+
+  it('returns denied response when permission check fails', async () => {
+    checkPermissionMock.mockResolvedValue(deniedPermissionResponse())
+    const res = await callRoute(postRoute, { body: { items: [ownedItem] } })
+    expect(res.status).toBe(403)
+    expect(deleteMirrorSnapshotsMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a 500 with the error message when the orchestrator call fails', async () => {
+    deleteMirrorSnapshotsMock.mockRejectedValue(new Error('boom'))
+    const res = await callRoute(postRoute, { body: { items: [ownedItem] } })
+    expect(res.status).toBe(500)
+    expect(await readJson(res)).toEqual({ error: 'boom' })
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/replication/snapshots/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/replication/snapshots/route.ts
@@ -6,21 +6,39 @@ import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const denied = await checkPermission(PERMISSIONS.AUTOMATION_VIEW, "global", "*")
     if (denied) return denied
 
+    // Forward the filters the orchestrator already applies before doing any SSH
+    // work. They were unreachable from the UI because this handler took no
+    // request, so every screen paid for a full cluster-wide inventory.
+    const params = request.nextUrl.searchParams
+    const clusterId = params.get("cluster_id") || undefined
+    const vmidRaw = params.get("vmid")
+    const vmid = vmidRaw && /^\d+$/.test(vmidRaw) ? Number.parseInt(vmidRaw, 10) : undefined
+
     const tenantConnectionIds = await getTenantConnectionIds()
     const client = getOrchestratorClient()
-    const response = await client.listMirrorSnapshots()
+    const response = await client.listMirrorSnapshots({ clusterId, vmid })
 
     const all = Array.isArray(response.data) ? response.data : []
     const filtered = all.filter((s: any) => !s.cluster_id || tenantConnectionIds.has(s.cluster_id))
 
     return NextResponse.json(filtered)
-  } catch {
-    return NextResponse.json([])
+  } catch (e: any) {
+    // Never answer an empty array here. The inventory has no pagination, so a
+    // large estate times out routinely, and returning [] told the operator they
+    // had no snapshots at all when they had tens of thousands.
+    if (e?.code !== "ORCHESTRATOR_UNAVAILABLE") {
+      console.error("Error listing mirror snapshots:", e)
+    }
+
+    return NextResponse.json(
+      { error: e?.message || "Failed to list snapshots" },
+      { status: 502 }
+    )
   }
 }
 

--- a/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/CreateJobDialog.tsx
@@ -14,6 +14,7 @@ import { useTagColors } from '@/contexts/TagColorContext'
 import type { BandwidthWindow, CreateReplicationJobRequest } from '@/lib/orchestrator/site-recovery.types'
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
+import { cadenceSeconds, formatWindow, retentionWindowSeconds } from './schedule/retentionWindow'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
 import RetentionSlider from './RetentionSlider'
 import NumericTextField from '@/components/ui/NumericTextField'
@@ -76,6 +77,22 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
   const [bandwidthWindows, setBandwidthWindows] = useState<BandwidthWindow[]>([])
   const [keepSource, setKeepSource] = useState(3)
   const [keepTarget, setKeepTarget] = useState(3)
+
+  // Spell out the cadence the schedule will really produce and how far back the
+  // kept points reach. Without this the user has no way to know that an RPO of
+  // 30 minutes replicates every 10, and discovers the retention depth they
+  // actually got only once the job has been running for days.
+  const retentionCaption = useMemo(() => {
+    const cadence = cadenceSeconds(scheduleValue)
+    const covered = retentionWindowSeconds(cadence, keepTarget)
+
+    if (!cadence || !covered) return t('siteRecovery.createJob.retentionTargetHelp')
+
+    return t('siteRecovery.createJob.retentionCoverage', {
+      cadence: formatWindow(cadence),
+      window: formatWindow(covered),
+    })
+  }, [scheduleValue, keepTarget, t])
 
   // Ceph VM IDs for the source cluster (only VMs with disks on RBD storage)
   const { data: cephVMsData } = useSWR(
@@ -738,7 +755,7 @@ export default function CreateJobDialog({ open, onClose, onSubmit, connections, 
                 label={t('siteRecovery.createJob.retentionTarget')}
                 value={keepTarget}
                 onChange={setKeepTarget}
-                helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+                helperText={retentionCaption}
               />
             </Stack>
           </Box>

--- a/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/EditJobDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   Alert, Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle,
@@ -8,6 +8,7 @@ import {
 } from '@mui/material'
 import ScheduleBuilder from './schedule/ScheduleBuilder'
 import { defaultTimezone, type ScheduleBuilderValue } from './schedule/types'
+import { cadenceSeconds, formatWindow, retentionWindowSeconds } from './schedule/retentionWindow'
 import BandwidthWindowsEditor from './BandwidthWindowsEditor'
 import RetentionSlider from './RetentionSlider'
 import NumericTextField from '@/components/ui/NumericTextField'
@@ -39,6 +40,20 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [is409, setIs409] = useState(false)
+
+  // Same caption as the create dialog: the cadence the schedule really produces
+  // and how far back the kept points reach. See schedule/retentionWindow.ts.
+  const retentionCaption = useMemo(() => {
+    const cadence = cadenceSeconds(scheduleValue)
+    const covered = retentionWindowSeconds(cadence, keepTarget)
+
+    if (!cadence || !covered) return t('siteRecovery.createJob.retentionTargetHelp')
+
+    return t('siteRecovery.createJob.retentionCoverage', {
+      cadence: formatWindow(cadence),
+      window: formatWindow(covered),
+    })
+  }, [scheduleValue, keepTarget, t])
 
   useEffect(() => {
     if (!job) return
@@ -168,7 +183,7 @@ export default function EditJobDialog({ open, job, onClose, onSubmit, connection
                 label={t('siteRecovery.createJob.retentionTarget')}
                 value={keepTarget}
                 onChange={setKeepTarget}
-                helperText={t('siteRecovery.createJob.retentionTargetHelp')}
+                helperText={retentionCaption}
               />
             </Stack>
           </Box>

--- a/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
+++ b/frontend/src/components/automation/site-recovery/ProtectionTab.tsx
@@ -677,10 +677,14 @@ export default function ProtectionTab({
                 <StatusChip status={selected.status} t={t} />
               </Box>
 
-              {/* Actions — top placement for visibility, full-width equal split */}
+              {/* Actions: top placement for visibility, full-width equal split.
+                  The Tooltip wrappers are flex containers so the button inside
+                  stretches to the row height like its unwrapped siblings;
+                  "Sync Now" wrapping onto two lines otherwise left "Edit"
+                  visibly shorter than "Pause" and "Delete". */}
               <Box sx={{ display: 'flex', gap: 1, mb: 2, '& > *': { flex: 1, minWidth: 0 } }}>
                 <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} disableHoverListener={selected.status !== 'failed_over'} arrow>
-                  <span style={{ display: 'block' }}>
+                  <span style={{ display: 'flex' }}>
                     <Button
                       variant='contained' size='small' fullWidth
                       startIcon={<i className='ri-refresh-line' />}
@@ -693,7 +697,7 @@ export default function ProtectionTab({
                 </Tooltip>
                 {selected.status === 'failed_over' ? (
                   <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} arrow>
-                    <span style={{ display: 'block' }}>
+                    <span style={{ display: 'flex' }}>
                       <Button variant='outlined' size='small' fullWidth startIcon={<i className='ri-play-circle-line' />} disabled>
                         {t('siteRecovery.protection.resume')}
                       </Button>
@@ -709,7 +713,7 @@ export default function ProtectionTab({
                   </Button>
                 )}
                 <Tooltip title={t('siteRecovery.jobs.failedOverTooltip')} disableHoverListener={selected.status !== 'failed_over'} arrow>
-                  <span style={{ display: 'block' }}>
+                  <span style={{ display: 'flex' }}>
                     <Button
                       variant='outlined' size='small' fullWidth
                       startIcon={<i className='ri-edit-line' />}

--- a/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
+++ b/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
@@ -60,6 +60,42 @@ describe('FrequencyPicker interval mode', () => {
 
     expect(offeredValues).toEqual([...ALLOWED_INTERVAL_MINUTES])
   })
+
+  it('switching from Interval to Hourly seeds the hourly default', async () => {
+    renderWithProviders(<Harness initial={{ mode: 'interval', everyMinutes: 30 }} />)
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Hourly' }))
+
+    expect(spec()).toEqual({ mode: 'hourly', everyHours: 2 })
+  })
+
+  it('changing the interval value updates the spec', async () => {
+    renderWithProviders(<Harness initial={{ mode: 'interval', everyMinutes: 30 }} />)
+
+    await userEvent.click(screen.getByRole('combobox'))
+    await userEvent.click(screen.getByRole('option', { name: 'Every 2 hours' }))
+
+    expect(spec()).toEqual({ mode: 'interval', everyMinutes: 120 })
+  })
+
+  it('labels the options in minutes below an hour and in hours from one hour', async () => {
+    renderWithProviders(<Harness initial={{ mode: 'interval', everyMinutes: 30 }} />)
+
+    await userEvent.click(screen.getByRole('combobox'))
+    const labels = screen.getAllByRole('option').map(option => option.textContent)
+
+    expect(labels).toEqual(
+      expect.arrayContaining(['Every 1 minute', 'Every 30 minutes', 'Every 1 hour', 'Every 2 hours', 'Every 24 hours'])
+    )
+  })
+
+  it('re-selecting the current tab is a no-op', async () => {
+    renderWithProviders(<Harness initial={{ mode: 'interval', everyMinutes: 30 }} />)
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Interval' }))
+
+    expect(spec()).toEqual({ mode: 'interval', everyMinutes: 30 })
+  })
 })
 
 describe('FrequencyPicker numeric fields', () => {

--- a/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
+++ b/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.test.tsx
@@ -15,7 +15,7 @@ import { cleanup } from '@testing-library/react'
 import { renderWithProviders, screen, userEvent } from '@/__tests__/setup/renderWithProviders'
 
 import FrequencyPicker from './FrequencyPicker'
-import type { ScheduleSpec } from './types'
+import { ALLOWED_INTERVAL_MINUTES, type ScheduleSpec } from './types'
 
 afterEach(cleanup)
 
@@ -42,6 +42,25 @@ const blur = () => userEvent.click(screen.getByRole('button', { name: 'elsewhere
 async function enableWindow() {
   await userEvent.click(screen.getByRole('checkbox'))
 }
+
+describe('FrequencyPicker interval mode', () => {
+  it('selecting Interval yields a valid interval spec', async () => {
+    renderWithProviders(<Harness initial={hourly()} />)
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Interval' }))
+
+    expect(spec()).toEqual({ mode: 'interval', everyMinutes: 30 })
+  })
+
+  it('offers exactly the allowed interval values', async () => {
+    renderWithProviders(<Harness initial={{ mode: 'interval', everyMinutes: 30 }} />)
+
+    await userEvent.click(screen.getByRole('combobox'))
+    const offeredValues = screen.getAllByRole('option').map(option => Number(option.getAttribute('data-value')))
+
+    expect(offeredValues).toEqual([...ALLOWED_INTERVAL_MINUTES])
+  })
+})
 
 describe('FrequencyPicker numeric fields', () => {
   it('shows the interval it is given', () => {

--- a/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.tsx
+++ b/frontend/src/components/automation/site-recovery/schedule/FrequencyPicker.tsx
@@ -5,7 +5,7 @@ import {
   Box, Checkbox, FormControlLabel, IconButton, MenuItem, Select, Stack, Tab, Tabs, TextField, Typography
 } from '@mui/material'
 import NumericTextField from '@/components/ui/NumericTextField'
-import type { ScheduleSpec } from './types'
+import { ALLOWED_INTERVAL_MINUTES, type ScheduleSpec } from './types'
 
 interface Props {
   value: ScheduleSpec
@@ -20,7 +20,8 @@ export default function FrequencyPicker({ value, onChange, disabled }: Props) {
 
   const setMode = (mode: ScheduleSpec['mode']) => {
     if (mode === value.mode) return
-    if (mode === 'hourly') onChange({ mode: 'hourly', everyHours: 2 })
+    if (mode === 'interval') onChange({ mode: 'interval', everyMinutes: 30 })
+    else if (mode === 'hourly') onChange({ mode: 'hourly', everyHours: 2 })
     else if (mode === 'daily') onChange({ mode: 'daily', times: ['03:00'], weekdays: [0, 1, 2, 3, 4, 5, 6] })
     else if (mode === 'weekly') onChange({ mode: 'weekly', weekdays: [0], time: '03:00' })
     else if (mode === 'monthly') onChange({ mode: 'monthly', dayOfMonth: 1, time: '03:00' })
@@ -34,11 +35,36 @@ export default function FrequencyPicker({ value, onChange, disabled }: Props) {
         variant='fullWidth'
         sx={{ minHeight: 36, mb: 2, '& .MuiTab-root': { minHeight: 36, textTransform: 'none' } }}
       >
+        <Tab value='interval' label={t('siteRecovery.schedule.freq.interval')} disabled={disabled} />
         <Tab value='hourly' label={t('siteRecovery.schedule.freq.hourly')} disabled={disabled} />
         <Tab value='daily' label={t('siteRecovery.schedule.freq.daily')} disabled={disabled} />
         <Tab value='weekly' label={t('siteRecovery.schedule.freq.weekly')} disabled={disabled} />
         <Tab value='monthly' label={t('siteRecovery.schedule.freq.monthly')} disabled={disabled} />
       </Tabs>
+
+      {value.mode === 'interval' && (
+        <Box>
+          <Typography variant='caption'>{t('siteRecovery.schedule.interval')}</Typography>
+          <Select
+            size='small' fullWidth
+            value={value.everyMinutes}
+            onChange={e => onChange({ ...value, everyMinutes: Number(e.target.value) })}
+            disabled={disabled}
+          >
+            {ALLOWED_INTERVAL_MINUTES.map(minutes => (
+              <MenuItem key={minutes} value={minutes}>
+                {minutes < 60
+                  ? t(minutes === 1
+                    ? 'siteRecovery.schedule.labels.intervalMinute'
+                    : 'siteRecovery.schedule.labels.intervalMinutes', { n: minutes })
+                  : t(minutes === 60
+                    ? 'siteRecovery.schedule.labels.intervalHour'
+                    : 'siteRecovery.schedule.labels.intervalHours', { n: minutes / 60 })}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
 
       {value.mode === 'hourly' && (
         <Stack spacing={1.5}>

--- a/frontend/src/components/automation/site-recovery/schedule/retentionWindow.test.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/retentionWindow.test.ts
@@ -80,6 +80,28 @@ describe('cadenceSeconds', () => {
     ).toBe(86400)
   })
 
+  // Only the hour matters to the gap computation, so two times in the same
+  // hour count as one and the schedule is still once a day.
+  it('collapses daily times that share an hour into a single run', () => {
+    expect(
+      cadenceSeconds(
+        value({ mode: 'scheduled', scheduleSpec: { mode: 'daily', times: ['03:00', '03:30'], weekdays: [1] } })
+      )
+    ).toBe(86400)
+  })
+
+  it('reads a weekly spec as a seven day gap', () => {
+    expect(
+      cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: { mode: 'weekly', weekdays: [0], time: '03:00' } }))
+    ).toBe(7 * 86400)
+  })
+
+  it('reads a monthly spec as a thirty day gap', () => {
+    expect(
+      cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: { mode: 'monthly', dayOfMonth: 1, time: '03:00' } }))
+    ).toBe(30 * 86400)
+  })
+
   it('returns 0 when a scheduled value carries no spec, so the caller can skip the caption', () => {
     expect(cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: null }))).toBe(0)
   })

--- a/frontend/src/components/automation/site-recovery/schedule/retentionWindow.test.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/retentionWindow.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  RPO_SCHEDULE_DIVISOR,
+  cadenceSeconds,
+  formatWindow,
+  retentionWindowSeconds,
+} from './retentionWindow'
+import { defaultTimezone, type ScheduleBuilderValue } from './types'
+
+function value(partial: Partial<ScheduleBuilderValue>): ScheduleBuilderValue {
+  return {
+    mode: 'rpo',
+    rpoTargetSeconds: 1800,
+    scheduleSpec: null,
+    timezone: defaultTimezone(),
+    ...partial,
+  }
+}
+
+describe('cadenceSeconds', () => {
+  // The whole point of the caption: an RPO of 30 minutes does NOT replicate
+  // every 30 minutes, the orchestrator schedules at a third of it for margin.
+  // Users had no way to know, and discovered the retention depth they really
+  // got only after the job had been running for days.
+  it('reports the real cadence of an RPO target, not the target itself', () => {
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 1800 }))).toBe(600)
+    expect(RPO_SCHEDULE_DIVISOR).toBe(3)
+  })
+
+  it('never reports a cadence below one minute', () => {
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 30 }))).toBe(60)
+  })
+
+  // rpoToCron divides by 180 in WHOLE minutes, so the cadence is always a
+  // multiple of a minute (or of an hour past 60 minutes). A 5 minute RPO runs
+  // `*/1`, i.e. every 60 seconds, not every 100: dividing the seconds by three
+  // overstated the window by half at that setting.
+  it('truncates to whole minutes exactly like the orchestrator cron', () => {
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 300 }))).toBe(60)
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 900 }))).toBe(300)
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 3600 }))).toBe(1200)
+    // 24 hours: 480 minutes, so `0 */8`, every 8 hours
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 86400 }))).toBe(8 * 3600)
+    // past 60 minutes the hour field truncates again: 100 minutes runs hourly
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 100 * 180 }))).toBe(3600)
+    // 1440 minutes or more between runs (a 3 day RPO) collapses to once a day
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 1440 * 180 }))).toBe(86400)
+    expect(cadenceSeconds(value({ mode: 'rpo', rpoTargetSeconds: 10 * 1440 * 180 }))).toBe(86400)
+  })
+
+  it('takes an interval spec at face value', () => {
+    expect(
+      cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: { mode: 'interval', everyMinutes: 30 } }))
+    ).toBe(1800)
+  })
+
+  it('reads an hourly spec', () => {
+    expect(
+      cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: { mode: 'hourly', everyHours: 4 } }))
+    ).toBe(4 * 3600)
+  })
+
+  // deriveRPOSeconds returns the NARROWEST gap, which is right for an RPO
+  // promise. Retention depth is bounded by the WIDEST one, so this must not
+  // reuse it: 09:00 and 17:00 leave a 16 hour gap overnight, not an 8 hour one.
+  it('uses the widest gap of an irregular daily schedule, not the narrowest', () => {
+    expect(
+      cadenceSeconds(
+        value({ mode: 'scheduled', scheduleSpec: { mode: 'daily', times: ['09:00', '17:00'], weekdays: [1] } })
+      )
+    ).toBe(16 * 3600)
+  })
+
+  it('treats a single daily time as a full day', () => {
+    expect(
+      cadenceSeconds(
+        value({ mode: 'scheduled', scheduleSpec: { mode: 'daily', times: ['03:00'], weekdays: [1] } })
+      )
+    ).toBe(86400)
+  })
+
+  it('returns 0 when a scheduled value carries no spec, so the caller can skip the caption', () => {
+    expect(cadenceSeconds(value({ mode: 'scheduled', scheduleSpec: null }))).toBe(0)
+  })
+})
+
+describe('retentionWindowSeconds', () => {
+  // N points spaced by the cadence span N-1 intervals, not N.
+  it('spans one interval fewer than the number of points', () => {
+    expect(retentionWindowSeconds(1800, 336)).toBe(335 * 1800)
+    expect(retentionWindowSeconds(600, 2)).toBe(600)
+  })
+
+  it('is zero when a single point or none is kept, since one point spans nothing', () => {
+    expect(retentionWindowSeconds(1800, 1)).toBe(0)
+    expect(retentionWindowSeconds(1800, 0)).toBe(0)
+  })
+
+  it('is zero when the cadence is unknown', () => {
+    expect(retentionWindowSeconds(0, 336)).toBe(0)
+    expect(retentionWindowSeconds(-1, 336)).toBe(0)
+  })
+
+  // The case the customer asked for: 30 minutes and 7 days of restore points.
+  it('confirms that 336 points at a true 30 minute cadence covers a week', () => {
+    const week = 7 * 86400
+    const covered = retentionWindowSeconds(1800, 336)
+
+    expect(covered).toBeLessThanOrEqual(week)
+    expect(covered).toBeGreaterThan(week - 2 * 1800)
+  })
+})
+
+describe('formatWindow', () => {
+  it('formats the units a reader cares about', () => {
+    expect(formatWindow(45 * 60)).toBe('45m')
+    expect(formatWindow(6 * 3600)).toBe('6h')
+    expect(formatWindow(6 * 3600 + 30 * 60)).toBe('6h 30m')
+    expect(formatWindow(3 * 86400)).toBe('3d')
+    expect(formatWindow(3 * 86400 + 11 * 3600)).toBe('3d 11h')
+  })
+
+  it('returns an empty string for nothing, so the caller can drop the caption', () => {
+    expect(formatWindow(0)).toBe('')
+    expect(formatWindow(-5)).toBe('')
+  })
+})

--- a/frontend/src/components/automation/site-recovery/schedule/retentionWindow.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/retentionWindow.ts
@@ -1,0 +1,102 @@
+import { type ScheduleBuilderValue, type ScheduleSpec } from './types'
+
+/**
+ * How much faster than the stated RPO target the orchestrator schedules a job.
+ *
+ * ⚠️ Mirrors rpoToCron in internal/replication/schedule_spec.go, which divides
+ * the RPO target by 180 seconds to get a cron interval in minutes, i.e. runs at
+ * a third of the target for margin. It is the reason a job labelled "30 minutes"
+ * replicates every ten, and the reason the user has to be told the difference
+ * rather than discover it in production.
+ */
+export const RPO_SCHEDULE_DIVISOR = 3
+
+/**
+ * The cadence rpoToCron really produces, in seconds.
+ *
+ * Step for step the same arithmetic as the Go function, because cron only
+ * takes whole minutes and whole hours: `rpoSec / 180` truncated to minutes
+ * (floor 1), then, at 60 minutes and beyond, truncated again to hours, and
+ * once a day past 24 hours. Dividing the seconds by three instead gave 100 s
+ * for a 5 minute RPO where the cron fires every 60, and the caption overstated
+ * the window by half.
+ */
+function rpoCadenceSeconds(rpoTargetSeconds: number): number {
+  const intervalMin = Math.floor(rpoTargetSeconds / (RPO_SCHEDULE_DIVISOR * 60))
+  if (intervalMin < 1) return 60
+  if (intervalMin < 60) return intervalMin * 60
+
+  const hours = Math.floor(intervalMin / 60)
+  if (hours < 24) return hours * 3600
+
+  return 86400
+}
+
+/**
+ * The WIDEST gap a schedule produces, in seconds.
+ *
+ * Deliberately not deriveRPOSeconds(), which returns the narrowest gap. Both are
+ * right for their own question: the narrowest bounds the data loss an RPO
+ * promises, the widest bounds how far back a fixed number of restore points
+ * reaches. Using the narrowest here would overstate the retention depth of any
+ * irregular schedule.
+ */
+export function cadenceSeconds(value: ScheduleBuilderValue): number {
+  if (value.mode === 'rpo') {
+    return rpoCadenceSeconds(value.rpoTargetSeconds)
+  }
+  if (!value.scheduleSpec) return 0
+
+  return widestGapSeconds(value.scheduleSpec)
+}
+
+function widestGapSeconds(spec: ScheduleSpec): number {
+  switch (spec.mode) {
+    case 'interval':
+      return spec.everyMinutes * 60
+    case 'hourly':
+      return spec.everyHours * 3600
+    case 'daily': {
+      const hours = Array.from(new Set(spec.times.map(t => Number.parseInt(t.slice(0, 2), 10)))).sort(
+        (a, b) => a - b
+      )
+      if (hours.length <= 1) return 86400
+      let widest = 0
+      for (let i = 1; i < hours.length; i++) {
+        widest = Math.max(widest, hours[i] - hours[i - 1])
+      }
+      widest = Math.max(widest, 24 - hours[hours.length - 1] + hours[0])
+
+      return widest * 3600
+    }
+    case 'weekly':
+      return 7 * 86400
+    case 'monthly':
+      return 30 * 86400
+  }
+}
+
+/** How far back `keep` restore points reach at a given cadence. */
+export function retentionWindowSeconds(cadenceSec: number, keep: number): number {
+  if (cadenceSec <= 0 || keep <= 1) return 0
+
+  // N points spaced by the cadence span N-1 intervals.
+  return (keep - 1) * cadenceSec
+}
+
+/**
+ * Compact, non-technical duration: "45 minutes", "6 hours", "3 days 11 hours".
+ * Returns an empty string for zero, so callers can skip the caption entirely.
+ */
+export function formatWindow(seconds: number): string {
+  if (seconds <= 0) return ''
+
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`
+  if (hours > 0) return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`
+
+  return `${minutes}m`
+}

--- a/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.test.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { scheduleToCron } from './scheduleToCron'
+import { deriveRPOSeconds, scheduleToCron } from './scheduleToCron'
 import { ALLOWED_INTERVAL_MINUTES, type ScheduleSpec } from './types'
 
 describe('scheduleToCron', () => {
@@ -54,6 +54,21 @@ describe('scheduleToCron', () => {
 
   it('throws on dayOfMonth out of range', () => {
     expect(() => scheduleToCron({ mode: 'monthly', dayOfMonth: 29, time: '03:00' }, '')).toThrow()
+  })
+})
+
+describe('deriveRPOSeconds', () => {
+  // The interval mode is the one whose RPO is the interval itself; the other
+  // modes derive theirs from the narrowest gap between two runs.
+  it.each<[ScheduleSpec, number]>([
+    [{ mode: 'interval', everyMinutes: 15 }, 900],
+    [{ mode: 'interval', everyMinutes: 120 }, 7200],
+    [{ mode: 'hourly', everyHours: 4 }, 4 * 3600],
+    [{ mode: 'daily', times: ['09:00', '17:00'], weekdays: [1] }, 8 * 3600],
+    [{ mode: 'weekly', weekdays: [0], time: '03:00' }, 7 * 86400],
+    [{ mode: 'monthly', dayOfMonth: 1, time: '03:00' }, 30 * 86400],
+  ])('%j → %i seconds', (spec, expected) => {
+    expect(deriveRPOSeconds(spec)).toBe(expected)
   })
 })
 

--- a/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.test.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { scheduleToCron } from './scheduleToCron'
-import type { ScheduleSpec } from './types'
+import { ALLOWED_INTERVAL_MINUTES, type ScheduleSpec } from './types'
 
 describe('scheduleToCron', () => {
   it.each<[ScheduleSpec, string, string]>([
@@ -15,6 +15,35 @@ describe('scheduleToCron', () => {
     expect(scheduleToCron(spec, tz)).toBe(expected)
   })
 
+  it.each<[number, string]>([
+    [1, '*/1 * * * *'],
+    [2, '*/2 * * * *'],
+    [3, '*/3 * * * *'],
+    [4, '*/4 * * * *'],
+    [5, '*/5 * * * *'],
+    [6, '*/6 * * * *'],
+    [10, '*/10 * * * *'],
+    [12, '*/12 * * * *'],
+    [15, '*/15 * * * *'],
+    [20, '*/20 * * * *'],
+    [30, '*/30 * * * *'],
+    [60, '0 */1 * * *'],
+    [120, '0 */2 * * *'],
+    [180, '0 */3 * * *'],
+    [240, '0 */4 * * *'],
+    [360, '0 */6 * * *'],
+    [480, '0 */8 * * *'],
+    [720, '0 */12 * * *'],
+    [1440, '0 0 * * *'],
+  ])('maps a %i-minute interval to %s', (everyMinutes, expected) => {
+    expect(ALLOWED_INTERVAL_MINUTES).toContain(everyMinutes)
+    expect(scheduleToCron({ mode: 'interval', everyMinutes }, '')).toBe(expected)
+  })
+
+  it('rejects a sub-hourly interval that does not divide 60', () => {
+    expect(() => scheduleToCron({ mode: 'interval', everyMinutes: 7 }, '')).toThrow()
+  })
+
   it('throws on empty weekdays', () => {
     expect(() => scheduleToCron({ mode: 'daily', times: ['03:00'], weekdays: [] }, '')).toThrow()
   })
@@ -25,5 +54,25 @@ describe('scheduleToCron', () => {
 
   it('throws on dayOfMonth out of range', () => {
     expect(() => scheduleToCron({ mode: 'monthly', dayOfMonth: 29, time: '03:00' }, '')).toThrow()
+  })
+})
+
+// Pins the list so any change to it is a deliberate act, and points at the
+// authoritative copy. The orchestrator rejects anything outside its own list
+// (internal/replication/schedule_spec.go, AllowedIntervalMinutes), so a value
+// added here alone produces a schedule the user cannot save.
+describe('ALLOWED_INTERVAL_MINUTES stays in step with the orchestrator', () => {
+  it('is exactly the set the orchestrator accepts', () => {
+    expect([...ALLOWED_INTERVAL_MINUTES]).toEqual([
+      1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30,
+      60, 120, 180, 240, 360, 480, 720, 1440,
+    ])
+  })
+
+  it('never offers a sub-hourly value that fails to divide 60', () => {
+    for (const m of ALLOWED_INTERVAL_MINUTES) {
+      if (m < 60) expect(60 % m).toBe(0)
+      else expect(m % 60).toBe(0)
+    }
   })
 })

--- a/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/scheduleToCron.ts
@@ -1,8 +1,11 @@
-import type { ScheduleSpec } from './types'
+import { ALLOWED_INTERVAL_MINUTES, type ScheduleSpec } from './types'
 
 export function scheduleToCron(spec: ScheduleSpec, tz: string): string {
   let body: string
   switch (spec.mode) {
+    case 'interval':
+      body = intervalToCron(spec)
+      break
     case 'hourly':
       body = hourlyToCron(spec)
       break
@@ -19,6 +22,15 @@ export function scheduleToCron(spec: ScheduleSpec, tz: string): string {
       throw new Error(`unknown schedule mode`)
   }
   return tz ? `CRON_TZ=${tz} ${body}` : body
+}
+
+function intervalToCron(s: Extract<ScheduleSpec, { mode: 'interval' }>): string {
+  if (!(ALLOWED_INTERVAL_MINUTES as readonly number[]).includes(s.everyMinutes)) {
+    throw new Error('everyMinutes must be an allowed interval')
+  }
+  if (s.everyMinutes < 60) return `*/${s.everyMinutes} * * * *`
+  if (s.everyMinutes === 1440) return '0 0 * * *'
+  return `0 */${s.everyMinutes / 60} * * *`
 }
 
 function hourlyToCron(s: Extract<ScheduleSpec, { mode: 'hourly' }>): string {
@@ -96,6 +108,8 @@ function weekdaysField(days: number[]): string {
 
 export function deriveRPOSeconds(spec: ScheduleSpec): number {
   switch (spec.mode) {
+    case 'interval':
+      return spec.everyMinutes * 60
     case 'hourly':
       return spec.everyHours * 3600
     case 'daily': {

--- a/frontend/src/components/automation/site-recovery/schedule/scheduleToLabel.test.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/scheduleToLabel.test.ts
@@ -4,6 +4,10 @@ import type { ScheduleSpec } from './types'
 
 const t = (key: string, params?: Record<string, string | number>): string => {
   const dict: Record<string, string> = {
+    'siteRecovery.schedule.labels.intervalMinute': 'Every {n} minute',
+    'siteRecovery.schedule.labels.intervalMinutes': 'Every {n} minutes',
+    'siteRecovery.schedule.labels.intervalHour': 'Every {n} hour',
+    'siteRecovery.schedule.labels.intervalHours': 'Every {n} hours',
     'siteRecovery.schedule.labels.dailyAllDays': 'Every day at {time}',
     'siteRecovery.schedule.labels.dailyWeekdays': 'Weekdays at {time}',
     'siteRecovery.schedule.labels.dailyCustom': '{days} at {time}',
@@ -26,6 +30,15 @@ const t = (key: string, params?: Record<string, string | number>): string => {
 }
 
 describe('scheduleToLabel', () => {
+  it.each<[ScheduleSpec, string]>([
+    [{ mode: 'interval', everyMinutes: 1 }, 'Every 1 minute'],
+    [{ mode: 'interval', everyMinutes: 30 }, 'Every 30 minutes'],
+    [{ mode: 'interval', everyMinutes: 60 }, 'Every 1 hour'],
+    [{ mode: 'interval', everyMinutes: 120 }, 'Every 2 hours'],
+  ])('interval singular and plural: %j', (spec, expected) => {
+    expect(scheduleToLabel(spec, '', t)).toBe(expected)
+  })
+
   it('daily all days', () => {
     const spec: ScheduleSpec = { mode: 'daily', times: ['03:00'], weekdays: [0, 1, 2, 3, 4, 5, 6] }
     expect(scheduleToLabel(spec, '', t)).toBe('Every day at 03:00')

--- a/frontend/src/components/automation/site-recovery/schedule/scheduleToLabel.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/scheduleToLabel.ts
@@ -12,6 +12,14 @@ export function scheduleToLabel(spec: ScheduleSpec, tz: string, t: TFn): string 
 
 function baseLabel(spec: ScheduleSpec, t: TFn): string {
   switch (spec.mode) {
+    case 'interval':
+      return spec.everyMinutes < 60
+        ? t(spec.everyMinutes === 1
+          ? 'siteRecovery.schedule.labels.intervalMinute'
+          : 'siteRecovery.schedule.labels.intervalMinutes', { n: spec.everyMinutes })
+        : t(spec.everyMinutes === 60
+          ? 'siteRecovery.schedule.labels.intervalHour'
+          : 'siteRecovery.schedule.labels.intervalHours', { n: spec.everyMinutes / 60 })
     case 'hourly': {
       if (spec.windowStart === undefined || spec.windowEnd === undefined) {
         return t('siteRecovery.schedule.labels.hourlyEvery', { n: spec.everyHours })

--- a/frontend/src/components/automation/site-recovery/schedule/types.ts
+++ b/frontend/src/components/automation/site-recovery/schedule/types.ts
@@ -1,6 +1,23 @@
 export type ScheduleMode = 'rpo' | 'scheduled'
 
+// Cadences the interval schedule mode accepts.
+//
+// Below 60, only divisors of 60 produce a REGULAR gap: `*/7` in a cron minute
+// field fires at 0,7,...,56 and then again at the next hour's 0, a 4 minute
+// gap, so the schedule would not honour the interval it claims. The same
+// reasoning applies to hours against 24.
+//
+// ⚠️ The orchestrator holds the authoritative copy in
+// internal/replication/schedule_spec.go (AllowedIntervalMinutes) and rejects
+// anything else. These two lists must stay identical: a value offered here and
+// refused there is a job the user cannot save.
+export const ALLOWED_INTERVAL_MINUTES = [
+  1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30,
+  60, 120, 180, 240, 360, 480, 720, 1440,
+] as const
+
 export type ScheduleSpec =
+  | { mode: 'interval'; everyMinutes: number }
   | { mode: 'hourly'; everyHours: number; windowStart?: number; windowEnd?: number }
   | { mode: 'daily'; times: string[]; weekdays: number[] }
   | { mode: 'weekly'; weekdays: number[]; time: string }

--- a/frontend/src/lib/orchestrator/client.test.ts
+++ b/frontend/src/lib/orchestrator/client.test.ts
@@ -206,6 +206,57 @@ describe('OrchestratorClient axios-style wrapper', () => {
     expect(url).toBe('http://localhost:8080/api/v1/metrics/conn-1/history')
   })
 
+  it('listMirrorSnapshots hits /replication/snapshots with GET and no query string by default', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().listMirrorSnapshots()
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/snapshots')
+    expect(init.method).toBe('GET')
+  })
+
+  it('listMirrorSnapshots forwards the cluster_id filter', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().listMirrorSnapshots({ clusterId: 'conn-1' })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/snapshots?cluster_id=conn-1')
+  })
+
+  it('listMirrorSnapshots forwards the vmid filter', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().listMirrorSnapshots({ vmid: 100 })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/snapshots?vmid=100')
+  })
+
+  it('listMirrorSnapshots forwards both filters and keeps a zero vmid', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().listMirrorSnapshots({ clusterId: 'conn-1', vmid: 0 })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/snapshots?cluster_id=conn-1&vmid=0')
+  })
+
+  it('listMirrorSnapshots omits the query string for an empty cluster_id', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([]))
+
+    const { getOrchestratorClient } = await import('./client')
+    await getOrchestratorClient().listMirrorSnapshots({ clusterId: '' })
+
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toBe('http://localhost:8080/api/v1/replication/snapshots')
+  })
+
   it('getRecommendations toggles the validate query flag', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse([]))
 

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -473,8 +473,15 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
     return this.delete<{ status: string; purged_snapshots?: number }>(`/replication/jobs/${id}`)
   }
 
-  listMirrorSnapshots() {
-    return this.get<any[]>('/replication/snapshots')
+  // The orchestrator applies these filters before touching any node, so passing
+  // them through is the difference between one `rbd ls` and a cluster-wide scan.
+  listMirrorSnapshots(filters: { clusterId?: string; vmid?: number } = {}) {
+    const q = new URLSearchParams()
+    if (filters.clusterId) q.set('cluster_id', filters.clusterId)
+    if (typeof filters.vmid === 'number') q.set('vmid', String(filters.vmid))
+    const suffix = q.toString() ? `?${q.toString()}` : ''
+
+    return this.get<any[]>(`/replication/snapshots${suffix}`)
   }
 
   getSnapshotUsage(cluster: string, pool: string, image: string, snap: string) {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4330,17 +4330,20 @@
       "engineComingSoon": "Kommt bald",
       "pvNote": "Installieren Sie das <pv>pv</pv>-Paket auf Quell- und Ziel-Nodes, um den Replikationsfortschritt anzuzeigen.",
       "pvInstallLabel": "<pv>pv</pv> automatisch auf Quell-Nodes installieren",
-      "pvInstallDesc": "Erforderlich zur Verfolgung des Replikationsfortschritts. Führt apt-get install pv via SSH aus."
+      "pvInstallDesc": "Erforderlich zur Verfolgung des Replikationsfortschritts. Führt apt-get install pv via SSH aus.",
+      "retentionCoverage": "Replikation alle {cadence}, diese Punkte decken {window} ab"
     },
     "schedule": {
       "modeRpo": "Kontinuierlich (RPO)",
       "modeScheduled": "Geplant",
       "freq": {
+        "interval": "Intervall",
         "hourly": "Stündlich",
         "daily": "Täglich",
         "weekly": "Wöchentlich",
         "monthly": "Monatlich"
       },
+      "interval": "Ausführen alle",
       "everyNHours": "Alle N Stunden",
       "hourWindow": "Auf Zeitfenster beschränken",
       "startHour": "Startstunde",
@@ -4361,6 +4364,10 @@
         "sat": "Sa"
       },
       "labels": {
+        "intervalMinute": "Alle {n} Minute",
+        "intervalMinutes": "Alle {n} Minuten",
+        "intervalHour": "Alle {n} Stunde",
+        "intervalHours": "Alle {n} Stunden",
         "dailyAllDays": "Täglich um {time}",
         "dailyWeekdays": "Werktags um {time}",
         "dailyCustom": "{days} um {time}",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4353,17 +4353,20 @@
       "engineComingSoon": "Coming soon",
       "pvNote": "Install the <pv>pv</pv> package on source and target nodes to display replication progress.",
       "pvInstallLabel": "Install <pv>pv</pv> automatically on source nodes",
-      "pvInstallDesc": "Required to track replication progress. Will run apt-get install pv via SSH."
+      "pvInstallDesc": "Required to track replication progress. Will run apt-get install pv via SSH.",
+      "retentionCoverage": "Replicates every {cadence}, so these points cover {window}"
     },
     "schedule": {
       "modeRpo": "Continuous (RPO)",
       "modeScheduled": "Scheduled",
       "freq": {
+        "interval": "Interval",
         "hourly": "Hourly",
         "daily": "Daily",
         "weekly": "Weekly",
         "monthly": "Monthly"
       },
+      "interval": "Run every",
       "everyNHours": "Every N hours",
       "hourWindow": "Limit to time window",
       "startHour": "Start hour",
@@ -4384,6 +4387,10 @@
         "sat": "Sat"
       },
       "labels": {
+        "intervalMinute": "Every {n} minute",
+        "intervalMinutes": "Every {n} minutes",
+        "intervalHour": "Every {n} hour",
+        "intervalHours": "Every {n} hours",
         "dailyAllDays": "Every day at {time}",
         "dailyWeekdays": "Weekdays at {time}",
         "dailyCustom": "{days} at {time}",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4353,17 +4353,20 @@
       "engineComingSoon": "Próximamente",
       "pvNote": "Instala el paquete <pv>pv</pv> en los nodos origen y destino para mostrar el progreso de la replicación.",
       "pvInstallLabel": "Instalar <pv>pv</pv> automáticamente en los nodos origen",
-      "pvInstallDesc": "Necesario para seguir el progreso de la replicación. Ejecutará apt-get install pv mediante SSH."
+      "pvInstallDesc": "Necesario para seguir el progreso de la replicación. Ejecutará apt-get install pv mediante SSH.",
+      "retentionCoverage": "Replica cada {cadence}, estos puntos cubren {window}"
     },
     "schedule": {
       "modeRpo": "Continuo (RPO)",
       "modeScheduled": "Programado",
       "freq": {
+        "interval": "Intervalo",
         "hourly": "Cada hora",
         "daily": "Diario",
         "weekly": "Semanal",
         "monthly": "Mensual"
       },
+      "interval": "Ejecutar cada",
       "everyNHours": "Cada N horas",
       "hourWindow": "Limitar a ventana horaria",
       "startHour": "Hora de inicio",
@@ -4384,6 +4387,10 @@
         "sat": "Sáb"
       },
       "labels": {
+        "intervalMinute": "Cada {n} minuto",
+        "intervalMinutes": "Cada {n} minutos",
+        "intervalHour": "Cada {n} hora",
+        "intervalHours": "Cada {n} horas",
         "dailyAllDays": "Todos los días a las {time}",
         "dailyWeekdays": "Días laborables a las {time}",
         "dailyCustom": "{days} a las {time}",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4353,17 +4353,20 @@
       "engineComingSoon": "Bientôt disponible",
       "pvNote": "Installez le paquet <pv>pv</pv> sur les nœuds source et cible pour afficher la progression des réplications.",
       "pvInstallLabel": "Installer <pv>pv</pv> automatiquement sur les nœuds source",
-      "pvInstallDesc": "Nécessaire pour suivre la progression des réplications. Exécutera apt-get install pv via SSH."
+      "pvInstallDesc": "Nécessaire pour suivre la progression des réplications. Exécutera apt-get install pv via SSH.",
+      "retentionCoverage": "Réplique toutes les {cadence}, ces points couvrent {window}"
     },
     "schedule": {
       "modeRpo": "Continu (RPO)",
       "modeScheduled": "Planifié",
       "freq": {
+        "interval": "Intervalle",
         "hourly": "Horaire",
         "daily": "Quotidien",
         "weekly": "Hebdomadaire",
         "monthly": "Mensuel"
       },
+      "interval": "Exécuter toutes les",
       "everyNHours": "Toutes les N heures",
       "hourWindow": "Limiter à une plage horaire",
       "startHour": "Début",
@@ -4384,6 +4387,10 @@
         "sat": "Sam"
       },
       "labels": {
+        "intervalMinute": "Toutes les {n} minute",
+        "intervalMinutes": "Toutes les {n} minutes",
+        "intervalHour": "Toutes les {n} heure",
+        "intervalHours": "Toutes les {n} heures",
         "dailyAllDays": "Tous les jours à {time}",
         "dailyWeekdays": "Jours ouvrés à {time}",
         "dailyCustom": "{days} à {time}",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4353,17 +4353,20 @@
       "engineComingSoon": "출시 예정",
       "pvNote": "복제 진행률을 표시하려면 소스 및 대상 노드에 <pv>pv</pv> 패키지를 설치하세요.",
       "pvInstallLabel": "소스 노드에 <pv>pv</pv> 자동 설치",
-      "pvInstallDesc": "복제 진행률 추적에 필요합니다. SSH를 통해 apt-get install pv를 실행합니다."
+      "pvInstallDesc": "복제 진행률 추적에 필요합니다. SSH를 통해 apt-get install pv를 실행합니다.",
+      "retentionCoverage": "{cadence}마다 복제되며, 이 복원 지점들은 {window}를 포함합니다"
     },
     "schedule": {
       "modeRpo": "연속 (RPO)",
       "modeScheduled": "예약",
       "freq": {
+        "interval": "간격",
         "hourly": "매시간",
         "daily": "매일",
         "weekly": "매주",
         "monthly": "매월"
       },
+      "interval": "실행 간격",
       "everyNHours": "N시간마다",
       "hourWindow": "시간대 제한",
       "startHour": "시작 시각",
@@ -4384,6 +4387,10 @@
         "sat": "토"
       },
       "labels": {
+        "intervalMinute": "{n}분마다",
+        "intervalMinutes": "{n}분마다",
+        "intervalHour": "{n}시간마다",
+        "intervalHours": "{n}시간마다",
         "dailyAllDays": "매일 {time}에",
         "dailyWeekdays": "평일 {time}에",
         "dailyCustom": "{days} {time}에",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4329,17 +4329,20 @@
       "engineComingSoon": "即将推出",
       "pvNote": "在源和目标节点上安装 <pv>pv</pv> 包以显示复制进度。",
       "pvInstallLabel": "在源节点上自动安装 <pv>pv</pv>",
-      "pvInstallDesc": "跟踪复制进度所需。将通过 SSH 运行 apt-get install pv。"
+      "pvInstallDesc": "跟踪复制进度所需。将通过 SSH 运行 apt-get install pv。",
+      "retentionCoverage": "每 {cadence} 复制一次，这些还原点覆盖 {window}"
     },
     "schedule": {
       "modeRpo": "持续（RPO）",
       "modeScheduled": "计划",
       "freq": {
+        "interval": "间隔",
         "hourly": "每小时",
         "daily": "每日",
         "weekly": "每周",
         "monthly": "每月"
       },
+      "interval": "运行间隔",
       "everyNHours": "每 N 小时",
       "hourWindow": "限制在时间窗口",
       "startHour": "开始时间",
@@ -4360,6 +4363,10 @@
         "sat": "六"
       },
       "labels": {
+        "intervalMinute": "每 {n} 分钟",
+        "intervalMinutes": "每 {n} 分钟",
+        "intervalHour": "每 {n} 小时",
+        "intervalHours": "每 {n} 小时",
         "dailyAllDays": "每天 {time}",
         "dailyWeekdays": "工作日 {time}",
         "dailyCustom": "{days} {time}",


### PR DESCRIPTION
## What

The schedule builder gets an **Interval** frequency that states the cadence directly, in minutes. Only regular cadences are offered (the divisors of 60 minutes, then of 24 hours): `*/7` in a cron minute field fires at 0, 7, ..., 56 and then at the next hour's 0, a 4 minute gap, so the schedule would not honour the interval it claims. `ALLOWED_INTERVAL_MINUTES` in `schedule/types.ts` mirrors the orchestrator's authoritative list, with a cross reference on both sides.

The Create and Edit job dialogs now spell out, under the target retention slider, the cadence the chosen schedule really produces and how far back the kept restore points reach ("Replicates every 30m, so these points cover 6d 23h"). `schedule/retentionWindow.ts` derives it from the widest gap of the schedule. In RPO mode it reproduces the orchestrator arithmetic step for step (the target divided by 180 in whole minutes, then whole hours past 60), so a 5 minute RPO reads "every 1m, cover 2m" and a 30 minute RPO "every 10m": the user learns the RPO/3 margin in the dialog rather than in production.

The mirror snapshot proxy route no longer turns a failure into an empty list. It answers 502 with the reason, and forwards the `cluster_id` and `vmid` filters the orchestrator already applies before any SSH work; they were unreachable because the handler took no request. The client also types the three new fields of the job payload: `schedule_interval_seconds`, `retention_window_seconds` and `max_retention_window_seconds`.

A second commit fixes an unrelated cosmetic defect met during testing: in the job detail panel, the Tooltip wrappers around Sync Now and Edit are plain spans, so those buttons did not stretch to the row height like Pause and Delete when Sync Now wrapped onto two lines.

## Why

#709. An RPO target of 30 minutes replicates every 10, because the orchestrator schedules at a third of the target for margin. Seven days of retention at a 30 minute cadence therefore needed 1008 snapshots per disk, above the hard cap of 500, and nothing in the UI said so. The snapshot inventory compounded it at scale by showing "no snapshots" whenever the orchestrator timed out.

## Testing

`vitest` on `components/automation/site-recovery`, `api/v1/orchestrator/replication` and `lib/orchestrator`: 27 files, 301 tests. `retentionWindow.test.ts` is new and pins the RPO arithmetic against the orchestrator's; `FrequencyPicker`, `scheduleToCron` and `scheduleToLabel` tests cover the new mode. The first push had no test for the snapshot proxy route, which SonarCloud flagged at 72% new code coverage; `snapshots/route.test.ts` is new in the third commit and covers the tenant filter, the forwarded `cluster_id` and `vmid` parameters, the 502 path with and without `ORCHESTRATOR_UNAVAILABLE`, and the POST handler, and `client.test.ts` covers the `listMirrorSnapshots` query string. The measured new code coverage is 98% locally.

Validated end to end in the browser on a lab with two Ceph clusters (PVE 9, one VM with an RBD disk): a job created in Interval 30 min got `CRON_TZ=Europe/Paris */30 * * * *`, `schedule_interval_seconds: 1800`, `retention_window_seconds` matching the caption, and its next sync on the half hour; Edit reloaded the Interval mode and switching to 5 minutes gave `*/5`. With the orchestrator stopped, the inventory route answered `{"error":"Orchestrator unavailable"}` where it used to answer `[]`. The `cluster_id` and `vmid` filters were checked against the orchestrator directly.

The orchestrator side ships separately and must be deployed first: an older orchestrator refuses the new mode with `schedule_spec invalid: unknown schedule mode "interval"`, which the job creation route surfaces as a 500 instead of saving an invalid job.
