### PR TITLE
Dashboard: Guests per Node widget, cluster > node > guest tree with live CPU and RAM

### DIFF
--- a/frontend/src/components/dashboard/widgetRegistry.js
+++ b/frontend/src/components/dashboard/widgetRegistry.js
@@ -35,6 +35,9 @@ const ZfsArcWidget = dynamic(() => import('./widgets/ZfsArcWidget'), { ssr: fals
 // VM Heatmap (CPU/RAM utilization grid)
 const VmHeatmapWidget = dynamic(() => import('./widgets/VmHeatmapWidget'), { ssr: false })
 
+// Node Guests (collapsible per-node guest list with CPU and RAM bars)
+const NodeGuestsWidget = dynamic(() => import('./widgets/NodeGuestsWidget'), { ssr: false })
+
 // Backup Calendar
 const BackupCalendarWidget = dynamic(() => import('./widgets/BackupCalendarWidget'), { ssr: false })
 
@@ -340,6 +343,18 @@ export const WIDGET_REGISTRY = {
     maxSize: { w: 12, h: 20 },
     noContainer: true,
     component: VmHeatmapWidget,
+  },
+  'node-guests': {
+    type: 'node-guests',
+    name: 'Guests per Node',
+    description: 'Guests of each node with their live CPU and RAM',
+    icon: 'ri-node-tree',
+    category: 'infrastructure',
+    defaultSize: { w: 6, h: 6 },
+    minSize: { w: 3, h: 3 },
+    maxSize: { w: 12, h: 20 },
+    noContainer: true,
+    component: NodeGuestsWidget,
   },
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/frontend/src/components/dashboard/widgets/NodeGuestsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/NodeGuestsWidget.jsx
@@ -1,0 +1,425 @@
+'use client'
+
+import React, { useCallback, useMemo } from 'react'
+
+import { useRouter } from 'next/navigation'
+
+import { useTranslations } from 'next-intl'
+import { Box, IconButton, Tooltip, Typography, useTheme } from '@mui/material'
+
+import ConnectionFilter from './ConnectionFilter'
+import { widgetColors } from './themeColors'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+// Same thresholds as Top Consumers, so a guest keeps its colour from one
+// widget to the next.
+function getBarColor(value) {
+  if (value >= 80) return '#ef4444'
+  if (value >= 50) return '#f59e0b'
+
+  return '#22c55e'
+}
+
+const STATUS_COLORS = { running: '#4caf50', stopped: '#f44336', paused: '#ff9800', suspended: '#ff9800' }
+const getStatusColor = (status) => STATUS_COLORS[status] || '#616161'
+
+const NODE_STATUS_COLORS = { online: '#4caf50', unknown: '#9e9e9e' }
+const getNodeStatusColor = (status) => NODE_STATUS_COLORS[status] || '#f44336'
+
+// Two clusters may both have a node called "pve1": the node key carries the
+// connection so their guests never end up in the same group. A cluster is
+// keyed by its bare connection id, which never carries a colon suffix.
+const nodeKey = (connId, node) => `${connId}:${node}`
+const pct = (value) => Math.round(Number(value) || 0)
+const num = (value) => Number(value) || 0
+
+// One grid for the three levels, so the CPU and RAM columns line up down the
+// whole tree. The depth shows through the left padding of the first cell.
+const GRID_COLUMNS = 'minmax(0, 1fr) minmax(64px, 88px) minmax(64px, 88px)'
+const INDENT = { cluster: 0, node: 2.25, guest: 4.5 }
+const MONO = '"JetBrains Mono", monospace'
+
+function MetricBar({ value, c }) {
+  // Node percentages arrive with one decimal, guests are already whole.
+  const v = Math.max(0, Math.min(100, pct(value)))
+  const color = getBarColor(v)
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+      <Box sx={{ flex: 1, height: 5, borderRadius: 3, bgcolor: c.surfaceSubtle, overflow: 'hidden' }}>
+        <Box sx={{ width: `${v}%`, height: '100%', borderRadius: 3, bgcolor: color, transition: 'width 0.4s ease' }} />
+      </Box>
+      <Typography sx={{ fontSize: '0.6786rem', fontWeight: 600, fontFamily: MONO, color, width: 30, textAlign: 'right', flexShrink: 0, lineHeight: 1.2 }}>
+        {v}%
+      </Typography>
+    </Box>
+  )
+}
+
+// The two metric cells of a header row: bars when the level has a load of
+// its own, blank cells otherwise (a node the API did not list, a cluster with
+// no node in scope).
+function MetricCells({ hasLoad, cpuPct, memPct, c }) {
+  if (!hasLoad) return <><span /><span /></>
+
+  return <><MetricBar value={cpuPct} c={c} /><MetricBar value={memPct} c={c} /></>
+}
+
+// ─── Rows ────────────────────────────────────────────────────────────────────
+// A focusable, collapsible header row shared by the cluster and node levels.
+function TreeHeader({ collapsed, onToggle, indent, metrics, sx, c, children }) {
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle() }
+  }
+
+  return (
+    <Box
+      role='button'
+      tabIndex={0}
+      aria-expanded={!collapsed}
+      onClick={onToggle}
+      onKeyDown={handleKeyDown}
+      sx={{
+        display: 'grid', gridTemplateColumns: GRID_COLUMNS, alignItems: 'center', columnGap: 1,
+        px: 0.5, py: 0.4, borderRadius: 1, cursor: 'pointer', userSelect: 'none',
+        ...sx,
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, pl: indent }}>
+        <i className={collapsed ? 'ri-arrow-right-s-line' : 'ri-arrow-down-s-line'} style={{ fontSize: '1rem', color: c.textMuted, flexShrink: 0 }} />
+        {children}
+      </Box>
+      {metrics}
+    </Box>
+  )
+}
+
+function ClusterRow({ cluster, collapsed, onToggle, c, t }) {
+  return (
+    <TreeHeader
+      collapsed={collapsed}
+      onToggle={onToggle}
+      indent={INDENT.cluster}
+      c={c}
+      sx={{ bgcolor: c.surfaceHover, '&:hover': { bgcolor: c.surfaceActive } }}
+      metrics={<MetricCells hasLoad={cluster.hasLoad} cpuPct={cluster.cpuPct} memPct={cluster.memPct} c={c} />}
+    >
+      <i className='ri-server-line' style={{ fontSize: '0.9286rem', color: c.textSecondary, flexShrink: 0 }} />
+      <Typography sx={{ fontWeight: 700, fontSize: '0.8214rem', color: c.textPrimary, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {cluster.name}
+      </Typography>
+      <Typography sx={{ fontSize: '0.6786rem', color: c.textMuted, whiteSpace: 'nowrap', flexShrink: 0 }}>
+        {t('dashboard.nodeGuests.nodes', { count: cluster.nodes.length })}
+      </Typography>
+      <Typography sx={{ fontSize: '0.6786rem', color: c.textMuted, fontFamily: MONO, flexShrink: 0 }}>
+        {`${cluster.running}/${cluster.total}`}
+      </Typography>
+    </TreeHeader>
+  )
+}
+
+function NodeRow({ group, collapsed, onToggle, isDark, c }) {
+  const online = group.status === 'online'
+
+  return (
+    <TreeHeader
+      collapsed={collapsed}
+      onToggle={onToggle}
+      indent={INDENT.node}
+      c={c}
+      sx={{ '&:hover': { bgcolor: c.surfaceHover } }}
+      metrics={<MetricCells hasLoad={group.hasLoad} cpuPct={group.cpuPct} memPct={group.memPct} c={c} />}
+    >
+      {/* A node is the Proxmox logo with its status dot, as in Nodes Status
+          and the Guest Map. */}
+      <Box sx={{ position: 'relative', width: 16, height: 16, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <img src={isDark ? '/images/proxmox-logo-dark.svg' : '/images/proxmox-logo.svg'} alt='' width={14} height={14} style={{ opacity: online ? 0.8 : 0.4 }} />
+        <Box sx={{ position: 'absolute', bottom: -1, right: -2, width: 6, height: 6, borderRadius: '50%', bgcolor: getNodeStatusColor(group.status), border: `1px solid ${c.dotBorder}` }} />
+      </Box>
+      <Typography sx={{ fontWeight: 700, fontSize: '0.7857rem', color: c.textPrimary, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {group.node}
+      </Typography>
+      <Typography sx={{ fontSize: '0.6786rem', color: c.textMuted, fontFamily: MONO, flexShrink: 0 }}>
+        {`${group.running}/${group.guests.length}`}
+      </Typography>
+    </TreeHeader>
+  )
+}
+
+function GuestRow({ vm, onOpen, c }) {
+  return (
+    <Box
+      onClick={() => onOpen(vm)}
+      sx={{
+        display: 'grid', gridTemplateColumns: GRID_COLUMNS, alignItems: 'center', columnGap: 1,
+        px: 0.5, py: 0.3, borderRadius: 1, cursor: 'pointer', transition: 'background 0.15s',
+        '&:hover': { bgcolor: c.surfaceHover },
+      }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, minWidth: 0, pl: INDENT.guest }}>
+        {/* A guest has no chevron: the empty slot keeps it one full step
+            deeper than its node, icon under icon. */}
+        <Box sx={{ width: 16, flexShrink: 0 }} />
+        <Box sx={{ position: 'relative', width: 16, height: 16, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <i className={vm.type === 'lxc' ? 'ri-instance-line' : 'ri-computer-line'} style={{ fontSize: '0.9286rem', color: c.textSecondary }} />
+          <Box sx={{ position: 'absolute', bottom: -1, right: -2, width: 6, height: 6, borderRadius: '50%', bgcolor: getStatusColor(vm.status), border: `1px solid ${c.dotBorder}` }} />
+        </Box>
+        <Typography sx={{ fontSize: '0.7857rem', fontWeight: 500, color: c.textPrimary, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {vm.name || `VM ${vm.vmid}`}
+        </Typography>
+        <Typography sx={{ fontSize: '0.6429rem', color: c.textFaint, flexShrink: 0 }}>#{vm.vmid}</Typography>
+      </Box>
+      {/* A stopped guest simply reads 0 %: the status dot says the rest. */}
+      <MetricBar value={vm.cpuPct} c={c} />
+      <MetricBar value={vm.ramPct} c={c} />
+    </Box>
+  )
+}
+
+// ─── Tree ────────────────────────────────────────────────────────────────────
+const emptyNode = (connId, nodeName) => ({
+  key: nodeKey(connId, nodeName), connId, node: nodeName, status: 'unknown',
+  cpuPct: 0, memPct: 0, cores: 0, cpuUsage: 0, memUsed: 0, memMax: 0, hasLoad: false, guests: [],
+})
+
+const mean = (rows, pick) => (rows.length ? rows.reduce((sum, r) => sum + num(pick(r)), 0) / rows.length : 0)
+
+// Cluster load from its nodes: CPU weighted by core count and RAM as a plain
+// sum when the API gave the raw figures, a mean of the node percentages
+// otherwise.
+function clusterLoad(nodes) {
+  const real = nodes.filter(n => n.hasLoad)
+  const cores = real.reduce((sum, n) => sum + n.cores, 0)
+  const memMax = real.reduce((sum, n) => sum + n.memMax, 0)
+
+  return {
+    hasLoad: real.length > 0,
+    cpuPct: cores > 0 ? (real.reduce((sum, n) => sum + n.cpuUsage * n.cores, 0) / cores) * 100 : mean(real, n => n.cpuPct),
+    memPct: memMax > 0 ? (real.reduce((sum, n) => sum + n.memUsed, 0) / memMax) * 100 : mean(real, n => n.memPct),
+  }
+}
+
+// The API lists every connection of the tenant in `clusters` BEFORE its RBAC
+// filter; only `nodes` and the guest lists are filtered. Cluster rows are
+// therefore derived from those two, and `clusters` only lends the real PVE
+// cluster names.
+const clusterNames = (data) => new Map((data?.clusters || []).map(cl => [cl.id, cl.name]))
+
+// Connections that carry at least one visible node or guest, before the
+// widget's own connection filter: what the filter menu may offer.
+function presentConnections(data) {
+  const names = clusterNames(data)
+  const seen = new Map()
+
+  for (const n of data?.nodes || []) if (!seen.has(n.connId)) seen.set(n.connId, names.get(n.connId) || n.connection || n.connId)
+
+  for (const g of [...(data?.vmList || []), ...(data?.lxcList || [])]) {
+    if (!g.template && !seen.has(g.connId)) seen.set(g.connId, names.get(g.connId) || g.connName || g.connId)
+  }
+
+  return [...seen].map(([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function buildTree(data, inScope) {
+  const names = clusterNames(data)
+  const clusters = new Map()
+
+  const ensureCluster = (connId, fallbackName) => {
+    if (!clusters.has(connId)) clusters.set(connId, { key: connId, name: names.get(connId) || fallbackName || connId, nodes: new Map() })
+
+    return clusters.get(connId)
+  }
+
+  // Every node the API knows comes first, so an idle node still shows up
+  // with its own load.
+  for (const n of data?.nodes || []) {
+    if (!inScope(n.connId)) continue
+
+    ensureCluster(n.connId, n.connection).nodes.set(nodeKey(n.connId, n.node), {
+      ...emptyNode(n.connId, n.node),
+      status: n.status, cpuPct: n.cpuPct, memPct: n.memPct, hasLoad: true,
+      cores: num(n._cpuCores), cpuUsage: num(n._cpuUsage), memUsed: num(n._memUsed), memMax: num(n._memMax),
+    })
+  }
+
+  const guests = [...(data?.vmList || []), ...(data?.lxcList || [])].filter(g => !g.template && inScope(g.connId))
+
+  for (const g of guests) {
+    const nodeName = g.node || 'unknown'
+    const cluster = ensureCluster(g.connId, g.connName)
+    const key = nodeKey(g.connId, nodeName)
+
+    if (!cluster.nodes.has(key)) cluster.nodes.set(key, emptyNode(g.connId, nodeName))
+
+    const mem = num(g.mem)
+    const maxmem = num(g.maxmem)
+
+    cluster.nodes.get(key).guests.push({ ...g, cpuPct: pct(num(g.cpu) * 100), ramPct: maxmem > 0 ? pct((mem / maxmem) * 100) : 0 })
+  }
+
+  const tree = [...clusters.values()].map((cl) => {
+    const nodes = [...cl.nodes.values()]
+
+    for (const group of nodes) {
+      // Running guests first, then by name: a stable order for a routine
+      // check, the bar colours already single out the hot ones.
+      group.guests.sort((a, b) => {
+        const ar = a.status === 'running'
+        const br = b.status === 'running'
+
+        if (ar !== br) return ar ? -1 : 1
+
+        return (a.name || '').localeCompare(b.name || '')
+      })
+      group.running = group.guests.filter(g => g.status === 'running').length
+    }
+
+    nodes.sort((a, b) => a.node.localeCompare(b.node))
+
+    return {
+      key: cl.key, name: cl.name, nodes, ...clusterLoad(nodes),
+      running: nodes.reduce((sum, n) => sum + n.running, 0),
+      total: nodes.reduce((sum, n) => sum + n.guests.length, 0),
+    }
+  })
+
+  tree.sort((a, b) => a.name.localeCompare(b.name))
+
+  return tree
+}
+
+// ─── Main Widget ─────────────────────────────────────────────────────────────
+function NodeGuestsWidget({ data, loading: dashboardLoading, config, onUpdateSettings }) {
+  const t = useTranslations()
+  const theme = useTheme()
+  const router = useRouter()
+  const isDark = theme.palette.mode === 'dark'
+  const c = widgetColors(isDark)
+
+  const settings = config?.settings || {}
+  const selectedConnections = useMemo(() => settings.selectedConnections || [], [settings.selectedConnections])
+  // The tree starts fully collapsed: the settings hold what the user opened.
+  const expanded = settings.expanded || []
+  const update = useCallback((patch) => { if (onUpdateSettings) onUpdateSettings(patch) }, [onUpdateSettings])
+
+  const allConnections = useMemo(() => presentConnections(data), [data])
+  const inScope = useCallback((connId) => selectedConnections.length === 0 || selectedConnections.includes(connId), [selectedConnections])
+
+  // Count before any filter, to tell "your filter hid everything" apart from
+  // "there is nothing to show at all".
+  const hasAnything = useMemo(
+    () => (data?.nodes || []).length > 0 || [...(data?.vmList || []), ...(data?.lxcList || [])].some(g => !g.template),
+    [data?.nodes, data?.vmList, data?.lxcList],
+  )
+
+  const tree = useMemo(() => buildTree(data, inScope), [data, inScope])
+
+  const stats = useMemo(() => ({
+    total: tree.reduce((sum, cl) => sum + cl.total, 0),
+    running: tree.reduce((sum, cl) => sum + cl.running, 0),
+  }), [tree])
+
+  const toggle = (key) => update({ expanded: expanded.includes(key) ? expanded.filter(k => k !== key) : [...expanded, key] })
+  const expandAll = () => update({ expanded: tree.flatMap(cl => [cl.key, ...cl.nodes.map(n => n.key)]) })
+  const collapseAll = () => update({ expanded: [] })
+  const handleFilterChange = (next) => update({ selectedConnections: next })
+
+  const openGuest = useCallback((vm) => {
+    router.push(`/infrastructure/inventory?vmid=${vm.vmid}&connId=${vm.connId}&node=${vm.node}&type=${vm.type}`)
+  }, [router])
+
+  const darkCard = {
+    bgcolor: isDark ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.03)',
+    border: '1px solid', borderColor: c.borderLight,
+    borderRadius: 'var(--proxcenter-card-radius)', p: 1.5,
+    transition: 'border-color 0.2s, box-shadow 0.2s',
+    '&:hover': { borderColor: c.borderHover, boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.3)' : '0 2px 8px rgba(0,0,0,0.08)' },
+  }
+
+  if (!data || dashboardLoading) {
+    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>Loading...</Typography></Box>
+  }
+
+  if (!hasAnything) {
+    return <Box sx={{ height: '100%', ...darkCard, display: 'flex', alignItems: 'center', justifyContent: 'center' }}><Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>{t('common.noData')}</Typography></Box>
+  }
+
+  const isEmpty = tree.length === 0
+
+  return (
+    <Box sx={{ height: '100%', ...darkCard, display: 'flex', flexDirection: 'column' }}>
+      {/* Toolbar */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0.5, gap: 0.5, flexWrap: 'wrap' }}>
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          <Typography sx={{ fontSize: '0.7143rem', opacity: 0.6 }}>{t('dashboard.nodeGuests.guests', { count: stats.total })}</Typography>
+          <Typography sx={{ fontSize: '0.7143rem', color: '#4caf50', fontWeight: 600 }}>{t('dashboard.nodeGuests.running', { count: stats.running })}</Typography>
+        </Box>
+        <Box sx={{ display: 'flex', gap: 0.25, alignItems: 'center' }}>
+          <Tooltip title={t('common.expandAll')}>
+            <IconButton size='small' aria-label={t('common.expandAll')} onClick={expandAll} sx={{ p: 0.25 }}>
+              <i className='ri-expand-up-down-line' style={{ fontSize: '1rem' }} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title={t('common.collapseAll')}>
+            <IconButton size='small' aria-label={t('common.collapseAll')} onClick={collapseAll} sx={{ p: 0.25 }}>
+              <i className='ri-contract-up-down-line' style={{ fontSize: '1rem' }} />
+            </IconButton>
+          </Tooltip>
+          {allConnections.length > 1 && <ConnectionFilter connections={allConnections} selected={selectedConnections} onChange={handleFilterChange} t={t} />}
+        </Box>
+      </Box>
+
+      {/* Column captions, on the same grid as the rows */}
+      {!isEmpty && (
+        <Box sx={{ display: 'grid', gridTemplateColumns: GRID_COLUMNS, columnGap: 1, px: 0.5, mb: 0.25 }}>
+          <span />
+          <Typography sx={{ fontSize: '0.6429rem', color: c.textFaint, fontWeight: 600, letterSpacing: 0.5 }}>{t('monitoring.cpu')}</Typography>
+          <Typography sx={{ fontSize: '0.6429rem', color: c.textFaint, fontWeight: 600, letterSpacing: 0.5 }}>RAM</Typography>
+        </Box>
+      )}
+
+      {/* Tree. The empty state lives here, never in place of the toolbar, so
+          the filter that emptied it stays reachable. */}
+      <Box sx={{
+        flex: 1, overflow: 'auto', minHeight: 0,
+        ...(isEmpty && { display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 0.75 }),
+      }}>
+        {isEmpty && (
+          <>
+            <Typography sx={{ opacity: 0.4, fontSize: '0.7857rem' }}>{t('common.noResults')}</Typography>
+            <Box onClick={() => handleFilterChange([])} sx={{
+              px: 0.75, py: 0.2, borderRadius: 1, cursor: 'pointer', fontSize: '0.7143rem', fontWeight: 600,
+              color: c.textMuted, bgcolor: c.borderLight,
+              '&:hover': { bgcolor: c.surfaceSubtle, color: c.textPrimary },
+            }}>{t('common.reset')}</Box>
+          </>
+        )}
+        {!isEmpty && tree.map((cluster, ci) => {
+          const clusterOpen = expanded.includes(cluster.key)
+
+          return (
+            // Clusters are set apart by a full-width rule, nodes inside a
+            // cluster by a lighter one indented to their level.
+            <Box key={cluster.key} sx={ci > 0 ? { mt: 1, pt: 0.75, borderTop: `1px solid ${c.border}` } : undefined}>
+              <ClusterRow cluster={cluster} collapsed={!clusterOpen} onToggle={() => toggle(cluster.key)} c={c} t={t} />
+              {clusterOpen && cluster.nodes.map((group, ni) => {
+                const nodeOpen = expanded.includes(group.key)
+
+                return (
+                  <Box key={group.key} sx={{ mt: 0.25, ...(ni > 0 && { pt: 0.25, borderTop: `1px solid ${c.borderLight}`, ml: INDENT.node }) }}>
+                    <Box sx={ni > 0 ? { ml: -INDENT.node } : undefined}>
+                      <NodeRow group={group} collapsed={!nodeOpen} onToggle={() => toggle(group.key)} isDark={isDark} c={c} />
+                      {nodeOpen && group.guests.map(vm => <GuestRow key={vm.id} vm={vm} onOpen={openGuest} c={c} />)}
+                    </Box>
+                  </Box>
+                )
+              })}
+            </Box>
+          )
+        })}
+      </Box>
+    </Box>
+  )
+}
+
+export default React.memo(NodeGuestsWidget)

--- a/frontend/src/components/dashboard/widgets/NodeGuestsWidget.test.tsx
+++ b/frontend/src/components/dashboard/widgets/NodeGuestsWidget.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { renderWithProviders, screen, fireEvent, within } from '@/__tests__/setup/renderWithProviders'
+
+import NodeGuestsWidget from './NodeGuestsWidget'
+
+/**
+ * #856: a cluster > node > guest tree where every guest shows its name, CPU
+ * and RAM at once. The Guest Map only ever shows one metric per tile and the
+ * name on hover, which is the gap this widget fills. The tree starts fully
+ * collapsed; what the user opens is saved in the widget settings.
+ */
+
+// This project does not enable Vitest globals, so RTL's auto-cleanup is off.
+afterEach(cleanup)
+
+type Row = Record<string, unknown>
+
+const node = (over: Row = {}): Row => ({
+  connId: 'c1', node: 'pve-1', name: 'pve-1', connection: 'cluster-1', connectionId: 'c1',
+  status: 'online', cpuPct: 12.5, memPct: 40,
+  _cpuCores: 8, _cpuUsage: 0.125, _memUsed: 4, _memMax: 10,
+  ...over,
+})
+
+const guest = (over: Row = {}): Row => ({
+  id: 'c1-pve-1-100', vmid: 100, name: 'web-01', node: 'pve-1', connId: 'c1', connName: 'cluster-1',
+  type: 'qemu', status: 'running', cpu: 0.25, mem: 2048, maxmem: 4096, template: false,
+  ...over,
+})
+
+// One cluster, two nodes with guests, one idle node without any. Every
+// percentage is distinct so a bare getByText pins the right cell. The cluster
+// load is derived from the nodes: CPU weighted by cores, (1 + 0.12 + 0.04) / 16
+// = 7 %, RAM as a plain sum, 7 / 30 = 23 %.
+const data = {
+  clusters: [{ id: 'c1', name: 'cluster-1', isCluster: true, nodes: 3, onlineNodes: 3 }],
+  nodes: [
+    node(),
+    node({ node: 'pve-2', name: 'pve-2', cpuPct: 3, memPct: 20, _cpuCores: 4, _cpuUsage: 0.03, _memUsed: 2, _memMax: 10 }),
+    node({ node: 'pve-3', name: 'pve-3', cpuPct: 1, memPct: 10, _cpuCores: 4, _cpuUsage: 0.01, _memUsed: 1, _memMax: 10 }),
+  ],
+  vmList: [
+    guest(),
+    guest({ id: 'c1-pve-1-101', vmid: 101, name: 'db-01', status: 'stopped', cpu: 0, mem: 0 }),
+  ],
+  lxcList: [
+    guest({ id: 'c1-pve-2-200', vmid: 200, name: 'proxy-01', node: 'pve-2', type: 'lxc', cpu: 0.05, mem: 512, maxmem: 8192 }),
+  ],
+}
+
+const ALL_KEYS = ['c1', 'c1:pve-1', 'c1:pve-2', 'c1:pve-3']
+const ALL_OPEN = { expanded: ALL_KEYS }
+const CLUSTER_OPEN = { expanded: ['c1'] }
+
+const render = (d: unknown, settings: Row = {}, onUpdateSettings = vi.fn()) => {
+  renderWithProviders(
+    <NodeGuestsWidget data={d} loading={false} config={{ settings }} onUpdateSettings={onUpdateSettings} />,
+  )
+
+  return onUpdateSettings
+}
+
+const header = (name: string) => screen.getByRole('button', { name: new RegExp(`^${name}\\b`) })
+const queryHeader = (name: string) => screen.queryByRole('button', { name: new RegExp(`^${name}\\b`) })
+
+describe('NodeGuestsWidget', () => {
+  it('starts fully collapsed, with only the cluster rows on screen', () => {
+    render(data)
+
+    expect(header('cluster-1')).toHaveAttribute('aria-expanded', 'false')
+    expect(queryHeader('pve-1')).not.toBeInTheDocument()
+    expect(screen.queryByText('web-01')).not.toBeInTheDocument()
+    // The cluster row still sums up what it hides.
+    expect(within(header('cluster-1')).getByText('2/3')).toBeInTheDocument()
+  })
+
+  it('tops the tree with a cluster row carrying the aggregated load', () => {
+    render(data)
+
+    const cluster = header('cluster-1')
+
+    expect(within(cluster).getByText('3 nodes')).toBeInTheDocument()
+    expect(within(cluster).getByText('2/3')).toBeInTheDocument()
+    // Weighted by cores, not a plain mean of the node percentages (5.5 %).
+    expect(within(cluster).getByText('7%')).toBeInTheDocument()
+    expect(within(cluster).getByText('23%')).toBeInTheDocument()
+  })
+
+  it('lists every guest under its node with name, CPU and RAM side by side', () => {
+    render(data, ALL_OPEN)
+
+    // Node rows carry the node's own load.
+    expect(header('pve-1')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('13%')).toBeInTheDocument()
+    expect(screen.getByText('40%')).toBeInTheDocument()
+
+    // Guest rows print the name and both metrics, no hover needed.
+    expect(screen.getByText('web-01')).toBeInTheDocument()
+    expect(screen.getByText('25%')).toBeInTheDocument()
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.getByText('proxy-01')).toBeInTheDocument()
+    expect(screen.getByText('5%')).toBeInTheDocument()
+    expect(screen.getByText('6%')).toBeInTheDocument()
+  })
+
+  it('keeps a node without any guest in the list', () => {
+    render(data, CLUSTER_OPEN)
+    expect(header('pve-3')).toBeInTheDocument()
+    expect(within(header('pve-3')).getByText('0/0')).toBeInTheDocument()
+  })
+
+  it('shows the running over total count of each node', () => {
+    render(data, CLUSTER_OPEN)
+    expect(within(header('pve-1')).getByText('1/2')).toBeInTheDocument()
+    expect(within(header('pve-2')).getByText('1/1')).toBeInTheDocument()
+  })
+
+  it('keeps a stopped guest in the same row format, bars at zero and no status text', () => {
+    render(data, ALL_OPEN)
+    expect(screen.getByText('db-01')).toBeInTheDocument()
+    expect(screen.queryByText('stopped')).not.toBeInTheDocument()
+    // CPU and RAM of the stopped guest, the only zero figures in the data set.
+    expect(screen.getAllByText('0%')).toHaveLength(2)
+  })
+
+  it('never shows a connection the user has no visible node or guest on', () => {
+    // The API lists every connection of the tenant in `clusters`, before the
+    // RBAC filter; only nodes and guests are filtered. A cluster row must
+    // come from those, never from the bare connection list.
+    render({ ...data, clusters: [...data.clusters, { id: 'c2', name: 'hidden-cluster', isCluster: true, nodes: 0, onlineNodes: 0 }] })
+
+    expect(header('cluster-1')).toBeInTheDocument()
+    expect(queryHeader('hidden-cluster')).not.toBeInTheDocument()
+    // One visible connection: no connection filter to offer.
+    expect(screen.queryByRole('button', { name: 'Filter' })).not.toBeInTheDocument()
+  })
+
+  it('offers the connection filter for the visible connections only', () => {
+    const second = {
+      clusters: [...data.clusters, { id: 'c2', name: 'cluster-2', isCluster: true, nodes: 1, onlineNodes: 1 }, { id: 'c3', name: 'hidden-cluster', isCluster: true, nodes: 0, onlineNodes: 0 }],
+      nodes: [...data.nodes, node({ connId: 'c2', connectionId: 'c2', connection: 'cluster-2', node: 'pve-b', name: 'pve-b', cpuPct: 2, memPct: 30 })],
+    }
+
+    render({ ...data, ...second })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filter' }))
+    expect(screen.getByRole('menuitem', { name: /cluster-1/ })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /cluster-2/ })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /hidden-cluster/ })).not.toBeInTheDocument()
+  })
+
+  it('names a cluster after the PVE cluster name when the API provides it', () => {
+    // The node rows carry the ProxCenter connection name; the cluster row
+    // prefers the real PVE cluster name from `clusters` when there is one.
+    render({ ...data, clusters: [{ id: 'c1', name: 'PVE-PROD', isCluster: true, nodes: 3, onlineNodes: 3 }] })
+    expect(header('PVE-PROD')).toBeInTheDocument()
+    expect(queryHeader('cluster-1')).not.toBeInTheDocument()
+  })
+
+  it('never lists templates', () => {
+    render({ ...data, vmList: [...data.vmList, guest({ id: 'c1-pve-1-900', vmid: 900, name: 'tpl-debian', template: true })] }, ALL_OPEN)
+    expect(screen.queryByText('tpl-debian')).not.toBeInTheDocument()
+    // The template does not count either.
+    expect(within(header('pve-1')).getByText('1/2')).toBeInTheDocument()
+  })
+
+  it('keeps a node folded unless the settings list it as expanded', () => {
+    render(data, { expanded: ['c1', 'c1:pve-2'] })
+
+    expect(header('pve-1')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText('web-01')).not.toBeInTheDocument()
+    // The header keeps its count and load, so a folded node is still informative.
+    expect(within(header('pve-1')).getByText('1/2')).toBeInTheDocument()
+    expect(screen.getByText('13%')).toBeInTheDocument()
+    // The node that is listed is open.
+    expect(screen.getByText('proxy-01')).toBeInTheDocument()
+  })
+
+  it('ignores an expanded node whose cluster is folded', () => {
+    render(data, { expanded: ['c1:pve-1'] })
+    expect(queryHeader('pve-1')).not.toBeInTheDocument()
+    expect(screen.queryByText('web-01')).not.toBeInTheDocument()
+  })
+
+  it('persists opening a cluster through the widget settings', () => {
+    const onUpdate = render(data)
+    fireEvent.click(header('cluster-1'))
+    expect(onUpdate).toHaveBeenCalledWith({ expanded: ['c1'] })
+  })
+
+  it('persists opening a node through the widget settings', () => {
+    const onUpdate = render(data, CLUSTER_OPEN)
+    fireEvent.click(header('pve-1'))
+    expect(onUpdate).toHaveBeenCalledWith({ expanded: ['c1', 'c1:pve-1'] })
+  })
+
+  it('persists folding a node through the widget settings', () => {
+    const onUpdate = render(data, ALL_OPEN)
+    fireEvent.click(header('pve-1'))
+    expect(onUpdate).toHaveBeenCalledWith({ expanded: ['c1', 'c1:pve-2', 'c1:pve-3'] })
+  })
+
+  it('expands every level at once', () => {
+    const onUpdate = render(data)
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+    expect(onUpdate).toHaveBeenCalledWith({ expanded: ALL_KEYS })
+  })
+
+  it('collapses every level at once', () => {
+    const onUpdate = render(data, ALL_OPEN)
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+    expect(onUpdate).toHaveBeenCalledWith({ expanded: [] })
+  })
+
+  it('keeps its controls when the connection filter hides everything', () => {
+    // A saved filter on a connection that no longer exists: nothing matches,
+    // yet the way out must stay on screen (same lesson as #611).
+    const onUpdate = render(data, { selectedConnections: ['gone'] })
+
+    expect(screen.getByText('No results')).toBeInTheDocument()
+    expect(queryHeader('cluster-1')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Reset'))
+    expect(onUpdate).toHaveBeenCalledWith({ selectedConnections: [] })
+  })
+
+  it('falls back to the plain no-data card when there is genuinely nothing', () => {
+    render({ clusters: [], nodes: [], vmList: [], lxcList: [] })
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Collapse all' })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -1,5 +1,7 @@
 {
   "common": {
+    "expandAll": "Alle aufklappen",
+    "collapseAll": "Alle zuklappen",
     "delete": "Löschen",
     "cancel": "Abbrechen",
     "save": "Speichern",
@@ -476,6 +478,7 @@
       "infraGlobalChart": "Infra CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "Guest-Heatmap",
+      "nodeGuests": "Guests pro Node",
       "drsStatus": "DRS-Status",
       "siteRecovery": "Site Recovery",
       "themeLogo": "Theme-Logo"
@@ -506,6 +509,7 @@
       "infraGlobalChart": "CPU/RAM pro Node über die gesamte Infrastruktur",
       "zfsArc": "ZFS-ARC-Speichernutzung pro Node (PVE 9+)",
       "vmHeatmap": "CPU/RAM-Heatmap aller Guests",
+      "nodeGuests": "Guests jedes Nodes mit aktueller CPU- und RAM-Auslastung",
       "drsStatus": "DRS-Status, aktive Migrationen und Empfehlungen",
       "siteRecovery": "VM-Schutz, RPO-Compliance und Replikationsstatus",
       "backupCalendar": "Backup-Verlauf über 30 Tage",
@@ -547,6 +551,11 @@
     },
     "widgetArc": {
       "noData": "Keine ZFS-ARC-Daten. Erfordert PVE 9 oder neuer auf einem Node mit ZFS."
+    },
+    "nodeGuests": {
+      "guests": "{count} Guests",
+      "running": "{count} aktiv",
+      "nodes": "{count} Nodes"
     }
   },
   "alerts": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -486,6 +486,7 @@
       "infraGlobalChart": "Infra CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "Guest Heatmap",
+      "nodeGuests": "Guests per Node",
       "drsStatus": "DRS Status",
       "siteRecovery": "Site Recovery",
       "sectionHeader": "Section",
@@ -519,6 +520,7 @@
       "infraGlobalChart": "Per-node CPU/RAM across all infrastructure",
       "zfsArc": "Per-node ZFS ARC memory usage (PVE 9+)",
       "vmHeatmap": "CPU/RAM heatmap of all guests",
+      "nodeGuests": "Guests of each node with their live CPU and RAM",
       "drsStatus": "DRS status, active migrations and recommendations",
       "siteRecovery": "VM protection, RPO compliance and replication status",
       "backupCalendar": "Backup history over 30 days",
@@ -560,6 +562,11 @@
     },
     "widgetArc": {
       "noData": "No ZFS ARC data. Requires PVE 9 or later on a node using ZFS."
+    },
+    "nodeGuests": {
+      "guests": "{count} guests",
+      "running": "{count} running",
+      "nodes": "{count} nodes"
     }
   },
   "alerts": {

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -486,6 +486,7 @@
       "infraGlobalChart": "Infra CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "Mapa de calor de guests",
+      "nodeGuests": "Guests por nodo",
       "drsStatus": "Estado de DRS",
       "siteRecovery": "Site Recovery",
       "sectionHeader": "Sección",
@@ -519,6 +520,7 @@
       "infraGlobalChart": "por-nodo CPU/RAM across all infrastructure",
       "zfsArc": "Uso de memoria ZFS ARC por nodo (PVE 9+)",
       "vmHeatmap": "CPU/RAM heatmap de all guests",
+      "nodeGuests": "Guests de cada nodo con su CPU y RAM en tiempo real",
       "drsStatus": "DRS estado, activo migraciones y recomendaciones",
       "siteRecovery": "VM protection, RPO compliance y replication estado",
       "backupCalendar": "Historial de backups de 30 días",
@@ -560,6 +562,11 @@
     },
     "widgetArc": {
       "noData": "Sin datos de ZFS ARC. Requiere PVE 9 o posterior en un nodo que use ZFS."
+    },
+    "nodeGuests": {
+      "guests": "{count} guests",
+      "running": "{count} en ejecución",
+      "nodes": "{count} nodos"
     }
   },
   "alerts": {

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -486,6 +486,7 @@
       "infraGlobalChart": "Infra CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "Heatmap guests",
+      "nodeGuests": "Guests par nœud",
       "drsStatus": "État DRS",
       "siteRecovery": "Reprise d'activité",
       "sectionHeader": "Section",
@@ -519,6 +520,7 @@
       "infraGlobalChart": "CPU/RAM par nœud sur toute l'infrastructure",
       "zfsArc": "Utilisation mémoire du cache ZFS ARC par nœud (PVE 9+)",
       "vmHeatmap": "Heatmap CPU/RAM de tous les guests",
+      "nodeGuests": "Guests de chaque nœud avec leur CPU et RAM en direct",
       "drsStatus": "Status DRS, migrations actives et recommandations",
       "siteRecovery": "Protection VMs, conformité RPO et status réplication",
       "backupCalendar": "Historique backups sur 30 jours",
@@ -560,6 +562,11 @@
     },
     "widgetArc": {
       "noData": "Aucune donnée ZFS ARC. Nécessite PVE 9 ou supérieur sur un nœud utilisant ZFS."
+    },
+    "nodeGuests": {
+      "guests": "{count} guests",
+      "running": "{count} en cours",
+      "nodes": "{count} nœuds"
     }
   },
   "alerts": {

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -486,6 +486,7 @@
       "infraGlobalChart": "인프라 CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "게스트 히트맵",
+      "nodeGuests": "노드별 게스트",
       "drsStatus": "DRS 상태",
       "siteRecovery": "사이트 복구",
       "sectionHeader": "섹션",
@@ -519,6 +520,7 @@
       "infraGlobalChart": "전체 인프라의 노드별 CPU/RAM",
       "zfsArc": "노드별 ZFS ARC 메모리 사용량 (PVE 9 이상)",
       "vmHeatmap": "모든 게스트의 CPU/RAM 히트맵",
+      "nodeGuests": "각 노드의 게스트와 실시간 CPU/RAM 사용량",
       "drsStatus": "DRS 상태, 진행 중인 마이그레이션 및 권장 사항",
       "siteRecovery": "VM 보호, RPO 준수 및 복제 상태",
       "backupCalendar": "최근 30일간의 백업 이력",
@@ -560,6 +562,11 @@
     },
     "widgetArc": {
       "noData": "ZFS ARC 데이터가 없습니다. ZFS를 사용하는 노드에서 PVE 9 이상이 필요합니다."
+    },
+    "nodeGuests": {
+      "guests": "게스트 {count}개",
+      "running": "실행 중 {count}개",
+      "nodes": "노드 {count}개"
     }
   },
   "alerts": {

--- a/frontend/src/messages/nodeGuestsMessages.test.ts
+++ b/frontend/src/messages/nodeGuestsMessages.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+describe('Guests per Node widget (#856) i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} names and describes the widget in the catalogue`, () => {
+      expect(messages?.dashboard?.widgetNames?.nodeGuests, `${locale}: widgetNames.nodeGuests`).toBeTypeOf('string')
+      expect(messages?.dashboard?.widgetDescs?.nodeGuests, `${locale}: widgetDescs.nodeGuests`).toBeTypeOf('string')
+    })
+
+    for (const key of ['guests', 'running', 'nodes']) {
+      it(`${locale} declares dashboard.nodeGuests.${key} with its {count} placeholder`, () => {
+        const value = messages?.dashboard?.nodeGuests?.[key]
+
+        expect(value, `${locale}: ${key}`).toBeTypeOf('string')
+        expect(value, `${locale}: {count} placeholder`).toContain('{count}')
+      })
+    }
+
+    // The toolbar reuses these two shared keys; de.json did not have them.
+    for (const key of ['expandAll', 'collapseAll']) {
+      it(`${locale} declares common.${key}`, () => {
+        const value = messages?.common?.[key]
+
+        expect(value, `${locale}: common.${key}`).toBeTypeOf('string')
+        expect(value!.length, `${locale}: common.${key} must not be empty`).toBeGreaterThan(0)
+      })
+    }
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -476,6 +476,7 @@
       "infraGlobalChart": "基础设施 CPU/RAM",
       "zfsArc": "ZFS ARC",
       "vmHeatmap": "客户机热力图",
+      "nodeGuests": "按节点的客户机",
       "drsStatus": "DRS 状态",
       "siteRecovery": "站点恢复",
       "themeLogo": "主题标志"
@@ -506,6 +507,7 @@
       "infraGlobalChart": "所有基础设施中每个节点的 CPU/RAM",
       "zfsArc": "各节点的 ZFS ARC 内存占用（PVE 9+）",
       "vmHeatmap": "所有客户机的 CPU/RAM 热力图",
+      "nodeGuests": "每个节点的客户机及其实时 CPU/RAM 使用率",
       "drsStatus": "DRS 状态、活跃迁移和建议",
       "siteRecovery": "虚拟机保护、RPO 合规性和复制状态",
       "backupCalendar": "30天备份历史",
@@ -547,6 +549,11 @@
     },
     "widgetArc": {
       "noData": "无 ZFS ARC 数据。需要 PVE 9 或更高版本，且节点使用 ZFS。"
+    },
+    "nodeGuests": {
+      "guests": "{count} 个客户机",
+      "running": "{count} 个运行中",
+      "nodes": "{count} 个节点"
     }
   },
   "alerts": {


### PR DESCRIPTION
## Summary

Issue #856 asks for a dashboard widget that lists the guests of each node with their name, CPU and RAM visible at once. The Guest Map shows one metric per tile and the guest name only on hover, and Top Consumers stops at ten guests with no node grouping, so an operator doing a routine check had to switch modes or open nodes one by one to correlate a guest, its host and its load.

This adds the **Guests per Node** widget (Infrastructure category): a cluster > node > guest tree where every row shows its CPU and RAM as bars in aligned columns. No API change, everything comes from `/api/v1/dashboard`.

Refs #856.

## Changes

- **Widget** `frontend/src/components/dashboard/widgets/NodeGuestsWidget.jsx`. Cluster rows carry the node count, the running/total guest count and a load aggregated from their nodes, CPU weighted by core count and RAM as a plain sum, since the API exposes no per-cluster figures. Node rows carry the Proxmox logo with a status dot and the node's own bars. Guest rows carry the type icon, a status dot (red when stopped), the name, the VMID and both bars; a stopped guest simply reads 0 %. The three levels share one grid so the CPU and RAM columns line up down the tree; a rule separates clusters, a lighter one separates nodes. Clicking a guest opens it in the inventory.
- **Collapsed by default.** The tree opens fully folded and the widget settings store what the user expanded (`expanded`, keys `connId` for a cluster and `connId:node` for a node). Expand all and collapse all buttons, the shared connection filter, and empty states that keep the controls on screen when a filter hides everything (same lesson as #611).
- **Scoping.** Cluster rows and the connection filter menu derive from the RBAC-filtered `nodes` and guest lists only. The `clusters` array, which the API builds before its RBAC filter, is used for the PVE cluster names alone, so a node- or VM-scoped user never sees a connection they hold no visible node or guest on.
- **Registry and catalogue.** `node-guests` entry after the Guest Map (`ri-node-tree`, 6x6, no container), name and description in `dashboard.widgetNames` / `widgetDescs`, and three widget strings under `dashboard.nodeGuests` in the six locales. `common.expandAll` and `common.collapseAll` were missing from `de.json` and are added.

## Tests

- `NodeGuestsWidget.test.tsx`, 19 tests: fully collapsed start, aggregated cluster load (weighted by cores, not a mean), name plus CPU plus RAM on every guest row, idle node kept, running/total counts, stopped guest format, templates excluded, per-level toggles persisted through the settings, expand all and collapse all payloads, a node listed as expanded under a folded cluster stays hidden, a connection filter that empties the tree keeps its controls, a connection without any visible node or guest never shown, filter menu limited to the visible connections, PVE cluster name preferred over the connection name, plain no-data card.
- `nodeGuestsMessages.test.ts`, 36 checks: the catalogue name and description, the three `{count}` strings and the two shared expand/collapse keys in the six locales.

## Not in this PR

- No text search and no per-guest network throughput; both were discussed on #824 and are not part of this request.
- The dashboard API still returns every connection of the tenant in `clusters` before its RBAC filter; the widget works around it, and issue #525 scopes the route itself.
