### PR TITLE
feat(drs): show what constrains placement, and scope the status payload

### DIFF
--- a/frontend/src/app/(dashboard)/automation/drs/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/drs/page.tsx
@@ -78,6 +78,10 @@ import DRSSettingsPanel, {
   defaultDRSSettings, 
   type DRSSettings
 } from '@/components/automation/drs/DRSSettingsPanel'
+import PlacementConstraintsCard, {
+  type PinnedGuest,
+  type BalancingDomain
+} from '@/components/automation/drs/PlacementConstraintsCard'
 import AffinityRulesManager, {
   type AffinityRule, 
   type VMInfo as AffinityVMInfo 
@@ -117,6 +121,11 @@ interface DRSStatus {
   active_migrations: number
   pending_count: number
   approved_count: number
+  // Optional: an orchestrator older than the placement filter does not send
+  // them, and the tenant-scoped proxy can legitimately return them empty.
+  pinned_guests?: PinnedGuest[]
+  pinned_guest_count?: number
+  balancing_domains?: BalancingDomain[]
 }
 
 interface DRSRecommendation {
@@ -411,7 +420,8 @@ const ClusterCard = ({
   onToggle,
   excludedNodeNames = [],
   isClusterExcluded = false,
-  drsMode = 'manual'
+  drsMode = 'manual',
+  balancingDomains = []
 }: {
   clusterId: string
   clusterName: string
@@ -422,9 +432,38 @@ const ClusterCard = ({
   excludedNodeNames?: string[]
   isClusterExcluded?: boolean
   drsMode?: string
+  balancingDomains?: BalancingDomain[]
 }) => {
   const theme = useTheme()
   const clusterRecs = recommendations.filter(r => r.connection_id === clusterId)
+
+  // What segments this cluster, if anything. The memory spread and the health
+  // score below are computed over every node, so on a segmented cluster they
+  // measure a gap no migration can close: the chip is what tells the operator
+  // that a low score here is a topology fact, not a DRS failure.
+  const placementConstraint = useMemo(() => {
+    const domains = balancingDomains.filter(d => d.connection_id === clusterId)
+
+    if (domains.length < 2) return null
+
+    const kinds = new Set(domains.flatMap(d => d.constraints || []))
+
+    if (kinds.size === 0) return null
+
+    const network = kinds.has('network')
+    const storage = kinds.has('storage')
+
+    return {
+      count: domains.length,
+      icon: network ? 'ri-git-branch-line' : 'ri-hard-drive-2-line',
+      labelKey:
+        network && storage
+          ? 'drsPage.placementConstrainedBoth'
+          : network
+            ? 'drsPage.placementConstrainedSdn'
+            : 'drsPage.placementConstrainedStorage'
+    }
+  }, [balancingDomains, clusterId])
   
   // Calculer le spread (écart max-min) de mémoire
   const memorySpread = useMemo(() => {
@@ -522,6 +561,21 @@ return 'neutral'
                   variant="outlined"
                   sx={{ height: 22, fontSize: '0.7rem', color: 'text.disabled', borderColor: 'text.disabled' }}
                 />
+              )}
+              {placementConstraint && (
+                <Tooltip
+                  arrow
+                  title={t('drsPage.placementConstrainedTooltip', { count: placementConstraint.count })}
+                >
+                  <Chip
+                    icon={<i className={placementConstraint.icon} style={{ fontSize: 14 }} />}
+                    label={t(placementConstraint.labelKey)}
+                    size="small"
+                    color="warning"
+                    variant="outlined"
+                    sx={{ height: 22, fontSize: '0.7rem', fontWeight: 600 }}
+                  />
+                </Tooltip>
               )}
             </Box>
             <Typography variant="caption" sx={{ opacity: 0.6 }}>
@@ -1374,6 +1428,11 @@ return () => setPageInfo('', '', '')
 
   // Data fetching (only when Enterprise mode is active)
   const { data: status, mutate: mutateStatus, isLoading: statusLoading } = useDRSStatus(isEnterprise)
+
+  // Already tenant-filtered by /api/v1/orchestrator/drs/status; default to
+  // empty so an older orchestrator simply renders nothing extra.
+  const pinnedGuests: PinnedGuest[] = status?.pinned_guests ?? []
+  const balancingDomains: BalancingDomain[] = status?.balancing_domains ?? []
 
   const { data: recommendationsRaw, mutate: mutateRecs, isLoading: recsLoading } = useDRSRecsHook(isEnterprise)
 
@@ -2267,6 +2326,7 @@ return next
                 excludedNodeNames={drsSettings?.excluded_nodes?.[cluster.id] || []}
                 isClusterExcluded={drsSettings?.excluded_clusters?.includes(cluster.id) || false}
                 drsMode={drsSettings?.cluster_modes?.[cluster.id] || status?.mode || 'manual'}
+                balancingDomains={balancingDomains}
               />
             ))
           )}
@@ -2282,6 +2342,13 @@ return next
               {t('drsPage.recsExplainer')}
             </Typography>
           </Alert>
+
+          {/* Why DRS is constrained here, on a zoned cluster */}
+          <PlacementConstraintsCard
+            pinnedGuests={pinnedGuests}
+            balancingDomains={balancingDomains}
+            connectionNames={connectionNames}
+          />
 
           {/* Migrations actives en cours */}
           {activeMigrations.length > 0 && (
@@ -2312,9 +2379,15 @@ return next
                   {[1, 2, 3].map(i => <Skeleton key={i} height={56} />)}
                 </Stack>
               ) : pendingRecs.length === 0 && activeMigrations.length === 0 ? (
-                <Alert severity="success" icon={<CheckCircleIcon />}>
-                  {t('drsPage.clustersEquilibrated')}
-                </Alert>
+                pinnedGuests.length > 0 ? (
+                  <Alert severity="info">
+                    {t('drsPage.someGuestsCannotMove')}
+                  </Alert>
+                ) : (
+                  <Alert severity="success" icon={<CheckCircleIcon />}>
+                    {t('drsPage.clustersEquilibrated')}
+                  </Alert>
+                )
               ) : pendingRecs.length === 0 ? (
                 <Alert severity="info">
                   {t('drsPage.noNewRecommendation', { count: activeMigrations.length })}

--- a/frontend/src/app/api/v1/orchestrator/drs/status/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/drs/status/route.ts
@@ -2,7 +2,8 @@
 import { NextResponse } from "next/server"
 
 import { getOrchestratorClient } from "@/lib/orchestrator/client"
-import { checkPermission, PERMISSIONS } from "@/lib/rbac"
+import { checkPermission, PERMISSIONS, getCurrentRbacInfraScope } from "@/lib/rbac"
+import { isFlatRecordVisible } from "@/lib/rbac/infraScope"
 import { getTenantConnectionIds } from "@/lib/tenant"
 
 export const runtime = "nodejs"
@@ -14,6 +15,7 @@ export async function GET() {
     if (denied) return denied
 
     const tenantConnectionIds = await getTenantConnectionIds()
+    const rbacScope = await getCurrentRbacInfraScope(PERMISSIONS.CONNECTION_VIEW)
     const client = getOrchestratorClient()
 
     // Fetch recommendations + migrations to recompute counts for tenant
@@ -29,7 +31,41 @@ export async function GET() {
     const filteredRecs = recs.filter((r: any) => !r.connection_id || tenantConnectionIds.has(r.connection_id))
     const filteredMigs = migs.filter((m: any) => !m.connection_id || tenantConnectionIds.has(m.connection_id))
 
-    const status = statusRes.data || {}
+    const status: Record<string, any> = statusRes.data || {}
+
+    // The orchestrator answers cluster-wide: this route is the tenant
+    // boundary. Anything it spreads verbatim leaks, so every row-shaped field
+    // has to be filtered here, not just the counts.
+    //
+    // pinned_guests and balancing_domains name guests and nodes, so unlike
+    // the recommendation and migration filters above they are fail-CLOSED: a
+    // row without a connection_id is dropped rather than shown to everyone.
+    // They also go through the RBAC infra scope, not just the tenant: these
+    // are the first DRS status fields to carry guest names, and a user scoped
+    // to one connection or one node has no business reading the others'.
+    const ownedRows = (rows: unknown): any[] =>
+      (Array.isArray(rows) ? rows : []).filter(
+        (row: any) => row?.connection_id && tenantConnectionIds.has(row.connection_id)
+      )
+
+    // A pinned guest names both a node and a guest, so the row-level gate can
+    // decide it outright.
+    const pinnedGuests = ownedRows(status.pinned_guests).filter((g: any) =>
+      isFlatRecordVisible(rbacScope, { connId: g.connection_id, node: g.node, vmid: g.vmid, nodeBound: true })
+    )
+
+    // A domain names a set of nodes and no guest. It is kept only when every
+    // node it names is visible: showing a partially visible domain would leak
+    // the names of nodes the caller has no grant on.
+    const balancingDomains = ownedRows(status.balancing_domains).filter((d: any) => {
+      const nodes: string[] = Array.isArray(d.nodes) ? d.nodes : []
+
+      if (nodes.length === 0) return false
+
+      return nodes.every(node =>
+        isFlatRecordVisible(rbacScope, { connId: d.connection_id, node, nodeBound: true })
+      )
+    })
 
     return NextResponse.json({
       ...status,
@@ -37,6 +73,9 @@ export async function GET() {
       active_migrations: filteredMigs.length,
       pending_count: filteredRecs.filter((r: any) => r.status === 'pending').length,
       approved_count: filteredRecs.filter((r: any) => r.status === 'approved').length,
+      pinned_guests: pinnedGuests,
+      pinned_guest_count: pinnedGuests.length,
+      balancing_domains: balancingDomains,
     })
   } catch (e: any) {
     if ((e as any)?.code !== 'ORCHESTRATOR_UNAVAILABLE') {
@@ -50,7 +89,10 @@ export async function GET() {
       recommendations: 0,
       active_migrations: 0,
       pending_count: 0,
-      approved_count: 0
+      approved_count: 0,
+      pinned_guests: [],
+      pinned_guest_count: 0,
+      balancing_domains: []
     })
   }
 }

--- a/frontend/src/app/api/v1/orchestrator/drs/status/statusScope.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/drs/status/statusScope.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Security: GET /api/v1/orchestrator/drs/status is a tenant boundary in front
+ * of a cluster-wide orchestrator endpoint. It used to spread the upstream
+ * payload verbatim and recompute only the recommendation and migration
+ * counts, so the pinned_guests and balancing_domains rows added with the DRS
+ * placement filter reached every tenant with other tenants' guest names,
+ * nodes and blocker reasons.
+ *
+ * These tests pin the corrected behaviour: both row-shaped fields are
+ * filtered on connection_id, the derived count follows the filtered list, and
+ * a row carrying no connection_id is dropped rather than shown to everyone.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { callRoute } from '@/__tests__/setup/route-test'
+
+const { tenantConnectionIdsMock, getDRSStatusMock, getRecommendationsMock, getActiveMigrationsMock, rbacScopeMock } = vi.hoisted(() => ({
+  tenantConnectionIdsMock: vi.fn(),
+  getDRSStatusMock: vi.fn(),
+  getRecommendationsMock: vi.fn(),
+  getActiveMigrationsMock: vi.fn(),
+  rbacScopeMock: vi.fn()
+}))
+
+vi.mock('@/lib/tenant', () => ({
+  getTenantConnectionIds: (...a: any[]) => tenantConnectionIdsMock(...a)
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: vi.fn().mockResolvedValue(null),
+  getCurrentRbacInfraScope: (...a: any[]) => rbacScopeMock(...a),
+  PERMISSIONS: { AUTOMATION_VIEW: 'automation.view', CONNECTION_VIEW: 'connection.view' }
+}))
+
+vi.mock('@/lib/orchestrator/client', () => ({
+  getOrchestratorClient: () => ({
+    getDRSStatus: (...a: any[]) => getDRSStatusMock(...a),
+    getRecommendations: (...a: any[]) => getRecommendationsMock(...a),
+    getActiveMigrations: (...a: any[]) => getActiveMigrationsMock(...a)
+  })
+}))
+
+const upstreamStatus = {
+  enabled: true,
+  mode: 'manual',
+  recommendations: 3,
+  active_migrations: 0,
+  pending_count: 3,
+  approved_count: 0,
+  pinned_guest_count: 3,
+  pinned_guests: [
+    { connection_id: 'mine', vmid: 9101, name: 'dmz-a', node: 'n1', reason: 'vnet vdmz unavailable on n2' },
+    { connection_id: 'theirs', vmid: 500, name: 'their-secret-vm', node: 'their-node', reason: 'storage X' },
+    { vmid: 777, name: 'orphan', node: 'n9', reason: 'no connection at all' }
+  ],
+  balancing_domains: [
+    { connection_id: 'mine', nodes: ['n1'], guests: 2, spread: 0 },
+    { connection_id: 'theirs', nodes: ['their-node-a', 'their-node-b'], guests: 5, spread: 12.5 },
+    { nodes: ['n9'], guests: 1, spread: 0 }
+  ]
+}
+
+const readBody = async (res: any) => JSON.parse(await res.text())
+
+describe('GET /api/v1/orchestrator/drs/status tenant scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tenantConnectionIdsMock.mockResolvedValue(new Set(['mine']))
+    // null scope = unrestricted (admin), the default for most of these tests.
+    rbacScopeMock.mockResolvedValue(null)
+    getDRSStatusMock.mockResolvedValue({ data: upstreamStatus })
+    getRecommendationsMock.mockResolvedValue({ data: [] })
+    getActiveMigrationsMock.mockResolvedValue({ data: [] })
+  })
+
+  it('keeps only the pinned guests of the caller s connections', async () => {
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests).toHaveLength(1)
+    expect(body.pinned_guests[0].vmid).toBe(9101)
+    expect(JSON.stringify(body)).not.toContain('their-secret-vm')
+    expect(JSON.stringify(body)).not.toContain('their-node')
+  })
+
+  it('recomputes pinned_guest_count from the filtered list, not upstream', async () => {
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guest_count).toBe(1)
+  })
+
+  it('keeps only the balancing domains of the caller s connections', async () => {
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.balancing_domains).toHaveLength(1)
+    expect(body.balancing_domains[0].nodes).toEqual(['n1'])
+  })
+
+  it('drops a row with no connection_id rather than showing it to everyone', async () => {
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests.some((g: any) => g.vmid === 777)).toBe(false)
+    expect(body.balancing_domains.some((d: any) => d.nodes.includes('n9'))).toBe(false)
+  })
+
+  it('answers empty rather than upstream when the tenant owns no connection', async () => {
+    tenantConnectionIdsMock.mockResolvedValue(new Set())
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests).toEqual([])
+    expect(body.pinned_guest_count).toBe(0)
+    expect(body.balancing_domains).toEqual([])
+  })
+
+  it('tolerates an orchestrator that does not send the fields at all', async () => {
+    getDRSStatusMock.mockResolvedValue({ data: { enabled: true, mode: 'manual' } })
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests).toEqual([])
+    expect(body.pinned_guest_count).toBe(0)
+    expect(body.balancing_domains).toEqual([])
+    expect(body.enabled).toBe(true)
+  })
+
+  it('falls back to an empty, safe payload when the orchestrator is down', async () => {
+    getDRSStatusMock.mockRejectedValue(Object.assign(new Error('down'), { code: 'ORCHESTRATOR_UNAVAILABLE' }))
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.enabled).toBe(false)
+    expect(body.pinned_guests).toEqual([])
+    expect(body.balancing_domains).toEqual([])
+  })
+})
+
+describe('GET /api/v1/orchestrator/drs/status RBAC infra scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Both connections belong to the tenant: only the RBAC scope narrows them.
+    tenantConnectionIdsMock.mockResolvedValue(new Set(['mine', 'theirs']))
+    getRecommendationsMock.mockResolvedValue({ data: [] })
+    getActiveMigrationsMock.mockResolvedValue({ data: [] })
+    getDRSStatusMock.mockResolvedValue({
+      data: {
+        enabled: true,
+        mode: 'manual',
+        pinned_guests: [
+          { connection_id: 'mine', vmid: 9101, name: 'dmz-a', node: 'n1', reason: 'vnet' },
+          { connection_id: 'mine', vmid: 9201, name: 'users-a', node: 'n2', reason: 'vnet' },
+          { connection_id: 'theirs', vmid: 500, name: 'their-vm', node: 'their-node', reason: 'storage' }
+        ],
+        balancing_domains: [
+          { connection_id: 'mine', nodes: ['n1'], guests: 1, spread: 0 },
+          { connection_id: 'mine', nodes: ['n1', 'n2'], guests: 2, spread: 4 },
+          { connection_id: 'theirs', nodes: ['their-node'], guests: 1, spread: 0 }
+        ]
+      }
+    })
+  })
+
+  // A user granted node n1 of connection "mine" and nothing else.
+  const nodeScopedToN1 = {
+    fullConnections: new Set<string>(),
+    guestDerived: false,
+    nodesByConnection: new Map([['mine', new Set(['n1'])]]),
+    guestGrantsByConnection: new Map()
+  }
+
+  it('keeps only the guests of the nodes the caller is granted', async () => {
+    rbacScopeMock.mockResolvedValue(nodeScopedToN1)
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests.map((g: any) => g.vmid)).toEqual([9101])
+    expect(body.pinned_guest_count).toBe(1)
+    expect(JSON.stringify(body)).not.toContain('their-vm')
+    expect(JSON.stringify(body)).not.toContain('users-a')
+  })
+
+  it('drops a domain that names a node the caller cannot see', async () => {
+    rbacScopeMock.mockResolvedValue(nodeScopedToN1)
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    // {n1} is entirely visible; {n1,n2} names n2, which is not granted.
+    expect(body.balancing_domains).toHaveLength(1)
+    expect(body.balancing_domains[0].nodes).toEqual(['n1'])
+    expect(JSON.stringify(body)).not.toContain('their-node')
+  })
+
+  it('leaves an unrestricted caller with everything the tenant owns', async () => {
+    rbacScopeMock.mockResolvedValue(null)
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.pinned_guests).toHaveLength(3)
+    expect(body.balancing_domains).toHaveLength(3)
+  })
+
+  it('drops a domain that names no node at all', async () => {
+    rbacScopeMock.mockResolvedValue(null)
+    getDRSStatusMock.mockResolvedValue({
+      data: { enabled: true, balancing_domains: [{ connection_id: 'mine', nodes: [], guests: 1, spread: 0 }] }
+    })
+    const { GET } = await import('./route')
+    const body = await readBody(await callRoute(GET as any))
+
+    expect(body.balancing_domains).toEqual([])
+  })
+})

--- a/frontend/src/components/automation/drs/PlacementConstraintsCard.test.tsx
+++ b/frontend/src/components/automation/drs/PlacementConstraintsCard.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import PlacementConstraintsCard, { type BalancingDomain, type PinnedGuest } from './PlacementConstraintsCard'
+
+// Keys are echoed with their interpolation values so the tests can assert the
+// counts and spreads actually reach the translation.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (k: string, vals?: Record<string, unknown>) =>
+    vals ? `${k} ${JSON.stringify(vals)}` : k
+}))
+
+afterEach(cleanup)
+
+const pinned = (over: Partial<PinnedGuest> = {}): PinnedGuest => ({
+  connection_id: 'dr',
+  vmid: 9101,
+  name: 't-dmz-a',
+  node: 'pve1-dr',
+  reason: 'network "vdmz" unavailable on node "pve2-dr": SDN zone "zdmz" is restricted to [pve1-dr]',
+  ...over
+})
+
+const domain = (over: Partial<BalancingDomain> = {}): BalancingDomain => ({
+  connection_id: 'dr',
+  nodes: ['pve1-dr', 'pve2-dr'],
+  guests: 1,
+  spread: 3.8194,
+  ...over
+})
+
+const names = { dr: 'PVE-DR', prod: 'PVE-PROD' }
+
+describe('PlacementConstraintsCard', () => {
+  it('renders nothing on a cluster with no placement restriction', () => {
+    const { container } = render(
+      <PlacementConstraintsCard pinnedGuests={[]} balancingDomains={[]} connectionNames={names} />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when a cluster has a single, cluster-wide domain', () => {
+    // One domain covering every node means nothing restricts placement, which
+    // is the common case and must stay silent.
+    const { container } = render(
+      <PlacementConstraintsCard
+        pinnedGuests={[]}
+        balancingDomains={[domain({ connection_id: 'prod', nodes: ['pve1', 'pve2', 'pve3'] })]}
+        connectionNames={names}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists the pinned guests with their node and the blocking reason', () => {
+    render(
+      <PlacementConstraintsCard
+        pinnedGuests={[pinned(), pinned({ vmid: 9102, name: 't-dmz-b' })]}
+        balancingDomains={[]}
+        connectionNames={names}
+      />
+    )
+
+    expect(screen.getByText('PVE-DR')).toBeInTheDocument()
+    expect(screen.getByText('t-dmz-a (9101)')).toBeInTheDocument()
+    expect(screen.getByText('t-dmz-b (9102)')).toBeInTheDocument()
+    expect(screen.getAllByText(/drsPage.pinnedGuestOn.*pve1-dr/)).toHaveLength(2)
+    expect(screen.getAllByText(/SDN zone "zdmz" is restricted/)).toHaveLength(2)
+  })
+
+  it('shows each multi-node domain with its guest count and spread', () => {
+    render(
+      <PlacementConstraintsCard
+        pinnedGuests={[]}
+        balancingDomains={[
+          domain(),
+          domain({ nodes: ['pve1-dr', 'pve2-dr', 'pve3-dr'], guests: 2, spread: 7.0102 })
+        ]}
+        connectionNames={names}
+      />
+    )
+
+    expect(screen.getByText(/drsPage.domainGuests.*"count":1/)).toBeInTheDocument()
+    expect(screen.getByText(/drsPage.domainGuests.*"count":2/)).toBeInTheDocument()
+    // One decimal, so an operator reads a spread rather than a float dump.
+    expect(screen.getByText(/drsPage.domainSpread.*"value":"3.8"/)).toBeInTheDocument()
+    expect(screen.getByText(/drsPage.domainSpread.*"value":"7.0"/)).toBeInTheDocument()
+  })
+
+  it('lists a single-node domain but shows no spread for it', () => {
+    // The cluster chip counts every domain, so the card must list every domain
+    // too: hiding the single-node ones made the tooltip say 4 while the card
+    // showed 2. A one-node domain has no spread worth reading, it has no target.
+    render(
+      <PlacementConstraintsCard
+        pinnedGuests={[pinned()]}
+        balancingDomains={[domain({ nodes: ['pve1-dr'], guests: 2, spread: 0 }), domain()]}
+        connectionNames={names}
+      />
+    )
+
+    expect(screen.queryByText(/"value":"0.0"/)).not.toBeInTheDocument()
+    expect(screen.getByText(/"value":"3.8"/)).toBeInTheDocument()
+    expect(screen.getByText('drsPage.domainNoTarget')).toBeInTheDocument()
+    expect(screen.getAllByText('pve1-dr')).toHaveLength(2)
+  })
+
+  it('groups by cluster and falls back to a short id when the name is unknown', () => {
+    render(
+      <PlacementConstraintsCard
+        pinnedGuests={[pinned(), pinned({ connection_id: 'cmtk6hu1r00007zjlo0kto72x', vmid: 42, name: 'x' })]}
+        balancingDomains={[]}
+        connectionNames={names}
+      />
+    )
+
+    expect(screen.getByText('PVE-DR')).toBeInTheDocument()
+    expect(screen.getByText('cmtk6hu1r000')).toBeInTheDocument()
+  })
+
+  it('renders a cluster that only has pinned guests, with no domain block', () => {
+    render(
+      <PlacementConstraintsCard pinnedGuests={[pinned()]} balancingDomains={[]} connectionNames={names} />
+    )
+
+    expect(screen.getByText('drsPage.pinnedGuestsTitle')).toBeInTheDocument()
+    expect(screen.queryByText('drsPage.balancingDomainsTitle')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/automation/drs/PlacementConstraintsCard.tsx
+++ b/frontend/src/components/automation/drs/PlacementConstraintsCard.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import Box from '@mui/material/Box'
+import Card from '@mui/material/Card'
+import CardContent from '@mui/material/CardContent'
+import Chip from '@mui/material/Chip'
+import Divider from '@mui/material/Divider'
+import Stack from '@mui/material/Stack'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { useTranslations } from 'next-intl'
+
+/** One guest that no node other than its own can run. */
+export interface PinnedGuest {
+  connection_id: string
+  vmid: number
+  name: string
+  node: string
+  reason: string
+}
+
+/** One set of nodes the guests of a cluster can move between. */
+export interface BalancingDomain {
+  connection_id: string
+  nodes: string[]
+  guests: number
+  spread: number
+  /** What segmented this domain: 'network' (bridge or SDN VNet), 'storage'. */
+  constraints?: string[]
+}
+
+interface Props {
+  pinnedGuests: PinnedGuest[]
+  balancingDomains: BalancingDomain[]
+  connectionNames: Record<string, string>
+}
+
+/**
+ * Why DRS is constrained on a cluster.
+ *
+ * A cluster cut into role-dedicated SDN zones has a load spread it can never
+ * bring down, and guests it can never move. Without this card the page shows
+ * an imbalance and no recommendation, which reads as a broken DRS. It renders
+ * nothing on a cluster with no placement restriction, which is the common case.
+ */
+const PlacementConstraintsCard = ({ pinnedGuests, balancingDomains, connectionNames }: Props) => {
+  const t = useTranslations()
+
+  // Only multi-domain clusters are worth showing: a single domain covering
+  // every node means nothing restricts placement there.
+  const constrainedClusters = useMemo(() => {
+    const domainsByCluster = new Map<string, BalancingDomain[]>()
+
+    for (const domain of balancingDomains) {
+      const list = domainsByCluster.get(domain.connection_id) || []
+
+      list.push(domain)
+      domainsByCluster.set(domain.connection_id, list)
+    }
+
+    const guestsByCluster = new Map<string, PinnedGuest[]>()
+
+    for (const guest of pinnedGuests) {
+      const list = guestsByCluster.get(guest.connection_id) || []
+
+      list.push(guest)
+      guestsByCluster.set(guest.connection_id, list)
+    }
+
+    const ids = new Set<string>()
+
+    for (const [id, domains] of domainsByCluster) {
+      if (domains.length > 1) ids.add(id)
+    }
+
+    for (const id of guestsByCluster.keys()) ids.add(id)
+
+    return [...ids]
+      .sort((a, b) => (connectionNames[a] || a).localeCompare(connectionNames[b] || b))
+      .map(id => ({
+        id,
+        name: connectionNames[id] || id.slice(0, 12),
+        // Every domain is listed, single-node ones included: the cluster chip
+        // counts them all, and hiding some here made the tooltip say 4 while
+        // the card showed 2. A one-node domain is also the most telling row,
+        // it is where the pinned guests sit.
+        domains: [...(domainsByCluster.get(id) || [])].sort((a, b) => b.nodes.length - a.nodes.length),
+        guests: guestsByCluster.get(id) || []
+      }))
+  }, [pinnedGuests, balancingDomains, connectionNames])
+
+  if (constrainedClusters.length === 0) return null
+
+  return (
+    <Card variant='outlined' sx={{ borderRadius: 2, borderColor: 'warning.main' }}>
+      <CardContent>
+        <Typography variant='subtitle2' sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <i className='ri-pushpin-line' style={{ fontSize: 18 }} />
+          {t('drsPage.placementConstraints')}
+        </Typography>
+        <Typography variant='caption' color='text.secondary' sx={{ display: 'block', mt: 0.5 }}>
+          {t('drsPage.placementConstraintsDesc')}
+        </Typography>
+
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          {constrainedClusters.map((cluster, index) => (
+            <Box key={cluster.id}>
+              {index > 0 && <Divider sx={{ mb: 2 }} />}
+              <Typography variant='body2' sx={{ fontWeight: 600, mb: 1 }}>
+                {cluster.name}
+              </Typography>
+
+              {cluster.domains.length > 0 && (
+                <Box sx={{ mb: cluster.guests.length > 0 ? 1.5 : 0 }}>
+                  <Typography variant='caption' color='text.secondary'>
+                    {t('drsPage.balancingDomainsTitle')}
+                  </Typography>
+                  <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                    {cluster.domains.map(domain => (
+                      <Box
+                        key={domain.nodes.join(',')}
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}
+                      >
+                        {domain.nodes.map(node => (
+                          <Chip key={node} label={node} size='small' variant='outlined' />
+                        ))}
+                        <Typography variant='caption' color='text.secondary'>
+                          {t('drsPage.domainGuests', { count: domain.guests })}
+                        </Typography>
+                        {domain.nodes.length > 1 && (
+                          <Typography variant='caption' color='text.secondary'>
+                            {t('drsPage.domainSpread', { value: domain.spread.toFixed(1) })}
+                          </Typography>
+                        )}
+                        {domain.nodes.length === 1 && (
+                          <Typography variant='caption' color='warning.main'>
+                            {t('drsPage.domainNoTarget')}
+                          </Typography>
+                        )}
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+
+              {cluster.guests.length > 0 && (
+                <Box>
+                  <Typography variant='caption' color='text.secondary'>
+                    {t('drsPage.pinnedGuestsTitle')}
+                  </Typography>
+                  <Stack spacing={0.75} sx={{ mt: 0.5 }}>
+                    {cluster.guests.map(guest => (
+                      <Box
+                        key={`${guest.connection_id}-${guest.vmid}`}
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}
+                      >
+                        <Tooltip title={guest.reason} arrow>
+                          <Chip
+                            label={`${guest.name} (${guest.vmid})`}
+                            size='small'
+                            color='warning'
+                            variant='outlined'
+                          />
+                        </Tooltip>
+                        <Typography variant='caption' color='text.secondary'>
+                          {t('drsPage.pinnedGuestOn', { node: guest.node })}
+                        </Typography>
+                        <Typography variant='caption' color='text.secondary' sx={{ opacity: 0.8 }}>
+                          {guest.reason}
+                        </Typography>
+                      </Box>
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+            </Box>
+          ))}
+        </Stack>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PlacementConstraintsCard

--- a/frontend/src/components/automation/drs/index.ts
+++ b/frontend/src/components/automation/drs/index.ts
@@ -3,3 +3,6 @@ export type { DRSSettings, ClusterVersionInfo } from './DRSSettingsPanel'
 
 export { default as AffinityRulesManager } from './AffinityRulesManager'
 export type { AffinityRule, VMInfo } from './AffinityRulesManager'
+
+export { default as PlacementConstraintsCard } from './PlacementConstraintsCard'
+export type { PinnedGuest, BalancingDomain } from './PlacementConstraintsCard'

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5748,7 +5748,20 @@
     "helpPreventOverprov": "Wenn aktiviert, migriert DRS keine VM auf einen Node, wenn dieser dadurch seine Kapazität überschreiten würde (zugewiesen > verfügbar). Verhindert Überallokation von Ressourcen.",
     "helpResourceWeights": "Wie stark jeder Ressourcentyp den Balancing-Score beeinflusst.",
     "helpResourceWeightsDesc": "Auf 0 setzen, um eine Ressource zu ignorieren. Auf 2 für maximale Priorität. Beispiel: Memory=1 CPU=0.3 Storage=0 bedeutet, DRS konzentriert sich hauptsächlich auf Speicher-Balance.",
-    "excludedFromDRS": "Vom DRS ausgeschlossen"
+    "excludedFromDRS": "Vom DRS ausgeschlossen",
+    "placementConstraints": "Platzierungsbeschränkungen",
+    "placementConstraintsDesc": "Diese Cluster können nicht frei ausgeglichen werden: eine Bridge, ein SDN-VNet oder ein Storage, den ein Gast benötigt, erreicht nicht alle Knoten.",
+    "balancingDomainsTitle": "Ausgleichsdomänen",
+    "domainGuests": "{count, plural, one {# Gast} other {# Gäste}}",
+    "domainSpread": "Spanne {value} Pkt.",
+    "pinnedGuestsTitle": "Nicht verschiebbare Gäste",
+    "pinnedGuestOn": "auf {node}",
+    "someGuestsCannotMove": "Derzeit nichts auszugleichen. Einige Gäste lassen sich überhaupt nicht verschieben, siehe die Platzierungsbeschränkungen oben.",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "Storage",
+    "placementConstrainedBoth": "SDN + Storage",
+    "placementConstrainedTooltip": "{count, plural, one {# Ausgleichsdomäne} other {# Ausgleichsdomänen}} in diesem Cluster: ein Gast kann sich nur innerhalb seiner eigenen bewegen. Die Speicherspanne und der Health-Score unten werden über alle Knoten berechnet und können hier daher nicht auf null sinken.",
+    "domainNoTarget": "kein Ziel möglich"
   },
   "usersPage": {
     "rbacRoles": "RBAC-Rollen",

--- a/frontend/src/messages/drsPlacementMessages.test.ts
+++ b/frontend/src/messages/drsPlacementMessages.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales: Record<string, any> = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+const plainKeys = [
+  'placementConstraints',
+  'placementConstraintsDesc',
+  'balancingDomainsTitle',
+  'pinnedGuestsTitle',
+  'someGuestsCannotMove',
+  'placementConstrainedSdn',
+  'placementConstrainedStorage',
+  'placementConstrainedBoth',
+  'domainNoTarget'
+]
+
+// Each of these carries an interpolation the card depends on; a locale that
+// drops the placeholder silently renders a sentence with a hole in it.
+// domainGuests is an ICU plural, so it carries "{count," and not "{count}".
+const interpolated: Record<string, string> = {
+  domainGuests: '{count,',
+  domainSpread: '{value}',
+  pinnedGuestOn: '{node}',
+  placementConstrainedTooltip: '{count,'
+}
+
+describe('DRS placement constraints i18n parity across the 6 served locales', () => {
+  it('every locale spells the guest count as an ICU plural', () => {
+    for (const [locale, messages] of Object.entries(locales)) {
+      const value: string = messages?.drsPage?.domainGuests
+
+      expect(value, `${locale}: domainGuests`).toBeTypeOf('string')
+      expect(value, `${locale}: plural form`).toMatch(/\{count,\s*plural,/)
+      expect(value, `${locale}: an "other" branch is required by ICU`).toContain('other {')
+    }
+  })
+
+  it('every locale spells the constrained-cluster tooltip as an ICU plural', () => {
+    for (const [locale, messages] of Object.entries(locales)) {
+      const value: string = messages?.drsPage?.placementConstrainedTooltip
+
+      expect(value, `${locale}: placementConstrainedTooltip`).toBeTypeOf('string')
+      expect(value, `${locale}: plural form`).toMatch(/\{count,\s*plural,/)
+      expect(value, `${locale}: an "other" branch is required by ICU`).toContain('other {')
+    }
+  })
+
+  for (const [locale, messages] of Object.entries(locales)) {
+    for (const key of plainKeys) {
+      it(`${locale} declares drsPage.${key}`, () => {
+        const value = messages?.drsPage?.[key]
+
+        expect(value, `${locale}: drsPage.${key}`).toBeTypeOf('string')
+        expect(value!.length, `${locale}: drsPage.${key} must not be empty`).toBeGreaterThan(0)
+      })
+    }
+
+    for (const [key, placeholder] of Object.entries(interpolated)) {
+      it(`${locale} declares drsPage.${key} with its ${placeholder} placeholder`, () => {
+        const value = messages?.drsPage?.[key]
+
+        expect(value, `${locale}: drsPage.${key}`).toBeTypeOf('string')
+        expect(value, `${locale}: ${placeholder} placeholder`).toContain(placeholder)
+      })
+    }
+  }
+})

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5791,7 +5791,20 @@
     "helpPreventOverprov": "When enabled, DRS will not migrate a VM to a node if it would cause that node to exceed its capacity (allocated > available). Prevents overcommitting resources.",
     "helpResourceWeights": "How much each resource type influences the balancing score.",
     "helpResourceWeightsDesc": "Set to 0 to ignore a resource. Set to 2 for maximum priority. For example, Memory=1 CPU=0.3 Storage=0 means DRS focuses primarily on memory balance.",
-    "excludedFromDRS": "Excluded from DRS"
+    "excludedFromDRS": "Excluded from DRS",
+    "placementConstraints": "Placement constraints",
+    "placementConstraintsDesc": "These clusters cannot balance freely: a bridge, an SDN VNet or a storage a guest needs does not reach every node.",
+    "balancingDomainsTitle": "Balancing domains",
+    "domainGuests": "{count, plural, one {# guest} other {# guests}}",
+    "domainSpread": "spread {value} pts",
+    "pinnedGuestsTitle": "Guests that cannot be moved",
+    "pinnedGuestOn": "on {node}",
+    "someGuestsCannotMove": "Nothing to balance right now. Some guests cannot be moved at all, see the placement constraints above.",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "Storage",
+    "placementConstrainedBoth": "SDN + storage",
+    "placementConstrainedTooltip": "{count, plural, one {# balancing domain} other {# balancing domains}} on this cluster: a guest can only move inside its own. The memory spread and the health score below are computed over every node, so they cannot come down to zero here.",
+    "domainNoTarget": "nowhere to move"
   },
   "usersPage": {
     "rbacRoles": "RBAC Roles",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -5791,7 +5791,20 @@
     "helpPreventOverprov": "Cuando está habilitado, DRS no migrará una VM a un nodo si eso haría que el nodo supere su capacidad (asignado > disponible). Evita el sobrecompromiso de recursos.",
     "helpResourceWeights": "Cuánto influye cada tipo de recurso en la puntuación de equilibrado.",
     "helpResourceWeightsDesc": "Establezca 0 para ignorar un recurso. Establezca 2 para prioridad máxima. Por ejemplo, Memoria=1 CPU=0.3 Almacenamiento=0 significa que DRS se centra principalmente en el equilibrio de memoria.",
-    "excludedFromDRS": "Excluido de DRS"
+    "excludedFromDRS": "Excluido de DRS",
+    "placementConstraints": "Restricciones de ubicación",
+    "placementConstraintsDesc": "Estos clústeres no pueden equilibrarse libremente: un puente, una VNet SDN o un almacenamiento que necesita un invitado no llega a todos los nodos.",
+    "balancingDomainsTitle": "Dominios de equilibrado",
+    "domainGuests": "{count, plural, one {# invitado} other {# invitados}}",
+    "domainSpread": "diferencia {value} pts",
+    "pinnedGuestsTitle": "Invitados que no se pueden mover",
+    "pinnedGuestOn": "en {node}",
+    "someGuestsCannotMove": "Nada que equilibrar por ahora. Algunos invitados no se pueden mover en absoluto, consulte las restricciones de ubicación arriba.",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "Almacenamiento",
+    "placementConstrainedBoth": "SDN + almacenamiento",
+    "placementConstrainedTooltip": "{count, plural, one {# dominio de equilibrado} other {# dominios de equilibrado}} en este clúster: un invitado solo puede moverse dentro del suyo. La diferencia de memoria y la puntuación de salud de abajo se calculan sobre todos los nodos, así que no pueden bajar a cero aquí.",
+    "domainNoTarget": "sin destino posible"
   },
   "usersPage": {
     "rbacRoles": "Roles RBAC",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -5791,7 +5791,20 @@
     "helpPreventOverprov": "Lorsqu'activé, DRS ne migrera pas une VM vers un nœud si cela causerait un dépassement de capacité (alloué > disponible). Empêche le surprovisionnement.",
     "helpResourceWeights": "L'influence de chaque type de ressource sur le score d'équilibrage.",
     "helpResourceWeightsDesc": "Mettre à 0 pour ignorer une ressource. Mettre à 2 pour priorité maximale. Exemple : Mémoire=1 CPU=0.3 Stockage=0 signifie que DRS se concentre principalement sur l'équilibre mémoire.",
-    "excludedFromDRS": "Exclu du DRS"
+    "excludedFromDRS": "Exclu du DRS",
+    "placementConstraints": "Contraintes de placement",
+    "placementConstraintsDesc": "Ces clusters ne peuvent pas s'équilibrer librement : un bridge, un VNet SDN ou un stockage dont un invité a besoin n'atteint pas tous les nœuds.",
+    "balancingDomainsTitle": "Domaines d'équilibrage",
+    "domainGuests": "{count, plural, one {# invité} other {# invités}}",
+    "domainSpread": "écart {value} pts",
+    "pinnedGuestsTitle": "Invités non déplaçables",
+    "pinnedGuestOn": "sur {node}",
+    "someGuestsCannotMove": "Rien à équilibrer pour le moment. Certains invités ne peuvent pas être déplacés du tout, voir les contraintes de placement ci-dessus.",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "Stockage",
+    "placementConstrainedBoth": "SDN + stockage",
+    "placementConstrainedTooltip": "{count, plural, one {# domaine d'équilibrage} other {# domaines d'équilibrage}} sur ce cluster : un invité ne peut se déplacer qu'à l'intérieur du sien. L'écart mémoire et le score de santé ci-dessous sont calculés sur tous les nœuds, ils ne peuvent donc pas descendre à zéro ici.",
+    "domainNoTarget": "aucune cible possible"
   },
   "usersPage": {
     "rbacRoles": "Rôles RBAC",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -5791,7 +5791,20 @@
     "helpPreventOverprov": "활성화하면 DRS는 노드의 용량을 초과하게 되는 경우(할당량 > 가용량) 해당 노드로 VM을 마이그레이션하지 않습니다. 리소스 오버커밋을 방지합니다.",
     "helpResourceWeights": "각 리소스 유형이 밸런싱 점수에 미치는 영향의 정도입니다.",
     "helpResourceWeightsDesc": "리소스를 무시하려면 0으로 설정하세요. 최대 우선순위는 2로 설정하세요. 예를 들어 메모리=1 CPU=0.3 스토리지=0은 DRS가 주로 메모리 균형에 집중함을 의미합니다.",
-    "excludedFromDRS": "DRS에서 제외됨"
+    "excludedFromDRS": "DRS에서 제외됨",
+    "placementConstraints": "배치 제약",
+    "placementConstraintsDesc": "이 클러스터는 자유롭게 균형을 맞출 수 없습니다. 게스트에 필요한 브리지, SDN VNet 또는 스토리지가 모든 노드에 도달하지 않습니다.",
+    "balancingDomainsTitle": "균형 도메인",
+    "domainGuests": "{count, plural, other {게스트 #개}}",
+    "domainSpread": "편차 {value} pts",
+    "pinnedGuestsTitle": "이동할 수 없는 게스트",
+    "pinnedGuestOn": "{node} 노드",
+    "someGuestsCannotMove": "지금은 균형을 맞출 것이 없습니다. 일부 게스트는 전혀 이동할 수 없습니다. 위의 배치 제약을 확인하세요.",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "스토리지",
+    "placementConstrainedBoth": "SDN + 스토리지",
+    "placementConstrainedTooltip": "{count, plural, other {이 클러스터의 균형 도메인 #개}}: 게스트는 자신의 도메인 안에서만 이동할 수 있습니다. 아래의 메모리 편차와 상태 점수는 모든 노드를 기준으로 계산되므로 여기서는 0이 될 수 없습니다.",
+    "domainNoTarget": "이동할 대상 없음"
   },
   "usersPage": {
     "rbacRoles": "RBAC 역할",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -5748,7 +5748,20 @@
     "helpPreventOverprov": "启用后，DRS 不会将 VM 迁移到会导致节点超出容量（已分配 > 可用）的节点。防止资源过度分配。",
     "helpResourceWeights": "每种资源类型对平衡评分的影响程度。",
     "helpResourceWeightsDesc": "设为 0 以忽略某种资源。设为 2 获得最高优先级。例如，内存=1 CPU=0.3 存储=0 意味着 DRS 主要关注内存平衡。",
-    "excludedFromDRS": "已从 DRS 排除"
+    "excludedFromDRS": "已从 DRS 排除",
+    "placementConstraints": "放置约束",
+    "placementConstraintsDesc": "这些集群无法自由均衡：来宾所需的网桥、SDN VNet 或存储并未覆盖所有节点。",
+    "balancingDomainsTitle": "均衡域",
+    "domainGuests": "{count, plural, other {# 个来宾}}",
+    "domainSpread": "差值 {value} 分",
+    "pinnedGuestsTitle": "无法迁移的来宾",
+    "pinnedGuestOn": "位于 {node}",
+    "someGuestsCannotMove": "目前无需均衡。部分来宾完全无法迁移，请参见上方的放置约束。",
+    "placementConstrainedSdn": "SDN",
+    "placementConstrainedStorage": "存储",
+    "placementConstrainedBoth": "SDN + 存储",
+    "placementConstrainedTooltip": "{count, plural, other {该集群有 # 个均衡域}}：来宾只能在自己的均衡域内迁移。下方的内存差值和健康评分按全部节点计算，因此在此无法降到零。",
+    "domainNoTarget": "无可迁移目标"
   },
   "usersPage": {
     "rbacRoles": "RBAC 角色",


### PR DESCRIPTION
Frontend side of the DRS placement work. Depends on the orchestrator PR that adds `pinned_guests`, `balancing_domains` and `constraints` to `/drs/status`; every field read here is optional, so an orchestrator without them simply renders nothing extra.

## Security: the status proxy was not filtering the new rows

`/api/v1/orchestrator/drs/status` is the tenant boundary in front of a cluster-wide orchestrator endpoint. It spread the upstream payload verbatim and recomputed only the recommendation and migration counts, so the two new row-shaped fields reached every tenant carrying other tenants' guest names, nodes and blocker reasons.

Both are now filtered on `connection_id` and are **fail-closed**: a row without one is dropped rather than shown to everyone, unlike the recommendation and migration filters beside them.

They also go through the RBAC infra scope, not just the tenant. These are the first DRS status fields to name guests, so a user scoped to a single connection or a single node should not read the others'. A pinned guest names a node and a guest, so the row-level gate decides it outright. A domain names a set of nodes and no guest, and is kept only when **every** node it names is visible: showing a partially visible domain would leak the names of nodes the caller has no grant on.

The neighbouring routes (recommendations, migrations) still filter on tenant alone. That is a pre-existing doctrine question, deliberately left out of this change.

## Why the page needed this at all

On a cluster cut into role-dedicated SDN zones, the load spread never comes down and DRS proposes nothing, because most guests cannot leave their zone. The page showed an imbalance, no recommendation, and a green "all clusters are balanced". Nothing said why. That reads as a broken DRS.

**A card in the Recommendations tab** lists, per cluster, the balancing domains with their nodes, guest count and spread, and the guests no other node can run with the blocking reason. A single-node domain shows "nowhere to move" rather than a spread of zero that means nothing. The card renders nothing at all on a cluster with no restriction.

**A chip in the cluster header** names the cause: SDN, storage, or both. It is read from what the orchestrator reports about each domain, not guessed from the reason strings. Its tooltip says plainly that the memory spread and the health score beside it are computed over every node and cannot come down to zero there.

That health score is deliberately left alone. Recomputing it per domain would change a number every customer reads, including on clusters with no SDN, for a benefit limited to segmented ones.

**The success alert no longer lies.** With nothing left to balance but guests pinned, the page says so instead of claiming every cluster is balanced.

## Tests

The status route has its own suite covering the tenant filter, the RBAC scope, the fail-closed behaviour on a row with no connection, an orchestrator that does not send the fields, and the offline fallback. The card has its own, including the two cases that must render nothing. The nine new message keys are checked across the six served locales, with the ICU plurals verified rather than assumed.

Full scope green, `tsc` at its baseline, eslint clean, `next build` green.

## Recette

Run against a live two-cluster lab with the matching orchestrator. The segmented cluster shows four domains and three pinned guests with their real reasons, the unrestricted one shows no chip and no card. Checked with homogenization on and off. One defect was caught by looking at the rendered page rather than the tests: the guest count read "1 guests", now an ICU plural.
