### PR TITLE
feat(rbac): infra-scope isolation for aggregate reads: changes, events, dashboard, alerts (#525)

### DIFF
--- a/frontend/src/__tests__/setup/rbacScope.ts
+++ b/frontend/src/__tests__/setup/rbacScope.ts
@@ -1,0 +1,52 @@
+/**
+ * RBAC infra-scope fixtures shared by the aggregate-read route tests
+ * (issue #525). One place for the scope shapes so a test reads as a grant
+ * ("node n1 of c1") instead of a three-line literal, and one accessor for
+ * the scope a route forwarded into a mocked visibility predicate.
+ */
+import type { RbacInfraScope } from '@/lib/rbac/infraScope'
+
+const EMPTY = (): RbacInfraScope => ({
+  fullConnections: new Set(),
+  nodesByConnection: new Map(),
+  guestDerived: false,
+  nodeGrantsByConnection: new Map(),
+  guestGrantsByConnection: new Map(),
+})
+
+/** A connection-scoped grant on `conn-1`, used as an opaque forwarded value. */
+export const FAKE_RBAC_SCOPE: RbacInfraScope = { ...EMPTY(), fullConnections: new Set(['conn-1']) }
+
+/** Node grants on one connection. */
+export function nodeScope(connId: string, ...nodes: string[]): RbacInfraScope {
+  return {
+    ...EMPTY(),
+    nodesByConnection: new Map([[connId, new Set(nodes)]]),
+    nodeGrantsByConnection: new Map([[connId, new Set(nodes)]]),
+  }
+}
+
+/** A single vm grant `connId:node:qemu:vmid`: the node shows in the tree, nothing else is granted. */
+export function vmScope(connId: string, node: string, vmid: string): RbacInfraScope {
+  return {
+    ...EMPTY(),
+    nodesByConnection: new Map([[connId, new Set([node])]]),
+    guestGrantsByConnection: new Map([[connId, new Set([vmid])]]),
+  }
+}
+
+/** Whole-connection grants. */
+export function connectionScope(...connIds: string[]): RbacInfraScope {
+  return { ...EMPTY(), fullConnections: new Set(connIds) }
+}
+
+/** A tag / pool only grant: no infra perimeter of its own. */
+export function guestDerivedScope(): RbacInfraScope {
+  return { ...EMPTY(), guestDerived: true }
+}
+
+/** `rbacScope` of the ctx a route passed to the FIRST call of a mocked predicate. */
+export function forwardedRbacScope(predicate: { mock: { calls: unknown[][] } }): unknown {
+  const ctx = predicate.mock.calls[0]?.[1] as { rbacScope?: unknown } | undefined
+  return ctx?.rbacScope
+}

--- a/frontend/src/app/api/v1/changes/changesScope.test.ts
+++ b/frontend/src/app/api/v1/changes/changesScope.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../__tests__/setup/route-test"
+import { connectionScope, guestDerivedScope, nodeScope } from "@/__tests__/setup/rbacScope"
 
-const { getInfraMock, orchestratorFetchMock, tenantConnectionIdsMock, vdcVmidsMock } = vi.hoisted(() => ({
+const { getInfraMock, orchestratorFetchMock, rbacScopeMock, tenantConnectionIdsMock, vdcVmidsMock } = vi.hoisted(() => ({
   getInfraMock: vi.fn(),
   orchestratorFetchMock: vi.fn(),
+  rbacScopeMock: vi.fn(),
   tenantConnectionIdsMock: vi.fn(),
   vdcVmidsMock: vi.fn(),
 }))
@@ -30,6 +32,7 @@ vi.mock("@/lib/alerts/vdcVmids", () => ({
 
 vi.mock("@/lib/rbac", () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: rbacScopeMock,
   PERMISSIONS: { CONNECTION_VIEW: "connection.view", ADMIN_SETTINGS: "admin.settings" },
 }))
 
@@ -39,6 +42,8 @@ const CLUSTER_LESS = { id: "ev1", node: "n1", resourceType: "vm", resourceId: "1
 const VM_OWNED = { id: "ev2", connectionId: "c1", node: "n1", resourceType: "vm", resourceId: "100" }
 const VM_NEIGHBOUR = { id: "ev4", connectionId: "c1", node: "n1", resourceType: "vm", resourceId: "999" }
 const NODE_EVENT = { id: "ev5", connectionId: "c1", node: "n1", resourceType: "node", resourceId: "n1" }
+const VM_OTHER_NODE = { id: "ev6", connectionId: "c1", node: "n2", resourceType: "vm", resourceId: "101" }
+const STORAGE_EVENT = { id: "ev7", connectionId: "c1", resourceType: "storage", resourceId: "local-lvm" }
 
 const IAAS_SCOPE = {
   connectionIds: new Set(["c1"]),
@@ -49,77 +54,46 @@ const IAAS_SCOPE = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  rbacScopeMock.mockResolvedValue(null)
   tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
   vdcVmidsMock.mockResolvedValue(new Map([["c1", new Set(["100"])]]))
   orchestratorFetchMock.mockResolvedValue({ data: [CLUSTER_LESS, VM_OWNED, VM_NEIGHBOUR, NODE_EVENT] })
 })
 
-describe("GET /api/v1/changes scope routing", () => {
-  it("provider: every record is KEPT, including cluster-less ones", async () => {
+describe("RBAC infra scope (issue #525)", () => {
+  const ids = (body: any) => body.data.map((r: any) => r.id)
+
+  beforeEach(() => {
     getInfraMock.mockResolvedValue({ kind: "provider" })
-
-    const { GET } = await import("./route")
-    const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev1", "ev2", "ev4", "ev5"])
+    orchestratorFetchMock.mockResolvedValue({ data: [CLUSTER_LESS, VM_OWNED, VM_NEIGHBOUR, NODE_EVENT, VM_OTHER_NODE, STORAGE_EVENT] })
   })
 
-  it("msp: cluster-less record is DROPPED, owned-connection records are KEPT (no guest masking)", async () => {
-    getInfraMock.mockResolvedValue({ kind: "msp", connectionIds: new Set(["c1"]) })
-
+  it("admin (null scope): the provider feed stays unrestricted", async () => {
     const { GET } = await import("./route")
     const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2", "ev4", "ev5"])
+    expect(ids(await res.json())).toEqual(["ev1", "ev2", "ev4", "ev5", "ev6", "ev7"])
+    expect(rbacScopeMock).toHaveBeenCalledWith("connection.view")
   })
 
-  it("iaas: only the vDC-owned guest record survives — neighbour VM and node/infra events are DROPPED", async () => {
-    getInfraMock.mockResolvedValue({ kind: "iaas", vdcScope: IAAS_SCOPE })
-
+  it("node scope: granted-node records and cluster-level records survive, the rest is dropped", async () => {
+    rbacScopeMock.mockResolvedValue(nodeScope("c1", "n1"))
     const { GET } = await import("./route")
     const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2"])
+    // ev1 has no connection, ev6 ran on n2; ev7 (storage) is a fact about c1.
+    expect(ids(await res.json())).toEqual(["ev2", "ev4", "ev5", "ev7"])
   })
 
-  it("iaas: drops a record whose node is outside the vDC scope", async () => {
-    getInfraMock.mockResolvedValue({
-      kind: "iaas",
-      vdcScope: { ...IAAS_SCOPE, nodesByConnection: new Map([["c1", new Set(["n2"])]]) },
-    })
-
+  it("connection scope on another connection: nothing survives", async () => {
+    rbacScopeMock.mockResolvedValue(connectionScope("c2"))
     const { GET } = await import("./route")
     const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    expect(body.data).toEqual([])
+    expect((await res.json()).data).toEqual([])
   })
 
-  it("iaas: excludes a record from a connection present in the tenant union but absent from the narrowed vDC scope", async () => {
-    // Union has both c1 and c2 (e.g. two vDCs), but the current vDC view
-    // context only narrows to c1 — c2's record must not leak into it, even
-    // with a VMID that matches c1's set.
-    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
-    const VM_OTHER_VDC = { id: "ev3", connectionId: "c2", node: "n1", resourceType: "vm", resourceId: "100" }
-    orchestratorFetchMock.mockResolvedValue({ data: [VM_OWNED, VM_OTHER_VDC] })
-    getInfraMock.mockResolvedValue({ kind: "iaas", vdcScope: IAAS_SCOPE })
-
+  it("guest-derived scope: tenant-level perimeter, minus connection-less records", async () => {
+    rbacScopeMock.mockResolvedValue(guestDerivedScope())
     const { GET } = await import("./route")
     const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2"])
+    expect(ids(await res.json())).toEqual(["ev2", "ev4", "ev5", "ev6", "ev7"])
   })
 })

--- a/frontend/src/app/api/v1/changes/recent/changesRecentScope.test.ts
+++ b/frontend/src/app/api/v1/changes/recent/changesRecentScope.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../../__tests__/setup/route-test"
+import { connectionScope, nodeScope } from "@/__tests__/setup/rbacScope"
 
-const { getInfraMock, orchestratorFetchMock, tenantConnectionIdsMock, vdcVmidsMock } = vi.hoisted(() => ({
+const { getInfraMock, orchestratorFetchMock, rbacScopeMock, tenantConnectionIdsMock, vdcVmidsMock } = vi.hoisted(() => ({
   getInfraMock: vi.fn(),
   orchestratorFetchMock: vi.fn(),
+  rbacScopeMock: vi.fn(),
   tenantConnectionIdsMock: vi.fn(),
   vdcVmidsMock: vi.fn(),
 }))
@@ -30,6 +32,7 @@ vi.mock("@/lib/alerts/vdcVmids", () => ({
 
 vi.mock("@/lib/rbac", () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: rbacScopeMock,
   PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
 }))
 
@@ -39,6 +42,8 @@ const CLUSTER_LESS = { id: "ev1", node: "n1", resourceType: "vm", resourceId: "1
 const VM_OWNED = { id: "ev2", connectionId: "c1", node: "n1", resourceType: "vm", resourceId: "100" }
 const VM_NEIGHBOUR = { id: "ev4", connectionId: "c1", node: "n1", resourceType: "vm", resourceId: "999" }
 const NODE_EVENT = { id: "ev5", connectionId: "c1", node: "n1", resourceType: "node", resourceId: "n1" }
+const VM_OTHER_NODE = { id: "ev6", connectionId: "c1", node: "n2", resourceType: "vm", resourceId: "101" }
+const STORAGE_EVENT = { id: "ev7", connectionId: "c1", resourceType: "storage", resourceId: "local-lvm" }
 
 const IAAS_SCOPE = {
   connectionIds: new Set(["c1"]),
@@ -49,71 +54,38 @@ const IAAS_SCOPE = {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  rbacScopeMock.mockResolvedValue(null)
   tenantConnectionIdsMock.mockResolvedValue(new Set(["c1"]))
   vdcVmidsMock.mockResolvedValue(new Map([["c1", new Set(["100"])]]))
   orchestratorFetchMock.mockResolvedValue({ data: [CLUSTER_LESS, VM_OWNED, VM_NEIGHBOUR, NODE_EVENT] })
 })
 
-describe("GET /api/v1/changes/recent scope routing", () => {
-  it("provider: every record is KEPT, including cluster-less ones", async () => {
+describe("RBAC infra scope (issue #525)", () => {
+  // The record gate itself is covered by lib/changes/visibility.test.ts and
+  // by the sibling /api/v1/changes suite; the dropdown only adds the limit.
+  beforeEach(() => {
     getInfraMock.mockResolvedValue({ kind: "provider" })
+  })
+
+  it("applies the limit AFTER the RBAC filter so a scoped user still gets a full dropdown", async () => {
+    rbacScopeMock.mockResolvedValue(nodeScope("c1", "n1"))
+    orchestratorFetchMock.mockResolvedValue({ data: [CLUSTER_LESS, VM_OTHER_NODE, VM_OWNED, VM_NEIGHBOUR, NODE_EVENT, STORAGE_EVENT] })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET", searchParams: { limit: "3" } })
+    const body = await res.json()
+
+    expect(body.data.map((r: any) => r.id)).toEqual(["ev2", "ev4", "ev5"])
+    expect(rbacScopeMock).toHaveBeenCalledWith("connection.view")
+  })
+
+  it("empties the dropdown for a user granted another connection only", async () => {
+    rbacScopeMock.mockResolvedValue(connectionScope("c2"))
 
     const { GET } = await import("./route")
     const res = await callRoute(GET, { method: "GET" })
+
     expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev1", "ev2", "ev4", "ev5"])
-  })
-
-  it("msp: cluster-less record is DROPPED, owned-connection records are KEPT (no guest masking)", async () => {
-    getInfraMock.mockResolvedValue({ kind: "msp", connectionIds: new Set(["c1"]) })
-
-    const { GET } = await import("./route")
-    const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2", "ev4", "ev5"])
-  })
-
-  it("iaas: only the vDC-owned guest record survives — neighbour VM and node/infra events are DROPPED", async () => {
-    getInfraMock.mockResolvedValue({ kind: "iaas", vdcScope: IAAS_SCOPE })
-
-    const { GET } = await import("./route")
-    const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2"])
-  })
-
-  it("iaas: excludes a record from a connection present in the tenant union but absent from the narrowed vDC scope", async () => {
-    tenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
-    const VM_OTHER_VDC = { id: "ev3", connectionId: "c2", node: "n1", resourceType: "vm", resourceId: "100" }
-    orchestratorFetchMock.mockResolvedValue({ data: [VM_OWNED, VM_OTHER_VDC] })
-    getInfraMock.mockResolvedValue({ kind: "iaas", vdcScope: IAAS_SCOPE })
-
-    const { GET } = await import("./route")
-    const res = await callRoute(GET, { method: "GET" })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    const ids = body.data.map((r: any) => r.id)
-    expect(ids).toEqual(["ev2"])
-  })
-
-  it("honors the limit param after filtering", async () => {
-    getInfraMock.mockResolvedValue({ kind: "provider" })
-
-    const { GET } = await import("./route")
-    const res = await callRoute(GET, { method: "GET", searchParams: { limit: "2" } })
-    expect(res.status).toBe(200)
-
-    const body = await res.json()
-    expect(body.data).toHaveLength(2)
+    expect((await res.json()).data).toEqual([])
   })
 })

--- a/frontend/src/app/api/v1/dashboard/dashboardScope.test.ts
+++ b/frontend/src/app/api/v1/dashboard/dashboardScope.test.ts
@@ -1,15 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../__tests__/setup/route-test"
+import { vmScope } from "@/__tests__/setup/rbacScope"
 
 // Hoist mocks so they can be referenced in vi.mock factories
-const { globalFindMany, sessionFindMany, getInfraMock, mockGetServerSession, mockListSnapshotsInNamespace, mockPbsFetch } = vi.hoisted(() => ({
+const { globalFindMany, sessionFindMany, alertFindUniqueMock, alertUpdateManyMock, getInfraMock, mockGetServerSession, mockListSnapshotsInNamespace, mockPbsFetch, rbacScopeMock } = vi.hoisted(() => ({
   globalFindMany: vi.fn(),
   sessionFindMany: vi.fn(),
+  alertFindUniqueMock: vi.fn().mockResolvedValue(null),
+  alertUpdateManyMock: vi.fn().mockResolvedValue({}),
   getInfraMock: vi.fn(),
   mockGetServerSession: vi.fn(),
   mockListSnapshotsInNamespace: vi.fn(),
   mockPbsFetch: vi.fn(),
+  rbacScopeMock: vi.fn(),
 }))
 
 // Keep REAL inventoryConnectionPlan + maskingScope; only mock getTenantInfrastructureScope
@@ -23,10 +27,10 @@ vi.mock("@/lib/tenant", () => ({
   getSessionPrisma: async () => ({
     connection: { findMany: sessionFindMany },
     alert: {
-      findUnique: vi.fn().mockResolvedValue(null),
+      findUnique: alertFindUniqueMock,
       create: vi.fn().mockResolvedValue({}),
       update: vi.fn().mockResolvedValue({}),
-      updateMany: vi.fn().mockResolvedValue({}),
+      updateMany: alertUpdateManyMock,
     },
   }),
   getCurrentTenantId: async () => "default",
@@ -77,7 +81,11 @@ vi.mock("@/lib/rbac", () => ({
   filterVmsByPermission: (_uid: any, list: any[]) => Promise.resolve(list),
   filterNodesByPermission: (_uid: any, list: any[]) => Promise.resolve(list),
   checkPermission: vi.fn().mockResolvedValue(null),
-  PERMISSIONS: {},
+  getCurrentRbacInfraScope: rbacScopeMock,
+  PERMISSIONS: { VM_VIEW: "vm.view", NODE_VIEW: "node.view" },
+}))
+vi.mock("@/lib/alerts/visibility", () => ({
+  isAlertInRbacScope: vi.fn().mockReturnValue(true),
 }))
 
 // Stub orchestrator + alert helpers
@@ -103,12 +111,108 @@ beforeEach(() => {
   // Reset finders to return empty lists
   globalFindMany.mockResolvedValue([])
   sessionFindMany.mockResolvedValue([])
+  rbacScopeMock.mockResolvedValue(null)
+  getConnByIdMock.mockResolvedValue({ baseUrl: "", apiToken: "" })
+  getPbsConnByIdMock.mockResolvedValue({ baseUrl: "", apiToken: "" })
   // Default session: provider tenant
   mockGetServerSession.mockResolvedValue({ user: { id: "u1", tenantId: "default" } })
   // Default PBS fetch: return empty arrays (no-op)
   mockPbsFetch.mockResolvedValue([])
   // Default namespace snapshot fetch: return empty
   mockListSnapshotsInNamespace.mockResolvedValue([])
+})
+
+describe("RBAC infra scope (issue #525)", () => {
+  beforeEach(() => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue([
+      { id: "p1", name: "PVE 1", type: "pve", hasCeph: false, tenantId: "default" },
+      { id: "p2", name: "PVE 2", type: "pve", hasCeph: false, tenantId: "default" },
+      { id: "pbs-1", name: "PBS 1", type: "pbs", hasCeph: false, tenantId: "default" },
+      { id: "pbs-2", name: "PBS 2", type: "pbs", hasCeph: false, tenantId: "default" },
+    ])
+  })
+
+  it("loads only the granted PVE connection for a node scope", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(),
+      nodesByConnection: new Map([["p1", new Set(["n1"])]]),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await res.json()
+    const clusterIds = (body.data.clusters ?? []).map((cluster: any) => cluster.id)
+
+    expect(getConnByIdMock).toHaveBeenCalledWith("p1", "default")
+    expect(getConnByIdMock).not.toHaveBeenCalledWith("p2", expect.anything())
+    expect(getPbsConnByIdMock).not.toHaveBeenCalled()
+    expect(clusterIds).not.toContain("p2")
+    expect(body.data.summary.standalones + body.data.summary.clusters).toBe(1)
+  })
+
+  it("loads only fully granted PVE and PBS connections", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(["p1", "pbs-1"]),
+      nodesByConnection: new Map(),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+
+    expect(res.status).toBe(200)
+    expect(getConnByIdMock).toHaveBeenCalledWith("p1", "default")
+    expect(getPbsConnByIdMock).toHaveBeenCalledWith("pbs-1", "default")
+    expect(getPbsConnByIdMock).not.toHaveBeenCalledWith("pbs-2", expect.anything())
+  })
+
+  it("opens every provider connection for an admin", async () => {
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+
+    expect(res.status).toBe(200)
+    expect(getConnByIdMock).toHaveBeenCalledWith("p1", "default")
+    expect(getConnByIdMock).toHaveBeenCalledWith("p2", "default")
+    expect(getPbsConnByIdMock).toHaveBeenCalledWith("pbs-1", "default")
+    expect(getPbsConnByIdMock).toHaveBeenCalledWith("pbs-2", "default")
+    expect(rbacScopeMock).toHaveBeenCalledWith(["vm.view", "node.view"])
+  })
+
+  it("fetches only guests and omits infrastructure aggregates for a VM-only user", async () => {
+    rbacScopeMock.mockResolvedValue(vmScope("p1", "n1", "100"))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await res.json()
+
+    expect(getConnByIdMock).toHaveBeenCalledWith("p1", "default")
+    expect(getConnByIdMock).not.toHaveBeenCalledWith("p2", expect.anything())
+    expect(body.data.clusters).toEqual([])
+    expect(body.data.summary.clusters + body.data.summary.standalones).toBe(0)
+    expect(getPbsConnByIdMock).not.toHaveBeenCalled()
+  })
+
+  it("skips alert synchronization for a scoped caller", async () => {
+    rbacScopeMock.mockResolvedValue(vmScope("p1", "n1", "100"))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    await res.json()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(alertUpdateManyMock).not.toHaveBeenCalled()
+    expect(alertFindUniqueMock).not.toHaveBeenCalled()
+  })
+
+  it("runs alert synchronization for an unrestricted admin", async () => {
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    expect(res.status).toBe(200)
+
+    await vi.waitFor(() => expect(alertUpdateManyMock).toHaveBeenCalled())
+  })
 })
 
 describe("GET /api/v1/dashboard scope routing", () => {

--- a/frontend/src/app/api/v1/dashboard/route.ts
+++ b/frontend/src/app/api/v1/dashboard/route.ts
@@ -15,7 +15,9 @@ import { generateFingerprint } from "@/lib/alerts/fingerprint"
 import { loadActiveSilenceFingerprints } from "@/lib/alerts/silenceFilter"
 import { mergeAndFilterDashboardAlerts } from "@/lib/alerts/dashboardAlertMerge"
 import { authOptions } from "@/lib/auth/config"
-import { filterVmsByPermission, filterNodesByPermission } from "@/lib/rbac"
+import { filterVmsByPermission, filterNodesByPermission, getCurrentRbacInfraScope, PERMISSIONS } from "@/lib/rbac"
+import { filterCandidateConnections, filterVisibleConnections, hasInfraGrant } from "@/lib/rbac/infraScope"
+import { isAlertInRbacScope } from "@/lib/alerts/visibility"
 import { alertsApi } from "@/lib/orchestrator/client"
 import { demoResponse } from "@/lib/demo/demo-api"
 import { getSetting } from "@/lib/db/settings"
@@ -180,6 +182,20 @@ export async function GET(req: Request) {
       const allowedPbs = infra.vdcScope.pbsConnectionIds
       pbsConnections = pbsConnections.filter(c => allowedPbs.has(c.id))
     }
+
+    // Caller's RBAC infra scope (issue #525), derived from the grants that
+    // carry what this page shows. Null = unrestricted. Clusters the user holds
+    // no grant on are not queried at all; cluster cards, Ceph, storage capacity
+    // and the locally evaluated alerts then follow the INFRA grants only (see
+    // hasInfraGrant in the aggregation loop), while a node-scoped user keeps
+    // their whole cluster's capacity (storage pools are cluster-wide, pruning
+    // them per node would under-count). PBS servers need an outright grant,
+    // like the inventory tree. A guest-derived (tag / pool) scope keeps every
+    // candidate cluster: only the per-guest filters below can decide for it.
+    const rbacScope = await getCurrentRbacInfraScope([PERMISSIONS.VM_VIEW, PERMISSIONS.NODE_VIEW])
+    pveConnections = filterCandidateConnections(pveConnections, rbacScope)
+    pbsConnections = filterVisibleConnections(pbsConnections, rbacScope)
+    const infraPveConnections = pveConnections.filter(c => hasInfraGrant(rbacScope, c.id)).length
 
     // ============================================
     // CHARGER PVE ET PBS EN PARALLÈLE
@@ -435,7 +451,10 @@ return null
     let globalStorageUsed = 0, globalStorageMax = 0
 
     for (const data of validPve) {
-      if (data.isCluster) totalClusters++
+      // A vm-only (or tag / pool) grant on this connection yields its guests
+      // and nothing else: no node, cluster card, Ceph or capacity figures.
+      const infraGranted = hasInfraGrant(rbacScope, data.conn.id)
+      if (data.isCluster && infraGranted) totalClusters++
 
       // vDC filtering: restrict nodes and guests to what the tenant's vDCs allow
       const allowedNodes = vdcScope?.nodesByConnection.get(data.conn.id)
@@ -463,10 +482,12 @@ return null
         : data.lxcs
 
       // Aggregate real storage per connection
-      globalStorageUsed += data.connStorageUsed || 0
-      globalStorageMax += data.connStorageMax || 0
+      if (infraGranted) {
+        globalStorageUsed += data.connStorageUsed || 0
+        globalStorageMax += data.connStorageMax || 0
+      }
 
-      for (const node of scopedNodes) {
+      for (const node of infraGranted ? scopedNodes : []) {
         allNodes.push({
           connId: data.conn.id, node: node.node,
           name: node.node, connection: data.conn.name || data.conn.id, connectionId: data.conn.id,
@@ -478,6 +499,8 @@ return null
 
       for (const vm of scopedVms) allVms.push({ ...vm, connId: data.conn.id, connection: data.conn.name, connectionId: data.conn.id })
       for (const lxc of scopedLxcs) allLxcs.push({ ...lxc, connId: data.conn.id, connection: data.conn.name, connectionId: data.conn.id })
+
+      if (!infraGranted) continue
 
       clusterInfos.push({
         id: data.conn.id, name: data.clusterName, isCluster: data.isCluster, nodes: scopedNodes.length,
@@ -735,7 +758,12 @@ return null
     // ============================================
     // SYNCHRONISER LES ALERTES EN BASE (async, non-bloquant)
     // ============================================
-    syncAlertsToDatabase(alerts).catch(err => console.error('[dashboard] Alert sync error:', err))
+    // Only an unrestricted read may drive the tenant-wide alert store: the
+    // sync auto-resolves every active alert missing from `alerts`, and a scoped
+    // caller's list is a subset of the tenant's (issue #525 review finding).
+    if (rbacScope === null) {
+      syncAlertsToDatabase(alerts).catch(err => console.error('[dashboard] Alert sync error:', err))
+    }
 
     // ============================================
     // RBAC FILTERING — scope data to user's permissions
@@ -842,6 +870,11 @@ return null
         const orchResponse = await alertsApi.getAlerts({ status: 'active', limit: 100 })
         const orchData = orchResponse.data as any
         orchAlerts = orchData?.data || (Array.isArray(orchData) ? orchData : [])
+        // Same RBAC gate as /api/v1/orchestrator/alerts: the merge below only
+        // knows node NAMES, which cannot tell two clusters apart.
+        if (rbacScope && Array.isArray(orchAlerts)) {
+          orchAlerts = orchAlerts.filter((a: any) => isAlertInRbacScope(a, rbacScope, tenantId))
+        }
       } catch {
         // Silently ignore orchestrator errors — not critical for dashboard
       }
@@ -859,7 +892,7 @@ return null
     return NextResponse.json({
       data: {
         summary: {
-          clusters: totalClusters, standalones: pveConnections.length - totalClusters,
+          clusters: totalClusters, standalones: infraPveConnections - totalClusters,
           nodes: filteredNodes.length, nodesOnline: fOnlineNodes, nodesOffline: filteredNodes.length - fOnlineNodes,
           vmsRunning: fVmsRunning, vmsTotal: filteredVms.length - fVmsTemplates, lxcRunning: fLxcRunning, lxcTotal: filteredLxcs.length,
           cpuPct: fCpuPct, ramPct: fRamPct,

--- a/frontend/src/app/api/v1/events/eventsDedup.test.ts
+++ b/frontend/src/app/api/v1/events/eventsDedup.test.ts
@@ -40,6 +40,8 @@ vi.mock("@/lib/proxmox/client", () => ({
 
 // RBAC -- pass everything through
 vi.mock("@/lib/rbac", () => ({
+  // The route now resolves the caller's RBAC infra scope (issue #525); null = unrestricted.
+  getCurrentRbacInfraScope: vi.fn().mockResolvedValue(null),
   checkPermission: vi.fn().mockResolvedValue(null),
   PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
 }))

--- a/frontend/src/app/api/v1/events/eventsScope.test.ts
+++ b/frontend/src/app/api/v1/events/eventsScope.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { callRoute } from "../../../../__tests__/setup/route-test"
+import { vmScope } from "@/__tests__/setup/rbacScope"
 
 // Hoist mocks so they can be referenced in vi.mock factories
-const { globalFindMany, sessionFindMany, getInfraMock, getConnByIdMock } = vi.hoisted(() => ({
+const { globalFindMany, sessionFindMany, getInfraMock, getConnByIdMock, pveFetchMock, rbacScopeMock } = vi.hoisted(() => ({
   globalFindMany: vi.fn(),
   sessionFindMany: vi.fn(),
   getInfraMock: vi.fn(),
   getConnByIdMock: vi.fn().mockResolvedValue({ baseUrl: "", apiToken: "" }),
+  pveFetchMock: vi.fn(),
+  rbacScopeMock: vi.fn(),
 }))
 
 // Keep REAL inventoryConnectionPlan + maskingScope; only mock getTenantInfrastructureScope
@@ -33,11 +36,12 @@ vi.mock("@/lib/connections/getConnection", () => ({
 }))
 
 // No-op PVE fetches
-vi.mock("@/lib/proxmox/client", () => ({ pveFetch: vi.fn().mockResolvedValue([]) }))
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: pveFetchMock }))
 
 // RBAC -- pass everything through
 vi.mock("@/lib/rbac", () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: rbacScopeMock,
   PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
 }))
 
@@ -48,13 +52,99 @@ vi.mock("@/lib/alerts/vdcVmids", () => ({
 
 // Stub task scope helper
 vi.mock("@/lib/tasks/scope", () => ({
-  extractTaskVmid: vi.fn().mockReturnValue(null),
+  extractTaskVmid: vi.fn((id: string) => id),
 }))
 
 beforeEach(() => {
   vi.clearAllMocks()
   globalFindMany.mockResolvedValue([])
   sessionFindMany.mockResolvedValue([])
+  rbacScopeMock.mockResolvedValue(null)
+  pveFetchMock.mockResolvedValue([])
+})
+
+describe("RBAC infra scope (issue #525)", () => {
+  beforeEach(() => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    globalFindMany.mockResolvedValue([
+      { id: "p1", name: "PVE 1", type: "pve" },
+      { id: "p2", name: "PVE 2", type: "pve" },
+    ])
+    getConnByIdMock.mockResolvedValue({ baseUrl: "https://pve", apiToken: "t" })
+    pveFetchMock.mockImplementation(async (_connection: any, path: string) => {
+      if (path === "/cluster/tasks") {
+        return [
+          { upid: "UPID:n1:...", node: "n1", type: "qmstart", id: "100", user: "root@pam", starttime: 1000, status: "OK", pid: 1, pstart: 1 },
+          { upid: "UPID:n2:...", node: "n2", type: "qmstart", id: "101", user: "root@pam", starttime: 1001, status: "OK", pid: 2, pstart: 2 },
+        ]
+      }
+      if (path === "/cluster/resources?type=vm") return []
+      if (path.startsWith("/cluster/log?")) {
+        return [
+          { uid: 1, time: 1000, msg: "m", node: "n1", pri: 6, tag: "t" },
+          { uid: 2, time: 1001, msg: "m", node: "n2", pri: 6, tag: "t" },
+        ]
+      }
+      return []
+    })
+  })
+
+  it("queries and returns only the granted node and connection", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(),
+      nodesByConnection: new Map([["p1", new Set(["n1"])]]),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await res.json()
+
+    expect(body.data.length).toBeGreaterThan(0)
+    expect(body.data.every((event: any) => event.node === "n1" && event.connectionId === "p1")).toBe(true)
+    expect(getConnByIdMock).not.toHaveBeenCalledWith("p2", expect.anything())
+    expect(body.meta.connections).toBe(1)
+  })
+
+  it("returns every node on a granted connection", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(["p1"]),
+      nodesByConnection: new Map(),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await res.json()
+
+    expect(new Set(body.data.map((event: any) => event.node))).toEqual(new Set(["n1", "n2"]))
+    expect(body.data.every((event: any) => event.connectionId === "p1")).toBe(true)
+    expect(getConnByIdMock).not.toHaveBeenCalledWith("p2", expect.anything())
+  })
+
+  it("opens every provider connection for an admin", async () => {
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+
+    expect(res.status).toBe(200)
+    expect(getConnByIdMock).toHaveBeenCalledWith("p1", undefined)
+    expect(getConnByIdMock).toHaveBeenCalledWith("p2", undefined)
+    expect(rbacScopeMock).toHaveBeenCalledWith("connection.view")
+  })
+
+  it("returns only the directly granted guest task for a VM-only user", async () => {
+    rbacScopeMock.mockResolvedValue(vmScope("p1", "n1", "100"))
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await res.json()
+
+    expect(body.data).toHaveLength(1)
+    expect(body.data.every((event: any) =>
+      event.connectionId === "p1" && event.category === "task" && event.entity === "100"
+    )).toBe(true)
+    expect(body.data.some((event: any) => event.category === "log")).toBe(false)
+  })
 })
 
 describe("GET /api/v1/events scope routing", () => {

--- a/frontend/src/app/api/v1/events/route.ts
+++ b/frontend/src/app/api/v1/events/route.ts
@@ -4,7 +4,8 @@ import { pveFetch } from '@/lib/proxmox/client'
 import { getConnectionById } from '@/lib/connections/getConnection'
 import { getSessionPrisma } from "@/lib/tenant"
 import { prisma as globalPrisma } from "@/lib/db/prisma"
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
+import { filterCandidateConnections, isFlatRecordVisible } from '@/lib/rbac/infraScope'
 import { getTenantInfrastructureScope, inventoryConnectionPlan, maskingScope } from '@/lib/tenant/infraScope'
 import { getVdcVmidsByConnection } from "@/lib/alerts/vdcVmids"
 import { extractTaskVmid } from "@/lib/tasks/scope"
@@ -81,6 +82,12 @@ export async function GET(req: Request) {
     // node).
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId) : null
 
+    // Caller's RBAC infra scope (issue #525): null = unrestricted. Connections
+    // the user holds no grant on are not even queried; tasks and logs are then
+    // gated per node. A guest-derived (tag / pool) scope keeps the tenant-level
+    // perimeter here, only the per-guest filter could narrow it.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW)
+
     const { searchParams } = new URL(req.url)
     const limit = Math.min(Number.parseInt(searchParams.get('limit') || '100'), 500)
     const source = searchParams.get('source') || 'all' // 'tasks', 'logs', 'all'
@@ -91,7 +98,10 @@ export async function GET(req: Request) {
     const connPrisma = plan.pveClient === 'global' ? globalPrisma : sessionPrisma
     const connWhere: any = { type: 'pve' }
     if (plan.pveConnectionIds) connWhere.id = { in: plan.pveConnectionIds }
-    const connections = await connPrisma.connection.findMany({ where: connWhere })
+    const connections = filterCandidateConnections(
+      await connPrisma.connection.findMany({ where: connWhere }),
+      rbacScope,
+    )
     
     if (connections.length === 0) {
       return NextResponse.json({ data: [] })
@@ -174,6 +184,13 @@ export async function GET(req: Request) {
                 return allowedVmids.has(vmid)
               })
             }
+            // RBAC infra scope: only tasks that ran on a granted node, or that
+            // target a directly granted guest, survive.
+            if (rbacScope) {
+              tasks = tasks.filter(t =>
+                isFlatRecordVisible(rbacScope, { connId: conn.id, node: t.node, vmid: extractTaskVmid(t.id) }),
+              )
+            }
 
             // Traiter les tâches - trier par date décroissante d'abord
             tasks.sort((a, b) => (b.starttime || 0) - (a.starttime || 0))
@@ -238,6 +255,9 @@ export async function GET(req: Request) {
             const allowedNodesLogs = vdcScope?.nodesByConnection.get(conn.id)
             if (allowedNodesLogs) {
               logs = logs.filter(l => !l.node || allowedNodesLogs.has(l.node))
+            }
+            if (rbacScope) {
+              logs = logs.filter(l => isFlatRecordVisible(rbacScope, { connId: conn.id, node: l.node }))
             }
 
             for (const log of logs) {

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/acknowledge/acknowledgeScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/acknowledge/acknowledgeScope.test.ts
@@ -12,6 +12,9 @@ const acknowledgeMock = vi.fn()
 const isAlertVisibleToTenantMock = vi.fn()
 const getInfraMock = vi.fn()
 const vdcVmidsMock = vi.fn()
+const { rbacScopeMock } = vi.hoisted(() => ({ rbacScopeMock: vi.fn() }))
+
+import { FAKE_RBAC_SCOPE, forwardedRbacScope } from '@/__tests__/setup/rbacScope'
 
 vi.mock('@/lib/orchestrator/client', () => ({
   alertsApi: {
@@ -34,6 +37,7 @@ vi.mock('@/lib/tenant/infraScope', async (orig) => ({
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
   PERMISSIONS: { ALERTS_MANAGE: 'alerts.manage' },
 }))
 
@@ -54,6 +58,7 @@ beforeEach(() => {
   isAlertVisibleToTenantMock.mockResolvedValue(true)
   getInfraMock.mockResolvedValue({ kind: 'iaas', vdcScope: { connectionIds: new Set(['conn-1']) } })
   vdcVmidsMock.mockResolvedValue(new Map())
+  rbacScopeMock.mockReset().mockResolvedValue(null)
 })
 
 describe('POST /api/v1/orchestrator/alerts/[id]/acknowledge', () => {
@@ -103,5 +108,23 @@ describe('POST /api/v1/orchestrator/alerts/[id]/acknowledge', () => {
 
     expect(res.status).toBe(500)
     expect((await res.json()).error).toBe('orchestrator down')
+  })
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  const acknowledge = () =>
+    callRoute(POST as Parameters<typeof callRoute>[0], { method: 'POST', params: { id: 'alert-abc' } })
+
+  it('forwards null for an unrestricted caller, then the caller scope once one resolves', async () => {
+    const unrestricted = await acknowledge()
+    expect(unrestricted.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBeNull()
+
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    isAlertVisibleToTenantMock.mockClear()
+    const scoped = await acknowledge()
+    expect(scoped.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('alerts.manage')
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/acknowledge/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/acknowledge/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 
@@ -39,7 +39,9 @@ export async function POST(
     const infra = await getTenantInfrastructureScope(tenantId, { ignoreVdcContext: true })
     const vdcScope = maskingScope(infra)
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId, { ignoreVdcContext: true }) : undefined
-    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }))) {
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_MANAGE)
+    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }))) {
       return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
     }
 

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/alertByIdScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/alertByIdScope.test.ts
@@ -11,6 +11,9 @@ const deleteAlertMock = vi.fn()
 const isAlertVisibleToTenantMock = vi.fn()
 const getTenantInfrastructureScopeMock = vi.fn()
 const maskingScopeMock = vi.fn()
+const { rbacScopeMock } = vi.hoisted(() => ({ rbacScopeMock: vi.fn() }))
+
+import { FAKE_RBAC_SCOPE, forwardedRbacScope } from '@/__tests__/setup/rbacScope'
 
 vi.mock('@/lib/orchestrator/client', () => ({
   alertsApi: {
@@ -35,6 +38,7 @@ vi.mock('@/lib/tenant/infraScope', () => ({
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
   PERMISSIONS: {
     ALERTS_VIEW: 'alerts.view',
     ALERTS_MANAGE: 'alerts.manage',
@@ -67,6 +71,7 @@ beforeEach(() => {
   isAlertVisibleToTenantMock.mockReset().mockResolvedValue(true)
   getTenantInfrastructureScopeMock.mockReset()
   maskingScopeMock.mockReset().mockReturnValue(null)
+  rbacScopeMock.mockReset().mockResolvedValue(null)
 })
 
 describe('GET /api/v1/orchestrator/alerts/[id] — infraKind forwarding', () => {
@@ -167,5 +172,35 @@ describe('DELETE /api/v1/orchestrator/alerts/[id] — infraKind forwarding', () 
       method: 'DELETE',
     })
     expect(res.status).toBe(404)
+  })
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  beforeEach(() => {
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'provider' })
+  })
+
+  it('GET forwards the caller scope, null when unrestricted', async () => {
+    const byIdRes = await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'alert-abc' } })
+    expect(byIdRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBeNull()
+
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    isAlertVisibleToTenantMock.mockClear()
+    await callRoute(GET as Parameters<typeof callRoute>[0], { params: { id: 'alert-abc' } })
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('alerts.view')
+  })
+
+  it('DELETE forwards the caller scope before deleting', async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    const deleteRes = await callRoute(DELETE as Parameters<typeof callRoute>[0], {
+      params: { id: 'alert-abc' },
+      method: 'DELETE',
+    })
+    expect(deleteRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('alerts.manage')
+    expect(deleteAlertMock).toHaveBeenCalledWith('alert-abc')
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/resolve/resolveScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/resolve/resolveScope.test.ts
@@ -12,6 +12,9 @@ const resolveMock = vi.fn()
 const isAlertVisibleToTenantMock = vi.fn()
 const getInfraMock = vi.fn()
 const vdcVmidsMock = vi.fn()
+const { rbacScopeMock } = vi.hoisted(() => ({ rbacScopeMock: vi.fn() }))
+
+import { FAKE_RBAC_SCOPE, forwardedRbacScope } from '@/__tests__/setup/rbacScope'
 
 vi.mock('@/lib/orchestrator/client', () => ({
   alertsApi: {
@@ -34,6 +37,7 @@ vi.mock('@/lib/tenant/infraScope', async (orig) => ({
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
   PERMISSIONS: { ALERTS_MANAGE: 'alerts.manage' },
 }))
 
@@ -54,6 +58,7 @@ beforeEach(() => {
   isAlertVisibleToTenantMock.mockResolvedValue(true)
   getInfraMock.mockResolvedValue({ kind: 'iaas', vdcScope: { connectionIds: new Set(['conn-1']) } })
   vdcVmidsMock.mockResolvedValue(new Map())
+  rbacScopeMock.mockReset().mockResolvedValue(null)
 })
 
 describe('POST /api/v1/orchestrator/alerts/[id]/resolve', () => {
@@ -104,5 +109,27 @@ describe('POST /api/v1/orchestrator/alerts/[id]/resolve', () => {
 
     expect(res.status).toBe(500)
     expect((await res.json()).error).toBe('orchestrator down')
+  })
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  it('forwards the caller scope into the visibility ctx', async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    const resolveRes = await callRoute(POST as Parameters<typeof callRoute>[0], {
+      method: 'POST',
+      params: { id: 'alert-abc' },
+    })
+    expect(resolveRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('alerts.manage')
+  })
+
+  it('forwards null for an unrestricted caller', async () => {
+    const resolveRes = await callRoute(POST as Parameters<typeof callRoute>[0], {
+      method: 'POST',
+      params: { id: 'alert-abc' },
+    })
+    expect(resolveRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBeNull()
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/resolve/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/resolve/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 
@@ -37,7 +37,9 @@ export async function POST(
     const infra = await getTenantInfrastructureScope(tenantId, { ignoreVdcContext: true })
     const vdcScope = maskingScope(infra)
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId, { ignoreVdcContext: true }) : undefined
-    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }))) {
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_MANAGE)
+    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }))) {
       return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
     }
 

--- a/frontend/src/app/api/v1/orchestrator/alerts/[id]/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/[id]/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 
@@ -40,7 +40,9 @@ export async function GET(
     const infra = await getTenantInfrastructureScope(tenantId, { ignoreVdcContext: true })
     const vdcScope = maskingScope(infra)
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId, { ignoreVdcContext: true }) : undefined
-    if (!(await isAlertVisibleToTenant(alert as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }))) {
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_VIEW)
+    if (!(await isAlertVisibleToTenant(alert as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }))) {
       return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
     }
 
@@ -83,7 +85,9 @@ export async function DELETE(
     const infra = await getTenantInfrastructureScope(tenantId, { ignoreVdcContext: true })
     const vdcScope = maskingScope(infra)
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId, { ignoreVdcContext: true }) : undefined
-    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }))) {
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_MANAGE)
+    if (!(await isAlertVisibleToTenant(alertRes.data as any, { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }))) {
       return NextResponse.json({ error: 'Alert not found' }, { status: 404 })
     }
 

--- a/frontend/src/app/api/v1/orchestrator/alerts/active/__tests__/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/active/__tests__/route.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it, vi, beforeEach } from 'vitest'
 const getActiveAlertsMock = vi.fn()
 const findManyMock = vi.fn()
 const isAlertVisibleToTenantMock = vi.fn()
+const { rbacScopeMock } = vi.hoisted(() => ({ rbacScopeMock: vi.fn() }))
+
+import { FAKE_RBAC_SCOPE, forwardedRbacScope } from '@/__tests__/setup/rbacScope'
 
 vi.mock('@/lib/orchestrator/client', () => ({
   alertsApi: { getActiveAlerts: (...args: unknown[]) => getActiveAlertsMock(...args) },
@@ -29,6 +32,7 @@ vi.mock('@/lib/tenant/infraScope', () => ({
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
   PERMISSIONS: { ALERTS_VIEW: 'alerts.view' },
 }))
 
@@ -51,6 +55,7 @@ beforeEach(() => {
   getActiveAlertsMock.mockReset()
   findManyMock.mockReset()
   isAlertVisibleToTenantMock.mockReset()
+  rbacScopeMock.mockReset().mockResolvedValue(null)
   isAlertVisibleToTenantMock.mockResolvedValue(true)
 })
 
@@ -146,5 +151,29 @@ describe('GET /api/v1/orchestrator/alerts/active', () => {
     const body = await res.json()
     expect(body).toHaveLength(1)
     expect(body[0].resource).toBe('n2')
+  })
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  const alert = { connection_id: 'conn-1', type: 'cpu', resource: 'node-1' }
+
+  beforeEach(() => {
+    getActiveAlertsMock.mockResolvedValue({ data: [alert] })
+    findManyMock.mockResolvedValue([])
+  })
+
+  it('forwards null for an unrestricted caller and keeps the alert', async () => {
+    const activeRes = await GET(makeReq())
+    expect(activeRes.status).toBe(200)
+    expect(await activeRes.json()).toHaveLength(1)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBeNull()
+  })
+
+  it('forwards the caller scope into the visibility ctx', async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    const activeRes = await GET(makeReq())
+    expect(activeRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('alerts.view')
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/active/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/active/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getSessionPrisma, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
@@ -38,7 +38,9 @@ export async function GET(req: Request) {
 
     const resData = response.data as any
     const alerts = Array.isArray(resData) ? resData : (resData?.data || [])
-    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_VIEW)
+    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }
     // isAlertVisibleToTenant is async (Postgres cutover made the rule
     // ownership lookup a Prisma query). Array.filter doesn't await its
     // predicate — it'd see a Promise, which is truthy, and let every

--- a/frontend/src/app/api/v1/orchestrator/alerts/alertsListScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/alertsListScope.test.ts
@@ -10,6 +10,9 @@ const getAlertsMock = vi.fn()
 const isAlertVisibleToTenantMock = vi.fn()
 const getTenantInfrastructureScopeMock = vi.fn()
 const maskingScopeMock = vi.fn()
+const { rbacScopeMock } = vi.hoisted(() => ({ rbacScopeMock: vi.fn() }))
+
+import { FAKE_RBAC_SCOPE, forwardedRbacScope } from '@/__tests__/setup/rbacScope'
 
 vi.mock('@/lib/orchestrator/client', () => ({
   alertsApi: { getAlerts: (...args: unknown[]) => getAlertsMock(...args) },
@@ -37,6 +40,7 @@ vi.mock('@/lib/tenant/infraScope', () => ({
 
 vi.mock('@/lib/rbac', () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
   PERMISSIONS: { CONNECTION_VIEW: 'connection.view' },
 }))
 
@@ -64,6 +68,7 @@ beforeEach(() => {
   isAlertVisibleToTenantMock.mockReset()
   getTenantInfrastructureScopeMock.mockReset()
   maskingScopeMock.mockReset()
+  rbacScopeMock.mockReset().mockResolvedValue(null)
   isAlertVisibleToTenantMock.mockResolvedValue(true)
 })
 
@@ -149,5 +154,27 @@ describe('GET /api/v1/orchestrator/alerts — infraKind forwarding', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data).toHaveLength(0)
+  })
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  beforeEach(() => {
+    getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'provider' })
+    maskingScopeMock.mockReturnValue(null)
+    getAlertsMock.mockResolvedValue({ data: { data: [alert1] } })
+  })
+
+  it('forwards the caller scope into the visibility ctx', async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+    const listRes = await GET(makeReq())
+    expect(listRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('connection.view')
+  })
+
+  it('forwards null for an unrestricted caller', async () => {
+    const listRes = await GET(makeReq())
+    expect(listRes.status).toBe(200)
+    expect(forwardedRbacScope(isAlertVisibleToTenantMock)).toBeNull()
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { DEFAULT_TENANT_ID, getCurrentTenantId, getSessionPrisma, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 import { clearVisibleTenantAlerts } from '@/lib/alerts/clearVisible'
@@ -60,7 +60,9 @@ export async function GET(req: Request) {
     // (orchestrator is not tenant-aware) would otherwise leak through.
     const allAlerts = response.data?.data || response.data || []
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId) : undefined
-    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW)
+    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }
     // isAlertVisibleToTenant became async in the Postgres cutover; resolve
     // each alert's visibility up-front before filtering, otherwise the
     // filter sees a Promise (truthy) and lets every alert through.

--- a/frontend/src/app/api/v1/orchestrator/alerts/rules/alertRulesScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/rules/alertRulesScope.test.ts
@@ -12,6 +12,7 @@ const {
   orchestratorFetchMock,
   getSessionPrismaMock,
   connectionFindManyMock,
+  rbacScopeMock,
 } = vi.hoisted(() => {
   const connectionFindManyMock = vi.fn()
   const getSessionPrismaMock = vi.fn().mockResolvedValue({
@@ -24,6 +25,7 @@ const {
     orchestratorFetchMock: vi.fn(),
     getSessionPrismaMock,
     connectionFindManyMock,
+    rbacScopeMock: vi.fn(),
   }
 })
 
@@ -46,6 +48,7 @@ vi.mock("@/lib/orchestrator/client", () => ({
 
 vi.mock("@/lib/rbac", () => ({
   checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...a: any[]) => rbacScopeMock(...a),
   PERMISSIONS: { CONNECTION_VIEW: "connection.view" },
 }))
 
@@ -90,6 +93,7 @@ beforeEach(() => {
   })
   // Default: orchestrator creates the rule successfully
   orchestratorFetchMock.mockResolvedValue({ id: "rule-1", name: "Test rule" })
+  rbacScopeMock.mockReset().mockResolvedValue(null)
 })
 
 // ---------------------------------------------------------------------------
@@ -275,5 +279,60 @@ describe("GET /api/v1/orchestrator/alerts/rules -- vDC view context filtering", 
     expect(ids).toContain("r-global")
     expect(ids).toContain("r-c1")
     expect(ids).not.toContain("r-c2")
+  })
+})
+
+describe("GET /api/v1/orchestrator/alerts/rules -- RBAC infra scope filtering", () => {
+  const RULES = [
+    { id: "r1", connection_id: "c1" },
+    { id: "r2", connection_id: "c2" },
+    { id: "r3" },
+  ]
+
+  beforeEach(() => {
+    getInfraMock.mockResolvedValue({ kind: "provider" })
+    getCurrentTenantIdMock.mockResolvedValue("default")
+    getTenantConnectionIdsMock.mockResolvedValue(new Set(["c1", "c2"]))
+    orchestratorFetchMock.mockResolvedValue(RULES)
+  })
+
+  it("returns every rule for an unrestricted admin", async () => {
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson<any[]>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.map((rule) => rule.id)).toEqual(["r1", "r2", "r3"])
+    expect(rbacScopeMock).toHaveBeenCalledWith("connection.view")
+  })
+
+  it("keeps connection-level and global rules for a node-scoped user", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(),
+      nodesByConnection: new Map([["c1", new Set(["n1"])]]),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson<any[]>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.map((rule) => rule.id)).toEqual(["r1", "r3"])
+  })
+
+  it("keeps granted connection and global rules for a connection-scoped user", async () => {
+    rbacScopeMock.mockResolvedValue({
+      fullConnections: new Set(["c2"]),
+      nodesByConnection: new Map(),
+      guestDerived: false,
+    })
+
+    const { GET } = await import("./route")
+    const res = await callRoute(GET, { method: "GET" })
+    const body = await readJson<any[]>(res)
+
+    expect(res.status).toBe(200)
+    expect(body.map((rule) => rule.id)).toEqual(["r2", "r3"])
   })
 })

--- a/frontend/src/app/api/v1/orchestrator/alerts/rules/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/rules/route.ts
@@ -4,7 +4,8 @@ import { orchestratorFetch } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getTenantConnectionIds, getSessionPrisma, DEFAULT_TENANT_ID } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
+import { isFlatRecordVisible } from '@/lib/rbac/infraScope'
 import { ruleVisibleToTenant, setRuleOwner } from '@/lib/alerts/ruleOwners'
 import { injectVdcNodeScope } from '@/lib/alerts/ruleScope'
 
@@ -45,7 +46,16 @@ export async function GET(req: Request) {
       ? ownershipFiltered.filter((r: any) => !r.connection_id || vdcScope.connectionIds.has(r.connection_id))
       : ownershipFiltered
 
-    return NextResponse.json(filtered)
+    // Caller's RBAC infra scope (issue #525): rules bound to a connection the
+    // user was not granted are dropped. A rule is connection-level config, so
+    // a node-scoped user keeps their cluster's rules; connection-less rules
+    // are tenant-global and stay visible, as under the vDC filter above.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW)
+    const rbacFiltered = rbacScope && Array.isArray(filtered)
+      ? filtered.filter((r: any) => !r.connection_id || isFlatRecordVisible(rbacScope, { connId: r.connection_id, nodeBound: false }))
+      : filtered
+
+    return NextResponse.json(rbacFiltered)
   } catch (error: any) {
     if ((error as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
       console.error('[orchestrator/alerts/rules] GET error:', error)

--- a/frontend/src/app/api/v1/orchestrator/alerts/summary/alertsSummaryScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/summary/alertsSummaryScope.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getAlertsMock,
+  findManyMock,
+  isAlertVisibleToTenantMock,
+  getTenantInfrastructureScopeMock,
+  maskingScopeMock,
+  rbacScopeMock,
+} = vi.hoisted(() => ({
+  getAlertsMock: vi.fn(),
+  findManyMock: vi.fn(),
+  isAlertVisibleToTenantMock: vi.fn(),
+  getTenantInfrastructureScopeMock: vi.fn(),
+  maskingScopeMock: vi.fn(),
+  rbacScopeMock: vi.fn(),
+}))
+
+import { FAKE_RBAC_SCOPE } from '@/__tests__/setup/rbacScope'
+
+const alert1 = {
+  connection_id: 'conn-1',
+  type: 'cpu',
+  severity: 'warning',
+  resource_type: 'node',
+  resource: 'pve-node-1',
+  status: 'active',
+  last_seen_at: '2026-01-01T00:00:00Z',
+}
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  alertsApi: { getAlerts: (...args: unknown[]) => getAlertsMock(...args) },
+}))
+
+vi.mock('@/lib/demo/demo-api', () => ({
+  demoResponse: () => null,
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: vi.fn().mockResolvedValue('default'),
+  getTenantConnectionIds: vi.fn().mockResolvedValue(new Set<string>(['conn-1'])),
+  getSessionPrisma: vi.fn().mockResolvedValue({
+    alertSilence: { findMany: (...args: unknown[]) => findManyMock(...args) },
+  }),
+}))
+
+vi.mock('@/lib/tenant/infraScope', () => ({
+  getTenantInfrastructureScope: (...args: unknown[]) => getTenantInfrastructureScopeMock(...args),
+  maskingScope: (...args: unknown[]) => maskingScopeMock(...args),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...args: unknown[]) => rbacScopeMock(...args),
+  PERMISSIONS: { CONNECTION_VIEW: 'connection.view' },
+}))
+
+vi.mock('@/lib/alerts/visibility', () => ({
+  isAlertVisibleToTenant: (...args: unknown[]) => isAlertVisibleToTenantMock(...args),
+}))
+
+vi.mock('@/lib/alerts/vdcVmids', () => ({
+  getVdcVmidsByConnection: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/alerts/orchestratorFingerprint', () => ({
+  buildOrchestratorFingerprint: (alert: { connection_id?: string; type?: string; resource?: string }) =>
+    `${alert.connection_id}:${alert.type}:${alert.resource}`,
+}))
+
+import { GET } from './route'
+
+function makeReq() {
+  return new Request('http://localhost/api/v1/orchestrator/alerts/summary')
+}
+
+beforeEach(() => {
+  getAlertsMock.mockReset().mockResolvedValue({ data: { data: [alert1] } })
+  findManyMock.mockReset().mockResolvedValue([])
+  isAlertVisibleToTenantMock.mockReset().mockResolvedValue(true)
+  getTenantInfrastructureScopeMock.mockReset().mockResolvedValue({ kind: 'provider' })
+  maskingScopeMock.mockReset().mockReturnValue(null)
+  rbacScopeMock.mockReset().mockResolvedValue(null)
+})
+
+describe('RBAC infra scope forwarding (issue #525)', () => {
+  it('forwards infraKind and the resolved RBAC scope', async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+
+    const res = await GET(makeReq())
+    const ctx = isAlertVisibleToTenantMock.mock.calls[0][1]
+
+    expect(res.status).toBe(200)
+    expect(ctx.infraKind).toBe('provider')
+    expect(ctx.rbacScope).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith('connection.view')
+  })
+
+  it('forwards infraKind and null for an unrestricted caller', async () => {
+    const res = await GET(makeReq())
+    const ctx = isAlertVisibleToTenantMock.mock.calls[0][1]
+
+    expect(res.status).toBe(200)
+    expect(ctx.infraKind).toBe('provider')
+    expect(ctx.rbacScope).toBeNull()
+  })
+
+  it('returns an all-zero summary when the alert is not visible', async () => {
+    isAlertVisibleToTenantMock.mockResolvedValue(false)
+
+    const res = await GET(makeReq())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({
+      total_active: 0,
+      critical: 0,
+      warning: 0,
+      info: 0,
+      acknowledged: 0,
+      resolved_today: 0,
+    })
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/alerts/summary/route.ts
@@ -4,7 +4,7 @@ import { alertsApi } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 import { getCurrentTenantId, getSessionPrisma, getTenantConnectionIds } from '@/lib/tenant'
 import { getTenantInfrastructureScope, maskingScope } from '@/lib/tenant/infraScope'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from '@/lib/rbac'
 import { isAlertVisibleToTenant } from '@/lib/alerts/visibility'
 import { getVdcVmidsByConnection } from '@/lib/alerts/vdcVmids'
 import { buildOrchestratorFingerprint } from '@/lib/alerts/orchestratorFingerprint'
@@ -35,7 +35,9 @@ export async function GET(req: Request) {
     const response = await alertsApi.getAlerts({ limit: 1000, offset: 0 })
     const allAlerts = response.data?.data || response.data || []
     const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId) : undefined
-    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }
+    // Caller's RBAC infra scope (issue #525), honoured inside isAlertVisibleToTenant.
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW)
+    const visibilityCtx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }
     // isAlertVisibleToTenant became async in the Postgres cutover; resolve
     // each alert's visibility up-front before filtering, otherwise the
     // filter sees a Promise (truthy) and lets every alert through.

--- a/frontend/src/lib/alerts/clearVisible.test.ts
+++ b/frontend/src/lib/alerts/clearVisible.test.ts
@@ -6,13 +6,16 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { getAlertsMock, deleteAlertMock, isVisibleMock, getInfraMock, vdcVmidsMock } = vi.hoisted(() => ({
+const { getAlertsMock, deleteAlertMock, isVisibleMock, getInfraMock, vdcVmidsMock, rbacScopeMock } = vi.hoisted(() => ({
   getAlertsMock: vi.fn(),
   deleteAlertMock: vi.fn(),
   isVisibleMock: vi.fn(),
   getInfraMock: vi.fn(),
   vdcVmidsMock: vi.fn(),
+  rbacScopeMock: vi.fn(),
 }))
+
+import { FAKE_RBAC_SCOPE } from "@/__tests__/setup/rbacScope"
 
 vi.mock("@/lib/orchestrator/client", () => ({
   alertsApi: {
@@ -32,6 +35,11 @@ vi.mock("@/lib/alerts/vdcVmids", () => ({
 vi.mock("@/lib/tenant", () => ({
   getCurrentTenantId: async () => "tenant-a",
   getTenantConnectionIds: async () => new Set(["c1"]),
+}))
+
+vi.mock("@/lib/rbac", () => ({
+  getCurrentRbacInfraScope: (...a: any[]) => rbacScopeMock(...a),
+  PERMISSIONS: { ALERTS_MANAGE: "alerts.manage" },
 }))
 
 // Keep the real maskingScope (pure function); only stub the scope resolver.
@@ -54,6 +62,7 @@ beforeEach(() => {
   vdcVmidsMock.mockResolvedValue(new Map([["c1", new Set(["100", "101"])]]))
   getAlertsMock.mockResolvedValue({ data: { data: ALERTS } })
   deleteAlertMock.mockResolvedValue({ data: { status: "ok" } })
+  rbacScopeMock.mockReset().mockResolvedValue(null)
 })
 
 describe("clearVisibleTenantAlerts", () => {
@@ -85,5 +94,28 @@ describe("clearVisibleTenantAlerts", () => {
 
     expect(cleared).toBe(0)
     expect(deleteAlertMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("RBAC infra scope forwarding (issue #525)", () => {
+  beforeEach(() => {
+    isVisibleMock.mockResolvedValue(true)
+  })
+
+  it("forwards the resolved RBAC scope", async () => {
+    rbacScopeMock.mockResolvedValue(FAKE_RBAC_SCOPE)
+
+    const cleared = await clearVisibleTenantAlerts("c1")
+
+    expect(cleared).toBe(3)
+    expect(isVisibleMock.mock.calls[0][1].rbacScope).toBe(FAKE_RBAC_SCOPE)
+    expect(rbacScopeMock).toHaveBeenCalledWith("alerts.manage")
+  })
+
+  it("forwards null for an unrestricted caller", async () => {
+    const cleared = await clearVisibleTenantAlerts("c1")
+
+    expect(cleared).toBe(3)
+    expect(isVisibleMock.mock.calls[0][1].rbacScope).toBeNull()
   })
 })

--- a/frontend/src/lib/alerts/clearVisible.ts
+++ b/frontend/src/lib/alerts/clearVisible.ts
@@ -16,6 +16,7 @@ import { isAlertVisibleToTenant } from "@/lib/alerts/visibility"
 import { getVdcVmidsByConnection } from "@/lib/alerts/vdcVmids"
 import { getCurrentTenantId, getTenantConnectionIds } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
+import { getCurrentRbacInfraScope, PERMISSIONS } from "@/lib/rbac"
 
 /** Returns the number of alerts actually cleared. */
 export async function clearVisibleTenantAlerts(connectionId?: string): Promise<number> {
@@ -24,7 +25,9 @@ export async function clearVisibleTenantAlerts(connectionId?: string): Promise<n
   const infra = await getTenantInfrastructureScope(tenantId)
   const vdcScope = maskingScope(infra)
   const vdcVmids = vdcScope ? await getVdcVmidsByConnection(tenantId) : undefined
-  const ctx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind }
+  // Caller's RBAC infra scope (issue #525): "clear all" clears what the list shows.
+  const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.ALERTS_MANAGE)
+  const ctx = { tenantId, tenantConnectionIds, vdcScope, vdcVmids, infraKind: infra.kind, rbacScope }
 
   // Same fetch shape as the GET list route (500-cap mirrors its page size).
   const response = await alertsApi.getAlerts({

--- a/frontend/src/lib/alerts/visibility.ts
+++ b/frontend/src/lib/alerts/visibility.ts
@@ -25,6 +25,7 @@ import { DEFAULT_TENANT_ID } from "@/lib/tenant"
 import { ruleVisibleToTenant } from "@/lib/alerts/ruleOwners"
 import type { VdcScope } from "@/lib/vdc/scope"
 import { resolveVmMeta, findVmMetaByVmid, type VmMeta } from "@/lib/cache/vmMetaCache"
+import { isFlatRecordVisible, type RbacInfraScope } from "@/lib/rbac/infraScope"
 
 export interface AlertVisibilityCtx {
   tenantId: string
@@ -41,6 +42,12 @@ export interface AlertVisibilityCtx {
    * cache fallback is skipped.
    */
   vdcVmids?: Map<string, Set<string>>
+  /**
+   * The CALLER's RBAC infra scope (role grants), ANDed with the tenant gates:
+   * a connection / node / vm scoped user only sees alerts attributable to
+   * their grants. Absent or null = unrestricted (issue #525).
+   */
+  rbacScope?: RbacInfraScope | null
 }
 
 interface OrchestratorAlertLike {
@@ -95,6 +102,12 @@ export async function isAlertVisibleToTenant(
   ctx: AlertVisibilityCtx,
 ): Promise<boolean> {
   const { tenantId, tenantConnectionIds, vdcScope, infraKind } = ctx
+
+  // Gate 0: the caller's RBAC infra scope. Sync and cheap, so it runs before
+  // the rule-ownership lookup; an out-of-scope alert never costs a query.
+  if (ctx.rbacScope && !isAlertInRbacScope(alert, ctx.rbacScope, tenantId)) {
+    return debugDeny(alert, 'rbac_infra_scope', { connection_id: alert.connection_id })
+  }
 
   // Gate 1: rule visibility.
   if (alert.rule_id) {
@@ -201,6 +214,59 @@ function identifyAlertVm(alert: OrchestratorAlertLike): VmIdent | null {
     return { node: alert.node, vmid: String(alert.resource_id) }
   }
   return null
+}
+
+/**
+ * Node an alert can be attributed to: the explicit field when present, the
+ * UPID of an event alert, a node alert's `resource` (the orchestrator stores
+ * the node name there), else the hosting node of the VM from the warm
+ * inventory index. Undefined when nothing resolves, cold cache included.
+ */
+function resolveAlertNode(alert: OrchestratorAlertLike, tenantId: string): string | undefined {
+  if (alert.node) return alert.node
+  if (alert.event_id) {
+    const node = parseUpid(alert.event_id)?.node
+    if (node) return node
+  }
+  if (String(alert.resource_type || '').toLowerCase() === 'node') return alert.resource || undefined
+  const ident = identifyAlertVm(alert)
+  if (!ident || !alert.connection_id) return undefined
+  const meta =
+    findVmMetaByVmid(alert.connection_id, ident.vmid, DEFAULT_TENANT_ID) ??
+    findVmMetaByVmid(alert.connection_id, ident.vmid, tenantId)
+  return meta?.node
+}
+
+/**
+ * RBAC infra-scope gate for one alert (issue #525), shared by every alert
+ * route through AlertVisibilityCtx.rbacScope and by the dashboard merge.
+ * Connection and guest-derived verdicts never touch the inventory index;
+ * node attribution is only attempted when a node scope applies to the
+ * alert's connection.
+ */
+export function isAlertInRbacScope(
+  alert: OrchestratorAlertLike,
+  scope: RbacInfraScope | null,
+  tenantId: string,
+): boolean {
+  if (scope === null) return true
+  const connId = alert.connection_id
+  if (!connId || scope.fullConnections.has(connId) || scope.guestDerived) {
+    return isFlatRecordVisible(scope, { connId })
+  }
+  // nodesByConnection carries the node of every node AND vm grant, so a
+  // connection missing from it holds no grant at all.
+  if (!scope.nodesByConnection.has(connId)) return false
+  const rt = String(alert.resource_type || '').toLowerCase()
+  // Cluster-wide alerts (storage, license, quorum, OSD, replication) are facts
+  // about the granted connection; anything else happened on a node.
+  const nodeBound = rt === 'node' || !SYSTEM_RESOURCE_TYPES.has(rt)
+  return isFlatRecordVisible(scope, {
+    connId,
+    node: resolveAlertNode(alert, tenantId),
+    vmid: identifyAlertVm(alert)?.vmid,
+    nodeBound,
+  })
 }
 
 /**

--- a/frontend/src/lib/alerts/visibilityRbacScope.test.ts
+++ b/frontend/src/lib/alerts/visibilityRbacScope.test.ts
@@ -1,0 +1,180 @@
+/**
+ * RBAC infra-scope gate on orchestrator alerts (issue #525): the caller's
+ * connection / node grants, ANDed with the tenant gates of
+ * isAlertVisibleToTenant. The orchestrator alert payload carries no `node`
+ * field, so node attribution goes through the UPID (event alerts), the
+ * `resource` of a node alert, or the warm inventory index (VM alerts).
+ * No database: rule ownership and the inventory index are mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { findVmMetaByVmidMock, ruleVisibleMock } = vi.hoisted(() => ({
+  findVmMetaByVmidMock: vi.fn(),
+  ruleVisibleMock: vi.fn(),
+}))
+
+vi.mock('@/lib/cache/vmMetaCache', () => ({
+  resolveVmMeta: vi.fn().mockReturnValue(null),
+  findVmMetaByVmid: (...a: unknown[]) => findVmMetaByVmidMock(...a),
+}))
+vi.mock('@/lib/alerts/ruleOwners', () => ({
+  ruleVisibleToTenant: (...a: unknown[]) => ruleVisibleMock(...a),
+}))
+vi.mock('@/lib/tenant', () => ({ DEFAULT_TENANT_ID: 'default' }))
+
+import { isAlertInRbacScope, isAlertVisibleToTenant, type AlertVisibilityCtx } from './visibility'
+import type { RbacInfraScope } from '@/lib/rbac/infraScope'
+
+const CONN = 'conn-1'
+const OTHER = 'conn-2'
+
+const scope = (over: Partial<RbacInfraScope> = {}): RbacInfraScope => ({
+  fullConnections: new Set<string>(),
+  nodesByConnection: new Map<string, Set<string>>(),
+  guestDerived: false,
+  ...over,
+})
+const nodeScope = () => scope({ nodesByConnection: new Map([[CONN, new Set(['pve1'])]]) })
+const connScope = () => scope({ fullConnections: new Set([CONN]) })
+const upid = (node: string) => `UPID:${node}:0000A1B2:00C3D4E5:6789ABCD:qmstart:100:root@pam:`
+
+beforeEach(() => {
+  findVmMetaByVmidMock.mockReset().mockReturnValue(null)
+  ruleVisibleMock.mockReset().mockResolvedValue(true)
+})
+
+describe('isAlertInRbacScope', () => {
+  it('null scope (admin / global grant) keeps everything, connection-less alerts included', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, null, 'default')).toBe(true)
+    expect(isAlertInRbacScope({ resource_type: 'license' }, null, 'default')).toBe(true)
+  })
+
+  it('a connection-less (cluster-wide) alert never reaches a scoped user', () => {
+    expect(isAlertInRbacScope({ resource_type: 'license' }, connScope(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ resource_type: 'license' }, nodeScope(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ resource_type: 'license' }, scope({ guestDerived: true }), 'default')).toBe(false)
+  })
+
+  it('connection grant keeps every alert of that connection and drops the others, without touching the index', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, connScope(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node', resource: 'pve9' }, connScope(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: OTHER, resource_type: 'vm', resource_id: 100 }, connScope(), 'default')).toBe(false)
+    expect(findVmMetaByVmidMock).not.toHaveBeenCalled()
+  })
+
+  it('guest-derived (tag / pool) scope keeps every connection-bound alert without touching the index', () => {
+    const s = scope({ guestDerived: true })
+    expect(isAlertInRbacScope({ connection_id: OTHER, resource_type: 'vm', resource_id: 100 }, s, 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node', resource: 'pve2' }, s, 'default')).toBe(true)
+    expect(findVmMetaByVmidMock).not.toHaveBeenCalled()
+  })
+
+  it('node scope: a node alert is attributed through `resource`', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node', resource: 'pve1' }, nodeScope(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node', resource: 'pve2' }, nodeScope(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node' }, nodeScope(), 'default')).toBe(false)
+    expect(findVmMetaByVmidMock).not.toHaveBeenCalled()
+  })
+
+  it('node scope: an explicit node field wins over any other attribution', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100, node: 'pve1' }, nodeScope(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100, node: 'pve2' }, nodeScope(), 'default')).toBe(false)
+    expect(findVmMetaByVmidMock).not.toHaveBeenCalled()
+  })
+
+  it('node scope: an event alert is attributed through its UPID', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'event', resource_id: 0, event_id: upid('pve1') }, nodeScope(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'event', resource_id: 0, event_id: upid('pve2') }, nodeScope(), 'default')).toBe(false)
+    expect(findVmMetaByVmidMock).not.toHaveBeenCalled()
+  })
+
+  it('node scope: a VM threshold alert is attributed through the inventory index', () => {
+    findVmMetaByVmidMock.mockReturnValue({ tags: [], node: 'pve1' })
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, nodeScope(), 'tenant-x')).toBe(true)
+    expect(findVmMetaByVmidMock).toHaveBeenCalledWith(CONN, '100', 'default')
+
+    findVmMetaByVmidMock.mockReturnValue({ tags: [], node: 'pve2' })
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, nodeScope(), 'tenant-x')).toBe(false)
+  })
+
+  it('node scope: falls back to the tenant index when the provider index has no entry', () => {
+    findVmMetaByVmidMock.mockImplementation((_c: string, _v: string, tenantId: string) =>
+      tenantId === 'tenant-x' ? { tags: [], node: 'pve1' } : null,
+    )
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, nodeScope(), 'tenant-x')).toBe(true)
+    expect(findVmMetaByVmidMock).toHaveBeenCalledWith(CONN, '100', 'tenant-x')
+  })
+
+  it('node scope: a VM alert whose node cannot be attributed (cold index) is denied', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, nodeScope(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 0 }, nodeScope(), 'default')).toBe(false)
+  })
+
+  it('node scope: cluster-wide alerts of the granted connection are kept', () => {
+    for (const rt of ['storage', 'license', 'cluster', 'system', 'osd', 'replication']) {
+      expect(isAlertInRbacScope({ connection_id: CONN, resource_type: rt }, nodeScope(), 'default')).toBe(true)
+    }
+  })
+
+  it('node scope: any alert of a connection without a grant is denied, cluster-wide ones included', () => {
+    expect(isAlertInRbacScope({ connection_id: OTHER, resource_type: 'storage' }, nodeScope(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: OTHER, resource_type: 'node', resource: 'pve1' }, nodeScope(), 'default')).toBe(false)
+  })
+})
+
+describe('isAlertInRbacScope under a vm grant (conn-1:pve1:qemu:100)', () => {
+  const vmGrant = () => scope({
+    nodesByConnection: new Map([[CONN, new Set(['pve1'])]]),
+    nodeGrantsByConnection: new Map(),
+    guestGrantsByConnection: new Map([[CONN, new Set(['100'])]]),
+  })
+
+  it('a threshold or event alert on the granted VMID passes, wherever the guest runs', () => {
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 100 }, vmGrant(), 'default')).toBe(true)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'event', resource_id: 0, event_id: upid('pve2') }, vmGrant(), 'default')).toBe(true)
+  })
+
+  it('another guest of the same host, the host itself and cluster-wide alerts are denied', () => {
+    findVmMetaByVmidMock.mockReturnValue({ tags: [], node: 'pve1' })
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'vm', resource_id: 101 }, vmGrant(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'node', resource: 'pve1' }, vmGrant(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: CONN, resource_type: 'storage' }, vmGrant(), 'default')).toBe(false)
+    expect(isAlertInRbacScope({ connection_id: OTHER, resource_type: 'vm', resource_id: 100 }, vmGrant(), 'default')).toBe(false)
+  })
+})
+
+describe('isAlertVisibleToTenant with ctx.rbacScope (gate 0)', () => {
+  const providerCtx = (rbacScope: RbacInfraScope | null | undefined): AlertVisibilityCtx => ({
+    tenantId: 'default',
+    tenantConnectionIds: new Set([CONN, OTHER]),
+    vdcScope: null,
+    infraKind: 'provider',
+    rbacScope,
+  })
+  const ruleAlert = { rule_id: 'rule-a', connection_id: OTHER, resource_type: 'vm', resource_id: 100 }
+
+  it('absent or null rbacScope leaves the tenant verdict untouched', async () => {
+    expect(await isAlertVisibleToTenant(ruleAlert, providerCtx(undefined))).toBe(true)
+    expect(await isAlertVisibleToTenant(ruleAlert, providerCtx(null))).toBe(true)
+  })
+
+  it('an out-of-scope alert is denied before the rule-ownership lookup runs', async () => {
+    expect(await isAlertVisibleToTenant(ruleAlert, providerCtx(connScope()))).toBe(false)
+    expect(ruleVisibleMock).not.toHaveBeenCalled()
+  })
+
+  it('an in-scope alert goes on to the tenant gates', async () => {
+    expect(await isAlertVisibleToTenant({ ...ruleAlert, connection_id: CONN }, providerCtx(connScope()))).toBe(true)
+    expect(ruleVisibleMock).toHaveBeenCalledWith('rule-a', 'default')
+  })
+
+  it('a scoped provider user no longer sees connection-less built-in alerts', async () => {
+    expect(await isAlertVisibleToTenant({ resource_type: 'license' }, providerCtx(null))).toBe(true)
+    expect(await isAlertVisibleToTenant({ resource_type: 'license' }, providerCtx(connScope()))).toBe(false)
+  })
+
+  it('a tenant-denied alert stays denied even when the RBAC scope allows it', async () => {
+    ruleVisibleMock.mockResolvedValue(false)
+    expect(await isAlertVisibleToTenant({ ...ruleAlert, connection_id: CONN }, providerCtx(connScope()))).toBe(false)
+  })
+})

--- a/frontend/src/lib/cache/vmMetaCache.ts
+++ b/frontend/src/lib/cache/vmMetaCache.ts
@@ -15,6 +15,8 @@ import { getTenantInventoriesFromCache } from "./inventoryCache"
 export interface VmMeta {
   tags: string[]
   pool?: string
+  /** Hosting node, for callers that only know (connection, vmid): alert node attribution. */
+  node?: string
 }
 
 type TenantIndex = {
@@ -52,7 +54,7 @@ function rebuildIndex(tenantId: string): Map<string, VmMeta> | null {
                   .map((t: string) => t.trim())
                   .filter(Boolean)
               : []
-          idx.set(rid, { tags, pool: g.pool || undefined })
+          idx.set(rid, { tags, pool: g.pool || undefined, node: node.node || undefined })
         }
       }
     }

--- a/frontend/src/lib/cache/vmMetaCacheContext.test.ts
+++ b/frontend/src/lib/cache/vmMetaCacheContext.test.ts
@@ -47,7 +47,7 @@ describe('vmMetaCache — context-keyed cache coverage (issue #633)', () => {
     setCachedInventory(inventory([guest(100, 'prod;web', 'pool-a')]), 'tA', 'vA')
     // The union key ('tA::all') was never warmed — only 'tA::vA' exists.
     const meta = resolveVmMeta('conn-1:n1:qemu:100', 'tA')
-    expect(meta).toEqual({ tags: ['prod', 'web'], pool: 'pool-a' })
+    expect(meta).toEqual({ tags: ['prod', 'web'], pool: 'pool-a', node: 'n1' })
   })
 
   it('merges guests across contexts and the freshest entry wins a per-VM conflict', async () => {
@@ -55,8 +55,8 @@ describe('vmMetaCache — context-keyed cache coverage (issue #633)', () => {
     await new Promise(resolve => setTimeout(resolve, 5))
     setCachedInventory(inventory([guest(100, 'fresh-tag'), guest(200, 'only-in-vA')]), 'tB', 'vA')
 
-    expect(resolveVmMeta('conn-1:n1:qemu:100', 'tB')).toEqual({ tags: ['fresh-tag'], pool: undefined })
-    expect(resolveVmMeta('conn-1:n1:qemu:200', 'tB')).toEqual({ tags: ['only-in-vA'], pool: undefined })
+    expect(resolveVmMeta('conn-1:n1:qemu:100', 'tB')).toEqual({ tags: ['fresh-tag'], pool: undefined, node: 'n1' })
+    expect(resolveVmMeta('conn-1:n1:qemu:200', 'tB')).toEqual({ tags: ['only-in-vA'], pool: undefined, node: 'n1' })
   })
 
   it('returns null when no context is warm for the tenant (cold cache, safe denial)', () => {

--- a/frontend/src/lib/changes/visibility.test.ts
+++ b/frontend/src/lib/changes/visibility.test.ts
@@ -67,3 +67,85 @@ describe("isChangeVisibleToTenant", () => {
     expect(isChangeVisibleToTenant({ ...VM_OWNED, resourceId: undefined }, iaasCtx())).toBe(false)
   })
 })
+
+describe("isChangeVisibleToTenant with ctx.rbacScope (issue #525)", () => {
+  const providerCtx = (rbacScope: ChangeVisibilityCtx["rbacScope"]): ChangeVisibilityCtx => ({
+    infraKind: "provider",
+    tenantConnectionIds: new Set(["c1", "c2"]),
+    vdcScope: null,
+    rbacScope,
+  })
+  const nodeScope = { fullConnections: new Set<string>(), nodesByConnection: new Map([["c1", new Set(["n1"])]]), guestDerived: false }
+  const connScope = { fullConnections: new Set(["c1"]), nodesByConnection: new Map<string, Set<string>>(), guestDerived: false }
+  const CLUSTER_LESS = { node: "n1", resourceType: "vm", resourceId: "100" }
+  const VM_N1 = { connectionId: "c1", node: "n1", resourceType: "vm", resourceId: "100" }
+  const CT_N2 = { connectionId: "c1", node: "n2", resourceType: "ct", resourceId: "101" }
+  const NODE_N2 = { connectionId: "c1", node: "n2", resourceType: "node", resourceId: "n2" }
+  const VM_NO_NODE = { connectionId: "c1", resourceType: "vm", resourceId: "102" }
+  const STORAGE = { connectionId: "c1", resourceType: "storage", resourceId: "local-lvm" }
+  const POOL = { connectionId: "c1", resourceType: "pool", resourceId: "pool-a" }
+  const VM_C2 = { connectionId: "c2", node: "n1", resourceType: "vm", resourceId: "100" }
+
+  it("absent or null scope: the provider verdict is untouched, cluster-less record included", () => {
+    expect(isChangeVisibleToTenant(CLUSTER_LESS, providerCtx(undefined))).toBe(true)
+    expect(isChangeVisibleToTenant(CLUSTER_LESS, providerCtx(null))).toBe(true)
+    expect(isChangeVisibleToTenant(VM_C2, providerCtx(null))).toBe(true)
+  })
+
+  it("connection scope: keeps every c1 record, drops c2 and cluster-less records", () => {
+    const ctx = providerCtx(connScope)
+    expect(isChangeVisibleToTenant(VM_N1, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(CT_N2, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(VM_NO_NODE, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(VM_C2, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(CLUSTER_LESS, ctx)).toBe(false)
+  })
+
+  it("node scope: keeps guest and node records on the granted node, drops the other node and unattributed guests", () => {
+    const ctx = providerCtx(nodeScope)
+    expect(isChangeVisibleToTenant(VM_N1, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(CT_N2, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(NODE_N2, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(VM_NO_NODE, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(VM_C2, ctx)).toBe(false)
+  })
+
+  it("node scope: storage and pool records of the granted connection are cluster-level facts and stay", () => {
+    const ctx = providerCtx(nodeScope)
+    expect(isChangeVisibleToTenant(STORAGE, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(POOL, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant({ ...STORAGE, connectionId: "c2" }, ctx)).toBe(false)
+  })
+
+  it("guest-derived scope: the tenant-level perimeter is kept, cluster-less records excepted", () => {
+    const ctx = providerCtx({ fullConnections: new Set<string>(), nodesByConnection: new Map<string, Set<string>>(), guestDerived: true })
+    expect(isChangeVisibleToTenant(CT_N2, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(VM_C2, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant(CLUSTER_LESS, ctx)).toBe(false)
+  })
+
+  it("RBAC and the vDC mask compose: a record must pass both", () => {
+    const ctx = iaasCtx({ rbacScope: connScope })
+    expect(isChangeVisibleToTenant(VM_OWNED, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant({ ...VM_OWNED, resourceId: "999" }, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(VM_OWNED, iaasCtx({ rbacScope: nodeScope }))).toBe(true)
+    expect(isChangeVisibleToTenant(VM_OWNED, iaasCtx({ rbacScope: { ...connScope, fullConnections: new Set(["c2"]) } }))).toBe(false)
+  })
+
+  it("vm scope: only the granted guest's records pass; host and cluster rows are denied", () => {
+    const vmScope = {
+      fullConnections: new Set<string>(),
+      nodesByConnection: new Map([["c1", new Set(["n1"])]]),
+      nodeGrantsByConnection: new Map<string, Set<string>>(),
+      guestGrantsByConnection: new Map([["c1", new Set(["100"])]]),
+      guestDerived: false,
+    }
+    const ctx = providerCtx(vmScope)
+    expect(isChangeVisibleToTenant(VM_N1, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant({ ...VM_N1, node: "n2" }, ctx)).toBe(true)
+    expect(isChangeVisibleToTenant({ ...VM_N1, resourceId: "101" }, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(NODE_N2, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant({ connectionId: "c1", node: "n1", resourceType: "node", resourceId: "n1" }, ctx)).toBe(false)
+    expect(isChangeVisibleToTenant(STORAGE, ctx)).toBe(false)
+  })
+})

--- a/frontend/src/lib/changes/visibility.ts
+++ b/frontend/src/lib/changes/visibility.ts
@@ -20,11 +20,16 @@
  *                               (VMID resolved in the vDC pools) survive.
  *                               node / storage / pool records are provider
  *                               infra concerns. Missing key = deny.
+ *  - caller RBAC infra scope   → ANDed on top of all of the above: a
+ *                               connection / node scoped user only sees the
+ *                               records attributable to their grants (#525).
  */
 
 import { getCurrentTenantId, getTenantConnectionIds } from "@/lib/tenant"
 import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
 import { getVdcVmidsByConnection } from "@/lib/alerts/vdcVmids"
+import { getCurrentRbacInfraScope, PERMISSIONS } from "@/lib/rbac"
+import { isFlatRecordVisible, type RbacInfraScope } from "@/lib/rbac/infraScope"
 
 const GUEST_RESOURCE_TYPES = new Set(["vm", "ct"])
 
@@ -33,6 +38,8 @@ export interface ChangeVisibilityCtx {
   tenantConnectionIds: Set<string>
   vdcScope: ReturnType<typeof maskingScope>
   vdcVmids?: Map<string, Set<string>>
+  /** Caller's RBAC infra scope; absent or null = unrestricted (issue #525). */
+  rbacScope?: RbacInfraScope | null
 }
 
 export async function buildChangeVisibilityCtx(): Promise<ChangeVisibilityCtx> {
@@ -45,10 +52,25 @@ export async function buildChangeVisibilityCtx(): Promise<ChangeVisibilityCtx> {
     tenantConnectionIds: await getTenantConnectionIds(),
     vdcScope,
     vdcVmids: vdcScope ? await getVdcVmidsByConnection(tenantId) : undefined,
+    rbacScope: await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW),
   }
 }
 
 export function isChangeVisibleToTenant(c: any, ctx: ChangeVisibilityCtx): boolean {
+  // Caller's RBAC infra scope first (sync, cheap). Guest records carry their
+  // VMID so a vm grant matches them; guest and node records are node-bound;
+  // storage / pool records are cluster-level facts.
+  if (ctx.rbacScope) {
+    const guest = GUEST_RESOURCE_TYPES.has(c.resourceType)
+    const visible = isFlatRecordVisible(ctx.rbacScope, {
+      connId: c.connectionId,
+      node: c.node,
+      vmid: guest ? c.resourceId : undefined,
+      nodeBound: guest || c.resourceType === "node",
+    })
+    if (!visible) return false
+  }
+
   if (!c.connectionId) return ctx.infraKind === "provider"
 
   if (!ctx.vdcScope) return ctx.tenantConnectionIds.has(c.connectionId)

--- a/frontend/src/lib/rbac/index.ts
+++ b/frontend/src/lib/rbac/index.ts
@@ -22,8 +22,11 @@ import {
   filterVisibleConnections,
   filterCandidateConnections,
   pruneEmptyConnections,
+  isFlatRecordVisible,
+  hasInfraGrant,
   tokenInfraScope,
   type RbacInfraScope,
+  type ScopePermissionFilter,
 } from './infraScope'
 
 export {
@@ -33,7 +36,10 @@ export {
   filterVisibleConnections,
   filterCandidateConnections,
   pruneEmptyConnections,
+  isFlatRecordVisible,
+  hasInfraGrant,
   type RbacInfraScope,
+  type ScopePermissionFilter,
 }
 
 export interface PermissionCheck {
@@ -796,15 +802,36 @@ export async function filterNodesByPermission<T extends { connId: string; node: 
 export async function getRbacInfraScope(
   principalOrUserId: string | Principal,
   tenantId?: string,
+  permission?: ScopePermissionFilter,
 ): Promise<RbacInfraScope | null> {
   const token = asTokenPrincipal(principalOrUserId)
   if (token) {
+    // A token's permission set is flat (checkTokenPermission gates it); its
+    // perimeter is the connection allow-list whatever the permission.
     return tokenInfraScope(token.connectionIds ?? null)
   }
   const userId = toUserId(principalOrUserId)
   const tid = resolveGrantTenantId(principalOrUserId, tenantId)
   const grants = await loadUserGrants(userId, tid)
-  return deriveRbacInfraScope(grants)
+  return deriveRbacInfraScope(grants, permission)
+}
+
+/**
+ * The caller's RBAC infra scope, resolved from the request principal in one
+ * call: null when unrestricted (super admin, a global grant of `permission`,
+ * token without a connection allow-list) or when no principal resolves at
+ * all, which the route's checkPermission has already rejected. Pass the
+ * permission the route checked so the perimeter is where THAT permission was
+ * granted, not the union of every assignment. Aggregate read routes resolve
+ * this once and feed it to isFlatRecordVisible / the alert visibility ctx
+ * (issue #525).
+ */
+export async function getCurrentRbacInfraScope(permission?: ScopePermissionFilter): Promise<RbacInfraScope | null> {
+  const ctx = await getRBACContext()
+  if (!ctx || ctx.isAdmin) return null
+  const principal = ctx.principal ?? ctx.userId
+  if (!principal) return null
+  return getRbacInfraScope(principal, ctx.tenantId, permission)
 }
 
 export type GuestVisibilityCheck = (guest: {

--- a/frontend/src/lib/rbac/infraScope.test.ts
+++ b/frontend/src/lib/rbac/infraScope.test.ts
@@ -1,6 +1,6 @@
 // frontend/src/lib/rbac/infraScope.test.ts
 import { describe, it, expect } from 'vitest'
-import { deriveRbacInfraScope, isConnectionVisible, applyRbacInfraFilter, filterVisibleConnections, mayHaveVisibleGuests, filterCandidateConnections, pruneEmptyConnections, tokenInfraScope } from './infraScope'
+import { deriveRbacInfraScope, isConnectionVisible, applyRbacInfraFilter, filterVisibleConnections, mayHaveVisibleGuests, filterCandidateConnections, pruneEmptyConnections, tokenInfraScope, isFlatRecordVisible, hasInfraGrant, type RbacInfraScope } from './infraScope'
 
 describe('deriveRbacInfraScope', () => {
   it('returns null (unrestricted) for super admins', () => {
@@ -210,5 +210,163 @@ describe('tokenInfraScope', () => {
   it('is never guest-derived', () => {
     expect(tokenInfraScope(['connA'])!.guestDerived).toBe(false)
     expect(tokenInfraScope(null)).toBeNull()
+  })
+})
+
+describe('isFlatRecordVisible (flat feeds, issue #525)', () => {
+  const scope = (over: Partial<RbacInfraScope> = {}): RbacInfraScope => ({
+    fullConnections: new Set<string>(),
+    nodesByConnection: new Map<string, Set<string>>(),
+    guestDerived: false,
+    ...over,
+  })
+  const nodeScope = () => scope({ nodesByConnection: new Map([['connA', new Set(['n1'])]]) })
+  const connScope = () => scope({ fullConnections: new Set(['connA']) })
+
+  it('null scope keeps every row, connection-less rows included', () => {
+    expect(isFlatRecordVisible(null, { connId: 'connA', node: 'n9' })).toBe(true)
+    expect(isFlatRecordVisible(null, {})).toBe(true)
+  })
+
+  it('a row with no connection never reaches a scoped user', () => {
+    expect(isFlatRecordVisible(connScope(), { node: 'n1' })).toBe(false)
+    expect(isFlatRecordVisible(nodeScope(), { connId: '', node: 'n1' })).toBe(false)
+    expect(isFlatRecordVisible(scope({ guestDerived: true }), { node: 'n1' })).toBe(false)
+  })
+
+  it('connection grant keeps every row of that connection, node named or not, and drops other connections', () => {
+    expect(isFlatRecordVisible(connScope(), { connId: 'connA', node: 'n7' })).toBe(true)
+    expect(isFlatRecordVisible(connScope(), { connId: 'connA' })).toBe(true)
+    expect(isFlatRecordVisible(connScope(), { connId: 'connB', node: 'n1' })).toBe(false)
+  })
+
+  it('node scope keeps a row on a granted node and drops a row on another node', () => {
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connA', node: 'n1' })).toBe(true)
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connA', node: 'n2' })).toBe(false)
+  })
+
+  it('node scope drops a node-bound row that names no node (the default)', () => {
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connA' })).toBe(false)
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connA', node: null, nodeBound: true })).toBe(false)
+  })
+
+  it('node scope keeps a cluster-level row of the granted connection', () => {
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connA', nodeBound: false })).toBe(true)
+  })
+
+  it('node scope drops every row of a connection without a grant, cluster-level ones included', () => {
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connB', node: 'n1' })).toBe(false)
+    expect(isFlatRecordVisible(nodeScope(), { connId: 'connB', nodeBound: false })).toBe(false)
+  })
+
+  it('guest-derived scope keeps every connection-bound row: only the per-guest filter can decide', () => {
+    const s = scope({ guestDerived: true, nodesByConnection: new Map([['connA', new Set(['n1'])]]) })
+    expect(isFlatRecordVisible(s, { connId: 'connA', node: 'n2' })).toBe(true)
+    expect(isFlatRecordVisible(s, { connId: 'connB' })).toBe(true)
+  })
+})
+
+describe('deriveRbacInfraScope: permission-aware derivation and vm grants (issue #525)', () => {
+  const grant = (scopeType: string, scopeTarget: string | null, ...permissions: string[]) =>
+    ({ scopeType, scopeTarget, permissions: new Set(permissions) })
+
+  it('without a permission every grant counts (the #524 tree semantics)', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [grant('node', 'c1:n1', 'alerts.manage'), grant('connection', 'c2', 'vm.view')] })!
+    expect([...s.fullConnections]).toEqual(['c2'])
+    expect([...s.nodesByConnection.keys()]).toEqual(['c1'])
+  })
+
+  it('with a permission only the grants carrying it shape the perimeter', () => {
+    const grants = {
+      superAdmin: false,
+      byScope: [grant('node', 'c1:n1', 'alerts.manage', 'connection.view'), grant('connection', 'c2', 'vm.view', 'connection.view')],
+    }
+    const manage = deriveRbacInfraScope(grants, 'alerts.manage')!
+    expect(manage.fullConnections.size).toBe(0)
+    expect([...manage.nodesByConnection.keys()]).toEqual(['c1'])
+    const view = deriveRbacInfraScope(grants, 'connection.view')!
+    expect([...view.fullConnections]).toEqual(['c2'])
+    expect([...view.nodesByConnection.keys()]).toEqual(['c1'])
+  })
+
+  it('a list of permissions matches a grant carrying any of them', () => {
+    const grants = {
+      superAdmin: false,
+      byScope: [grant('node', 'c1:n1', 'node.view'), grant('vm', 'c2:n2:qemu:200', 'vm.view'), grant('connection', 'c3', 'backup.view')],
+    }
+    const s = deriveRbacInfraScope(grants, ['vm.view', 'node.view'])!
+    expect([...s.nodesByConnection.keys()].sort()).toEqual(['c1', 'c2'])
+    expect(s.fullConnections.has('c3')).toBe(false)
+  })
+
+  it('only a global grant OF the permission makes the user unrestricted', () => {
+    const grants = { superAdmin: false, byScope: [grant('global', null, 'backup.view'), grant('node', 'c1:n1', 'connection.view')] }
+    expect(deriveRbacInfraScope(grants)).toBeNull()
+    expect(deriveRbacInfraScope(grants, 'backup.view')).toBeNull()
+    const s = deriveRbacInfraScope(grants, 'connection.view')!
+    expect([...s.nodesByConnection.get('c1')!]).toEqual(['n1'])
+  })
+
+  it('a grant without a permission set is ignored under a permission filter, kept without one', () => {
+    const grants = { superAdmin: false, byScope: [{ scopeType: 'connection', scopeTarget: 'c1' }] }
+    expect(deriveRbacInfraScope(grants)!.fullConnections.has('c1')).toBe(true)
+    expect(deriveRbacInfraScope(grants, 'vm.view')!.fullConnections.size).toBe(0)
+  })
+
+  it('a node grant is outright, a vm grant only lends its node to the tree and keeps the VMID', () => {
+    const s = deriveRbacInfraScope({ superAdmin: false, byScope: [grant('node', 'c1:n1', 'vm.view'), grant('vm', 'c1:n2:qemu:200', 'vm.view')] })!
+    expect([...s.nodesByConnection.get('c1')!].sort()).toEqual(['n1', 'n2'])
+    expect([...s.nodeGrantsByConnection!.get('c1')!]).toEqual(['n1'])
+    expect([...s.guestGrantsByConnection!.get('c1')!]).toEqual(['200'])
+  })
+
+  it('a token scope carries empty node and guest grant maps', () => {
+    const s = tokenInfraScope(['a'])!
+    expect(s.nodeGrantsByConnection!.size).toBe(0)
+    expect(s.guestGrantsByConnection!.size).toBe(0)
+  })
+})
+
+describe('isFlatRecordVisible with vm grants, and hasInfraGrant (issue #525)', () => {
+  const derived = (...byScope: Array<{ scopeType: string; scopeTarget: string | null }>) =>
+    deriveRbacInfraScope({ superAdmin: false, byScope })!
+  const vmOnly = () => derived({ scopeType: 'vm', scopeTarget: 'c1:n1:qemu:100' })
+  const mixed = () => derived({ scopeType: 'node', scopeTarget: 'c1:n1' }, { scopeType: 'vm', scopeTarget: 'c1:n2:qemu:200' })
+
+  it('vm grant: only rows naming that VMID pass, wherever the guest runs now', () => {
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', node: 'n1', vmid: '100' })).toBe(true)
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', node: 'n3', vmid: 100 })).toBe(true)
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', node: 'n1', vmid: '101' })).toBe(false)
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', vmid: '101' })).toBe(false)
+  })
+
+  it('vm grant: node-level and cluster-level rows of the host are denied', () => {
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', node: 'n1' })).toBe(false)
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1', nodeBound: false })).toBe(false)
+    expect(isFlatRecordVisible(vmOnly(), { connId: 'c1' })).toBe(false)
+  })
+
+  it('node grant still covers every guest of the node; a vm grant adds its own guest elsewhere', () => {
+    expect(isFlatRecordVisible(mixed(), { connId: 'c1', node: 'n1', vmid: '999' })).toBe(true)
+    expect(isFlatRecordVisible(mixed(), { connId: 'c1', node: 'n2', vmid: '200' })).toBe(true)
+    expect(isFlatRecordVisible(mixed(), { connId: 'c1', node: 'n2', vmid: '201' })).toBe(false)
+    expect(isFlatRecordVisible(mixed(), { connId: 'c1', node: 'n2' })).toBe(false)
+    expect(isFlatRecordVisible(mixed(), { connId: 'c1', nodeBound: false })).toBe(true)
+  })
+
+  it('a hand-built scope without nodeGrantsByConnection treats every listed node as an outright grant', () => {
+    const legacy: RbacInfraScope = { fullConnections: new Set(), nodesByConnection: new Map([['c1', new Set(['n1'])]]), guestDerived: false }
+    expect(isFlatRecordVisible(legacy, { connId: 'c1', node: 'n1', vmid: '5' })).toBe(true)
+    expect(isFlatRecordVisible(legacy, { connId: 'c1', nodeBound: false })).toBe(true)
+    expect(hasInfraGrant(legacy, 'c1')).toBe(true)
+  })
+
+  it('hasInfraGrant: admin, connection and node grants yes; vm-only and tag / pool no', () => {
+    expect(hasInfraGrant(null, 'c1')).toBe(true)
+    expect(hasInfraGrant(derived({ scopeType: 'connection', scopeTarget: 'c1' }), 'c1')).toBe(true)
+    expect(hasInfraGrant(mixed(), 'c1')).toBe(true)
+    expect(hasInfraGrant(vmOnly(), 'c1')).toBe(false)
+    expect(hasInfraGrant(mixed(), 'c2')).toBe(false)
+    expect(hasInfraGrant(derived({ scopeType: 'tag', scopeTarget: 'prod' }), 'c1')).toBe(false)
   })
 })

--- a/frontend/src/lib/rbac/infraScope.ts
+++ b/frontend/src/lib/rbac/infraScope.ts
@@ -15,7 +15,11 @@
 export type RbacInfraScope = {
   /** Connections granted whole (connection scope) -> ALL their nodes are visible. */
   fullConnections: Set<string>
-  /** Per-connection node names granted (node / vm scope) -> only those nodes. */
+  /**
+   * Per-connection node names the TREE may show: node grants plus the node of
+   * every vm grant (a vm-scoped user still sees their host in the tree, with
+   * the guests pruned by filterVmsByPermission).
+   */
   nodesByConnection: Map<string, Set<string>>
   /**
    * True when the user holds a tag or pool grant. The perimeter is then whatever
@@ -23,7 +27,19 @@ export type RbacInfraScope = {
    * token principal.
    */
   guestDerived: boolean
+  /**
+   * Per-connection node names granted OUTRIGHT (node scope). Flat feeds gate on
+   * this rather than on nodesByConnection so a vm grant does not open its whole
+   * node (issue #525). Absent on a hand-built scope = every node listed in
+   * nodesByConnection is an outright grant.
+   */
+  nodeGrantsByConnection?: Map<string, Set<string>>
+  /** Per-connection VMIDs granted directly (vm scope). Absent = none. */
+  guestGrantsByConnection?: Map<string, Set<string>>
 }
+
+/** Permission(s) a grant must carry to count; `undefined` = every grant counts. */
+export type ScopePermissionFilter = string | readonly string[] | undefined
 
 const TREE_SCOPE_TYPES = new Set(['connection', 'node', 'vm'])
 const FLAT_SCOPE_TYPES = new Set(['tag', 'pool'])
@@ -33,19 +49,43 @@ const FLAT_SCOPE_TYPES = new Set(['tag', 'pool'])
  * unrestricted (super admin or holds a `global` scope); callers must then skip
  * RBAC tree pruning. A non-null scope with empty sets and `guestDerived: false`
  * restricts the tree to nothing (no infra and no flat grants).
+ *
+ * `permission` narrows the derivation to the grants that carry the permission
+ * the route checked (any of them when a list is given): the perimeter is where
+ * that permission was granted, and only a global grant OF that permission makes
+ * the user unrestricted. Without it every grant counts, whatever it allows,
+ * which is the #524 tree semantics.
  */
-export function deriveRbacInfraScope(grants: {
-  superAdmin: boolean
-  byScope: ReadonlyArray<{ scopeType: string; scopeTarget: string | null }>
-}): RbacInfraScope | null {
+export function deriveRbacInfraScope(
+  grants: {
+    superAdmin: boolean
+    byScope: ReadonlyArray<{ scopeType: string; scopeTarget: string | null; permissions?: ReadonlySet<string> }>
+  },
+  permission?: ScopePermissionFilter,
+): RbacInfraScope | null {
   if (grants.superAdmin) return null
-  if (grants.byScope.some(g => g.scopeType === 'global')) return null
+  const wanted = permission === undefined ? null : new Set(typeof permission === 'string' ? [permission] : permission)
+  const carries = (g: { permissions?: ReadonlySet<string> }): boolean =>
+    wanted === null || (g.permissions !== undefined && [...wanted].some(p => g.permissions!.has(p)))
+  const relevant = grants.byScope.filter(carries)
+  if (relevant.some(g => g.scopeType === 'global')) return null
 
   const fullConnections = new Set<string>()
   const nodesByConnection = new Map<string, Set<string>>()
+  const nodeGrantsByConnection = new Map<string, Set<string>>()
+  const guestGrantsByConnection = new Map<string, Set<string>>()
   let guestDerived = false
 
-  for (const g of grants.byScope) {
+  const addTo = (map: Map<string, Set<string>>, connId: string, value: string) => {
+    let set = map.get(connId)
+    if (!set) {
+      set = new Set<string>()
+      map.set(connId, set)
+    }
+    set.add(value)
+  }
+
+  for (const g of relevant) {
     if (FLAT_SCOPE_TYPES.has(g.scopeType) && g.scopeTarget) {
       guestDerived = true
       continue
@@ -61,15 +101,15 @@ export function deriveRbacInfraScope(grants: {
     // node => connId:nodeName ; vm => connId:nodeName:type:vmid
     const nodeName = parts[1]
     if (!nodeName) continue
-    let set = nodesByConnection.get(connId)
-    if (!set) {
-      set = new Set<string>()
-      nodesByConnection.set(connId, set)
+    addTo(nodesByConnection, connId, nodeName)
+    if (g.scopeType === 'node') {
+      addTo(nodeGrantsByConnection, connId, nodeName)
+    } else if (parts[3]) {
+      addTo(guestGrantsByConnection, connId, parts[3])
     }
-    set.add(nodeName)
   }
 
-  return { fullConnections, nodesByConnection, guestDerived }
+  return { fullConnections, nodesByConnection, guestDerived, nodeGrantsByConnection, guestGrantsByConnection }
 }
 
 /** Whether a whole connection is granted outright (infra scopes only). */
@@ -158,5 +198,62 @@ export function pruneEmptyConnections<C extends { id: string; nodes: ReadonlyArr
  */
 export function tokenInfraScope(connectionIds: string[] | null): RbacInfraScope | null {
   if (connectionIds === null) return null
-  return { fullConnections: new Set(connectionIds), nodesByConnection: new Map(), guestDerived: false }
+  return {
+    fullConnections: new Set(connectionIds),
+    nodesByConnection: new Map(),
+    guestDerived: false,
+    nodeGrantsByConnection: new Map(),
+    guestGrantsByConnection: new Map(),
+  }
+}
+
+/** Node names granted outright on a connection (see RbacInfraScope.nodeGrantsByConnection). */
+function outrightNodes(scope: RbacInfraScope, connId: string): Set<string> | undefined {
+  return scope.nodeGrantsByConnection ? scope.nodeGrantsByConnection.get(connId) : scope.nodesByConnection.get(connId)
+}
+
+/**
+ * Whether the user holds an INFRA grant on a connection: the whole connection
+ * or at least one node outright. A vm-only or tag / pool grant does not count,
+ * those users are resource-flat and get no cluster or node facts (quorum, Ceph,
+ * storage capacity, cluster cards). Null scope = admin, always true.
+ */
+export function hasInfraGrant(scope: RbacInfraScope | null, connId: string): boolean {
+  if (scope === null) return true
+  if (scope.fullConnections.has(connId)) return true
+  return (outrightNodes(scope, connId)?.size ?? 0) > 0
+}
+
+/**
+ * Row-level gate for FLAT feeds (change events, PVE tasks and logs, alerts,
+ * alert rules): records that name a connection and maybe a node or a guest,
+ * with no tree to prune. Null scope = admin / unrestricted. A guest-derived
+ * (tag / pool) scope cannot be decided here, only the per-guest predicate can,
+ * so it keeps every connection-bound row and the feed stays at its tenant-level
+ * perimeter for such users.
+ *
+ * A row is visible when it sits on a node granted outright, or names a VMID
+ * granted directly (vm scope, wherever the guest runs now). A row that names
+ * a node or a guest matching neither is denied. A row naming neither is a
+ * cluster-level fact (storage, quorum, a rule) kept only for a user holding a
+ * node grant on that connection and only when `nodeBound` is false; a
+ * node-bound row that could not be attributed (a VM alert on a cold index) is
+ * denied. A row with no connection at all is provider-internal state and never
+ * reaches a scoped user.
+ */
+export function isFlatRecordVisible(
+  scope: RbacInfraScope | null,
+  record: { connId?: string | null; node?: string | null; vmid?: string | number | null; nodeBound?: boolean },
+): boolean {
+  if (scope === null) return true
+  const connId = record.connId
+  if (!connId) return false
+  if (scope.fullConnections.has(connId) || scope.guestDerived) return true
+  const nodeGrants = outrightNodes(scope, connId)
+  if (record.node && nodeGrants?.has(record.node)) return true
+  const vmid = record.vmid === undefined || record.vmid === null ? undefined : String(record.vmid)
+  if (vmid !== undefined && scope.guestGrantsByConnection?.get(connId)?.has(vmid)) return true
+  if (record.node || vmid !== undefined) return false
+  if (!nodeGrants || nodeGrants.size === 0) return false
+  return record.nodeBound === false
 }

--- a/frontend/src/lib/rbac/principalAware.test.ts
+++ b/frontend/src/lib/rbac/principalAware.test.ts
@@ -28,6 +28,7 @@ import {
   filterVmsByPermission,
   filterNodesByPermission,
   getRbacInfraScope,
+  getCurrentRbacInfraScope,
   PERMISSIONS,
 } from './index'
 import { tokenInfraScope } from './infraScope'
@@ -424,5 +425,33 @@ describe('module hygiene (contract assertion (b) precondition)', () => {
     const { readFileSync } = await import('node:fs')
     const source = readFileSync('src/lib/rbac/index.ts', 'utf8')
     expect(source.includes('getServerSession')).toBe(false)
+  })
+})
+
+describe('getCurrentRbacInfraScope: the caller scope in one call (issue #525)', () => {
+  it('returns null without any principal (the route already rejected that caller)', async () => {
+    expect(await getCurrentRbacInfraScope()).toBeNull()
+  })
+
+  it('maps a connection-scoped token to a full-connection scope, a fleet-wide token to null', async () => {
+    const scoped = await seedApiToken({ scopes: ['vms:read'], connectionIds: ['conn-1'] })
+    headersMock.mockResolvedValue(tokenHeaders(scoped.secret, 'vms-list', '/api/v1/vms'))
+    const scope = await getCurrentRbacInfraScope()
+    expect(scope?.fullConnections).toEqual(new Set(['conn-1']))
+    expect(scope?.nodesByConnection.size).toBe(0)
+    expect(scope?.guestDerived).toBe(false)
+
+    const fleet = await seedApiToken({ scopes: ['vms:read'], connectionIds: null })
+    headersMock.mockResolvedValue(tokenHeaders(fleet.secret, 'vms-list', '/api/v1/vms'))
+    expect(await getCurrentRbacInfraScope()).toBeNull()
+  })
+
+  it('a grantless session user gets an empty, restricting scope rather than null', async () => {
+    getServerSessionMock.mockResolvedValue({ user: { id: 'user-norant', tenantId: 'default' } })
+    const scope = await getCurrentRbacInfraScope()
+    expect(scope).not.toBeNull()
+    expect(scope?.fullConnections.size).toBe(0)
+    expect(scope?.nodesByConnection.size).toBe(0)
+    expect(scope?.guestDerived).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #525. Follow-up to #524, which scoped the inventory tree, the topology page, the connections list and the live inventory stream to a user's RBAC connection/node grants. This PR extends the same isolation to the aggregate read endpoints that still returned rows for connections a scoped user was not granted: the change feed, PVE tasks and logs, the dashboard, orchestrator alerts and alert rules. Enterprise only. Admins, global grants and tag/pool scopes keep today's behaviour.

## Model

A new pure helper, `isFlatRecordVisible(scope, { connId, node, vmid, nodeBound })` in `lib/rbac/infraScope.ts`, gates rows that name a connection and maybe a node or a guest. A row is visible when it sits on a node granted outright or names a VMID granted directly (vm scope, wherever the guest runs now). A row naming a node or a guest matching neither is denied. A row naming neither is a cluster-level fact (storage, quorum, a rule) kept only for a user holding a node grant on that connection and only when `nodeBound` is false. A node-bound row that could not be attributed, such as a VM alert while the inventory index is cold, is denied. A row with no connection at all is provider-internal state and never reaches a scoped user. A guest-derived (tag/pool) scope cannot be decided at this level, so those users keep the tenant-level perimeter on these feeds.

`RbacInfraScope` gains two optional, additive fields: `nodeGrantsByConnection` (nodes granted outright) and `guestGrantsByConnection` (VMIDs granted directly). `nodesByConnection` keeps its tree semantics, so nothing changes for the #524 consumers; a hand-built scope without the new fields treats every listed node as an outright grant.

`getCurrentRbacInfraScope(permission)` resolves the caller scope in one call, derived only from the grants that carry the permission the route checked (`connection.view`, `alerts.view`, `alerts.manage`, or `vm.view`/`node.view` for the dashboard). Only a global grant of that permission makes the user unrestricted. Without a permission the derivation keeps the #524 union semantics.

## Surfaces

- `/api/v1/changes` and `/changes/recent`: the caller scope is resolved in `buildChangeVisibilityCtx` and applied inside `isChangeVisibleToTenant`, ANDed with the tenant and vDC gates. Guest records carry their VMID, storage and pool records are cluster-level.
- `/api/v1/events`: connections the user holds no grant on are not queried at all; tasks are gated per node and per VMID, cluster logs per node.
- `/api/v1/dashboard`: PVE connections pre-filtered to candidates, PBS servers need an outright grant like the inventory tree. Cluster cards, Ceph, storage capacity and the locally evaluated alerts follow infra grants only, so a vm-only user gets their guests and nothing else, while a node-scoped user keeps their whole cluster's capacity (storage pools are cluster-wide). Orchestrator alerts go through the same gate as the alerts routes. The local alert sync only runs for unrestricted reads: it auto-resolves every active alert missing from the evaluated list, and a scoped caller's list is a subset of the tenant's.
- Orchestrator alerts: `isAlertVisibleToTenant` gains a gate 0 on `ctx.rbacScope`, wired in list, active, summary, `[id]` GET and DELETE, acknowledge, resolve and clear-visible. The orchestrator alert payload carries no `node` field, so attribution goes through the UPID of an event alert, the `resource` of a node alert, or the hosting node from the inventory index (`VmMeta.node`, new).
- Alert rules: rules bound to a connection the user was not granted are dropped; connection-less rules are tenant-global configuration and stay visible, as they do under the vDC filter.

## Tests

Unit contract tests for the pure helpers, the permission-aware derivation, the alert gate and the change gate; per-route scope tests extended with node-scoped, connection-scoped, vm-scoped, guest-derived and admin cases, plus the dashboard sync guard and permission forwarding. Shared fixtures live in `src/__tests__/setup/rbacScope.ts`. Full suite green (659 files, 7388 tests), typecheck identical to main, ESLint clean.

End-to-end on the lab with throwaway accounts (node scope on one host, vm scope on one guest, connection scope on the DR cluster, admin witness): events, changes, dashboard, alerts and rules matched the model for every account; alert access by id returns 404 out of scope for GET, acknowledge, resolve and delete; a synthetic active local alert survived six scoped dashboard reads and was resolved by the first admin read.

## Out of scope, noted for follow-up

The dashboard merges orchestrator alerts without the tenant visibility predicate: the merge filters by visible node names and lets every non-node alert through as soon as one node is visible. This predates this PR and deserves its own issue. The #524 tree consumers (inventory, topology, connections list) still derive the scope from every grant; passing them the checked permission would be consistent but is a separate change.
