### PR TITLE
ci(backend-tests): take the Go version from the backend go.mod

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -460,7 +460,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.25'
+          go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum
 
       - name: Run backend tests


### PR DESCRIPTION
The backend test job pins Go 1.25, while the orchestrator image already builds on 1.26. Raising `golang.org/x/crypto` to v0.56.0 (CVE-2026-78662 and CVE-2026-56855, both SSH connection deadlocks reachable from a malicious peer) lifts the backend's `go` directive to 1.26.0, which the pinned runner would refuse.

Reading `go-version-file: backend/go.mod` keeps the job on whatever toolchain the backend declares, so the next bump cannot split the two again.

Order matters: this needs to land before the x/crypto bump reaches the backend's main, otherwise `test-backend` fails in between.
