### PR TITLE
fix(topology): resolve SDN VNet segments in the topology views

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/topology/components/TopologyDetailsSidebar.segment.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/components/TopologyDetailsSidebar.segment.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import frMessages from '@/messages/fr.json'
+
+import type { SelectedNodeInfo, VlanContainerNodeData, VlanGroupNodeData } from '../types'
+import TopologyDetailsSidebar from './TopologyDetailsSidebar'
+
+const vnetGroup: VlanGroupNodeData = {
+  label: 'VLAN 137',
+  connectionId: 'conn-1',
+  nodeName: 'pve2-dr',
+  vlanTag: 137,
+  bridge: 'prod-lan',
+  segmentKey: 'vnet-tv1',
+  segmentTag: 137,
+  vnet: 'tv1',
+  zone: 'tzvl1',
+  zoneType: 'vlan',
+  vmCount: 2,
+  width: 170,
+  height: 50,
+}
+
+const vxlanContainer: VlanContainerNodeData = {
+  label: 'VNI 4242',
+  vlanTag: null,
+  bridge: 'overlay',
+  segmentKey: 'vnet-tvx1',
+  segmentTag: 4242,
+  vnet: 'tvx1',
+  zone: 'tzvx1',
+  zoneType: 'vxlan',
+  subnet: '10.42.0.0/24',
+  vms: [{ vmid: 100, name: 'Debian13', vmType: 'qemu', vmStatus: 'stopped', nodeName: 'pve2-dr', ip: '10.42.0.37' }],
+  width: 240,
+  height: 120,
+}
+
+function render(node: SelectedNodeInfo, french = false) {
+  return renderWithProviders(
+    <TopologyDetailsSidebar node={node} onClose={vi.fn()} connections={[]} />,
+    french ? { locale: 'fr', messages: frMessages as Record<string, unknown> } : undefined,
+  )
+}
+
+/** Value rendered next to a caption, as the segment header lays them out. */
+function valueOf(label: string): string | null | undefined {
+  return screen.getByText(label).parentElement?.querySelector('.MuiTypography-body1')?.textContent
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('segment details of a VLAN group', () => {
+  it('names an SDN VNet as such, with its VLAN and its zone', () => {
+    render({ type: 'vlanGroup', data: vnetGroup })
+
+    expect(screen.getByText('VLAN 137')).toBeInTheDocument()
+    expect(valueOf('VNet')).toBe('prod-lan')
+    expect(valueOf('VLAN')).toBe('137')
+    expect(valueOf('SDN zone')).toBe('tzvl1 (vlan)')
+    expect(valueOf('VMs')).toBe('2')
+    expect(screen.queryByText('Bridge')).toBeNull()
+  })
+
+  it('shows a plain bridge and no SDN rows when the bucket is not a VNet', () => {
+    render({
+      type: 'vlanGroup',
+      data: { ...vnetGroup, label: 'VLAN 99', bridge: 'vmbr0', segmentKey: 'vlan-99', segmentTag: 99, vlanTag: 99, vnet: undefined, zone: undefined, zoneType: undefined },
+    })
+
+    expect(valueOf('Bridge')).toBe('vmbr0')
+    expect(screen.queryByText('VNet')).toBeNull()
+    expect(screen.queryByText('SDN zone')).toBeNull()
+  })
+
+  it('translates the segment-less title', () => {
+    render(
+      {
+        type: 'vlanGroup',
+        data: { ...vnetGroup, label: 'No VLAN', bridge: 'vmbr0', segmentKey: 'no-vlan', segmentTag: null, vlanTag: null, vnet: undefined, zone: undefined, zoneType: undefined },
+      },
+      true,
+    )
+
+    expect(screen.getByText('Sans VLAN')).toBeInTheDocument()
+    expect(screen.queryByText('No VLAN')).toBeNull()
+  })
+
+  it('omits the zone type when the zone could not be resolved', () => {
+    render({ type: 'vlanGroup', data: { ...vnetGroup, zoneType: '' } })
+
+    expect(valueOf('SDN zone')).toBe('tzvl1')
+  })
+})
+
+describe('segment details of a VLAN container', () => {
+  it('reports a VXLAN VNet with no 802.1Q VLAN row', () => {
+    render({ type: 'vlanContainer', data: vxlanContainer })
+
+    expect(screen.getByText('VNI 4242')).toBeInTheDocument()
+    expect(valueOf('VNet')).toBe('overlay')
+    expect(valueOf('SDN zone')).toBe('tzvx1 (vxlan)')
+    expect(valueOf('VMs')).toBe('1')
+    expect(screen.queryByText('VLAN')).toBeNull()
+    expect(screen.getByText('10.42.0.0/24')).toBeInTheDocument()
+    expect(screen.getByText('Debian13')).toBeInTheDocument()
+  })
+
+  it('drops the subnet row when no guest IP allowed deriving one', () => {
+    render({ type: 'vlanContainer', data: { ...vxlanContainer, subnet: null } })
+
+    expect(screen.queryByText('Subnet')).toBeNull()
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/topology/components/TopologyDetailsSidebar.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/components/TopologyDetailsSidebar.tsx
@@ -16,12 +16,14 @@ import type {
   VmSummaryNodeData,
   VlanGroupNodeData,
   VlanContainerNodeData,
+  TopologySegmentFields,
   TagGroupNodeData,
   ProxCenterNodeData,
   InventoryCluster,
   InventoryGuest,
 } from '../types'
-import { getStatusColor, getVmStatusColor, getResourceStatus } from '../lib/topologyColors'
+import { getStatusColor, getVmStatusColor, getResourceStatus, getSegmentColor, segmentIcon } from '../lib/topologyColors'
+import { NO_SEGMENT_KEY } from '@/lib/proxmox/nicSegment'
 import { AreaChart, Area, XAxis, YAxis, Tooltip } from 'recharts'
 import ChartContainer from '@/components/ChartContainer'
 
@@ -646,38 +648,53 @@ function VmSummaryDetails({ data }: { data: VmSummaryNodeData }) {
 /* VLAN Group details                                                 */
 /* ------------------------------------------------------------------ */
 
-function VlanGroupDetails({ data }: { data: VlanGroupNodeData }) {
+/** One label/value pair of the segment header. */
+function SegmentField({ label, value }: { label: string; value: string | number }) {
+  return (
+    <Box>
+      <Typography variant='caption' color='text.secondary'>
+        {label}
+      </Typography>
+      <Typography variant='body1' fontWeight={600}>
+        {value}
+      </Typography>
+    </Box>
+  )
+}
+
+/**
+ * Title and identity rows shared by the two segment buckets. An SDN VNet is
+ * named as such, with its zone, because a VNet-backed guest carries no per-NIC
+ * VLAN: reading `bridge` alone would show a raw id like `v42fc503`.
+ */
+function SegmentHeader({ data, vmCount }: { data: TopologySegmentFields & { label: string; vlanTag: number | null; bridge: string }; vmCount: number }) {
   const t = useTranslations('topology')
+  const color = getSegmentColor(data.segmentTag)
+  const isVnet = Boolean(data.vnet)
 
   return (
     <>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-        <i className='ri-router-line' style={{ fontSize: 20, color: '#1976d2' }} />
+        <i className={segmentIcon(data.segmentKey, data.vnet)} style={{ fontSize: 20, color }} />
         <Typography variant='subtitle1' fontWeight={700}>
-          {data.vlanTag != null ? `${t('vlan')} ${data.vlanTag}` : t('noVlan')}
+          {data.segmentKey === NO_SEGMENT_KEY ? t('noVlan') : data.label}
         </Typography>
       </Box>
       <Divider sx={{ mb: 1.5 }} />
-      <Box sx={{ display: 'flex', gap: 3, mb: 1.5 }}>
-        <Box>
-          <Typography variant='caption' color='text.secondary'>
-            {t('bridge')}
-          </Typography>
-          <Typography variant='body1' fontWeight={600}>
-            {data.bridge}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography variant='caption' color='text.secondary'>
-            {t('vms')}
-          </Typography>
-          <Typography variant='body1' fontWeight={600}>
-            {data.vmCount}
-          </Typography>
-        </Box>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 3, mb: 1.5 }}>
+        <SegmentField label={isVnet ? t('vnet') : t('bridge')} value={data.bridge} />
+        {isVnet && data.vlanTag != null && <SegmentField label={t('vlan')} value={data.vlanTag} />}
+        {isVnet && data.zone && (
+          <SegmentField label={t('sdnZone')} value={data.zoneType ? `${data.zone} (${data.zoneType})` : data.zone} />
+        )}
+        <SegmentField label={t('vms')} value={vmCount} />
       </Box>
     </>
   )
+}
+
+function VlanGroupDetails({ data }: { data: VlanGroupNodeData }) {
+  return <SegmentHeader data={data} vmCount={data.vmCount} />
 }
 
 /* ------------------------------------------------------------------ */
@@ -689,31 +706,7 @@ function VlanContainerDetails({ data }: { data: VlanContainerNodeData }) {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-        <i className='ri-router-line' style={{ fontSize: 20, color: '#1976d2' }} />
-        <Typography variant='subtitle1' fontWeight={700}>
-          {data.vlanTag != null ? `${t('vlan')} ${data.vlanTag}` : t('noVlan')}
-        </Typography>
-      </Box>
-      <Divider sx={{ mb: 1.5 }} />
-      <Box sx={{ display: 'flex', gap: 3, mb: 1.5 }}>
-        <Box>
-          <Typography variant='caption' color='text.secondary'>
-            {t('bridge')}
-          </Typography>
-          <Typography variant='body1' fontWeight={600}>
-            {data.bridge}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography variant='caption' color='text.secondary'>
-            {t('vms')}
-          </Typography>
-          <Typography variant='body1' fontWeight={600}>
-            {data.vms.length}
-          </Typography>
-        </Box>
-      </Box>
+      <SegmentHeader data={data} vmCount={data.vms.length} />
       {data.subnet && (
         <Box sx={{ mb: 1.5 }}>
           <Typography variant='caption' color='text.secondary'>

--- a/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanContainerNode.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanContainerNode.tsx
@@ -5,21 +5,16 @@ import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps } from '@xyflow/react'
 import { Box, Typography } from '@mui/material'
+import { useTranslations } from 'next-intl'
 
 import type { VlanContainerNodeData } from '../../types'
-import { getVmStatusColor } from '../../lib/topologyColors'
-
-const VLAN_COLORS = ['#1976d2', '#7b1fa2', '#00838f', '#c62828', '#2e7d32', '#f57c00']
-
-function getVlanColor(tag: number | null): string {
-  if (tag == null) return '#9e9e9e'
-
-  return VLAN_COLORS[tag % VLAN_COLORS.length]
-}
+import { getSegmentColor, getVmStatusColor, segmentIcon } from '../../lib/topologyColors'
+import { NO_SEGMENT_KEY } from '@/lib/proxmox/nicSegment'
 
 function VlanContainerNodeComponent({ data }: NodeProps) {
+  const t = useTranslations('topology')
   const d = data as unknown as VlanContainerNodeData
-  const color = getVlanColor(d.vlanTag)
+  const color = getSegmentColor(d.segmentTag)
 
   return (
     <Box
@@ -55,9 +50,9 @@ function VlanContainerNodeComponent({ data }: NodeProps) {
           gap: 0.75,
         }}
       >
-        <i className='ri-router-line' style={{ fontSize: 15, color }} />
-        <Typography variant='caption' fontWeight={700} sx={{ flex: 1 }}>
-          {d.label}
+        <i className={segmentIcon(d.segmentKey, d.vnet)} style={{ fontSize: 15, color }} />
+        <Typography variant='caption' fontWeight={700} noWrap sx={{ flex: 1 }}>
+          {d.segmentKey === NO_SEGMENT_KEY ? t('noVlan') : d.label}
         </Typography>
         <Typography
           variant='caption'

--- a/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanGroupNode.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanGroupNode.tsx
@@ -5,20 +5,16 @@ import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps } from '@xyflow/react'
 import { Box, Typography } from '@mui/material'
+import { useTranslations } from 'next-intl'
 
 import type { VlanGroupNodeData } from '../../types'
-
-const VLAN_COLORS = ['#1976d2', '#7b1fa2', '#00838f', '#c62828', '#2e7d32', '#f57c00']
-
-function getVlanColor(tag: number | null): string {
-  if (tag == null) return '#9e9e9e'
-
-  return VLAN_COLORS[tag % VLAN_COLORS.length]
-}
+import { getSegmentColor, segmentIcon } from '../../lib/topologyColors'
+import { NO_SEGMENT_KEY } from '@/lib/proxmox/nicSegment'
 
 function VlanGroupNodeComponent({ data }: NodeProps) {
+  const t = useTranslations('topology')
   const d = data as unknown as VlanGroupNodeData
-  const color = getVlanColor(d.vlanTag)
+  const color = getSegmentColor(d.segmentTag)
 
   return (
     <Box
@@ -44,9 +40,9 @@ function VlanGroupNodeComponent({ data }: NodeProps) {
       <Handle type='target' position={Position.Top} style={{ background: color }} />
 
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-        <i className='ri-router-line' style={{ fontSize: 15, color }} />
+        <i className={segmentIcon(d.segmentKey, d.vnet)} style={{ fontSize: 15, color }} />
         <Typography variant='caption' fontWeight={700} noWrap sx={{ flex: 1 }}>
-          {d.vlanTag != null ? `VLAN ${d.vlanTag}` : 'No VLAN'}
+          {d.segmentKey === NO_SEGMENT_KEY ? t('noVlan') : d.label}
         </Typography>
         <Typography
           variant='caption'

--- a/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanNodes.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/components/nodes/VlanNodes.test.tsx
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import type { ReactElement } from 'react'
+
+import { renderWithProviders, screen } from '@/__tests__/setup/renderWithProviders'
+import frMessages from '@/messages/fr.json'
+
+import type { VlanContainerNodeData, VlanGroupNodeData } from '../../types'
+import { VlanContainerNode } from './VlanContainerNode'
+import { VlanGroupNode } from './VlanGroupNode'
+
+/** Both nodes render a `Handle`, which needs the React Flow store. */
+function renderNode(ui: ReactElement) {
+  return renderWithProviders(<ReactFlowProvider>{ui}</ReactFlowProvider>)
+}
+
+/**
+ * Same, under the French catalogue. The canvas nodes used to hardcode an
+ * English "No VLAN", so rendering in another locale is what proves the label
+ * now comes from next-intl.
+ */
+function renderNodeInFrench(ui: ReactElement) {
+  return renderWithProviders(<ReactFlowProvider>{ui}</ReactFlowProvider>, {
+    locale: 'fr',
+    messages: frMessages as Record<string, unknown>,
+  })
+}
+
+const vnetGroup: VlanGroupNodeData = {
+  label: 'VLAN 137',
+  connectionId: 'conn-1',
+  nodeName: 'pve2-dr',
+  vlanTag: 137,
+  bridge: 'prod-lan',
+  segmentKey: 'vnet-tv1',
+  segmentTag: 137,
+  vnet: 'tv1',
+  zone: 'tzvl1',
+  zoneType: 'vlan',
+  vmCount: 2,
+  width: 170,
+  height: 50,
+}
+
+const untaggedGroup: VlanGroupNodeData = {
+  label: 'No VLAN',
+  connectionId: 'conn-1',
+  nodeName: 'pve1',
+  vlanTag: null,
+  bridge: 'vmbr0',
+  segmentKey: 'no-vlan',
+  segmentTag: null,
+  vmCount: 1,
+  width: 170,
+  height: 50,
+}
+
+const vnetContainer: VlanContainerNodeData = {
+  label: 'VNI 4242',
+  vlanTag: null,
+  bridge: 'overlay',
+  segmentKey: 'vnet-tvx1',
+  segmentTag: 4242,
+  vnet: 'tvx1',
+  zone: 'tzvx1',
+  zoneType: 'vxlan',
+  subnet: null,
+  vms: [
+    { vmid: 100, name: 'Debian13', vmType: 'qemu', vmStatus: 'stopped', nodeName: 'pve2-dr', ip: '10.42.0.37' },
+    { vmid: 101, name: 'ct-web', vmType: 'lxc', vmStatus: 'running', nodeName: 'pve2-dr', ip: null },
+  ],
+  width: 240,
+  height: 120,
+}
+
+/** The `data` prop React Flow hands a custom node. */
+const asNodeProps = (data: unknown) => ({ data, id: 'n1', type: 't', selected: false }) as any
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('VlanGroupNode', () => {
+  it('shows the resolved segment label and the VNet alias as its bridge', () => {
+    const { container } = renderNode(<VlanGroupNode {...asNodeProps(vnetGroup)} />)
+
+    expect(screen.getByText('VLAN 137')).toBeInTheDocument()
+    expect(screen.getByText('prod-lan')).toBeInTheDocument()
+    expect(screen.getByText('2')).toBeInTheDocument()
+    expect(container.querySelector('.ri-git-branch-line')).not.toBeNull()
+  })
+
+  it('translates the segment-less label instead of hardcoding English', () => {
+    const { container } = renderNodeInFrench(<VlanGroupNode {...asNodeProps(untaggedGroup)} />)
+
+    expect(screen.getByText('Sans VLAN')).toBeInTheDocument()
+    expect(screen.queryByText('No VLAN')).toBeNull()
+    expect(container.querySelector('.ri-link-unlink')).not.toBeNull()
+  })
+
+  it('marks a plain per-NIC VLAN with the router icon', () => {
+    const { container } = renderNode(
+      <VlanGroupNode {...asNodeProps({ ...untaggedGroup, label: 'VLAN 99', segmentKey: 'vlan-99', segmentTag: 99, vlanTag: 99 })} />,
+    )
+
+    expect(screen.getByText('VLAN 99')).toBeInTheDocument()
+    expect(container.querySelector('.ri-router-line')).not.toBeNull()
+  })
+})
+
+describe('VlanContainerNode', () => {
+  it('labels a VXLAN bucket with its VNI and lists its guests', () => {
+    const { container } = renderNode(<VlanContainerNode {...asNodeProps(vnetContainer)} />)
+
+    expect(screen.getByText('VNI 4242')).toBeInTheDocument()
+    expect(screen.getByText('Debian13')).toBeInTheDocument()
+    expect(screen.getByText('ct-web')).toBeInTheDocument()
+    // A guest with an IP shows it, one without falls back to its vmid.
+    expect(screen.getByText('10.42.0.37')).toBeInTheDocument()
+    expect(screen.getByText('101')).toBeInTheDocument()
+    expect(container.querySelector('.ri-git-branch-line')).not.toBeNull()
+  })
+
+  it('translates the segment-less label instead of hardcoding English', () => {
+    const { container } = renderNodeInFrench(
+      <VlanContainerNode
+        {...asNodeProps({ ...vnetContainer, label: 'No VLAN', segmentKey: 'no-vlan', segmentTag: null, vnet: undefined, zoneType: undefined })}
+      />,
+    )
+
+    expect(screen.getByText('Sans VLAN')).toBeInTheDocument()
+    expect(screen.queryByText('No VLAN')).toBeNull()
+    expect(container.querySelector('.ri-link-unlink')).not.toBeNull()
+  })
+
+  it('renders an empty bucket without a guest row', () => {
+    renderNode(<VlanContainerNode {...asNodeProps({ ...vnetContainer, vms: [] })} />)
+
+    expect(screen.getByText('VNI 4242')).toBeInTheDocument()
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.test.tsx
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+
+import { server, http, HttpResponse } from '@/__tests__/setup/msw-server'
+
+import type { InventoryCluster } from '../types'
+import { useTopologyNetworks } from './useTopologyNetworks'
+
+const NETWORKS_URL = '*/api/v1/vms/networks'
+
+const CONN = 'cmtk6hu1r00007zjlo0kto72x'
+const KEY = `${CONN}:qemu:pve2-dr:100`
+
+const clusters: InventoryCluster[] = [
+  {
+    id: CONN,
+    name: 'PVE-DR',
+    type: 'pve',
+    isCluster: true,
+    status: 'online',
+    nodes: [
+      {
+        node: 'pve2-dr',
+        status: 'online',
+        guests: [
+          { vmid: 100, name: 'Debian13', status: 'stopped', type: 'qemu', node: 'pve2-dr' },
+          { vmid: '101', name: 'ct-web', status: 'running', type: 'lxc', node: 'pve2-dr' },
+        ],
+      },
+      { node: 'pve3-dr', status: 'online', guests: [] },
+    ],
+  },
+]
+
+const vnetSegment = {
+  key: 'vnet-tv1',
+  label: 'VLAN 137',
+  vlan: 137,
+  tag: 137,
+  bridgeLabel: 'prod-lan',
+  vnet: 'tv1',
+  zone: 'tzvl1',
+  zoneType: 'vlan',
+}
+
+/** Serve one payload and capture the bodies the hook posted. */
+function serve(payload: unknown): { bodies: any[] } {
+  const bodies: any[] = []
+
+  server.use(
+    http.post(NETWORKS_URL, async ({ request }) => {
+      bodies.push(await request.json())
+
+      return HttpResponse.json(payload)
+    }),
+  )
+
+  return { bodies }
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('useTopologyNetworks', () => {
+  it('does not call the API while disabled', async () => {
+    const { bodies } = serve({ data: {} })
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, false))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(bodies).toHaveLength(0)
+    expect(result.current.networkMap.size).toBe(0)
+  })
+
+  it('does not call the API when there is no connection', async () => {
+    const { bodies } = serve({ data: {} })
+
+    renderHook(() => useTopologyNetworks([], true))
+
+    await waitFor(() => expect(bodies).toHaveLength(0))
+  })
+
+  it('does not call the API when no node holds a guest', async () => {
+    const { bodies } = serve({ data: {} })
+    const empty: InventoryCluster[] = [{ ...clusters[0], nodes: [{ node: 'pve3-dr', status: 'online', guests: [] }] }]
+
+    renderHook(() => useTopologyNetworks(empty, true))
+
+    await waitFor(() => expect(bodies).toHaveLength(0))
+  })
+
+  it('posts every guest of every node, vmid coerced to a string', async () => {
+    const { bodies } = serve({ data: {} })
+
+    renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(bodies).toHaveLength(1))
+    expect(bodies[0]).toEqual({
+      vms: [
+        { connId: CONN, type: 'qemu', node: 'pve2-dr', vmid: '100' },
+        { connId: CONN, type: 'lxc', node: 'pve2-dr', vmid: '101' },
+      ],
+    })
+  })
+
+  it('keeps the segment the server resolved', async () => {
+    serve({
+      data: {
+        [KEY]: { networks: [{ bridge: 'tv1', vlanTag: null, ip: '10.42.0.37', cidr: 24, segment: vnetSegment }] },
+      },
+    })
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(result.current.networkMap.size).toBe(1))
+    expect(result.current.networkMap.get(KEY)).toEqual([
+      { bridge: 'tv1', vlanTag: null, ip: '10.42.0.37', cidr: 24, segment: vnetSegment },
+    ])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('rebuilds a segment from the tag when the payload carries none', async () => {
+    serve({
+      data: {
+        [KEY]: { networks: [{ bridge: 'vmbr0', vlanTag: 99 }, { bridge: 'vmbr0' }, {}] },
+      },
+    })
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(result.current.networkMap.size).toBe(1))
+    expect(result.current.networkMap.get(KEY)).toEqual([
+      {
+        bridge: 'vmbr0',
+        vlanTag: 99,
+        ip: null,
+        cidr: null,
+        segment: { key: 'vlan-99', label: 'VLAN 99', vlan: 99, tag: 99, bridgeLabel: 'vmbr0' },
+      },
+      {
+        bridge: 'vmbr0',
+        vlanTag: null,
+        ip: null,
+        cidr: null,
+        segment: { key: 'no-vlan', label: 'No VLAN', vlan: null, tag: null, bridgeLabel: 'vmbr0' },
+      },
+      {
+        bridge: 'unknown',
+        vlanTag: null,
+        ip: null,
+        cidr: null,
+        segment: { key: 'no-vlan', label: 'No VLAN', vlan: null, tag: null, bridgeLabel: 'unknown' },
+      },
+    ])
+  })
+
+  it('tolerates a guest entry without a networks array', async () => {
+    serve({ data: { [KEY]: {} } })
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(result.current.networkMap.size).toBe(1))
+    expect(result.current.networkMap.get(KEY)).toEqual([])
+  })
+
+  it('tolerates a response with no data at all', async () => {
+    serve({})
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.networkMap.size).toBe(0)
+  })
+
+  it('clears the map when the request fails', async () => {
+    server.use(http.post(NETWORKS_URL, () => HttpResponse.error()))
+
+    const { result } = renderHook(() => useTopologyNetworks(clusters, true))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.networkMap.size).toBe(0)
+  })
+
+  it('drops the map when the view is disabled, and refetches when enabled again', async () => {
+    const { bodies } = serve({
+      data: { [KEY]: { networks: [{ bridge: 'tv1', vlanTag: null, segment: vnetSegment }] } },
+    })
+
+    const { result, rerender } = renderHook(
+      ({ on }: { on: boolean }) => useTopologyNetworks(clusters, on),
+      { initialProps: { on: true } },
+    )
+
+    await waitFor(() => expect(result.current.networkMap.size).toBe(1))
+
+    rerender({ on: false })
+    await waitFor(() => expect(result.current.networkMap.size).toBe(0))
+
+    rerender({ on: true })
+    await waitFor(() => expect(bodies).toHaveLength(2))
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.ts
@@ -2,6 +2,8 @@
 
 import { useState, useEffect, useRef } from 'react'
 
+import { NO_SEGMENT_KEY, NO_SEGMENT_LABEL, type NicSegment } from '@/lib/proxmox/nicSegment'
+
 import type { InventoryCluster } from '../types'
 
 export interface VmNetworkInfo {
@@ -9,6 +11,21 @@ export interface VmNetworkInfo {
   vlanTag: number | null
   ip: string | null
   cidr: number | null
+  /**
+   * Segment resolved server-side (SDN VNet > per-NIC tag > host bridge VLAN).
+   * `vlanTag` alone cannot group SDN-attached guests: a VNet carries its tag on
+   * the VNet, never on the guest NIC.
+   */
+  segment: NicSegment
+}
+
+/** Segment of a payload that predates server-side resolution, from its tag. */
+function fallbackSegment(vlanTag: number | null, bridge: string): NicSegment {
+  if (vlanTag != null) {
+    return { key: `vlan-${vlanTag}`, label: `VLAN ${vlanTag}`, vlan: vlanTag, tag: vlanTag, bridgeLabel: bridge }
+  }
+
+  return { key: NO_SEGMENT_KEY, label: NO_SEGMENT_LABEL, vlan: null, tag: null, bridgeLabel: bridge }
 }
 
 export type NetworkMap = Map<string, VmNetworkInfo[]>
@@ -66,7 +83,18 @@ export function useTopologyNetworks(connections: InventoryCluster[], enabled: bo
         for (const [key, value] of Object.entries(data)) {
           const networks = (value as any)?.networks || []
 
-          map.set(key, networks.map((n: any) => ({ bridge: n.bridge, vlanTag: n.vlanTag, ip: n.ip || null, cidr: n.cidr ?? null })))
+          map.set(key, networks.map((n: any) => {
+            const bridge = n.bridge || 'unknown'
+            const vlanTag = n.vlanTag ?? null
+
+            return {
+              bridge,
+              vlanTag,
+              ip: n.ip || null,
+              cidr: n.cidr ?? null,
+              segment: (n.segment as NicSegment | undefined) ?? fallbackSegment(vlanTag, bridge),
+            }
+          }))
         }
 
         setNetworkMap(map)

--- a/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/hooks/useTopologyNetworks.ts
@@ -37,7 +37,10 @@ export function useTopologyNetworks(connections: InventoryCluster[], enabled: bo
 
   useEffect(() => {
     if (!enabled || connections.length === 0) {
-      setNetworkMap(new Map())
+      // Keep an already empty map's identity: this branch runs on every effect
+      // pass, and handing back a fresh Map re-renders the caller, which would
+      // loop forever for a caller passing an inline `[]` as its connections.
+      setNetworkMap(prev => (prev.size === 0 ? prev : new Map()))
       fetchedRef.current = false
 
       return

--- a/frontend/src/app/(dashboard)/infrastructure/topology/lib/buildTopologyGraph.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/lib/buildTopologyGraph.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildVnetIndex, resolveNicSegment } from '@/lib/proxmox/nicSegment'
+import { buildSdnVnets } from '@/lib/proxmox/sdnVnetMap'
+
+import { buildTopologyGraph } from './buildTopologyGraph'
+import type { InventoryData, TopologyFilters, VlanContainerNodeData, VlanGroupNodeData } from '../types'
+import type { NetworkMap, VmNetworkInfo } from '../hooks/useTopologyNetworks'
+
+const CONN = 'cmtk6kkex000d7zjlt3abo6e4'
+
+/** Inventory with two guests on pve1, as /api/v1/inventory returns it. */
+const inventory: InventoryData = {
+  clusters: [
+    {
+      id: CONN,
+      name: 'PVE-PROD',
+      type: 'pve',
+      isCluster: true,
+      status: 'online',
+      nodes: [
+        {
+          node: 'pve1',
+          status: 'online',
+          cpu: 0.1,
+          maxcpu: 8,
+          mem: 4_000_000_000,
+          maxmem: 16_000_000_000,
+          uptime: 1000,
+          guests: [
+            { vmid: 100, name: 'Debian13', status: 'running', type: 'qemu', node: 'pve1' },
+            { vmid: 101, name: 'ct-web', status: 'running', type: 'lxc', node: 'pve1' },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+/** The VNet/zone pair a VLAN zone produces, resolved as the route does. */
+const vnetById = buildVnetIndex(
+  buildSdnVnets(
+    [
+      { vnet: 'tv1', alias: 'prod', zone: 'tzvl1', tag: 137 },
+      { vnet: 'v42fc503', alias: 'lan', zone: 'zvx', tag: 4242 },
+    ],
+    [
+      { zone: 'tzvl1', type: 'vlan', bridge: 'vmbr0' },
+      { zone: 'zvx', type: 'vxlan' },
+    ],
+  ),
+)
+
+/** A NIC of the payload, with its segment resolved server-side. */
+function nic(bridge: string, tag: number | null, ip: string | null = null, cidr: number | null = null): VmNetworkInfo {
+  return {
+    bridge,
+    vlanTag: tag,
+    ip,
+    cidr,
+    segment: resolveNicSegment({ bridge, tag }, vnetById, new Map([['vmbr1', 30]])),
+  }
+}
+
+function networkMap(entries: Array<[string, VmNetworkInfo[]]>): NetworkMap {
+  return new Map(entries)
+}
+
+const qemuKey = `${CONN}:qemu:pve1:100`
+const lxcKey = `${CONN}:lxc:pve1:101`
+
+const networkFilters: TopologyFilters = { vmThreshold: 20, viewMode: 'network' }
+const infraFilters: TopologyFilters = { vmThreshold: 20, viewMode: 'infra', groupByVlan: true }
+
+function containers(data: InventoryData, map: NetworkMap): VlanContainerNodeData[] {
+  return buildTopologyGraph(data, networkFilters, map)
+    .nodes.filter((n) => n.type === 'vlanContainer')
+    .map((n) => n.data as unknown as VlanContainerNodeData)
+}
+
+function groups(data: InventoryData, map: NetworkMap): VlanGroupNodeData[] {
+  return buildTopologyGraph(data, infraFilters, map)
+    .nodes.filter((n) => n.type === 'vlanGroup')
+    .map((n) => n.data as unknown as VlanGroupNodeData)
+}
+
+describe('buildTopologyGraph network view', () => {
+  it('buckets a VLAN-zone VNet guest on its VLAN instead of No VLAN', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null)]],
+        [lxcKey, [nic('tv1', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('vnet-tv1')
+    expect(found[0].label).toBe('VLAN 137')
+    expect(found[0].vlanTag).toBe(137)
+    expect(found[0].bridge).toBe('prod')
+    expect(found[0].vnet).toBe('tv1')
+    expect(found[0].zone).toBe('tzvl1')
+    expect(found[0].zoneType).toBe('vlan')
+    expect(found[0].vms.map((v) => v.vmid)).toEqual([100, 101])
+  })
+
+  it('labels a VXLAN VNet guest with its VNI and reports no VLAN id', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('v42fc503', null)]],
+        [lxcKey, [nic('v42fc503', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('vnet-v42fc503')
+    expect(found[0].label).toBe('VNI 4242')
+    expect(found[0].segmentTag).toBe(4242)
+    expect(found[0].vlanTag).toBeNull()
+    expect(found[0].bridge).toBe('lan')
+  })
+
+  it('keeps a VNet bucket and a same-tag per-NIC bucket apart', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null)]],
+        [lxcKey, [nic('vmbr0', 137)]],
+      ]),
+    )
+
+    expect(found.map((c) => c.segmentKey).sort()).toEqual(['vlan-137', 'vnet-tv1'])
+    expect(found.every((c) => c.vlanTag === 137)).toBe(true)
+  })
+
+  it('resolves the traditional bondX.N bridge instead of No VLAN', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('vmbr1', null)]],
+        [lxcKey, [nic('vmbr1', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('vlan-30')
+    expect(found[0].label).toBe('VLAN 30')
+    expect(found[0].bridge).toBe('vmbr1')
+    expect(found[0].vnet).toBeUndefined()
+  })
+
+  it('still buckets a genuinely untagged guest under No VLAN', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('vmbr0', null)]],
+        [lxcKey, [nic('vmbr0', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('no-vlan')
+    expect(found[0].vlanTag).toBeNull()
+    expect(found[0].segmentTag).toBeNull()
+    expect(found[0].bridge).toBe('vmbr0')
+  })
+
+  it('buckets a guest with no readable NIC under No VLAN with an unknown bridge', () => {
+    const found = containers(inventory, networkMap([[qemuKey, []], [lxcKey, []]]))
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('no-vlan')
+    expect(found[0].bridge).toBe('unknown')
+  })
+
+  it('still derives the subnet from a guest IP inside a VNet bucket', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null, '10.42.0.37', 24)]],
+        [lxcKey, [nic('tv1', null, '10.42.0.38', 24)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].subnet).toBe('10.42.0.0/24')
+  })
+
+  it('emits one container per segment when a guest has several NICs', () => {
+    const found = containers(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null), nic('vmbr0', 50)]],
+        [lxcKey, [nic('tv1', null)]],
+      ]),
+    )
+
+    expect(found.map((c) => c.segmentKey).sort()).toEqual(['vlan-50', 'vnet-tv1'])
+  })
+})
+
+describe('buildTopologyGraph infra view grouped by VLAN', () => {
+  it('groups a VNet guest under its VNet rather than No VLAN', () => {
+    const found = groups(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null)]],
+        [lxcKey, [nic('tv1', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('vnet-tv1')
+    expect(found[0].label).toBe('VLAN 137')
+    expect(found[0].bridge).toBe('prod')
+    expect(found[0].vmCount).toBe(2)
+  })
+
+  it('splits a VNet guest from an untagged one on the same node', () => {
+    const found = groups(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('v42fc503', null)]],
+        [lxcKey, [nic('vmbr0', null)]],
+      ]),
+    )
+
+    expect(found.map((g) => g.segmentKey).sort()).toEqual(['no-vlan', 'vnet-v42fc503'])
+  })
+
+  it('groups on the primary NIC when a guest has several', () => {
+    const found = groups(
+      inventory,
+      networkMap([
+        [qemuKey, [nic('tv1', null), nic('vmbr0', 50)]],
+        [lxcKey, [nic('tv1', null)]],
+      ]),
+    )
+
+    expect(found).toHaveLength(1)
+    expect(found[0].segmentKey).toBe('vnet-tv1')
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/topology/lib/buildTopologyGraph.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/lib/buildTopologyGraph.ts
@@ -16,8 +16,38 @@ import type {
   PbsServerNodeData,
   NodeStatus,
 } from '../types'
-import type { NetworkMap } from '../hooks/useTopologyNetworks'
+import type { NetworkMap, VmNetworkInfo } from '../hooks/useTopologyNetworks'
 import { getResourceStatus, getStatusColor, getVmStatusColor } from './topologyColors'
+import { NO_SEGMENT_KEY, NO_SEGMENT_LABEL, type NicSegment } from '@/lib/proxmox/nicSegment'
+
+/** Bucket a guest with no readable NIC at all falls into. */
+const UNKNOWN_SEGMENT: NicSegment = {
+  key: NO_SEGMENT_KEY,
+  label: NO_SEGMENT_LABEL,
+  vlan: null,
+  tag: null,
+  bridgeLabel: 'unknown',
+}
+
+/**
+ * Segment a NIC is bucketed under. Resolution happens server-side (SDN VNet >
+ * per-NIC tag > host bridge VLAN, see lib/proxmox/nicSegment.ts); this only
+ * covers the NIC being absent.
+ */
+function segmentOf(nic: VmNetworkInfo | undefined): NicSegment {
+  return nic?.segment ?? UNKNOWN_SEGMENT
+}
+
+/** The segment fields both VLAN bucket nodes carry, from a resolved segment. */
+function segmentFields(segment: NicSegment) {
+  return {
+    segmentKey: segment.key,
+    segmentTag: segment.tag,
+    ...(segment.vnet !== undefined ? { vnet: segment.vnet } : {}),
+    ...(segment.zone !== undefined ? { zone: segment.zone } : {}),
+    ...(segment.zoneType !== undefined ? { zoneType: segment.zoneType } : {}),
+  }
+}
 
 function buildVmNode(
   conn: { id: string },
@@ -77,6 +107,9 @@ function buildVmEdge(sourceId: string, vmId: string, status: string): Edge {
 /* Network (VLAN-only) view                                           */
 /* ------------------------------------------------------------------ */
 
+/** One segment bucket of the network view: its identity plus its guests. */
+type VlanBucket = { segment: NicSegment; cidrs: number[]; vms: VlanContainerVm[] }
+
 function buildNetworkView(
   data: InventoryData,
   filters: TopologyFilters,
@@ -94,15 +127,13 @@ function buildNetworkView(
   let grandTotalVms = 0
   let grandTotalNodes = 0
 
-  // Per-cluster: collect VMs into VLAN buckets
-  const clusterVlanMap = new Map<
-    string,
-    Map<string, { vlanTag: number | null; bridge: string; cidrs: number[]; vms: VlanContainerVm[] }>
-  >()
+  // Per-cluster: collect VMs into segment buckets (one SDN VNet, one VLAN id,
+  // or the segment-less catch-all)
+  const clusterVlanMap = new Map<string, Map<string, VlanBucket>>()
 
   for (const conn of clusters) {
     grandTotalNodes += conn.nodes.length
-    const buckets = new Map<string, { vlanTag: number | null; bridge: string; cidrs: number[]; vms: VlanContainerVm[] }>()
+    const buckets = new Map<string, VlanBucket>()
 
     for (const node of conn.nodes) {
       let guests = node.guests || []
@@ -120,13 +151,13 @@ function buildNetworkView(
         const nics = networkMap?.get(netKey) || []
 
         if (nics.length === 0) {
-          const groupKey = 'no-vlan'
+          const segment = UNKNOWN_SEGMENT
 
-          if (!buckets.has(groupKey)) {
-            buckets.set(groupKey, { vlanTag: null, bridge: 'unknown', cidrs: [], vms: [] })
+          if (!buckets.has(segment.key)) {
+            buckets.set(segment.key, { segment, cidrs: [], vms: [] })
           }
 
-          buckets.get(groupKey)!.vms.push({
+          buckets.get(segment.key)!.vms.push({
             vmid,
             name: guest.name || `VM ${vmid}`,
             vmType: type,
@@ -136,15 +167,13 @@ function buildNetworkView(
           })
         } else {
           for (const nic of nics) {
-            const vlanTag = nic.vlanTag ?? null
-            const bridge = nic.bridge ?? 'unknown'
-            const groupKey = vlanTag != null ? `vlan-${vlanTag}` : 'no-vlan'
+            const segment = segmentOf(nic)
 
-            if (!buckets.has(groupKey)) {
-              buckets.set(groupKey, { vlanTag, bridge, cidrs: [], vms: [] })
+            if (!buckets.has(segment.key)) {
+              buckets.set(segment.key, { segment, cidrs: [], vms: [] })
             }
 
-            const bucket = buckets.get(groupKey)!
+            const bucket = buckets.get(segment.key)!
 
             if (nic.cidr != null && !bucket.cidrs.includes(nic.cidr)) {
               bucket.cidrs.push(nic.cidr)
@@ -273,9 +302,10 @@ function buildNetworkView(
         }
 
         const containerData: VlanContainerNodeData = {
-          label: bucket.vlanTag != null ? `VLAN ${bucket.vlanTag}` : 'No VLAN',
-          vlanTag: bucket.vlanTag,
-          bridge: bucket.bridge,
+          label: bucket.segment.label,
+          vlanTag: bucket.segment.vlan,
+          bridge: bucket.segment.bridgeLabel,
+          ...segmentFields(bucket.segment),
           subnet,
           vms: bucket.vms,
           width: 240,
@@ -437,8 +467,8 @@ function buildInfraView(
         if (guests.length <= filters.vmThreshold) {
           // Check if VLAN grouping is enabled and data is available
           if (filters.groupByVlan && networkMap && networkMap.size > 0) {
-            // Group VMs by VLAN tag
-            const vlanGroups = new Map<string, { vlanTag: number | null; bridge: string; guests: InventoryGuest[] }>()
+            // Group VMs by the segment of their primary NIC
+            const vlanGroups = new Map<string, { segment: NicSegment; guests: InventoryGuest[] }>()
 
             for (const guest of guests) {
               const vmid = typeof guest.vmid === 'string' ? guest.vmid : String(guest.vmid)
@@ -446,17 +476,14 @@ function buildInfraView(
               const key = `${conn.id}:${type}:${node.node}:${vmid}`
               const netInfo = networkMap.get(key)
 
-              // Use first NIC's VLAN info
-              const firstNic = netInfo?.[0]
-              const vlanTag = firstNic?.vlanTag ?? null
-              const bridge = firstNic?.bridge ?? 'unknown'
-              const groupKey = vlanTag != null ? `vlan-${vlanTag}` : 'no-vlan'
+              // Use the first NIC's segment
+              const segment = segmentOf(netInfo?.[0])
 
-              if (!vlanGroups.has(groupKey)) {
-                vlanGroups.set(groupKey, { vlanTag, bridge, guests: [] })
+              if (!vlanGroups.has(segment.key)) {
+                vlanGroups.set(segment.key, { segment, guests: [] })
               }
 
-              vlanGroups.get(groupKey)!.guests.push(guest)
+              vlanGroups.get(segment.key)!.guests.push(guest)
             }
 
             // Create VLAN group nodes and edges
@@ -464,11 +491,12 @@ function buildInfraView(
               const vlanNodeId = `vlan-${conn.id}-${node.node}-${groupKey}`
 
               const vlanData: VlanGroupNodeData = {
-                label: group.vlanTag != null ? `VLAN ${group.vlanTag}` : 'No VLAN',
+                label: group.segment.label,
                 connectionId: conn.id,
                 nodeName: node.node,
-                vlanTag: group.vlanTag,
-                bridge: group.bridge,
+                vlanTag: group.segment.vlan,
+                bridge: group.segment.bridgeLabel,
+                ...segmentFields(group.segment),
                 vmCount: group.guests.length,
                 width: 170,
                 height: 50,

--- a/frontend/src/app/(dashboard)/infrastructure/topology/lib/topologyColors.test.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/lib/topologyColors.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { NO_SEGMENT_KEY } from '@/lib/proxmox/nicSegment'
+
+import { getSegmentColor, segmentIcon } from './topologyColors'
+
+describe('getSegmentColor', () => {
+  it('paints the segment-less bucket grey', () => {
+    expect(getSegmentColor(null)).toBe('#9e9e9e')
+    expect(getSegmentColor(undefined)).toBe('#9e9e9e')
+  })
+
+  it('gives one stable colour per segment id', () => {
+    const first = getSegmentColor(137)
+
+    expect(first).toMatch(/^#[0-9a-f]{6}$/)
+    expect(getSegmentColor(137)).toBe(first)
+    expect(getSegmentColor(250)).not.toBe(first)
+  })
+
+  it('colours a VXLAN VNI, whose id is far outside the VLAN range', () => {
+    expect(getSegmentColor(4242)).toMatch(/^#[0-9a-f]{6}$/)
+    expect(getSegmentColor(16_777_215)).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('never indexes outside the palette, negatives included', () => {
+    for (const tag of [0, 1, 5, 6, 7, -1, -6, 4094]) {
+      expect(getSegmentColor(tag), `tag ${tag}`).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+})
+
+describe('segmentIcon', () => {
+  it('marks an SDN VNet with the branch icon', () => {
+    expect(segmentIcon('vnet-tv1', 'tv1')).toBe('ri-git-branch-line')
+    expect(segmentIcon(NO_SEGMENT_KEY, 'tv1')).toBe('ri-git-branch-line')
+  })
+
+  it('marks the segment-less bucket with a broken link', () => {
+    expect(segmentIcon(NO_SEGMENT_KEY)).toBe('ri-link-unlink')
+  })
+
+  it('marks a plain VLAN with the router icon', () => {
+    expect(segmentIcon('vlan-137')).toBe('ri-router-line')
+    expect(segmentIcon('vlan-99', undefined)).toBe('ri-router-line')
+  })
+})

--- a/frontend/src/app/(dashboard)/infrastructure/topology/lib/topologyColors.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/lib/topologyColors.ts
@@ -1,3 +1,5 @@
+import { NO_SEGMENT_KEY } from '@/lib/proxmox/nicSegment'
+
 import type { NodeStatus } from '../types'
 
 export function getResourceStatus(usage: number, isOnline: boolean): NodeStatus {
@@ -47,4 +49,28 @@ export function getVmStatusColor(status: string): string {
     default:
       return '#9e9e9e'
   }
+}
+
+const SEGMENT_COLORS = ['#1976d2', '#7b1fa2', '#00838f', '#c62828', '#2e7d32', '#f57c00']
+
+/**
+ * Colour of a network segment bucket, keyed by its segment id (a VLAN id, or a
+ * VXLAN VNI). Grey when the bucket names no segment, so the "No VLAN" bucket
+ * stays visually neutral. Both VLAN bucket node types share this palette.
+ */
+export function getSegmentColor(tag: number | null | undefined): string {
+  if (tag == null) return '#9e9e9e'
+
+  return SEGMENT_COLORS[Math.abs(tag) % SEGMENT_COLORS.length]
+}
+
+/**
+ * Icon of a segment bucket, following the inventory Network view: an SDN VNet
+ * is a branch, a plain VLAN a router, and no segment a broken link.
+ */
+export function segmentIcon(segmentKey: string, vnet?: string): string {
+  if (vnet) return 'ri-git-branch-line'
+  if (segmentKey === NO_SEGMENT_KEY) return 'ri-link-unlink'
+
+  return 'ri-router-line'
 }

--- a/frontend/src/app/(dashboard)/infrastructure/topology/types.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/topology/types.ts
@@ -129,11 +129,31 @@ export interface VmSummaryNodeData {
   height: number
 }
 
-export interface VlanGroupNodeData {
+/**
+ * Segment identity shared by the two VLAN bucket nodes. A bucket is one SDN
+ * VNet, one VLAN id, or the segment-less catch-all: `vlanTag` alone cannot say
+ * which, because a VXLAN VNet has no VLAN id and two VNets of different zones
+ * may carry the same one.
+ */
+export interface TopologySegmentFields {
+  /** Bucket key: `vnet-<id>`, `vlan-<n>`, or `no-vlan`. */
+  segmentKey: string
+  /** Segment id whatever its kind: a VLAN id, or a VXLAN VNI. */
+  segmentTag: number | null
+  /** SDN VNet id, only when the bucket is a VNet. */
+  vnet?: string
+  /** Zone id of that VNet. */
+  zone?: string
+  /** Zone type of that VNet: 'vlan' | 'vxlan' | 'qinq' | 'evpn' | 'simple' | ''. */
+  zoneType?: string
+}
+
+export interface VlanGroupNodeData extends TopologySegmentFields {
   [key: string]: unknown
   label: string
   connectionId: string
   nodeName: string
+  /** The 802.1Q VLAN id, null for a VXLAN/EVPN/simple VNet or no segment. */
   vlanTag: number | null
   bridge: string
   vmCount: number
@@ -161,9 +181,10 @@ export interface VlanContainerVm {
   ip: string | null
 }
 
-export interface VlanContainerNodeData {
+export interface VlanContainerNodeData extends TopologySegmentFields {
   [key: string]: unknown
   label: string
+  /** The 802.1Q VLAN id, null for a VXLAN/EVPN/simple VNet or no segment. */
   vlanTag: number | null
   bridge: string
   subnet: string | null

--- a/frontend/src/app/api/v1/vms/networks/route.test.ts
+++ b/frontend/src/app/api/v1/vms/networks/route.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildBridgeVlanMap } from '@/lib/proxmox/hostVlanMap'
+import { buildSdnVnets } from '@/lib/proxmox/sdnVnetMap'
+import { buildVnetIndex, resolveNicSegment } from '@/lib/proxmox/nicSegment'
+
+import { parseNetKeys } from './route'
+
+/**
+ * Payloads captured verbatim from a PVE 9.2.2 cluster carrying two VLAN zones
+ * and one VXLAN zone on the same bridge. They pin the field names the segment
+ * resolution depends on: a zone names its kind in `type`, a VNet carries `tag`
+ * and `alias`, and a guest NIC attached to a VNet has NO `tag=` at all.
+ *
+ * The `net*` keys are deliberately NOT in index order. PVE serializes a guest
+ * config from a Perl hash, whose iteration order is randomized per process
+ * (measured on perl 5.40: five reads of the same config gave five different
+ * orders), so a caller that takes the head of the list as the primary NIC only
+ * works if the parser restores the order.
+ */
+const VM_CONFIG = {
+  net2: 'virtio=BC:24:11:00:00:03,bridge=vmbr0',
+  name: 'Debian13',
+  net4: 'virtio=BC:24:11:00:00:05,bridge=vmbr0,tag=99',
+  boot: 'order=scsi0;net0',
+  net0: 'virtio=BC:24:11:C0:F0:6F,bridge=tv1',
+  net3: 'virtio=BC:24:11:00:00:04,bridge=tvx1',
+  scsi0: 'CephStoragePool:vm-100-disk-0,iothread=1,size=20G',
+  net1: 'virtio=BC:24:11:00:00:02,bridge=tv2',
+}
+
+const SDN_VNETS = [
+  { alias: 'prod-lan', tag: 137, type: 'vnet', vnet: 'tv1', zone: 'tzvl1' },
+  { alias: 'dmz', tag: 250, type: 'vnet', vnet: 'tv2', zone: 'tzvl2' },
+  { alias: 'overlay', tag: 4242, type: 'vnet', vnet: 'tvx1', zone: 'tzvx1' },
+]
+
+const SDN_ZONES = [
+  { bridge: 'vmbr0', nodes: 'pve1-dr,pve2-dr,pve3-dr', type: 'vlan', zone: 'tzvl1' },
+  { bridge: 'vmbr0', nodes: 'pve1-dr,pve2-dr,pve3-dr', type: 'vlan', zone: 'tzvl2' },
+  { peers: '10.42.0.111,10.42.0.112,10.42.0.113', type: 'vxlan', zone: 'tzvx1' },
+]
+
+const NODE_NETWORK = [
+  { active: 1, bridge_ports: 'nic0', cidr: '10.42.0.112/24', iface: 'vmbr0', type: 'bridge' },
+  { active: 1, iface: 'nic0', type: 'eth' },
+]
+
+describe('parseNetKeys on a real PVE 9.2.2 guest', () => {
+  it('reads no VLAN tag at all from a VNet-backed NIC', () => {
+    const nics = parseNetKeys(VM_CONFIG, 'qemu')
+
+    expect(nics.map((n) => n.bridge)).toEqual(['tv1', 'tv2', 'vmbr0', 'tvx1', 'vmbr0'])
+    expect(nics.slice(0, 4).every((n) => n.vlanTag === null)).toBe(true)
+    expect(nics[4].vlanTag).toBe(99)
+  })
+
+  it('restores NIC index order whatever order PVE returned the keys in', () => {
+    expect(parseNetKeys(VM_CONFIG, 'qemu').map((n) => n.iface)).toEqual([
+      'net0',
+      'net1',
+      'net2',
+      'net3',
+      'net4',
+    ])
+  })
+
+  it('puts net0 first for every permutation of the same config', () => {
+    const keys = Object.keys(VM_CONFIG)
+
+    for (let shift = 0; shift < keys.length; shift++) {
+      const rotated: Record<string, unknown> = {}
+
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[(i + shift) % keys.length]
+
+        rotated[key] = (VM_CONFIG as Record<string, unknown>)[key]
+      }
+
+      const nics = parseNetKeys(rotated, 'qemu')
+
+      expect(nics[0].iface, `shift ${shift}`).toBe('net0')
+      expect(nics[0].bridge, `shift ${shift}`).toBe('tv1')
+    }
+  })
+
+  it('orders by numeric index, not lexicographically', () => {
+    const many = { net10: 'virtio,bridge=vmbr10', net2: 'virtio,bridge=vmbr2', net0: 'virtio,bridge=vmbr0' }
+
+    expect(parseNetKeys(many, 'qemu').map((n) => n.iface)).toEqual(['net0', 'net2', 'net10'])
+  })
+})
+
+describe('segment resolution over the route payloads', () => {
+  it('gives every NIC its real segment instead of one No VLAN bucket', () => {
+    const vnetById = buildVnetIndex(buildSdnVnets(SDN_VNETS, SDN_ZONES))
+    const bridgeVlanMap = buildBridgeVlanMap(NODE_NETWORK)
+
+    const resolved = parseNetKeys(VM_CONFIG, 'qemu').map((nic) => {
+      const segment = resolveNicSegment({ bridge: nic.bridge, tag: nic.vlanTag }, vnetById, bridgeVlanMap)
+
+      return { key: segment.key, label: segment.label, vlan: segment.vlan, bridge: segment.bridgeLabel }
+    })
+
+    expect(resolved).toEqual([
+      { key: 'vnet-tv1', label: 'VLAN 137', vlan: 137, bridge: 'prod-lan' },
+      { key: 'vnet-tv2', label: 'VLAN 250', vlan: 250, bridge: 'dmz' },
+      { key: 'no-vlan', label: 'No VLAN', vlan: null, bridge: 'vmbr0' },
+      { key: 'vnet-tvx1', label: 'VNI 4242', vlan: null, bridge: 'overlay' },
+      { key: 'vlan-99', label: 'VLAN 99', vlan: 99, bridge: 'vmbr0' },
+    ])
+  })
+
+  it('would have bucketed four of the five NICs as No VLAN before the fix', () => {
+    // The grouping this route fed until now: `vlanTag != null ? vlan-N : no-vlan`.
+    const before = parseNetKeys(VM_CONFIG, 'qemu').map((n) => (n.vlanTag != null ? `vlan-${n.vlanTag}` : 'no-vlan'))
+
+    expect(before).toEqual(['no-vlan', 'no-vlan', 'no-vlan', 'no-vlan', 'vlan-99'])
+  })
+})

--- a/frontend/src/app/api/v1/vms/networks/route.ts
+++ b/frontend/src/app/api/v1/vms/networks/route.ts
@@ -1,25 +1,47 @@
 import { NextResponse } from "next/server"
 
 import { pveFetch } from "@/lib/proxmox/client"
-import { getConnectionById } from "@/lib/connections/getConnection"
+import { getConnectionById, type PveConn } from "@/lib/connections/getConnection"
 import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { getCurrentTenantId } from "@/lib/tenant"
+import { getTenantInfrastructureScope, maskingScope } from "@/lib/tenant/infraScope"
+import { buildBridgeVlanMap } from "@/lib/proxmox/hostVlanMap"
+import { buildSdnVnets, type SdnVnet } from "@/lib/proxmox/sdnVnetMap"
+import { buildVnetIndex, resolveNicSegment, type NicSegment } from "@/lib/proxmox/nicSegment"
 
 export const runtime = "nodejs"
+
+type VmNic = {
+  iface: string
+  bridge: string
+  vlanTag: number | null
+  ip: string | null
+  cidr: number | null
+  /**
+   * Resolved segment: the SDN VNet the bridge names, else the per-NIC tag, else
+   * the VLAN of the host bridge. Added because the topology used to read
+   * `vlanTag` alone, which sent every SDN-attached guest to the "No VLAN"
+   * bucket. See lib/proxmox/nicSegment.ts.
+   */
+  segment: NicSegment
+}
 
 /**
  * POST /api/v1/vms/networks
  *
- * Bulk-fetch network config (bridge + VLAN tag) for a list of VMs.
+ * Bulk-fetch network config (bridge + VLAN tag + resolved segment) for a list of VMs.
  *
  * Body: { vms: [{ connId, type, node, vmid }] }
- * Response: { data: { "connId:type:node:vmid": { networks: [{ iface, bridge, vlanTag }] } } }
+ * Response: { data: { "connId:type:node:vmid": { networks: [{ iface, bridge, vlanTag, segment }] } } }
  */
 
-function parseNetKeys(config: Record<string, unknown>, vmType: string): Array<{ iface: string; bridge: string; vlanTag: number | null; ip: string | null; cidr: number | null }> {
-  const networks: Array<{ iface: string; bridge: string; vlanTag: number | null; ip: string | null; cidr: number | null }> = []
+export function parseNetKeys(config: Record<string, unknown>, vmType: string): Array<{ iface: string; bridge: string; vlanTag: number | null; ip: string | null; cidr: number | null }> {
+  const networks: Array<{ index: number; iface: string; bridge: string; vlanTag: number | null; ip: string | null; cidr: number | null }> = []
 
   for (const [key, value] of Object.entries(config)) {
-    if (!/^net\d+$/.test(key) || typeof value !== 'string') continue
+    const match = /^net(\d+)$/.exec(key)
+
+    if (!match || typeof value !== 'string') continue
 
     let bridge = ''
     let vlanTag: number | null = null
@@ -77,17 +99,81 @@ function parseNetKeys(config: Record<string, unknown>, vmType: string): Array<{ 
     }
 
     if (bridge) {
-      networks.push({ iface: key, bridge, vlanTag, ip, cidr })
+      networks.push({ index: Number.parseInt(match[1], 10), iface: key, bridge, vlanTag, ip, cidr })
     }
   }
 
-  return networks
+  // PVE serializes a guest config from a Perl hash, whose iteration order is
+  // randomized per process (Perl >= 5.18), so `net0` is NOT reliably the first
+  // key returned. Callers treat the head of this list as the primary NIC (the
+  // topology groups a guest by it), so the order has to be restored here.
+  networks.sort((a, b) => a.index - b.index)
+
+  return networks.map(({ index: _index, ...nic }) => nic)
+}
+
+/**
+ * Resolve a connection's SDN VNets, joined with their zones so a VNet-backed
+ * NIC can name its real segment. Fault-tolerant on purpose: a cluster without
+ * SDN, or an SDN endpoint the token cannot read, yields an empty index and
+ * resolution simply degrades to per-NIC tags.
+ */
+async function fetchSdnVnets(conn: PveConn): Promise<SdnVnet[]> {
+  let vnetsRaw: any[] = []
+  let zonesRaw: any[] = []
+
+  try {
+    const vnets = await pveFetch<any[]>(conn, "/cluster/sdn/vnets")
+    if (Array.isArray(vnets)) vnetsRaw = vnets
+  } catch {
+    // SDN unavailable — no VNet grouping, raw bridge names stay.
+    return []
+  }
+
+  // Zones are independent: without them a VNet keeps zoneType '' and is still
+  // grouped on its own, it just cannot say "VLAN" vs "VNI".
+  try {
+    const zones = await pveFetch<any[]>(conn, "/cluster/sdn/zones")
+    if (Array.isArray(zones)) zonesRaw = zones
+  } catch { /* zone metadata unavailable */ }
+
+  return buildSdnVnets(vnetsRaw, zonesRaw)
+}
+
+/**
+ * Per-node `bridge -> VLAN` maps for the nodes actually hosting the requested
+ * guests. Resolves the traditional layout (a `bondX.N` sub-interface feeding a
+ * dedicated bridge), whose guests carry no per-NIC tag.
+ */
+async function fetchBridgeVlanMaps(conn: PveConn, nodes: string[]): Promise<Map<string, Map<string, number>>> {
+  const byNode = new Map<string, Map<string, number>>()
+
+  await Promise.all(
+    nodes.map(async (node) => {
+      try {
+        const ifaces = await pveFetch<any[]>(conn, `/nodes/${encodeURIComponent(node)}/network`)
+
+        byNode.set(node, buildBridgeVlanMap(Array.isArray(ifaces) ? ifaces : []))
+      } catch {
+        // Host network unreadable for this node — per-NIC tags only.
+        byNode.set(node, new Map())
+      }
+    })
+  )
+
+  return byNode
 }
 
 export async function POST(req: Request) {
   try {
     const denied = await checkPermission(PERMISSIONS.VM_VIEW)
     if (denied) return denied
+
+    // SDN VNets are provider-scope data, exactly as in the inventory Network
+    // view: an iaas tenant gets no VNet grouping, so its guests on a VNet keep
+    // the "No VLAN" bucket rather than learning the provider's segment names.
+    const vdcScope = maskingScope(await getTenantInfrastructureScope(await getCurrentTenantId()))
+    const isProviderScope = !vdcScope
 
     const body = await req.json()
     const vms = body.vms || []
@@ -109,12 +195,20 @@ export async function POST(req: Request) {
       byConnection.get(vm.connId)!.push({ type: vm.type, node: vm.node, vmid: vm.vmid })
     }
 
-    const data: Record<string, { networks: Array<{ iface: string; bridge: string; vlanTag: number | null; ip: string | null; cidr: number | null }> }> = {}
+    const data: Record<string, { networks: VmNic[] }> = {}
 
     await Promise.all(
       Array.from(byConnection.entries()).map(async ([connId, connVms]) => {
         try {
           const connData = await getConnectionById(connId)
+
+          // Segment context, fetched once per connection rather than per guest.
+          const nodeNames = [...new Set(connVms.map((vm) => vm.node))]
+          const [sdnVnets, bridgeVlanByNode] = await Promise.all([
+            isProviderScope ? fetchSdnVnets(connData) : Promise.resolve([] as SdnVnet[]),
+            fetchBridgeVlanMaps(connData, nodeNames),
+          ])
+          const vnetById = buildVnetIndex(sdnVnets)
 
           const results = await Promise.allSettled(
             connVms.map(async (vm) => {
@@ -123,7 +217,11 @@ export async function POST(req: Request) {
                 `/nodes/${encodeURIComponent(vm.node)}/${vm.type}/${vm.vmid}/config`
               )
 
-              const networks = parseNetKeys(config || {}, vm.type)
+              const bridgeVlanMap = bridgeVlanByNode.get(vm.node) ?? new Map<string, number>()
+              const networks: VmNic[] = parseNetKeys(config || {}, vm.type).map((nic) => ({
+                ...nic,
+                segment: resolveNicSegment({ bridge: nic.bridge, tag: nic.vlanTag }, vnetById, bridgeVlanMap),
+              }))
               const key = `${connId}:${vm.type}:${vm.node}:${vm.vmid}`
 
               return { key, networks }

--- a/frontend/src/app/api/v1/vms/networks/routePost.test.ts
+++ b/frontend/src/app/api/v1/vms/networks/routePost.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  checkPermission: vi.fn(async () => null as any),
+  getConnectionById: vi.fn(async (id: string) => ({
+    id,
+    name: 'PVE-DR',
+    baseUrl: 'https://10.42.0.111:8006',
+    apiToken: 'token',
+    insecureDev: true,
+    behindProxy: false,
+  })),
+  getCurrentTenantId: vi.fn(async () => 'default'),
+  getTenantInfrastructureScope: vi.fn(async () => null as any),
+  maskingScope: vi.fn((scope: any) => scope),
+  pveFetch: vi.fn(async (_conn: any, _path: string) => undefined as any),
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: h.checkPermission,
+  PERMISSIONS: { VM_VIEW: 'vm.view' },
+}))
+vi.mock('@/lib/connections/getConnection', () => ({ getConnectionById: h.getConnectionById }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId }))
+vi.mock('@/lib/tenant/infraScope', () => ({
+  getTenantInfrastructureScope: h.getTenantInfrastructureScope,
+  maskingScope: h.maskingScope,
+}))
+vi.mock('@/lib/proxmox/client', () => ({ pveFetch: h.pveFetch }))
+
+import { POST } from './route'
+import { callRoute, readJson } from '@/__tests__/setup/route-test'
+
+const CONN = 'cmtk6hu1r00007zjlo0kto72x'
+const NODE = 'pve2-dr'
+const KEY = `${CONN}:qemu:${NODE}:100`
+
+const VNETS = [
+  { vnet: 'tv1', alias: 'prod-lan', zone: 'tzvl1', tag: 137 },
+  { vnet: 'tvx1', alias: 'overlay', zone: 'tzvx1', tag: 4242 },
+]
+const ZONES = [
+  { zone: 'tzvl1', type: 'vlan', bridge: 'vmbr0' },
+  { zone: 'tzvx1', type: 'vxlan', peers: '10.42.0.111' },
+]
+const NODE_NETWORK = [
+  { iface: 'vmbr0', type: 'bridge', bridge_ports: 'nic0', active: 1 },
+  { iface: 'vmbr1', type: 'bridge', bridge_ports: 'bond0.30', active: 1 },
+  { iface: 'bond0.30', type: 'vlan', active: 1 },
+]
+
+/** Guest config as PVE returns it: the VNet NIC carries no `tag=`. */
+const GUEST_CONFIG: Record<string, unknown> = {
+  name: 'Debian13',
+  net0: 'virtio=BC:24:11:C0:F0:6F,bridge=tv1',
+  net1: 'virtio=BC:24:11:00:00:04,bridge=tvx1',
+  net2: 'virtio=BC:24:11:00:00:05,bridge=vmbr0,tag=99',
+  net3: 'virtio=BC:24:11:00:00:06,bridge=vmbr1',
+  net4: 'virtio=BC:24:11:00:00:07,bridge=vmbr0',
+}
+
+type Overrides = {
+  vnets?: () => unknown
+  zones?: () => unknown
+  network?: () => unknown
+  config?: () => unknown
+}
+
+/** Route pveFetch by path, so a test can make one endpoint fail in isolation. */
+function stubPve(over: Overrides = {}) {
+  h.pveFetch.mockImplementation(async (_conn: any, path: string) => {
+    if (path === '/cluster/sdn/vnets') return (over.vnets ?? (() => VNETS))()
+    if (path === '/cluster/sdn/zones') return (over.zones ?? (() => ZONES))()
+    if (path.endsWith('/network')) return (over.network ?? (() => NODE_NETWORK))()
+    if (path.endsWith('/config')) return (over.config ?? (() => GUEST_CONFIG))()
+
+    throw new Error(`unexpected path ${path}`)
+  })
+}
+
+const oneVm = { vms: [{ connId: CONN, type: 'qemu', node: NODE, vmid: '100' }] }
+
+type NetworksResponse = { data: Record<string, { networks: any[] }> }
+
+async function post(body: unknown): Promise<NetworksResponse> {
+  return (await readJson<NetworksResponse>(await callRoute(POST, { body: body as any })))!
+}
+
+/** Segment keys of the response, in NIC order. */
+function keysOf(json: NetworksResponse): string[] {
+  return (json.data[KEY]?.networks ?? []).map((n: any) => n.segment.key)
+}
+
+beforeEach(() => {
+  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.getCurrentTenantId.mockReset().mockResolvedValue('default')
+  h.getTenantInfrastructureScope.mockReset().mockResolvedValue(null)
+  h.maskingScope.mockReset().mockImplementation((scope: any) => scope)
+  h.getConnectionById.mockClear()
+  h.pveFetch.mockReset()
+  stubPve()
+})
+
+describe('POST /api/v1/vms/networks', () => {
+  it('returns the RBAC denial untouched', async () => {
+    const denied = new Response('no', { status: 403 })
+
+    h.checkPermission.mockResolvedValue(denied as any)
+
+    const res = await callRoute(POST, { body: oneVm as any })
+
+    expect(res.status).toBe(403)
+    expect(h.pveFetch).not.toHaveBeenCalled()
+  })
+
+  it('short-circuits on an empty or malformed vms list', async () => {
+    expect(await post({ vms: [] })).toEqual({ data: {} })
+    expect(await post({})).toEqual({ data: {} })
+    expect(await post({ vms: 'nope' })).toEqual({ data: {} })
+    expect(h.pveFetch).not.toHaveBeenCalled()
+  })
+
+  it('resolves each NIC to its segment, VNets first', async () => {
+    const json = await post(oneVm)
+    const nets = json.data[KEY].networks
+
+    expect(nets.map((n: any) => n.iface)).toEqual(['net0', 'net1', 'net2', 'net3', 'net4'])
+    expect(nets.map((n: any) => [n.segment.key, n.segment.label, n.segment.vlan])).toEqual([
+      ['vnet-tv1', 'VLAN 137', 137],
+      ['vnet-tvx1', 'VNI 4242', null],
+      ['vlan-99', 'VLAN 99', 99],
+      ['vlan-30', 'VLAN 30', 30],
+      ['no-vlan', 'No VLAN', null],
+    ])
+    expect(nets[0].vlanTag).toBeNull()
+    expect(nets[0].segment.bridgeLabel).toBe('prod-lan')
+  })
+
+  it('fetches the SDN and host network context once, not once per guest', async () => {
+    await post({
+      vms: [
+        { connId: CONN, type: 'qemu', node: NODE, vmid: '100' },
+        { connId: CONN, type: 'qemu', node: NODE, vmid: '101' },
+        { connId: CONN, type: 'lxc', node: NODE, vmid: '102' },
+      ],
+    })
+
+    const paths = h.pveFetch.mock.calls.map((c: any[]) => c[1])
+
+    expect(paths.filter((p: string) => p === '/cluster/sdn/vnets')).toHaveLength(1)
+    expect(paths.filter((p: string) => p === '/cluster/sdn/zones')).toHaveLength(1)
+    expect(paths.filter((p: string) => p.endsWith('/network'))).toHaveLength(1)
+    expect(paths.filter((p: string) => p.endsWith('/config'))).toHaveLength(3)
+    expect(h.getConnectionById).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips SDN entirely for a tenant scope, leaving VNet guests untagged', async () => {
+    h.maskingScope.mockReturnValue({ poolsByConnection: new Map() } as any)
+
+    const json = await post(oneVm)
+
+    expect(h.pveFetch.mock.calls.map((c: any[]) => c[1])).not.toContain('/cluster/sdn/vnets')
+    expect(keysOf(json)).toEqual(['no-vlan', 'no-vlan', 'vlan-99', 'vlan-30', 'no-vlan'])
+    expect(json.data[KEY].networks[0].segment.bridgeLabel).toBe('tv1')
+  })
+
+  it('degrades to per-NIC tags when the SDN vnets endpoint fails', async () => {
+    stubPve({ vnets: () => { throw new Error('501 no such method') } })
+
+    const json = await post(oneVm)
+
+    expect(h.pveFetch.mock.calls.map((c: any[]) => c[1])).not.toContain('/cluster/sdn/zones')
+    expect(keysOf(json)).toEqual(['no-vlan', 'no-vlan', 'vlan-99', 'vlan-30', 'no-vlan'])
+  })
+
+  it('still groups VNets when only the zones endpoint fails', async () => {
+    stubPve({ zones: () => { throw new Error('403') } })
+
+    const json = await post(oneVm)
+    const nets = json.data[KEY].networks
+
+    expect(nets[0].segment.key).toBe('vnet-tv1')
+    // Without the zone there is no way to say VLAN or VNI, so the alias stands in.
+    expect(nets[0].segment.label).toBe('prod-lan')
+    expect(nets[0].segment.zoneType).toBe('')
+    expect(nets[0].segment.vlan).toBeNull()
+  })
+
+  it('falls back to per-NIC tags when a node network is unreadable', async () => {
+    stubPve({ network: () => { throw new Error('connection refused') } })
+
+    // vmbr1 loses its bondX.N VLAN, the rest is unaffected.
+    expect(keysOf(await post(oneVm))).toEqual(['vnet-tv1', 'vnet-tvx1', 'vlan-99', 'no-vlan', 'no-vlan'])
+  })
+
+  it('tolerates non-array SDN and network payloads', async () => {
+    stubPve({ vnets: () => null, zones: () => 'nope', network: () => ({}) })
+
+    expect(keysOf(await post(oneVm))).toEqual(['no-vlan', 'no-vlan', 'vlan-99', 'no-vlan', 'no-vlan'])
+  })
+
+  it('omits a guest whose config fetch fails, keeping the others', async () => {
+    h.pveFetch.mockImplementation(async (_conn: any, path: string) => {
+      if (path === '/cluster/sdn/vnets') return VNETS
+      if (path === '/cluster/sdn/zones') return ZONES
+      if (path.endsWith('/network')) return NODE_NETWORK
+      if (path.endsWith('/100/config')) throw new Error('does not exist')
+
+      return GUEST_CONFIG
+    })
+
+    const json = await post({
+      vms: [
+        { connId: CONN, type: 'qemu', node: NODE, vmid: '100' },
+        { connId: CONN, type: 'qemu', node: NODE, vmid: '101' },
+      ],
+    })
+
+    expect(Object.keys(json.data)).toEqual([`${CONN}:qemu:${NODE}:101`])
+  })
+
+  it('drops entries missing a field rather than calling PVE for them', async () => {
+    const json = await post({
+      vms: [
+        { type: 'qemu', node: NODE, vmid: '100' },
+        { connId: CONN, node: NODE, vmid: '100' },
+        { connId: CONN, type: 'qemu', vmid: '100' },
+        { connId: CONN, type: 'qemu', node: NODE },
+      ],
+    })
+
+    expect(json.data).toEqual({})
+    expect(h.pveFetch).not.toHaveBeenCalled()
+  })
+
+  it('keeps other connections when one cannot be resolved', async () => {
+    h.getConnectionById.mockImplementation(async (id: string) => {
+      if (id === 'broken') throw new Error('connection not found')
+
+      return { id, name: 'PVE-DR', baseUrl: 'https://10.42.0.111:8006', apiToken: 't', insecureDev: true, behindProxy: false }
+    })
+
+    const json = await post({
+      vms: [
+        { connId: 'broken', type: 'qemu', node: 'pve1', vmid: '1' },
+        { connId: CONN, type: 'qemu', node: NODE, vmid: '100' },
+      ],
+    })
+
+    expect(Object.keys(json.data)).toEqual([KEY])
+  })
+
+  it('answers 500 on a malformed request body', async () => {
+    const res = await callRoute(POST, {
+      method: 'POST',
+      body: 'not json' as any,
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/frontend/src/lib/proxmox/nicSegment.test.ts
+++ b/frontend/src/lib/proxmox/nicSegment.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSdnVnets, type SdnVnet } from './sdnVnetMap'
+import { buildVnetIndex, NO_SEGMENT_KEY, resolveNicSegment } from './nicSegment'
+
+/** Build the vnet index the way the route does: raw PVE payloads, then joined. */
+function indexOf(vnets: any[], zones: any[]): Map<string, SdnVnet> {
+  return buildVnetIndex(buildSdnVnets(vnets, zones))
+}
+
+const noVnets = new Map<string, SdnVnet>()
+const noBridges = new Map<string, number>()
+
+describe('resolveNicSegment', () => {
+  it('resolves a VLAN-zone VNet to its VLAN id, which the NIC never carries', () => {
+    const byId = indexOf(
+      [{ vnet: 'tv1', alias: 'prod', zone: 'tzvl1', tag: 137 }],
+      [{ zone: 'tzvl1', type: 'vlan', bridge: 'vmbr0' }],
+    )
+
+    const segment = resolveNicSegment({ bridge: 'tv1' }, byId, noBridges)
+
+    expect(segment.key).toBe('vnet-tv1')
+    expect(segment.label).toBe('VLAN 137')
+    expect(segment.vlan).toBe(137)
+    expect(segment.tag).toBe(137)
+    expect(segment.bridgeLabel).toBe('prod')
+    expect(segment.vnet).toBe('tv1')
+    expect(segment.zone).toBe('tzvl1')
+    expect(segment.zoneType).toBe('vlan')
+  })
+
+  it('labels a VXLAN-zone VNet as a VNI and reports no 802.1Q VLAN', () => {
+    const byId = indexOf(
+      [{ vnet: 'v42fc503', alias: 'lan', zone: 'zvx', tag: 4242 }],
+      [{ zone: 'zvx', type: 'vxlan', peers: '10.42.0.101,10.42.0.102' }],
+    )
+
+    const segment = resolveNicSegment({ bridge: 'v42fc503' }, byId, noBridges)
+
+    expect(segment.key).toBe('vnet-v42fc503')
+    expect(segment.label).toBe('VNI 4242')
+    expect(segment.vlan).toBeNull()
+    expect(segment.tag).toBe(4242)
+  })
+
+  it('treats a QinQ zone as a VLAN zone', () => {
+    const byId = indexOf(
+      [{ vnet: 'tvq', zone: 'zq', tag: 300 }],
+      [{ zone: 'zq', type: 'qinq' }],
+    )
+
+    expect(resolveNicSegment({ bridge: 'tvq' }, byId, noBridges).vlan).toBe(300)
+  })
+
+  it('falls back to the VNet name when the zone type names no segment', () => {
+    const byId = indexOf(
+      [{ vnet: 'vsimple', alias: 'flat', zone: 'zs' }],
+      [{ zone: 'zs', type: 'simple' }],
+    )
+
+    const segment = resolveNicSegment({ bridge: 'vsimple' }, byId, noBridges)
+
+    expect(segment.key).toBe('vnet-vsimple')
+    expect(segment.label).toBe('flat')
+    expect(segment.vlan).toBeNull()
+    expect(segment.tag).toBeNull()
+  })
+
+  it('uses the raw VNet id as the label when the VNet has no alias', () => {
+    const byId = indexOf([{ vnet: 'v42fc503', zone: 'zs' }], [{ zone: 'zs', type: 'simple' }])
+
+    const segment = resolveNicSegment({ bridge: 'v42fc503' }, byId, noBridges)
+
+    expect(segment.label).toBe('v42fc503')
+    expect(segment.bridgeLabel).toBe('v42fc503')
+  })
+
+  it('keys two same-tag VNets of different zones apart, as PVE allows them', () => {
+    // Measured on the lab: `tv1 tag=137 zone=tzvl1` and `tv2 tag=137 zone=tzvl2`
+    // are both accepted on vmbr0. Grouping by tag would fuse two isolated L2s.
+    const byId = indexOf(
+      [
+        { vnet: 'tv1', zone: 'tzvl1', tag: 137 },
+        { vnet: 'tv2', zone: 'tzvl2', tag: 137 },
+      ],
+      [
+        { zone: 'tzvl1', type: 'vlan', bridge: 'vmbr0' },
+        { zone: 'tzvl2', type: 'vlan', bridge: 'vmbr0' },
+      ],
+    )
+
+    const a = resolveNicSegment({ bridge: 'tv1' }, byId, noBridges)
+    const b = resolveNicSegment({ bridge: 'tv2' }, byId, noBridges)
+
+    expect(a.key).not.toBe(b.key)
+    expect(a.label).toBe(b.label)
+  })
+
+  it('lets the VNet win over a per-NIC tag on the same NIC', () => {
+    const byId = indexOf(
+      [{ vnet: 'tv1', zone: 'tzvl1', tag: 137 }],
+      [{ zone: 'tzvl1', type: 'vlan' }],
+    )
+
+    const segment = resolveNicSegment({ bridge: 'tv1', tag: 99 }, byId, noBridges)
+
+    expect(segment.key).toBe('vnet-tv1')
+    expect(segment.vlan).toBe(137)
+  })
+
+  it('keeps the per-NIC tag on a VLAN-aware bridge', () => {
+    const segment = resolveNicSegment({ bridge: 'vmbr0', tag: 137 }, noVnets, noBridges)
+
+    expect(segment.key).toBe('vlan-137')
+    expect(segment.label).toBe('VLAN 137')
+    expect(segment.vlan).toBe(137)
+    expect(segment.bridgeLabel).toBe('vmbr0')
+    expect(segment.vnet).toBeUndefined()
+  })
+
+  it('resolves the traditional bondX.N layout from the host bridge map', () => {
+    const bridges = new Map<string, number>([['vmbr1', 30]])
+
+    const segment = resolveNicSegment({ bridge: 'vmbr1' }, noVnets, bridges)
+
+    expect(segment.key).toBe('vlan-30')
+    expect(segment.vlan).toBe(30)
+    expect(segment.bridgeLabel).toBe('vmbr1')
+  })
+
+  it('prefers the per-NIC tag over the host bridge VLAN', () => {
+    const bridges = new Map<string, number>([['vmbr1', 30]])
+
+    expect(resolveNicSegment({ bridge: 'vmbr1', tag: 137 }, noVnets, bridges).vlan).toBe(137)
+  })
+
+  it('ignores a non-VLAN tag value so the host bridge fallback still applies', () => {
+    const bridges = new Map<string, number>([['vmbr1', 30]])
+
+    expect(resolveNicSegment({ bridge: 'vmbr1', tag: 0 }, noVnets, bridges).vlan).toBe(30)
+    expect(resolveNicSegment({ bridge: 'vmbr0', tag: 0 }, noVnets, noBridges).key).toBe(NO_SEGMENT_KEY)
+  })
+
+  it('reports no segment for a plain untagged bridge', () => {
+    const segment = resolveNicSegment({ bridge: 'vmbr0' }, noVnets, noBridges)
+
+    expect(segment.key).toBe(NO_SEGMENT_KEY)
+    expect(segment.label).toBe('No VLAN')
+    expect(segment.vlan).toBeNull()
+    expect(segment.bridgeLabel).toBe('vmbr0')
+  })
+
+  it('degrades to the per-NIC tag when SDN is out of scope or unavailable', () => {
+    // Tenant scope ships no VNets, exactly like the inventory Network view.
+    const onVnet = resolveNicSegment({ bridge: 'v42fc503' }, noVnets, noBridges)
+
+    expect(onVnet.key).toBe(NO_SEGMENT_KEY)
+    expect(onVnet.bridgeLabel).toBe('v42fc503')
+
+    expect(resolveNicSegment({ bridge: 'vmbr0', tag: 137 }, noVnets, noBridges).key).toBe('vlan-137')
+  })
+
+  it('labels a missing bridge rather than emitting an empty string', () => {
+    expect(resolveNicSegment({}, noVnets, noBridges).bridgeLabel).toBe('unknown')
+    expect(resolveNicSegment({ bridge: null }, noVnets, noBridges).bridgeLabel).toBe('unknown')
+  })
+})
+
+describe('buildVnetIndex', () => {
+  it('indexes VNets by id and is null-safe', () => {
+    expect(buildVnetIndex(undefined).size).toBe(0)
+    expect(buildVnetIndex(null).size).toBe(0)
+    expect(buildVnetIndex([]).size).toBe(0)
+
+    const byId = buildVnetIndex([
+      { vnet: 'a', zone: 'z', zoneType: 'vlan', tag: 10 },
+      { vnet: '', zone: 'z', zoneType: 'vlan' },
+    ] as SdnVnet[])
+
+    expect(byId.size).toBe(1)
+    expect(byId.get('a')?.tag).toBe(10)
+  })
+})

--- a/frontend/src/lib/proxmox/nicSegment.ts
+++ b/frontend/src/lib/proxmox/nicSegment.ts
@@ -1,0 +1,126 @@
+/**
+ * Network segment resolution for a single guest NIC.
+ *
+ * A guest NIC names its segment in three mutually exclusive ways, and reading
+ * only the first one is what made SDN invisible to /infrastructure/topology:
+ *
+ *  1. SDN VNet: `net0=virtio=...,bridge=v42fc503`. The NIC carries NO `tag=` at
+ *     all; the segment id lives on the VNet (`/cluster/sdn/vnets`) and its
+ *     meaning (VLAN id vs VXLAN VNI) on the VNet's zone (`/cluster/sdn/zones`).
+ *  2. VLAN-aware bridge: `bridge=vmbr0,tag=137`, the tag is on the NIC.
+ *  3. Traditional layout: `bridge=vmbr1` where a `bondX.N` sub-interface feeds
+ *     that bridge, so the VLAN lives in the node's host network config.
+ *
+ * A VNet wins over a per-NIC tag: the VNet is the real L2 domain, and that is
+ * how the inventory Network view and the firewall VM rules table already bucket
+ * a guest. Two VNets in DIFFERENT zones may legitimately carry the same tag on
+ * the same bridge (PVE only enforces tag uniqueness inside one zone), so the
+ * group key is the VNet id, never the tag.
+ *
+ * See sdnVnetMap.ts for the VNet/zone join this consumes and hostVlanMap.ts for
+ * the bridge-to-VLAN map behind case 3.
+ */
+
+import { resolveEffectiveTag } from './hostVlanMap'
+import { sdnSegmentLabel, type SdnVnet } from './sdnVnetMap'
+
+/**
+ * Group key of the segment-less bucket. Kept as the historical `no-vlan` string
+ * so a client that already renders that bucket needs no migration.
+ */
+export const NO_SEGMENT_KEY = 'no-vlan'
+
+/** Display label of the segment-less bucket. Translated at the render site. */
+export const NO_SEGMENT_LABEL = 'No VLAN'
+
+/** The segment a guest NIC rides, resolved from the three PVE models above. */
+export type NicSegment = {
+  /** Grouping key: `vnet-<id>`, `vlan-<n>`, or NO_SEGMENT_KEY. */
+  key: string
+  /** Display label: "VLAN 137", "VNI 4242", the VNet alias, or NO_SEGMENT_LABEL. */
+  label: string
+  /** The 802.1Q VLAN id the NIC really rides. Null for VXLAN/EVPN/simple zones. */
+  vlan: number | null
+  /** Segment id whatever its kind: a VLAN id, or a VXLAN VNI. Null when none. */
+  tag: number | null
+  /** Bridge as it should be shown: the VNet alias when the bridge is a VNet. */
+  bridgeLabel: string
+  /** VNet id, only when the bridge is an SDN VNet. */
+  vnet?: string
+  /** Zone id of that VNet. */
+  zone?: string
+  /** Zone type of that VNet: 'vlan' | 'vxlan' | 'qinq' | 'evpn' | 'simple' | ''. */
+  zoneType?: string
+}
+
+/** Index resolved VNets by their id, so a NIC bridge can be matched in O(1). */
+export function buildVnetIndex(vnets: SdnVnet[] | null | undefined): Map<string, SdnVnet> {
+  const byId = new Map<string, SdnVnet>()
+  if (!Array.isArray(vnets)) return byId
+
+  for (const v of vnets) {
+    if (v && typeof v.vnet === 'string' && v.vnet.length > 0) byId.set(v.vnet, v)
+  }
+
+  return byId
+}
+
+/** Whether a zone type carries an 802.1Q VLAN id rather than an overlay VNI. */
+function isVlanZone(zoneType: string): boolean {
+  return zoneType === 'vlan' || zoneType === 'qinq'
+}
+
+/**
+ * Resolve one NIC's segment. `vnetById` is empty when SDN is unavailable or out
+ * of the caller's scope, and `bridgeVlanMap` is empty when the node's host
+ * network could not be read: in both cases resolution degrades to the per-NIC
+ * tag, exactly the behaviour that predates this helper.
+ */
+export function resolveNicSegment(
+  nic: { bridge?: string | null; tag?: number | null },
+  vnetById: Map<string, SdnVnet>,
+  bridgeVlanMap: Map<string, number>,
+): NicSegment {
+  const bridge = nic.bridge || ''
+
+  const vnet = bridge ? vnetById.get(bridge) : undefined
+  if (vnet) {
+    const name = vnet.alias || vnet.vnet
+    const tag = vnet.tag ?? null
+
+    const segment: NicSegment = {
+      key: `vnet-${vnet.vnet}`,
+      label: sdnSegmentLabel(vnet) || name,
+      vlan: isVlanZone(vnet.zoneType) ? tag : null,
+      tag,
+      bridgeLabel: name,
+      vnet: vnet.vnet,
+      zone: vnet.zone,
+      zoneType: vnet.zoneType,
+    }
+
+    return segment
+  }
+
+  // 0 and negatives are not VLAN ids: PVE writes no `tag=` for an untagged NIC,
+  // so a bogus value must not shadow the host-bridge fallback.
+  const nicTag = Number.isInteger(nic.tag) && (nic.tag as number) > 0 ? (nic.tag as number) : undefined
+  const effective = resolveEffectiveTag(nicTag, bridge, bridgeVlanMap)
+  if (effective !== undefined) {
+    return {
+      key: `vlan-${effective}`,
+      label: `VLAN ${effective}`,
+      vlan: effective,
+      tag: effective,
+      bridgeLabel: bridge || 'unknown',
+    }
+  }
+
+  return {
+    key: NO_SEGMENT_KEY,
+    label: NO_SEGMENT_LABEL,
+    vlan: null,
+    tag: null,
+    bridgeLabel: bridge || 'unknown',
+  }
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -6834,6 +6834,8 @@
     "vlan": "VLAN",
     "noVlan": "Kein VLAN",
     "bridge": "Bridge",
+    "vnet": "VNet",
+    "sdnZone": "SDN-Zone",
     "proxcenterRoot": "ProxCeingeben",
     "totalClusters": "gesamt Cluster",
     "infraView": "Infrastruktur",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -6890,6 +6890,8 @@
     "vlan": "VLAN",
     "noVlan": "No VLAN",
     "bridge": "Bridge",
+    "vnet": "VNet",
+    "sdnZone": "SDN zone",
     "proxcenterRoot": "ProxCenter",
     "totalClusters": "Total Clusters",
     "infraView": "Infrastructure",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -6890,6 +6890,8 @@
     "vlan": "VLAN",
     "noVlan": "Sin VLAN",
     "bridge": "Puente",
+    "vnet": "VNet",
+    "sdnZone": "Zona SDN",
     "proxcenterRoot": "ProxCenter",
     "totalClusters": "Total de clusters",
     "infraView": "Infraestructura",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -6891,6 +6891,8 @@
     "vlan": "VLAN",
     "noVlan": "Sans VLAN",
     "bridge": "Bridge",
+    "vnet": "VNet",
+    "sdnZone": "Zone SDN",
     "proxcenterRoot": "ProxCenter",
     "totalClusters": "Clusters totaux",
     "infraView": "Infrastructure",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -6890,6 +6890,8 @@
     "vlan": "VLAN",
     "noVlan": "VLAN 없음",
     "bridge": "브리지",
+    "vnet": "VNet",
+    "sdnZone": "SDN 존",
     "proxcenterRoot": "ProxCenter",
     "totalClusters": "총 클러스터",
     "infraView": "인프라",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -6834,6 +6834,8 @@
     "vlan": "VLAN",
     "noVlan": "无 VLAN",
     "bridge": "网桥",
+    "vnet": "VNet",
+    "sdnZone": "SDN 区域",
     "proxcenterRoot": "ProxCenter",
     "totalClusters": "集群总数",
     "infraView": "基础设施",


### PR DESCRIPTION
## Problem

In `/infrastructure/topology`, guests attached to an SDN VNet were not grouped on their VLAN. They all landed in the single "No VLAN" bucket, with the raw VNet id (for example `v42fc503`) displayed as their bridge.

The cause is that the topology reads the per-NIC `tag=` alone. A guest attached to a VNet carries no `tag=` at all: the segment id lives on the VNet, and its meaning (an 802.1Q VLAN id or a VXLAN VNI) lives on the VNet's zone. The same blind spot also missed the traditional layout, where a `bondX.N` sub-interface feeds a dedicated bridge and the guests on it carry no tag either.

The topology has its own network data path, distinct from the inventory Network view, and it never picked up the SDN and host bridge resolution that already shipped for that view.

## What changed

A new pure helper, `src/lib/proxmox/nicSegment.ts`, resolves one NIC's segment in a fixed order: the SDN VNet the bridge names, else the per-NIC tag, else the VLAN of the host bridge. It consumes the two libraries that already existed and that the topology never called, `sdnVnetMap.ts` for the VNet and zone join and `hostVlanMap.ts` for the bridge to VLAN map.

`POST /api/v1/vms/networks` now resolves the segment server side and ships it per NIC. It fetches the SDN VNets and zones once per connection and the host network once per node, instead of once per guest.

Both grouping sites in `buildTopologyGraph.ts`, the Network view and the infra view grouped by VLAN, bucket on that segment. A VLAN or QinQ zone yields "VLAN 137", a VXLAN or EVPN zone yields "VNI 4242", and the VNet alias replaces the raw id wherever a bridge is shown. The details sidebar gains a VNet row and an SDN zone row, and the canvas nodes stop hardcoding an English "No VLAN" label.

## Two decisions worth reviewing

**The bucket key is the VNet id, never the tag.** Two VNets in different zones may legitimately carry the same tag on the same bridge, because PVE only enforces tag uniqueness inside a single zone. Keying on the tag would fuse two isolated L2 domains into one bucket. Both VNets therefore get their own bucket, and both display "VLAN 137", distinguished by their alias.

**SDN VNets are read in provider scope only**, mirroring the inventory Network view. An iaas tenant keeps the "No VLAN" bucket on a VNet rather than learning the provider's segment names.

## Ordering defect found during lab verification

The fix looked correct in unit tests but not on screen, and the reason is worth recording. `parseNetKeys` returned NICs in the order PVE sent the config keys, and the infra view takes the head of that list as the guest's primary NIC. PVE serializes a guest config from a Perl hash, whose iteration order is randomized per process since Perl 5.18, so `net0` is not reliably the first key returned. On a guest with five NICs the view was electing an arbitrary one, and it picked an untagged NIC.

`parseNetKeys` now sorts by NIC index, numerically so that `net10` stays after `net2`. Note for anyone reproducing this: `pvesh get --output-format json` sorts keys on output, so a payload captured with the CLI shows an order the HTTP API does not guarantee.

## Verification

Verified end to end on a lab cluster running PVE 9.2.2, on a guest given one NIC per branch of the resolution: two VLAN zone VNets (tags 137 and 250), one VXLAN zone VNet (VNI 4242), one plain untagged bridge, and one VLAN aware bridge with `tag=99`. Before the fix, four of those five NICs fell into "No VLAN". After it, each one resolves to its own segment, and both views were checked on screen.

Guest configs and SDN payloads from that cluster are frozen as fixtures in `route.test.ts`, so the field names and the key ordering stay pinned without any dependency on a live cluster.

- 3 new test files, `nicSegment.test.ts`, `buildTopologyGraph.test.ts` (the topology library had no tests at all) and `route.test.ts`
- Full suite green: 664 files, 7472 tests
- `next build` green, `tsc` baseline unchanged, eslint clean on the touched files
