### PR TITLE
Updates: enterprise-only repositories no longer block a node with an active subscription

### DIFF
--- a/frontend/src/components/NodeUpdateDialog.tsx
+++ b/frontend/src/components/NodeUpdateDialog.tsx
@@ -35,7 +35,7 @@ import {
 
 import ConfirmCloseDialog from '@/components/ConfirmCloseDialog'
 import { NodeInfo, formatMemory } from '@/components/hardware/utils'
-import { computeRepoIssues, type RepoIssue } from '@/lib/proxmox/aptRepositories'
+import { loadNodeRepoIssues, type RepoIssue } from '@/lib/proxmox/aptRepositories'
 
 interface RunningVmInfo {
   vmid: number
@@ -315,17 +315,15 @@ export default function NodeUpdateDialog({
       })
       .catch(() => {})
 
-    fetch(`/api/v1/connections/${connectionId}/nodes/${encodeURIComponent(nodeName)}/apt/repositories`)
-      .then(res => res.json())
-      .then(json => {
-        // Guard on `data` itself, not on `standard_repos`: a node whose only
-        // problem is an unparsable file returns an empty repo list with a
-        // populated `errors[]`, and bailing here would hide it.
-        if (cancelled || !json.data) return
+    // Repositories and subscription status read together: enterprise-only
+    // repositories are only a problem without an active subscription. A null
+    // answer means the repositories could not be read, keep the previous verdict.
+    loadNodeRepoIssues(connectionId, nodeName)
+      .then(issues => {
+        if (cancelled || !issues) return
 
-        setRepoIssues(computeRepoIssues(json.data))
+        setRepoIssues(issues)
       })
-      .catch(() => {})
       .finally(() => {
         if (!cancelled) setRepoChecking(false)
       })

--- a/frontend/src/lib/proxmox/aptRepositories.test.ts
+++ b/frontend/src/lib/proxmox/aptRepositories.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   computeRepoIssues,
   formatRepoError,
   isRepoEnabled,
+  isSubscriptionActive,
+  loadNodeRepoIssues,
   readRepoErrors,
   readStandardRepos,
 } from './aptRepositories'
@@ -95,7 +97,7 @@ describe('computeRepoIssues on the real lab payload', () => {
   })
 
   it('does NOT flag ceph, whose no-subscription counterpart is enabled', () => {
-    expect(issues.some(i => i.kind === 'enterprise' && i.component === 'ceph-squid')).toBe(false)
+    expect(issues.some(i => i.kind === 'enterprise' && i.component === 'Ceph')).toBe(false)
   })
 
   it('surfaces both unparsable files with their full path', () => {
@@ -151,7 +153,7 @@ describe('computeRepoIssues', () => {
           { handle: 'ceph-squid-no-subscription' },
         ],
       })
-    ).toEqual([{ kind: 'enterprise', component: 'ceph-squid' }])
+    ).toEqual([{ kind: 'enterprise', component: 'Ceph' }])
   })
 
   it('stays silent when a ceph enterprise repo does have its no-subscription pair', () => {
@@ -208,5 +210,207 @@ describe('readRepoErrors', () => {
     expect(readRepoErrors({})).toEqual([])
     expect(readRepoErrors({ errors: 'boom' })).toEqual([])
     expect(readRepoErrors(null)).toEqual([])
+  })
+})
+
+/**
+ * The node of issue #853, rebuilt from the customer's screenshots (PVE 9.2.4,
+ * 2026-09-03): an active subscription and the production layout Proxmox
+ * recommends, PVE enterprise plus Ceph enterprise, no no-subscription
+ * repository anywhere. PVE lights BOTH Ceph release handles for their single
+ * ceph-squid repository, which is why the dialog listed three problems.
+ */
+const ISSUE_853_PAYLOAD = {
+  'standard-repos': [
+    { handle: 'enterprise', name: 'Enterprise', status: 1 },
+    { handle: 'no-subscription', name: 'No-Subscription' },
+    { handle: 'test', name: 'Test' },
+    { handle: 'ceph-squid-enterprise', name: 'Ceph Squid Enterprise', status: 1 },
+    { handle: 'ceph-squid-no-subscription', name: 'Ceph Squid No-Subscription' },
+    { handle: 'ceph-squid-test', name: 'Ceph Squid Test' },
+    { handle: 'ceph-tentacle-enterprise', name: 'Ceph Tentacle Enterprise', status: 1 },
+    { handle: 'ceph-tentacle-no-subscription', name: 'Ceph Tentacle No-Subscription' },
+    { handle: 'ceph-tentacle-test', name: 'Ceph Tentacle Test' },
+  ],
+  errors: [],
+}
+
+describe('computeRepoIssues with the subscription status, issue #853', () => {
+  it('lets a subscribed node keep its enterprise-only repositories', () => {
+    expect(computeRepoIssues(ISSUE_853_PAYLOAD, { subscriptionActive: true })).toEqual([])
+  })
+
+  it('still blocks the same layout on a node without an active subscription', () => {
+    expect(computeRepoIssues(ISSUE_853_PAYLOAD, { subscriptionActive: false })).toEqual([
+      { kind: 'enterprise' },
+      { kind: 'enterprise', component: 'Ceph' },
+    ])
+  })
+
+  it('treats an omitted subscription status as not active, the strict side', () => {
+    expect(computeRepoIssues(ISSUE_853_PAYLOAD)).toHaveLength(2)
+  })
+
+  it('reports Ceph once even though PVE lights every Ceph release handle', () => {
+    const ceph = computeRepoIssues(ISSUE_853_PAYLOAD).filter(i => i.kind === 'enterprise' && i.component)
+
+    expect(ceph).toEqual([{ kind: 'enterprise', component: 'Ceph' }])
+  })
+
+  it('keeps reporting unreadable files on a subscribed node, apt chokes on them regardless', () => {
+    expect(
+      computeRepoIssues({ ...ISSUE_853_PAYLOAD, errors: LAB_PVE9_PAYLOAD.errors }, { subscriptionActive: true })
+    ).toEqual([
+      { kind: 'parse', detail: '/etc/apt/sources.list.d/ceph.sources.BAK: invalid extension' },
+      { kind: 'parse', detail: '/etc/apt/sources.list.d/pve-enterprise.sources.BAK: invalid extension' },
+    ])
+  })
+})
+
+/**
+ * `pvesh get /nodes/pve1/apt/repositories` on the PVE 9 lab, 2026-09-03: one
+ * ceph.sources pointing at ceph-tentacle no-subscription, and PVE marks the
+ * squid AND tentacle no-subscription handles as enabled. A configured but
+ * disabled repo (pve-enterprise.sources here) carries `status: 0`.
+ */
+const LAB_PVE9_SINGLE_CEPH_REPO_PAYLOAD = {
+  'standard-repos': [
+    { handle: 'enterprise', status: 0 },
+    { handle: 'no-subscription', status: 1 },
+    { handle: 'test' },
+    { handle: 'ceph-squid-enterprise' },
+    { handle: 'ceph-squid-no-subscription', status: 1 },
+    { handle: 'ceph-squid-test' },
+    { handle: 'ceph-tentacle-enterprise' },
+    { handle: 'ceph-tentacle-no-subscription', status: 1 },
+    { handle: 'ceph-tentacle-test' },
+  ],
+  errors: [],
+}
+
+describe('computeRepoIssues on the lab node with a single Ceph repository', () => {
+  it('stays silent on the free layout even though two release handles light up', () => {
+    expect(computeRepoIssues(LAB_PVE9_SINGLE_CEPH_REPO_PAYLOAD)).toEqual([])
+  })
+})
+
+describe('isSubscriptionActive', () => {
+  it('accepts the active status PVE sends, whatever its casing or padding', () => {
+    expect(isSubscriptionActive('active')).toBe(true)
+    expect(isSubscriptionActive(' Active ')).toBe(true)
+  })
+
+  it('rejects every other status PVE can answer, and every non-string', () => {
+    for (const status of ['new', 'notfound', 'invalid', 'expired', 'suspended', 'unknown', '', undefined, null, 1, true]) {
+      expect(isSubscriptionActive(status)).toBe(false)
+    }
+  })
+})
+
+describe('loadNodeRepoIssues', () => {
+  type Answer = { json: unknown } | { reject: string } | { badJson: true }
+
+  /** A fetch that answers per URL suffix, recording every call. */
+  function fetchAnswering(answers: Record<string, Answer>) {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const impl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init })
+      const key = Object.keys(answers).find(k => url.endsWith(k))
+      const answer = key ? answers[key] : undefined
+
+      if (!answer) throw new Error(`unexpected fetch ${url}`)
+      if ('reject' in answer) throw new Error(answer.reject)
+
+      return {
+        json: async () => {
+          if ('badJson' in answer) throw new SyntaxError('Unexpected token <')
+
+          return answer.json
+        },
+      }
+    })
+
+    return { fetch: impl as unknown as typeof fetch, calls }
+  }
+
+  it('lets a subscribed node keep its enterprise-only repositories', async () => {
+    const { fetch, calls } = fetchAnswering({
+      '/apt/repositories': { json: { data: ISSUE_853_PAYLOAD } },
+      '/subscription': { json: { data: { status: 'active', level: 'c' } } },
+    })
+
+    await expect(loadNodeRepoIssues('conn-1', 'NAINTPVE01', fetch)).resolves.toEqual([])
+
+    expect(calls.map(c => c.url)).toEqual([
+      '/api/v1/connections/conn-1/nodes/NAINTPVE01/apt/repositories',
+      '/api/v1/connections/conn-1/nodes/NAINTPVE01/subscription',
+    ])
+    expect(calls[1].init).toEqual({ cache: 'no-store' })
+  })
+
+  it('blocks the same layout when the node has no subscription key', async () => {
+    const { fetch } = fetchAnswering({
+      '/apt/repositories': { json: { data: ISSUE_853_PAYLOAD } },
+      '/subscription': { json: { data: { status: 'notfound' } } },
+    })
+
+    await expect(loadNodeRepoIssues('conn-1', 'pve1', fetch)).resolves.toEqual([
+      { kind: 'enterprise' },
+      { kind: 'enterprise', component: 'Ceph' },
+    ])
+  })
+
+  it('treats an unreadable subscription as not active, the strict side', async () => {
+    const network = fetchAnswering({
+      '/apt/repositories': { json: { data: ISSUE_853_PAYLOAD } },
+      '/subscription': { reject: 'fetch failed' },
+    })
+    const html = fetchAnswering({
+      '/apt/repositories': { json: { data: ISSUE_853_PAYLOAD } },
+      '/subscription': { badJson: true },
+    })
+    const denied = fetchAnswering({
+      '/apt/repositories': { json: { data: ISSUE_853_PAYLOAD } },
+      '/subscription': { json: { error: 'Forbidden' } },
+    })
+
+    for (const { fetch } of [network, html, denied]) {
+      await expect(loadNodeRepoIssues('conn-1', 'pve1', fetch)).resolves.toHaveLength(2)
+    }
+  })
+
+  it('answers null when the repositories themselves could not be read', async () => {
+    const failed = fetchAnswering({
+      '/apt/repositories': { reject: 'fetch failed' },
+      '/subscription': { json: { data: { status: 'active' } } },
+    })
+    const errored = fetchAnswering({
+      '/apt/repositories': { json: { error: 'PVE 401' } },
+      '/subscription': { json: { data: { status: 'active' } } },
+    })
+
+    await expect(loadNodeRepoIssues('conn-1', 'pve1', failed.fetch)).resolves.toBeNull()
+    await expect(loadNodeRepoIssues('conn-1', 'pve1', errored.fetch)).resolves.toBeNull()
+  })
+
+  it('still reports an unparsable repository file on a subscribed node', async () => {
+    const { fetch } = fetchAnswering({
+      '/apt/repositories': { json: { data: { 'standard-repos': [], errors: LAB_PVE9_PAYLOAD.errors } } },
+      '/subscription': { json: { data: { status: 'active' } } },
+    })
+
+    await expect(loadNodeRepoIssues('conn-1', 'pve1', fetch)).resolves.toHaveLength(2)
+  })
+
+  it('encodes the node name in both URLs', async () => {
+    const { fetch, calls } = fetchAnswering({
+      '/apt/repositories': { json: { data: { 'standard-repos': [] } } },
+      '/subscription': { json: { data: { status: 'notfound' } } },
+    })
+
+    await loadNodeRepoIssues('conn-1', 'pve 1', fetch)
+
+    expect(calls[0].url).toBe('/api/v1/connections/conn-1/nodes/pve%201/apt/repositories')
+    expect(calls[1].url).toBe('/api/v1/connections/conn-1/nodes/pve%201/subscription')
   })
 })

--- a/frontend/src/lib/proxmox/aptRepositories.ts
+++ b/frontend/src/lib/proxmox/aptRepositories.ts
@@ -13,6 +13,12 @@
  *    matches anything.
  *  - Each `errors[]` item is `{ path, error }`. There is no `message` field, so
  *    reading one prints "undefined" and hides the offending file path.
+ *  - One Ceph repository lights EVERY Ceph release handle. proxmox-apt matches a
+ *    configured repository against a standard handle by URI or by signing key,
+ *    and all Ceph releases share the Proxmox key, so a single `ceph-squid`
+ *    repository reports both `ceph-squid-*` and `ceph-tentacle-*` as configured
+ *    (measured on PVE 9, 2026-09-03). Counting handles counts the same
+ *    repository twice.
  */
 
 export interface StandardRepo {
@@ -36,6 +42,18 @@ export type RepoIssue =
   | { kind: 'enterprise'; component?: string }
   | { kind: 'parse'; detail: string }
 
+export interface RepoIssueOptions {
+  /**
+   * Whether `GET /nodes/{node}/subscription` answered `status: "active"`.
+   * With an active subscription the enterprise repositories ARE the supported
+   * production setup and `apt update` authenticates against them, so they are
+   * not a problem (issue #853: a subscribed customer was refused every update).
+   * Unknown or unreadable counts as "no subscription", the side that still
+   * blocks an `apt update` doomed to a 401.
+   */
+  subscriptionActive?: boolean
+}
+
 /** Accepts the raw PVE payload or our own normalized `standard_repos` shape. */
 export function readStandardRepos(payload: any): StandardRepo[] {
   const list = payload?.['standard-repos'] ?? payload?.standard_repos
@@ -53,6 +71,15 @@ export function isRepoEnabled(status: number | boolean | null | undefined): bool
   return status === true || status === 1
 }
 
+/**
+ * `GET /nodes/{node}/subscription` says `status: "active"` for a valid key and
+ * `notfound`, `new`, `invalid`, `expired` or `suspended` otherwise. Only the
+ * first one means the enterprise repositories will serve packages.
+ */
+export function isSubscriptionActive(status: unknown): boolean {
+  return typeof status === 'string' && status.trim().toLowerCase() === 'active'
+}
+
 /** `/etc/apt/sources.list.d/x.sources.BAK: invalid extension` */
 export function formatRepoError(e: AptRepoError): string {
   const detail = [e?.path, e?.error].filter(Boolean).join(': ')
@@ -64,10 +91,61 @@ export function formatRepoError(e: AptRepoError): string {
  * Repository problems that make `apt update` fail on this node, so the update
  * wizard can refuse to start and say why.
  */
-export function computeRepoIssues(payload: any): RepoIssue[] {
+export function computeRepoIssues(payload: any, options: RepoIssueOptions = {}): RepoIssue[] {
+  const issues: RepoIssue[] = []
+
+  if (!options.subscriptionActive) {
+    issues.push(...enterpriseRepoIssues(readStandardRepos(payload)))
+  }
+
+  for (const e of readRepoErrors(payload)) {
+    issues.push({ kind: 'parse', detail: formatRepoError(e) })
+  }
+
+  return issues
+}
+
+/**
+ * The repository problems of a node as the update dialog needs them: the
+ * repository payload and the subscription status are read together, the
+ * latter deciding whether enterprise-only repositories count. A subscription
+ * that cannot be read counts as not active, the strict side. Returns `null`
+ * when the repository payload itself could not be read, so the caller keeps
+ * its previous verdict instead of reporting a clean node.
+ */
+export async function loadNodeRepoIssues(
+  connectionId: string,
+  nodeName: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<RepoIssue[] | null> {
+  const nodePath = `/api/v1/connections/${connectionId}/nodes/${encodeURIComponent(nodeName)}`
+
+  const [repositories, subscriptionActive] = await Promise.all([
+    fetchImpl(`${nodePath}/apt/repositories`)
+      .then(res => res.json())
+      .catch(() => null),
+    fetchImpl(`${nodePath}/subscription`, { cache: 'no-store' })
+      .then(res => res.json())
+      .then(json => isSubscriptionActive(json?.data?.status))
+      .catch(() => false),
+  ])
+
+  // Guard on `data` itself, not on `standard_repos`: a node whose only
+  // problem is an unparsable file returns an empty repo list with a
+  // populated `errors[]`, and bailing on that would hide it.
+  if (!repositories?.data) return null
+
+  return computeRepoIssues(repositories.data, { subscriptionActive })
+}
+
+/**
+ * Enterprise repositories enabled without their no-subscription counterpart,
+ * which only matters on a node whose subscription is not active.
+ */
+function enterpriseRepoIssues(repos: StandardRepo[]): RepoIssue[] {
   const status: Record<string, number | boolean | null | undefined> = {}
 
-  for (const repo of readStandardRepos(payload)) {
+  for (const repo of repos) {
     if (repo?.handle) status[repo.handle] = repo.status
   }
 
@@ -77,21 +155,32 @@ export function computeRepoIssues(payload: any): RepoIssue[] {
     issues.push({ kind: 'enterprise' })
   }
 
-  // Ceph and any future product ship their own `<product>-enterprise` /
-  // `<product>-no-subscription` pair alongside the PVE one.
+  // Ceph and any future product ship their own `<product>-<release>-enterprise`
+  // / `<product>-<release>-no-subscription` pair alongside the PVE one. One
+  // issue per product, not per release handle: PVE marks every release of a
+  // product as configured for a single repository (see the header note).
+  const flagged = new Set<string>()
+
   for (const [handle, s] of Object.entries(status)) {
-    if (isRepoEnabled(s) && handle.endsWith('-enterprise') && handle !== 'enterprise') {
-      const base = handle.replace(/-enterprise$/, '')
+    if (!isRepoEnabled(s) || handle === 'enterprise' || !handle.endsWith('-enterprise')) continue
 
-      if (!isRepoEnabled(status[`${base}-no-subscription`])) {
-        issues.push({ kind: 'enterprise', component: base })
-      }
-    }
-  }
+    const base = handle.replace(/-enterprise$/, '')
 
-  for (const e of readRepoErrors(payload)) {
-    issues.push({ kind: 'parse', detail: formatRepoError(e) })
+    if (isRepoEnabled(status[`${base}-no-subscription`])) continue
+
+    const product = repoProductLabel(base)
+
+    if (flagged.has(product)) continue
+    flagged.add(product)
+    issues.push({ kind: 'enterprise', component: product })
   }
 
   return issues
+}
+
+/** `ceph-squid` and `ceph-tentacle` are both the `Ceph` product. */
+function repoProductLabel(base: string): string {
+  const product = base.split('-')[0] || base
+
+  return product.charAt(0).toUpperCase() + product.slice(1)
 }

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -6397,7 +6397,7 @@
     "sshNotConfiguredTitle": "SSH nicht konfiguriert",
     "sshNotConfiguredDescription": "SSH-Zugriff ist für diese Verbindung nicht aktiviert. Konfigurieren Sie SSH-Anmeldedaten unter Einstellungen → Verbindungen, um Node-Updates zu verwenden.",
     "repoIssuesTitle": "Repository-Probleme ({count})",
-    "repoIssuesDescription": "Enterprise-Repositories sind ohne No-Subscription-Alternative aktiviert. Update-Befehle schlagen ohne gültiges Proxmox-Abonnement fehl. Aktivieren Sie das No-Subscription-Repository oder deaktivieren Sie das Enterprise-Repository auf den betroffenen Nodes.",
+    "repoIssuesDescription": "Enterprise-Repositories sind ohne No-Subscription-Alternative auf Nodes ohne aktives Proxmox-Abonnement aktiviert, apt update schlägt dort fehl. Aktivieren Sie das No-Subscription-Repository, deaktivieren Sie das Enterprise-Repository oder aktivieren Sie das Abonnement auf den betroffenen Nodes.",
     "repoEnterprisePve": "Das PVE-Enterprise-Repository ist ohne No-Subscription-Alternative aktiviert.",
     "repoEnterpriseComponent": "Das Enterprise-Repository {component} ist ohne No-Subscription-Alternative aktiviert.",
     "repoParseErrorsDescription": "APT kann eine oder mehrere Repository-Dateien auf diesem Node nicht lesen. Nur Dateien mit der Endung .list oder .sources werden ausgewertet, eine umbenannte Sicherung wie pve-enterprise.sources.BAK bricht daher jedes Update. Verschieben Sie diese Dateien aus /etc/apt/sources.list.d/ heraus und laden Sie die Repositories neu.",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -6452,7 +6452,7 @@
     "sshNotConfiguredTitle": "SSH not configured",
     "sshNotConfiguredDescription": "SSH access is not enabled for this connection. Configure SSH credentials in Settings → Connections to use node updates.",
     "repoIssuesTitle": "Repository Issues ({count})",
-    "repoIssuesDescription": "Enterprise repositories are enabled without a no-subscription alternative. Update commands will fail without a valid Proxmox subscription. Enable the no-subscription repository or disable the enterprise repository on the affected nodes.",
+    "repoIssuesDescription": "Enterprise repositories are enabled without a no-subscription alternative on nodes that have no active Proxmox subscription, so apt update will fail there. Enable the no-subscription repository, disable the enterprise repository, or activate the subscription on the affected nodes.",
     "repoEnterprisePve": "The PVE Enterprise repository is enabled without a no-subscription alternative.",
     "repoEnterpriseComponent": "The {component} enterprise repository is enabled without a no-subscription alternative.",
     "repoParseErrorsDescription": "APT cannot read one or more repository files on this node. Only files ending in .list or .sources are parsed, so a renamed backup such as pve-enterprise.sources.BAK breaks every update. Move those files out of /etc/apt/sources.list.d/ and reload the repositories.",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -6452,7 +6452,7 @@
     "sshNotConfiguredTitle": "SSH no configurado",
     "sshNotConfiguredDescription": "El acceso SSH no está habilitado para esta conexión. Configure credenciales SSH en Configuración → Conexiones para usar actualizaciones de nodo.",
     "repoIssuesTitle": "Problemas de repositorio ({count})",
-    "repoIssuesDescription": "Los repositorios Enterprise están habilitados sin una alternativa no-subscription. Los comandos de actualización fallarán sin una suscripción válida de Proxmox. Habilite el repositorio no-subscription o deshabilite el repositorio Enterprise en los nodos afectados.",
+    "repoIssuesDescription": "Hay repositorios Enterprise habilitados sin una alternativa no-subscription en nodos sin una suscripción Proxmox activa, por lo que apt update fallará en ellos. Habilite el repositorio no-subscription, deshabilite el repositorio Enterprise o active la suscripción en los nodos afectados.",
     "repoEnterprisePve": "El repositorio PVE Enterprise está habilitado sin una alternativa no-subscription.",
     "repoEnterpriseComponent": "El repositorio enterprise {component} está habilitado sin una alternativa no-subscription.",
     "repoParseErrorsDescription": "APT no puede leer uno o varios archivos de repositorio en este nodo. Solo se analizan los archivos que terminan en .list o .sources, por lo que una copia renombrada como pve-enterprise.sources.BAK rompe cualquier actualización. Mueva esos archivos fuera de /etc/apt/sources.list.d/ y vuelva a cargar los repositorios.",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -6447,7 +6447,7 @@
     "sshNotConfiguredTitle": "SSH non configuré",
     "sshNotConfiguredDescription": "L'accès SSH n'est pas activé pour cette connexion. Configurez les identifiants SSH dans Paramètres → Connexions pour utiliser les mises à jour de nœuds.",
     "repoIssuesTitle": "Problèmes de dépôts ({count})",
-    "repoIssuesDescription": "Des dépôts enterprise sont activés sans alternative no-subscription. Les commandes de mise à jour échoueront sans un abonnement Proxmox valide. Activez le dépôt no-subscription ou désactivez le dépôt enterprise sur les nœuds concernés.",
+    "repoIssuesDescription": "Des dépôts enterprise sont activés sans alternative no-subscription sur des nœuds sans abonnement Proxmox actif : apt update y échouera. Activez le dépôt no-subscription, désactivez le dépôt enterprise ou activez l'abonnement sur les nœuds concernés.",
     "repoEnterprisePve": "Le dépôt PVE Enterprise est activé sans alternative no-subscription.",
     "repoEnterpriseComponent": "Le dépôt enterprise {component} est activé sans alternative no-subscription.",
     "repoParseErrorsDescription": "APT ne parvient pas à lire un ou plusieurs fichiers de dépôt sur ce nœud. Seuls les fichiers en .list ou .sources sont analysés : une sauvegarde renommée comme pve-enterprise.sources.BAK casse toutes les mises à jour. Déplacez ces fichiers hors de /etc/apt/sources.list.d/ puis rechargez les dépôts.",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -6452,7 +6452,7 @@
     "sshNotConfiguredTitle": "SSH가 구성되지 않았습니다",
     "sshNotConfiguredDescription": "이 연결에 SSH 접근이 활성화되어 있지 않습니다. 노드 업데이트를 사용하려면 설정 → 연결에서 SSH 자격 증명을 구성하세요.",
     "repoIssuesTitle": "저장소 문제 ({count})",
-    "repoIssuesDescription": "no-subscription 대체 저장소 없이 Enterprise 저장소가 활성화되어 있습니다. 유효한 Proxmox 구독이 없으면 업데이트 명령이 실패합니다. 해당 노드에서 no-subscription 저장소를 활성화하거나 Enterprise 저장소를 비활성화하세요.",
+    "repoIssuesDescription": "활성 Proxmox 구독이 없는 노드에서 no-subscription 대체 저장소 없이 Enterprise 저장소가 활성화되어 있어 apt update가 실패합니다. 해당 노드에서 no-subscription 저장소를 활성화하거나 Enterprise 저장소를 비활성화하거나 구독을 활성화하세요.",
     "repoEnterprisePve": "no-subscription 대체 저장소 없이 PVE Enterprise 저장소가 활성화되어 있습니다.",
     "repoEnterpriseComponent": "no-subscription 대체 저장소 없이 {component} enterprise 저장소가 활성화되어 있습니다.",
     "repoParseErrorsDescription": "이 노드의 저장소 파일을 APT가 읽을 수 없습니다. .list 또는 .sources로 끝나는 파일만 분석되므로 pve-enterprise.sources.BAK처럼 이름을 바꾼 백업 파일은 모든 업데이트를 실패시킵니다. 해당 파일을 /etc/apt/sources.list.d/ 밖으로 옮기고 저장소를 다시 불러오세요.",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -6399,7 +6399,7 @@
     "sshNotConfiguredTitle": "SSH 未配置",
     "sshNotConfiguredDescription": "此连接未启用 SSH 访问。请在设置 → 连接中配置 SSH 凭据以使用节点更新功能。",
     "repoIssuesTitle": "仓库问题 ({count})",
-    "repoIssuesDescription": "已启用企业仓库但没有免费订阅替代源。没有有效的 Proxmox 订阅，更新命令将失败。请在受影响的节点上启用免费订阅仓库或禁用企业仓库。",
+    "repoIssuesDescription": "在没有有效 Proxmox 订阅的节点上启用了企业仓库且没有免费订阅替代源，apt update 将在这些节点上失败。请在受影响的节点上启用免费订阅仓库、禁用企业仓库或激活订阅。",
     "repoEnterprisePve": "已启用 PVE 企业仓库但没有免费订阅替代源。",
     "repoEnterpriseComponent": "已启用 {component} 企业仓库但没有免费订阅替代源。",
     "repoParseErrorsDescription": "APT 无法读取该节点上的一个或多个仓库文件。只有以 .list 或 .sources 结尾的文件才会被解析，因此像 pve-enterprise.sources.BAK 这样重命名的备份会导致所有更新失败。请将这些文件移出 /etc/apt/sources.list.d/ 并重新加载仓库。",


### PR DESCRIPTION
## Summary

A customer with an active Proxmox subscription, running the production repository layout Proxmox recommends (PVE enterprise plus Ceph enterprise, no no-subscription repository anywhere), was refused every node update with "Repository Issues (3)" (issue #853). The pre-flight of the Node Update dialog (`computeRepoIssues`) declared any enterprise repository enabled without its no-subscription counterpart a blocking error and never read `GET /nodes/{node}/subscription`, so every subscribed node was blocked, and the message told them the update would fail without the valid subscription they actually had. Their Proxmox UI said "All OK, you have production-ready repositories configured".

The third line of their screenshot, a `ceph-tentacle` enterprise repository they do not have, comes from Proxmox itself: proxmox-apt matches a configured repository against a standard handle by URI or by signing key, and every Ceph release shares the Proxmox key, so one `ceph-squid` repository lights `ceph-squid-*` and `ceph-tentacle-*` alike. Reproduced on a PVE 9 lab node whose single `ceph-tentacle` no-subscription repository reports both no-subscription handles as enabled.

Refs #853.

## Changes

- **Subscription-aware check.** `computeRepoIssues(payload, { subscriptionActive })` skips the enterprise rules when the node's subscription is active: with a subscription, enterprise-only repositories are the supported setup and apt authenticates against them. Any other status keeps the check strict, and so does a subscription that cannot be read, since a failed read must not pass for a clean node. Unparsable repository files (a stray `.sources.BAK`) stay blocking regardless. `isSubscriptionActive` recognises PVE's `active` status among `new`, `notfound`, `invalid`, `expired` and `suspended`.
- **`loadNodeRepoIssues`** reads the repositories and the subscription status together for the dialog and returns `null` when the repositories themselves could not be read, so the dialog keeps its previous verdict instead of reporting a clean node. `NodeUpdateDialog.tsx` calls it; the Start button gating is unchanged.
- **One line per product for Ceph.** Enterprise repositories of a product are reported once (`component: 'Ceph'`) instead of once per release handle, since PVE marks every release handle for a single repository.
- **Wording.** `updates.repoIssuesDescription`, shared by the Node Update dialog and the Rolling Update wizard, now says the affected nodes have no active Proxmox subscription and lists activating the subscription among the remedies, in the six catalogs.
- The Rolling Update wizard's pre-flight runs in the orchestrator and receives the same rule in a separate change, to ship with the same release; the reworded description assumes it.

## Tests

- `aptRepositories.test.ts`, 37 tests, 14 new: the customer's exact payload with an active subscription (no issue), without one (the PVE issue plus a single Ceph one), with the option omitted (strict), parse errors kept on a subscribed node, the lab payload where one Ceph repository lights two release handles (silent), `isSubscriptionActive` on every status PVE can answer and on non-strings, and `loadNodeRepoIssues` with an injected fetch: active, `notfound`, network failure, HTML answer and 403 on the subscription endpoint (all strict), unreadable repositories answering `null`, a parse error on a subscribed node, node name encoding and `cache: 'no-store'` on the subscription request.
- The fixtures are `pvesh` captures from the PVE 9 lab plus the payload rebuilt from the customer's screenshots. The lab has no subscription key, so the active path is covered by the unit tests only.

## Not in this PR

- No acknowledge or bypass of repository issues: with the subscription read, a blocked node is one where `apt update` would fail.
- The compliance hardening rule that also reads `standard-repos` (`lib/compliance/hardening.ts`) is untouched.
