### PR TITLE
fix(migration): stop warm migrations from wedging NBD devices on Linux/LVM guests (#535)

### DIFF
--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.test.tsx
@@ -804,6 +804,9 @@ describe('migration dialog options', () => {
     status: 'poweredOff',
     guestOS: 'Ubuntu Linux (64-bit)',
   }
+  // Warm is only offered for vmware/vcenter sources (warmAllowedFor); ESXI_VM's
+  // hostType 'esxi' is a cold-only fixture, so the warm tests use this one.
+  const WARM_VM = { ...ESXI_VM, hostType: 'vmware', committed: 20 * 1024 ** 3 }
   const THICK_LVM = { storage: 'san-lvm', type: 'lvm', content: 'images', total: 1099511627776, avail: 879609302220 }
   const ZFS = { storage: 'tank', type: 'zfspool', content: 'images', total: 1099511627776, avail: 879609302220 }
   const START_AFTER_LABEL = 'Start VM after migration'
@@ -836,13 +839,16 @@ describe('migration dialog options', () => {
   // Harness owning the dialog-open state the same way InventoryDetails does:
   // the option family comes from the real useMigrationOptions hook, so this
   // exercises the production reset path rather than a test-local copy.
-  function OptionsHarness({ dialogOverrides = {} }: { dialogOverrides?: Partial<InventoryDialogsProps> }) {
+  function OptionsHarness({ dialogOverrides = {}, vm = ESXI_VM }: {
+    dialogOverrides?: Partial<InventoryDialogsProps>
+    vm?: InventoryDialogsProps['esxiMigrateVm']
+  }) {
     const [esxiMigrateVm, setEsxiMigrateVm] = React.useState<any>(null)
     const [bulkMigOpen, setBulkMigOpen] = React.useState(false)
     const options = useMigrationOptions({ esxiMigrateVm, bulkMigOpen })
     return (
       <>
-        <button onClick={() => setEsxiMigrateVm(ESXI_VM)}>harness-open-single</button>
+        <button onClick={() => setEsxiMigrateVm(vm)}>harness-open-single</button>
         <button onClick={() => setEsxiMigrateVm(null)}>harness-close-single</button>
         <InventoryDialogs
           {...makeProps({
@@ -902,6 +908,120 @@ describe('migration dialog options', () => {
 
     fireEvent.click(screen.getByText('harness-open-single'))
     expect(getSwitch(AUTO_CUTOVER_LABEL).checked).toBe(true)
+  })
+
+  it('blocks the launch when the target storage is too small', async () => {
+    const preflightBodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations/preflight', async ({ request }) => {
+        const body = await request.json() as any
+        preflightBodies.push(body)
+        return HttpResponse.json({
+          ok: true, missing: [], kind: 'vddk', vddkTokenConfigured: false,
+          space: { storage: body.targetStorage, availableBytes: 12 * 1024 ** 3, requiredBytes: body.requiredDiskBytes, sufficient: false },
+        })
+      }),
+    )
+    renderWithProviders(
+      <OptionsHarness
+        vm={WARM_VM}
+        dialogOverrides={{
+          migType: 'warm', migTargetStorage: 'san-lvm', migStorages: [THICK_LVM, ZFS],
+          migTargetConn: CONN_ID, migTargetNode: NODE_NAME,
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    await screen.findByText(/Not enough free space on san-lvm: 12\.0 GB available, 20\.0 GB needed/)
+    expect(screen.getByRole('button', { name: /Migrate to Proxmox/ })).toBeDisabled()
+    expect(preflightBodies[0]).toMatchObject({
+      action: 'warm-check', targetStorage: 'san-lvm', requiredDiskBytes: 20 * 1024 ** 3,
+    })
+  })
+
+  it('enables the launch when the storage is large enough', async () => {
+    const preflightBodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations/preflight', async ({ request }) => {
+        const body = await request.json() as any
+        preflightBodies.push(body)
+        return HttpResponse.json({
+          ok: true, missing: [], kind: 'vddk', vddkTokenConfigured: false,
+          space: { storage: body.targetStorage, availableBytes: 32 * 1024 ** 3, requiredBytes: body.requiredDiskBytes, sufficient: true },
+        })
+      }),
+    )
+    renderWithProviders(
+      <OptionsHarness
+        vm={WARM_VM}
+        dialogOverrides={{
+          migType: 'warm', migTargetStorage: 'san-lvm', migStorages: [THICK_LVM, ZFS],
+          migTargetConn: CONN_ID, migTargetNode: NODE_NAME,
+          // Warm launch also requires a running source and SSH on the target.
+          esxiMigrateVm: { ...WARM_VM, status: 'poweredOn' },
+          migPveConnections: [{ id: CONN_ID, name: 'pve-lab', sshEnabled: true }],
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    await screen.findByText(/Target node is ready for warm migration/)
+    expect(screen.queryByText(/Not enough free space/)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Migrate to Proxmox/ })).toBeEnabled()
+    expect(preflightBodies[0]).toMatchObject({
+      action: 'warm-check', targetStorage: 'san-lvm', requiredDiskBytes: 20 * 1024 ** 3,
+    })
+  })
+
+  it('shows the read error when the storage cannot be read', async () => {
+    const preflightBodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations/preflight', async ({ request }) => {
+        const body = await request.json() as any
+        preflightBodies.push(body)
+        return HttpResponse.json({
+          ok: true, missing: [], kind: 'vddk', vddkTokenConfigured: false,
+          space: { storage: 'san-lvm', availableBytes: 0, requiredBytes: 0, sufficient: false, error: 'No such storage.' },
+        })
+      }),
+    )
+    renderWithProviders(
+      <OptionsHarness vm={WARM_VM} dialogOverrides={{
+        migType: 'warm', migTargetStorage: 'san-lvm', migStorages: [THICK_LVM, ZFS],
+        migTargetConn: CONN_ID, migTargetNode: NODE_NAME,
+      }} />,
+    )
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    await screen.findByText(/Could not read the free space of san-lvm on the target node: No such storage\./)
+    expect(screen.getByRole('button', { name: /Migrate to Proxmox/ })).toBeDisabled()
+    expect(preflightBodies[0]).toMatchObject({ action: 'warm-check', targetStorage: 'san-lvm' })
+  })
+
+  it('sends no targetStorage when none is selected', async () => {
+    const preflightBodies: any[] = []
+    server.use(
+      http.post('*/api/v1/migrations/preflight', async ({ request }) => {
+        const body = await request.json() as any
+        preflightBodies.push(body)
+        return HttpResponse.json({
+          ok: true, missing: [], kind: 'vddk', vddkTokenConfigured: false,
+          space: { storage: body.targetStorage, availableBytes: 12 * 1024 ** 3, requiredBytes: body.requiredDiskBytes, sufficient: true },
+        })
+      }),
+    )
+    renderWithProviders(
+      <OptionsHarness vm={{ ...WARM_VM, committed: undefined }} dialogOverrides={{
+        migType: 'warm', migTargetStorage: '', migStorages: [THICK_LVM, ZFS],
+        migTargetConn: CONN_ID, migTargetNode: NODE_NAME,
+      }} />,
+    )
+
+    fireEvent.click(screen.getByText('harness-open-single'))
+    await waitFor(() => expect(preflightBodies.length).toBeGreaterThan(0))
+    expect(preflightBodies[0].targetStorage).toBeUndefined()
+    expect(preflightBodies[0].requiredDiskBytes).toBe(0)
   })
 
   // #663: the budget only governs the automatic decision, so it follows the

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/InventoryDialogs.tsx
@@ -768,7 +768,8 @@ printf 'Types: deb\\nURIs: http://download.proxmox.com/debian/pve\\nSuites: %s\\
   // 'nbd' for an XCP-ng one (nbdkit + its nbd plugin + nbd-client, no VDDK and
   // nothing to install from the Enterprise repo). It drives which remediation
   // the not-ready alert offers.
-  const [warmPreflight, setWarmPreflight] = useState<{ key: string; loading: boolean; ok: boolean; missing: string[]; kind: 'nbd' | 'vddk'; error?: string; tokenConfigured?: boolean; osUnsupported?: boolean; debianMajor?: number } | null>(null)
+  type WarmSpace = { storage: string; availableBytes: number; requiredBytes: number; sufficient: boolean; error?: string }
+  const [warmPreflight, setWarmPreflight] = useState<{ key: string; loading: boolean; ok: boolean; missing: string[]; kind: 'nbd' | 'vddk'; error?: string; tokenConfigured?: boolean; osUnsupported?: boolean; debianMajor?: number; space?: WarmSpace } | null>(null)
   // Bumped after a successful automated node setup so this effect re-runs and
   // the go/no-go flips to ready without the user having to reselect the node.
   const [warmPreflightRefresh, setWarmPreflightRefresh] = useState(0)
@@ -777,7 +778,9 @@ printf 'Types: deb\\nURIs: http://download.proxmox.com/debian/pve\\nSuites: %s\\
       setWarmPreflight(null)
       return
     }
-    const key = `${migTargetConn}::${migTargetNode}`
+    // The storage is part of the key: the free-space verdict below belongs to
+    // one storage, and switching storage must re-run the check.
+    const key = `${migTargetConn}::${migTargetNode}::${migTargetStorage}`
     // Which runtime the node needs follows the source, so the expected kind is
     // known before the answer comes back: it keeps the loading and network-error
     // states on the right remediation instead of defaulting to the VDDK one.
@@ -789,24 +792,29 @@ printf 'Types: deb\\nURIs: http://download.proxmox.com/debian/pve\\nSuites: %s\\
       headers: { 'Content-Type': 'application/json' },
       // sourceConnectionId picks the probe: an XCP-ng source is checked for the
       // NBD toolchain, everything else for the VDDK runtime.
-      body: JSON.stringify({ targetConnectionId: migTargetConn, targetNode: migTargetNode, action: 'warm-check', sourceConnectionId: esxiMigrateVm?.connId }),
+      // targetStorage + requiredDiskBytes let the server compare the storage's
+      // live free space with the source disks (same rule as the cold engine).
+      body: JSON.stringify({ targetConnectionId: migTargetConn, targetNode: migTargetNode, action: 'warm-check', sourceConnectionId: esxiMigrateVm?.connId, targetStorage: migTargetStorage || undefined, requiredDiskBytes: esxiMigrateVm?.committed || 0 }),
     })
       .then(r => r.json())
-      .then((d: { ok?: boolean; missing?: string[]; kind?: string; error?: string; vddkTokenConfigured?: boolean; osUnsupported?: boolean; debianMajor?: number }) => {
+      .then((d: { ok?: boolean; missing?: string[]; kind?: string; error?: string; vddkTokenConfigured?: boolean; osUnsupported?: boolean; debianMajor?: number; space?: WarmSpace }) => {
         // vddkTokenConfigured: server-side boolean saying an Enterprise VDDK
         // package token exists, i.e. the automated "Prepare this node" action
         // can work. The token itself never reaches the client.
-        if (!cancelled) setWarmPreflight({ key, loading: false, ok: !!d.ok, missing: d.missing || [], kind: d.kind === 'nbd' ? 'nbd' : 'vddk', error: d.error, tokenConfigured: !!d.vddkTokenConfigured, osUnsupported: !!d.osUnsupported, debianMajor: d.debianMajor })
+        if (!cancelled) setWarmPreflight({ key, loading: false, ok: !!d.ok, missing: d.missing || [], kind: d.kind === 'nbd' ? 'nbd' : 'vddk', error: d.error, tokenConfigured: !!d.vddkTokenConfigured, osUnsupported: !!d.osUnsupported, debianMajor: d.debianMajor, space: d.space })
       })
       .catch(() => { if (!cancelled) setWarmPreflight({ key, loading: false, ok: false, missing: [], kind: expectedKind }) })
     return () => { cancelled = true }
-  }, [singleWarmAllowed, esxiMigrateVm?.hostType, esxiMigrateVm?.connId, migType, migTargetConn, migTargetNode, warmPreflightRefresh])
+  }, [singleWarmAllowed, esxiMigrateVm?.hostType, esxiMigrateVm?.connId, esxiMigrateVm?.committed, migType, migTargetConn, migTargetNode, migTargetStorage, warmPreflightRefresh])
   // Only trust the verdict when it belongs to the currently selected target. On a
   // node/connection switch the state briefly still holds the prior target's result
   // (the effect re-runs after render); ignoring a mismatched key stops a stale "ready"
   // from re-enabling the launch against a node that has not passed the current check.
   const warmPreflightCurrent =
-    warmPreflight && warmPreflight.key === `${migTargetConn}::${migTargetNode}` ? warmPreflight : null
+    warmPreflight && warmPreflight.key === `${migTargetConn}::${migTargetNode}::${migTargetStorage}` ? warmPreflight : null
+  // Free-space verdict for the selected storage; undefined while loading or when
+  // no storage is chosen yet. Blocks the launch on its own, independently of ok.
+  const warmSpaceShort = warmPreflightCurrent && !warmPreflightCurrent.loading && warmPreflightCurrent.space && !warmPreflightCurrent.space.sufficient ? warmPreflightCurrent.space : null
 
   // Automated warm-node provisioning (Enterprise VDDK package). Offered inside
   // the not-ready alert only when the server reported a configured package
@@ -2841,6 +2849,21 @@ return
                     )
                   )}
 
+                  {/* Warm target too small: the engine refuses it at planning time (disks'
+                      capacity plus a 10 % margin, like the cold engine), so say so while the
+                      storage can still be changed, with the two figures that matter. */}
+                  {migType === 'warm' && warmSpaceShort && (
+                    <Alert severity="error" sx={{ fontSize: 12 }} icon={<i className="ri-hard-drive-2-line" style={{ fontSize: 18 }} />}>
+                      {warmSpaceShort.error
+                        ? t('inventoryPage.esxiMigration.warmStorageCheckFailed', { storage: warmSpaceShort.storage, error: warmSpaceShort.error })
+                        : t('inventoryPage.esxiMigration.warmStorageInsufficient', {
+                            storage: warmSpaceShort.storage,
+                            available: (warmSpaceShort.availableBytes / 1073741824).toFixed(1),
+                            required: (warmSpaceShort.requiredBytes / 1073741824).toFixed(1),
+                          })}
+                    </Alert>
+                  )}
+
                   {/* CBT-fallback warning: the source VM cannot use CBT (pre-existing
                       snapshot / old hardware version / independent or multi-writer disk),
                       so warm falls back to the checksum block-diff, which shuts the
@@ -3480,6 +3503,8 @@ return
                   // failed check, and a click can't beat the verdict to fire a doomed
                   // migration. Cluster-auto is not gated (the engine backstop covers it).
                   if (migType === 'warm' && migTargetNode !== '__auto__' && !warmPreflightCurrent?.ok) return true
+                  // Warm: the selected storage cannot hold the source disks (or could not be read).
+                  if (migType === 'warm' && warmSpaceShort) return true
                   return false
                 })()}
                 sx={{ textTransform: 'none' }}

--- a/frontend/src/app/api/v1/migrations/preflight/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/preflight/route.test.ts
@@ -14,7 +14,16 @@ vi.mock("@/lib/migration/v2v-preflight", () => ({
 }))
 // The warm go/no-go helper — the new action under test.
 vi.mock("@/lib/migration/warm/vddk-preflight", () => ({
-  runWarmNodePreflight: vi.fn(async () => ({ ok: false, missing: ["vddk-plugin"], error: "node not prepared" })),
+  runWarmNodePreflight: vi.fn(async () => ({ ok: true, missing: [] })),
+}))
+vi.mock("@/lib/migration/warm/xcpng-node-preflight", () => ({
+  runXcpngWarmNodePreflight: vi.fn(async () => ({ ok: true, missing: [] })),
+}))
+vi.mock("@/lib/migration/warm/target-space", () => ({
+  checkTargetStorageSpace: vi.fn(),
+}))
+vi.mock("@/lib/db/prisma", () => ({
+  prisma: { connection: { findUnique: vi.fn(async () => ({ type: "vmware" })) } },
 }))
 // Only the boolean flag is consumed here; mocking also keeps the module's
 // ssh2/prisma import chain out of this test.
@@ -27,14 +36,74 @@ import { callRoute, readJson } from "@/__tests__/setup/route-test"
 import { runWarmNodePreflight } from "@/lib/migration/warm/vddk-preflight"
 import { isVddkPackageTokenConfigured } from "@/lib/migration/warm/vddk-provision"
 import { runV2vPreflight } from "@/lib/migration/v2v-preflight"
+import { runXcpngWarmNodePreflight } from "@/lib/migration/warm/xcpng-node-preflight"
+import { checkTargetStorageSpace, type TargetSpaceResult } from "@/lib/migration/warm/target-space"
+import { prisma } from "@/lib/db/prisma"
 
 const mockWarm = runWarmNodePreflight as unknown as ReturnType<typeof vi.fn>
 const mockV2v = runV2vPreflight as unknown as ReturnType<typeof vi.fn>
 const mockTokenConfigured = isVddkPackageTokenConfigured as unknown as ReturnType<typeof vi.fn>
+const mockSpace = vi.mocked(checkTargetStorageSpace)
+const mockSource = prisma.connection.findUnique as unknown as ReturnType<typeof vi.fn>
+const spaceVerdict: TargetSpaceResult = {
+  storage: "ZFS-Pool", type: "zfspool", availableBytes: 12 * 1024 ** 3,
+  requiredBytes: 16 * 1024 ** 3, sufficient: false,
+}
+const warmBody = {
+  action: "warm-check", sourceConnectionId: "src", targetConnectionId: "c1", targetNode: "pve1",
+}
 
-beforeEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockSource.mockResolvedValue({ type: "vmware" })
+  mockSpace.mockResolvedValue(spaceVerdict)
+})
 
 describe("POST /api/v1/migrations/preflight — warm-check action", () => {
+  it("returns target space alongside the VDDK runtime verdict", async () => {
+    const res = await callRoute(POST, {
+      body: { ...warmBody, targetStorage: "ZFS-Pool", requiredDiskBytes: spaceVerdict.requiredBytes },
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockSource).toHaveBeenCalledWith({ where: { id: "src" }, select: { type: true } })
+    expect(mockSpace).toHaveBeenCalledExactlyOnceWith("c1", "pve1", "ZFS-Pool", spaceVerdict.requiredBytes)
+    expect(await res.json()).toEqual({ ok: true, missing: [], kind: "vddk", vddkTokenConfigured: false, space: spaceVerdict })
+    expect(runXcpngWarmNodePreflight).not.toHaveBeenCalled()
+  })
+
+  it("omits space and does not check storage when targetStorage is absent", async () => {
+    const res = await callRoute(POST, { body: { ...warmBody, requiredDiskBytes: spaceVerdict.requiredBytes } })
+
+    expect(res.status).toBe(200)
+    expect(mockSpace).not.toHaveBeenCalled()
+    const json = await res.json()
+    expect(json.kind).toBe("vddk")
+    expect(json.space).toBeUndefined()
+    expect(json).not.toHaveProperty("space")
+  })
+
+  it.each([-1, "abc"])("clamps requiredDiskBytes %j to zero", async (requiredDiskBytes) => {
+    const res = await callRoute(POST, { body: { ...warmBody, targetStorage: "ZFS-Pool", requiredDiskBytes } })
+
+    expect(res.status).toBe(200)
+    expect(mockSpace).toHaveBeenCalledExactlyOnceWith("c1", "pve1", "ZFS-Pool", 0)
+    expect((await res.json()).space).toEqual(spaceVerdict)
+  })
+
+  it("returns target space alongside the NBD runtime verdict for an XCP-ng source", async () => {
+    mockSource.mockResolvedValueOnce({ type: "xcpng" })
+    const res = await callRoute(POST, {
+      body: { ...warmBody, targetStorage: "ZFS-Pool", requiredDiskBytes: spaceVerdict.requiredBytes },
+    })
+
+    expect(res.status).toBe(200)
+    expect(mockSpace).toHaveBeenCalledExactlyOnceWith("c1", "pve1", "ZFS-Pool", spaceVerdict.requiredBytes)
+    expect(runXcpngWarmNodePreflight).toHaveBeenCalledExactlyOnceWith("c1", "pve1")
+    expect(mockWarm).not.toHaveBeenCalled()
+    expect(await res.json()).toEqual({ ok: true, missing: [], kind: "nbd", vddkTokenConfigured: false, space: spaceVerdict })
+  })
+
   it("dispatches warm-check to runWarmNodePreflight and returns its go/no-go verbatim", async () => {
     mockWarm.mockResolvedValueOnce({ ok: false, missing: ["vddk-plugin", "vddk-lib"], error: "node not prepared" })
     const res = await callRoute(POST, { body: { action: "warm-check", targetConnectionId: "c1", targetNode: "pve1" } })

--- a/frontend/src/app/api/v1/migrations/preflight/route.ts
+++ b/frontend/src/app/api/v1/migrations/preflight/route.ts
@@ -5,6 +5,7 @@ import { runV2vPreflight, installV2vPackages, startVirtioWinDownload, checkVirti
 import { runWarmNodePreflight } from "@/lib/migration/warm/vddk-preflight"
 import { runXcpngWarmNodePreflight } from "@/lib/migration/warm/xcpng-node-preflight"
 import { isVddkPackageTokenConfigured } from "@/lib/migration/warm/vddk-provision"
+import { checkTargetStorageSpace } from "@/lib/migration/warm/target-space"
 import { prisma } from "@/lib/db/prisma"
 import { safeLog } from "@/lib/log/sanitize"
 
@@ -18,6 +19,7 @@ export async function POST(req: Request) {
     sourceConnectionId?: string
     targetConnectionId?: string
     targetNode?: string
+    targetStorage?: string
     requiredDiskBytes?: number
     action?: string
     vmName?: string
@@ -31,7 +33,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
   }
 
-  const { sourceConnectionId, targetConnectionId, targetNode, requiredDiskBytes, action, vmName, sourceType, vddkLibdir } = body
+  const { sourceConnectionId, targetConnectionId, targetNode, targetStorage, requiredDiskBytes, action, vmName, sourceType, vddkLibdir } = body
 
   if (!targetConnectionId || !targetNode) {
     return NextResponse.json(
@@ -69,16 +71,24 @@ export async function POST(req: Request) {
     // one runs, and `kind` tells the dialog which one answered. On the nbd path
     // there is nothing to install from the Enterprise repo, so the VDDK token
     // flag is always false there.
+    //
+    // `space` is the target storage's live free space against the source disks
+    // (requiredDiskBytes, the dialog's committed size) plus the 10 % margin the
+    // cold engine applies. Only computed when the dialog names a storage; it is
+    // independent of the runtime verdict so the dialog can show both.
     if (action === "warm-check") {
       const sourceConn = sourceConnectionId
         ? await prisma.connection.findUnique({ where: { id: sourceConnectionId }, select: { type: true } })
         : null
+      const space = targetStorage
+        ? await checkTargetStorageSpace(targetConnectionId, targetNode, targetStorage, Math.max(0, Number(requiredDiskBytes) || 0))
+        : undefined
       if (sourceConn?.type === "xcpng") {
         const nbdResult = await runXcpngWarmNodePreflight(targetConnectionId, targetNode)
-        return NextResponse.json({ ...nbdResult, kind: "nbd", vddkTokenConfigured: false })
+        return NextResponse.json({ ...nbdResult, kind: "nbd", vddkTokenConfigured: false, space })
       }
       const result = await runWarmNodePreflight(targetConnectionId, targetNode, vddkLibdir)
-      return NextResponse.json({ ...result, kind: "vddk", vddkTokenConfigured: isVddkPackageTokenConfigured() })
+      return NextResponse.json({ ...result, kind: "vddk", vddkTokenConfigured: isVddkPackageTokenConfigured(), space })
     }
 
     const result = await runV2vPreflight(

--- a/frontend/src/lib/migration/nbd-holders.test.ts
+++ b/frontend/src/lib/migration/nbd-holders.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest"
+import { NBD_RELEASE_HOLDERS_FN, nbdReleaseHoldersCall } from "./nbd-holders"
+
+describe("NBD_RELEASE_HOLDERS_FN", () => {
+  it("defines the recursive walker and holder release entry point", () => {
+    expect(NBD_RELEASE_HOLDERS_FN).toContain("nbd_release_tree() {")
+    expect(NBD_RELEASE_HOLDERS_FN).toContain("nbd_release_holders() {")
+  })
+
+  it("walks kernel holder links and releases children before acting on the node", () => {
+    expect(NBD_RELEASE_HOLDERS_FN).toContain("for h in /sys/class/block/$1/holders/*; do")
+    expect(NBD_RELEASE_HOLDERS_FN).toContain('nbd_release_tree "$(basename "$h")"')
+    expect(NBD_RELEASE_HOLDERS_FN).toContain('case "$1" in')
+    expect(NBD_RELEASE_HOLDERS_FN.indexOf('nbd_release_tree "$(basename "$h")"'))
+      .toBeLessThan(NBD_RELEASE_HOLDERS_FN.indexOf('case "$1" in'))
+  })
+
+  it("removes device-mapper holders and stops md holders by device path", () => {
+    expect(NBD_RELEASE_HOLDERS_FN).toContain('dm-*) dmsetup remove --retry "/dev/$1" >/dev/null 2>&1 ;;')
+    expect(NBD_RELEASE_HOLDERS_FN).toContain('md*) mdadm --stop "/dev/$1" >/dev/null 2>&1 ;;')
+  })
+
+  it("starts from the whole device and each of its partitions", () => {
+    expect(NBD_RELEASE_HOLDERS_FN).toContain('/sys/class/block/$d /sys/class/block/${d}p*')
+  })
+
+  it("never selects or changes LVM volumes by name", () => {
+    for (const command of ["vgchange", "lvchange", "lvremove", "pvscan", "vgremove"]) {
+      expect(NBD_RELEASE_HOLDERS_FN).not.toContain(command)
+    }
+  })
+
+  it("uses POSIX sh syntax", () => {
+    for (const syntax of ["local ", "[[", "function "]) {
+      expect(NBD_RELEASE_HOLDERS_FN).not.toContain(syntax)
+    }
+  })
+})
+
+describe("nbdReleaseHoldersCall", () => {
+  it("accepts a literal device path", () => {
+    expect(nbdReleaseHoldersCall("/dev/nbd3")).toBe("nbd_release_holders /dev/nbd3")
+  })
+
+  it("preserves a quoted shell variable reference", () => {
+    expect(nbdReleaseHoldersCall('"$NBD"')).toBe('nbd_release_holders "$NBD"')
+  })
+})

--- a/frontend/src/lib/migration/nbd-holders.ts
+++ b/frontend/src/lib/migration/nbd-holders.ts
@@ -1,0 +1,54 @@
+/**
+ * Release everything the host stacked on top of an NBD device we own, so the
+ * device can actually be detached (#535).
+ *
+ * When a guest disk is attached to /dev/nbdN, udev fires `pvscan --cache -aay`
+ * and the host's LVM auto-activates the GUEST volume group it finds on the
+ * device (whole-disk PV) or on one of its partitions (nbdNpM, when the nbd
+ * module was loaded with max_part>0). The activated device-mapper LVs hold the
+ * NBD device open: `nbd-client -d` / `qemu-nbd --disconnect` then return 0
+ * without freeing it, /sys/block/nbdN/pid keeps a dead pid, and `rmmod nbd`
+ * refuses, until the node is rebooted.
+ *
+ * Scoping is by CONSTRUCTION, never by name: we walk the kernel's own holder
+ * links (/sys/class/block/<dev>/holders/*) starting from the device we own and
+ * its partitions, release the leaves first (a thin LV before its pool, a pool
+ * before its tdata/tmeta), and only ever touch a device-mapper (`dm-*`) or md
+ * (`md*`) node reached that way. No `vgchange -an <name>` and no regex on VG
+ * names: a guest VG may be called `pve` exactly like the host's, and a
+ * mis-scoped deactivation would take the node down.
+ *
+ * POSIX sh only (the SSH layer may wrap commands in `sudo sh -c`, i.e. dash):
+ * no `local`, no arrays, no `[[`. A for-list is expanded once before the loop
+ * runs, so the recursive call reassigning `h` does not disturb the outer
+ * iteration. Every step is best-effort (errors silenced) so a teardown never
+ * aborts on an already-gone holder.
+ */
+export const NBD_RELEASE_HOLDERS_FN = [
+  "nbd_release_tree() {",
+  "  for h in /sys/class/block/$1/holders/*; do",
+  '    [ -e "$h" ] || continue',
+  '    nbd_release_tree "$(basename "$h")"',
+  "  done",
+  '  case "$1" in',
+  '    dm-*) dmsetup remove --retry "/dev/$1" >/dev/null 2>&1 ;;',
+  '    md*) mdadm --stop "/dev/$1" >/dev/null 2>&1 ;;',
+  "  esac",
+  "}",
+  "nbd_release_holders() {",
+  '  d=$(basename "$1")',
+  '  for p in /sys/class/block/$d /sys/class/block/${d}p*; do',
+  '    [ -e "$p" ] || continue',
+  '    nbd_release_tree "$(basename "$p")"',
+  "  done",
+  "}",
+].join("\n")
+
+/**
+ * The call line. `dev` is a literal device path (`/dev/nbd3`) or a shell
+ * variable reference (`"$NBD"`); NBD_RELEASE_HOLDERS_FN must be defined earlier
+ * in the same script.
+ */
+export function nbdReleaseHoldersCall(dev: string): string {
+  return `nbd_release_holders ${dev}`
+}

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -33,6 +33,7 @@ import { adoptImportAndAttachFileVolume } from "./adopt-file-volume"
 import { pveSetVmConfig, destroyPveVm } from "./pve-vm-config"
 import { waitForPveTask, getNodeIpForMigration } from "./pve-tasks"
 import { convertDisksToQcow2 } from "./qcow2-convert"
+import { buildUefiInjectScript } from "./uefi-inject"
 import { startJobHeartbeat } from "./job-heartbeat"
 import { capturePipelineStatus, writePipelineExit } from "./pipe-exit"
 import { interpretPollExit, MAX_CONSECUTIVE_POLL_FAILURES } from "./poll-exit"
@@ -2556,51 +2557,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
         if (pveParams.bios === "ovmf" && isFileBased && localVolumes[0]) {
           await appendLog(jobId, "Ensuring UEFI fallback bootloader is present on EFI partition...", "info")
           const bootDiskPath = localVolumes[0].devicePath
-          const injectScript = [
-            'set +e',
-            'modprobe nbd max_part=16 2>/dev/null',
-            // Find a free nbd device (no pid file means unused)
-            'NBD=""',
-            'for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do',
-            '  if [ ! -s /sys/block/nbd$i/pid ] 2>/dev/null; then NBD=/dev/nbd$i; break; fi',
-            'done',
-            '[ -z "$NBD" ] && { echo "INJECT_RESULT=NO_FREE_NBD"; exit 0; }',
-            `qemu-nbd --connect="$NBD" --format=raw "${bootDiskPath}" 2>/dev/null || { echo "INJECT_RESULT=NBD_FAIL"; exit 0; }`,
-            'sleep 1',
-            'partprobe "$NBD" 2>/dev/null',
-            'sleep 1',
-            // Find EFI System Partition by GUID
-            `EFI_PART=$(lsblk -nr -o NAME,PARTTYPE "$NBD" 2>/dev/null | awk 'tolower($2)=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print "/dev/"$1; exit}')`,
-            // Fallback: look for any FAT partition on the disk
-            'if [ -z "$EFI_PART" ]; then',
-            '  for p in ${NBD}p*; do',
-            '    [ -e "$p" ] && blkid -s TYPE -o value "$p" 2>/dev/null | grep -qi vfat && EFI_PART="$p" && break',
-            '  done',
-            'fi',
-            'if [ -z "$EFI_PART" ]; then',
-            '  qemu-nbd --disconnect "$NBD" >/dev/null 2>&1',
-            '  echo "INJECT_RESULT=NO_EFI_PART"; exit 0',
-            'fi',
-            'MNT=$(mktemp -d /tmp/efi-inject-XXXXXX)',
-            'if ! mount -t vfat -o rw "$EFI_PART" "$MNT" 2>/dev/null; then',
-            '  qemu-nbd --disconnect "$NBD" >/dev/null 2>&1; rmdir "$MNT"',
-            '  echo "INJECT_RESULT=MOUNT_FAIL"; exit 0',
-            'fi',
-            'RESULT=NO_BOOTLOADER',
-            // Windows: copy bootmgfw.efi to \EFI\Boot\bootx64.efi if missing
-            'if [ -f "$MNT/EFI/Microsoft/Boot/bootmgfw.efi" ]; then',
-            '  if [ -f "$MNT/EFI/Boot/bootx64.efi" ] || [ -f "$MNT/EFI/BOOT/BOOTX64.EFI" ]; then',
-            '    RESULT=ALREADY_PRESENT',
-            '  else',
-            '    mkdir -p "$MNT/EFI/Boot" && cp "$MNT/EFI/Microsoft/Boot/bootmgfw.efi" "$MNT/EFI/Boot/bootx64.efi" && RESULT=WINDOWS_INJECTED',
-            '  fi',
-            'elif [ -f "$MNT/EFI/Boot/bootx64.efi" ] || [ -f "$MNT/EFI/BOOT/BOOTX64.EFI" ]; then',
-            '  RESULT=ALREADY_PRESENT',
-            'fi',
-            'sync; umount "$MNT"; rmdir "$MNT"',
-            'qemu-nbd --disconnect "$NBD" >/dev/null 2>&1',
-            'echo "INJECT_RESULT=$RESULT"',
-          ].join('\n')
+          const injectScript = buildUefiInjectScript(bootDiskPath)
           const injectResult = await executeSSH(config.targetConnectionId, nodeIp, injectScript)
           const out = injectResult.output || ""
           if (out.includes("INJECT_RESULT=WINDOWS_INJECTED")) {

--- a/frontend/src/lib/migration/uefi-inject.test.ts
+++ b/frontend/src/lib/migration/uefi-inject.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest"
+import { buildUefiInjectScript } from "./uefi-inject"
+
+const BOOT_DISK_PATH = "/mnt/pve/local/images/100/vm-100-disk-0.raw"
+
+describe("buildUefiInjectScript", () => {
+  it("defines the holder release functions once before calling them", () => {
+    const s = buildUefiInjectScript(BOOT_DISK_PATH)
+    expect(s.match(/nbd_release_tree\(\) \{/g)).toHaveLength(1)
+    expect(s.match(/nbd_release_holders\(\) \{/g)).toHaveLength(1)
+    expect(s).toContain('nbd_release_holders "$NBD";')
+    expect(s.indexOf("nbd_release_holders() {"))
+      .toBeLessThan(s.indexOf('nbd_release_holders "$NBD";'))
+  })
+
+  it("releases holders on the same line before every disconnect", () => {
+    const lines = buildUefiInjectScript(BOOT_DISK_PATH).split("\n")
+      .filter(line => line.includes("qemu-nbd --disconnect"))
+    expect(lines).toHaveLength(3)
+    for (const line of lines) {
+      expect(line).toMatch(/^\s*nbd_release_holders "\$NBD"; qemu-nbd --disconnect "\$NBD" >\/dev\/null 2>&1/)
+    }
+    expect(lines[1]).toContain('; rmdir "$MNT"')
+  })
+
+  it("keeps best-effort execution, partition support, and the boot disk path", () => {
+    const s = buildUefiInjectScript(BOOT_DISK_PATH)
+    expect(s.split("\n")[0]).toBe("set +e")
+    expect(s).toContain("modprobe nbd max_part=16")
+    expect(s).toContain('qemu-nbd --connect="$NBD" --format=raw "/mnt/pve/local/images/100/vm-100-disk-0.raw"')
+  })
+
+  it("preserves all result markers for the caller", () => {
+    const s = buildUefiInjectScript(BOOT_DISK_PATH)
+    for (const result of [
+      "NO_FREE_NBD", "NBD_FAIL", "NO_EFI_PART", "MOUNT_FAIL",
+      "WINDOWS_INJECTED", "ALREADY_PRESENT", "NO_BOOTLOADER",
+    ]) {
+      expect(s).toContain(`RESULT=${result}`)
+    }
+    expect(s).toContain('echo "INJECT_RESULT=$RESULT"')
+  })
+})

--- a/frontend/src/lib/migration/uefi-inject.ts
+++ b/frontend/src/lib/migration/uefi-inject.ts
@@ -1,0 +1,61 @@
+import { NBD_RELEASE_HOLDERS_FN, nbdReleaseHoldersCall } from "./nbd-holders"
+
+/**
+ * Shell script run on the target node after a cold migration of an OVMF guest
+ * on file-based storage: attach the copied boot disk with qemu-nbd, mount the
+ * EFI System Partition and make sure the fallback loader \EFI\Boot\bootx64.efi
+ * exists (Windows only stores bootmgfw.efi under \EFI\Microsoft\Boot\).
+ * `partprobe` publishes the guest partitions, so the host's LVM can
+ * auto-activate a Linux guest's volume group on them (#535): every
+ * `qemu-nbd --disconnect` is preceded by the holder release, otherwise the
+ * device stays pinned until reboot. Echoes `INJECT_RESULT=<code>` for the
+ * caller; never fails the migration.
+ */
+export function buildUefiInjectScript(bootDiskPath: string): string {
+  return [
+    'set +e',
+    NBD_RELEASE_HOLDERS_FN,
+    'modprobe nbd max_part=16 2>/dev/null',
+    // Find a free nbd device (no pid file means unused)
+    'NBD=""',
+    'for i in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do',
+    '  if [ ! -s /sys/block/nbd$i/pid ] 2>/dev/null; then NBD=/dev/nbd$i; break; fi',
+    'done',
+    '[ -z "$NBD" ] && { echo "INJECT_RESULT=NO_FREE_NBD"; exit 0; }',
+    `qemu-nbd --connect="$NBD" --format=raw "${bootDiskPath}" 2>/dev/null || { echo "INJECT_RESULT=NBD_FAIL"; exit 0; }`,
+    'sleep 1',
+    'partprobe "$NBD" 2>/dev/null',
+    'sleep 1',
+    // Find EFI System Partition by GUID
+    `EFI_PART=$(lsblk -nr -o NAME,PARTTYPE "$NBD" 2>/dev/null | awk 'tolower($2)=="c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print "/dev/"$1; exit}')`,
+    // Fallback: look for any FAT partition on the disk
+    'if [ -z "$EFI_PART" ]; then',
+    '  for p in ${NBD}p*; do',
+    '    [ -e "$p" ] && blkid -s TYPE -o value "$p" 2>/dev/null | grep -qi vfat && EFI_PART="$p" && break',
+    '  done',
+    'fi',
+    'if [ -z "$EFI_PART" ]; then',
+    `  ${nbdReleaseHoldersCall('"$NBD"')}; qemu-nbd --disconnect "$NBD" >/dev/null 2>&1`,
+    '  echo "INJECT_RESULT=NO_EFI_PART"; exit 0',
+    'fi',
+    'MNT=$(mktemp -d /tmp/efi-inject-XXXXXX)',
+    'if ! mount -t vfat -o rw "$EFI_PART" "$MNT" 2>/dev/null; then',
+    `  ${nbdReleaseHoldersCall('"$NBD"')}; qemu-nbd --disconnect "$NBD" >/dev/null 2>&1; rmdir "$MNT"`,
+    '  echo "INJECT_RESULT=MOUNT_FAIL"; exit 0',
+    'fi',
+    'RESULT=NO_BOOTLOADER',
+    // Windows: copy bootmgfw.efi to \EFI\Boot\bootx64.efi if missing
+    'if [ -f "$MNT/EFI/Microsoft/Boot/bootmgfw.efi" ]; then',
+    '  if [ -f "$MNT/EFI/Boot/bootx64.efi" ] || [ -f "$MNT/EFI/BOOT/BOOTX64.EFI" ]; then',
+    '    RESULT=ALREADY_PRESENT',
+    '  else',
+    '    mkdir -p "$MNT/EFI/Boot" && cp "$MNT/EFI/Microsoft/Boot/bootmgfw.efi" "$MNT/EFI/Boot/bootx64.efi" && RESULT=WINDOWS_INJECTED',
+    '  fi',
+    'elif [ -f "$MNT/EFI/Boot/bootx64.efi" ] || [ -f "$MNT/EFI/BOOT/BOOTX64.EFI" ]; then',
+    '  RESULT=ALREADY_PRESENT',
+    'fi',
+    'sync; umount "$MNT"; rmdir "$MNT"',
+    `${nbdReleaseHoldersCall('"$NBD"')}; qemu-nbd --disconnect "$NBD" >/dev/null 2>&1`,
+    'echo "INJECT_RESULT=$RESULT"',
+  ].join('\n')
+}

--- a/frontend/src/lib/migration/warm/target-space.test.ts
+++ b/frontend/src/lib/migration/warm/target-space.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
-import { evaluateTargetSpace, checkTargetStorageSpace, gib } from "./target-space"
+import { evaluateTargetSpace, checkTargetStorageSpace, assertTargetStorageSpace, gib } from "./target-space"
 
 vi.mock("@/lib/connections/getConnection", () => ({ getConnectionById: vi.fn() }))
 vi.mock("@/lib/proxmox/client", () => ({ pveFetch: vi.fn() }))
@@ -118,5 +118,37 @@ describe("gib", () => {
     { bytes: 0, expected: "0.0" },
   ])("formats $bytes bytes as $expected GiB", ({ bytes, expected }) => {
     expect(gib(bytes)).toBe(expected)
+  })
+})
+
+describe("assertTargetStorageSpace (planning-time guard)", () => {
+  beforeEach(() => {
+    mockConnection.mockReset()
+    mockFetch.mockReset()
+    mockConnection.mockResolvedValue({ baseUrl: "https://pve.local:8006", apiToken: "t" } as never)
+  })
+
+  it("returns the verdict when the storage can hold the disks plus the margin", async () => {
+    mockFetch.mockResolvedValue({ avail: 44.7 * GiB, type: "zfspool" })
+    await expect(assertTargetStorageSpace("tgt", "pve1", "ZFS-Pool", 16 * GiB)).resolves.toMatchObject({
+      storage: "ZFS-Pool",
+      type: "zfspool",
+      requiredBytes: 16 * GiB,
+      sufficient: true,
+    })
+  })
+
+  it("throws the operator-facing message with both figures when the storage is too small", async () => {
+    mockFetch.mockResolvedValue({ avail: 12.2 * GiB, type: "zfspool" })
+    await expect(assertTargetStorageSpace("tgt", "pve1", "ZFS-Pool", 16 * GiB)).rejects.toThrow(
+      'Insufficient disk space on "ZFS-Pool": 12.2 GB free, need 16.0 GB plus a 10% margin',
+    )
+  })
+
+  it("throws a read error, not a space verdict, when the node cannot report the storage", async () => {
+    mockFetch.mockRejectedValue(new Error("PVE 400 /nodes/pve1/storage/nope/status: No such storage."))
+    await expect(assertTargetStorageSpace("tgt", "pve1", "nope", 16 * GiB)).rejects.toThrow(
+      /^Cannot read free space on "nope" \(node pve1\): PVE 400 .*No such storage\.$/,
+    )
   })
 })

--- a/frontend/src/lib/migration/warm/target-space.test.ts
+++ b/frontend/src/lib/migration/warm/target-space.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { getConnectionById } from "@/lib/connections/getConnection"
+import { pveFetch } from "@/lib/proxmox/client"
+import { evaluateTargetSpace, checkTargetStorageSpace, gib } from "./target-space"
+
+vi.mock("@/lib/connections/getConnection", () => ({ getConnectionById: vi.fn() }))
+vi.mock("@/lib/proxmox/client", () => ({ pveFetch: vi.fn() }))
+
+const GiB = 1024 ** 3
+const mockConnection = vi.mocked(getConnectionById)
+const mockFetch = vi.mocked(pveFetch)
+
+describe("evaluateTargetSpace", () => {
+  it.each([22, 23])("accepts %i GiB for 20 GiB of disks, including the 10% margin", (availableGiB) => {
+    expect(evaluateTargetSpace("ZFS-Pool", { avail: availableGiB * GiB, type: "zfspool" }, 20 * GiB)).toEqual({
+      storage: "ZFS-Pool",
+      type: "zfspool",
+      availableBytes: availableGiB * GiB,
+      requiredBytes: 20 * GiB,
+      sufficient: true,
+    })
+  })
+
+  it.each([0, 21])("rejects %i GiB when 20 GiB plus the margin is required", (availableGiB) => {
+    expect(evaluateTargetSpace("ZFS-Pool", { avail: availableGiB * GiB }, 20 * GiB)).toMatchObject({
+      availableBytes: availableGiB * GiB,
+      sufficient: false,
+    })
+  })
+
+  it.each([
+    { label: "missing avail", status: {} },
+    { label: "non-numeric avail", status: { avail: "abc" } },
+    { label: "negative avail", status: { avail: -1 } },
+    { label: "null status", status: null },
+    { label: "undefined status", status: undefined },
+  ])("treats $label as zero available bytes", ({ status }) => {
+    expect(evaluateTargetSpace("ZFS-Pool", status, 20 * GiB)).toMatchObject({
+      availableBytes: 0,
+      sufficient: false,
+    })
+  })
+
+  it.each([undefined, null, 123, false, {}])("does not copy a non-string storage type (%j)", (type) => {
+    expect(evaluateTargetSpace("ZFS-Pool", { avail: 22 * GiB, type }, 20 * GiB).type).toBeUndefined()
+  })
+
+  it("accepts zero required bytes even when no space is available", () => {
+    expect(evaluateTargetSpace("empty-pool", { avail: 0 }, 0)).toEqual({
+      storage: "empty-pool",
+      type: undefined,
+      availableBytes: 0,
+      requiredBytes: 0,
+      sufficient: true,
+    })
+  })
+})
+
+describe("checkTargetStorageSpace", () => {
+  const connection = {
+    id: "target-conn",
+    name: "Target",
+    baseUrl: "https://pve.local:8006",
+    apiToken: "test-token",
+    insecureDev: false,
+    behindProxy: false,
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockConnection.mockResolvedValue(connection)
+  })
+
+  it.each([
+    { node: "pve1", storage: "ZFS-Pool", path: "/nodes/pve1/storage/ZFS-Pool/status", availableGiB: 22, sufficient: true },
+    { node: "pve1", storage: "ZFS Pool+backup", path: "/nodes/pve1/storage/ZFS%20Pool%2Bbackup/status", availableGiB: 21, sufficient: false },
+    { node: "pve 1", storage: "ZFS-Pool", path: "/nodes/pve%201/storage/ZFS-Pool/status", availableGiB: 22, sufficient: true },
+  ])("fetches $path and returns the evaluated verdict", async ({ node, storage, path, availableGiB, sufficient }) => {
+    mockFetch.mockResolvedValue({ avail: availableGiB * GiB, type: "zfspool" })
+
+    const result = await checkTargetStorageSpace("target-conn", node, storage, 20 * GiB)
+
+    expect(mockConnection).toHaveBeenCalledExactlyOnceWith("target-conn")
+    expect(mockFetch).toHaveBeenCalledExactlyOnceWith(connection, path)
+    expect(mockFetch.mock.calls[0][0]).toBe(connection)
+    expect(result).toEqual({ storage, type: "zfspool", availableBytes: availableGiB * GiB, requiredBytes: 20 * GiB, sufficient })
+  })
+
+  it("returns an insufficient verdict without throwing when PVE rejects", async () => {
+    mockFetch.mockRejectedValue(new Error("PVE 400 ...No such storage"))
+
+    await expect(checkTargetStorageSpace("target-conn", "pve1", "ZFS-Pool", 20 * GiB)).resolves.toEqual({
+      storage: "ZFS-Pool",
+      availableBytes: 0,
+      requiredBytes: 20 * GiB,
+      sufficient: false,
+      error: "PVE 400 ...No such storage",
+    })
+  })
+
+  it("returns an insufficient verdict without throwing when connection lookup rejects", async () => {
+    mockConnection.mockRejectedValue(new Error("Connection not found"))
+
+    await expect(checkTargetStorageSpace("target-conn", "pve1", "ZFS-Pool", 20 * GiB)).resolves.toEqual({
+      storage: "ZFS-Pool",
+      availableBytes: 0,
+      requiredBytes: 20 * GiB,
+      sufficient: false,
+      error: "Connection not found",
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})
+
+describe("gib", () => {
+  it.each([
+    { bytes: 13079048192, expected: "12.2" },
+    { bytes: 0, expected: "0.0" },
+  ])("formats $bytes bytes as $expected GiB", ({ bytes, expected }) => {
+    expect(gib(bytes)).toBe(expected)
+  })
+})

--- a/frontend/src/lib/migration/warm/target-space.ts
+++ b/frontend/src/lib/migration/warm/target-space.ts
@@ -1,0 +1,76 @@
+import { pveFetch } from "@/lib/proxmox/client"
+import { getConnectionById } from "@/lib/connections/getConnection"
+
+/**
+ * Free space on the warm target storage versus what the source disks need.
+ *
+ * Warm writes each target disk as a block volume of the source disk's full
+ * capacity: a zvol reserves that capacity up front (zfspool without `sparse`),
+ * LVM allocates it, RBD and LVM-thin grow into it as the copy lands. Cold
+ * already refuses a target below the disks' size plus a 10 % margin at
+ * planning time; warm had no such guard and only failed at volume allocation,
+ * after the node preflight had said "ready". The dialog now asks this
+ * before enabling the launch, and the engine applies the same rule as a
+ * backstop for the cluster-auto node choice.
+ */
+export interface TargetSpaceResult {
+  storage: string
+  /** PVE storage type as reported by the node (zfspool, lvmthin, rbd, ...). */
+  type?: string
+  availableBytes: number
+  requiredBytes: number
+  /** availableBytes covers requiredBytes plus TARGET_SPACE_MARGIN. */
+  sufficient: boolean
+  /** Set when the node could not report the storage (unknown storage, node down). */
+  error?: string
+}
+
+/** Same 10 % headroom the cold engine applies to its target-storage check. */
+export const TARGET_SPACE_MARGIN = 1.1
+
+/** Pure verdict from a PVE storage status payload (`avail` in bytes). */
+export function evaluateTargetSpace(
+  storage: string,
+  status: { avail?: unknown; type?: unknown } | null | undefined,
+  requiredBytes: number,
+): TargetSpaceResult {
+  const parsed = Number(status?.avail ?? 0)
+  const availableBytes = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+  return {
+    storage,
+    type: typeof status?.type === "string" ? status.type : undefined,
+    availableBytes,
+    requiredBytes,
+    sufficient: availableBytes >= requiredBytes * TARGET_SPACE_MARGIN,
+  }
+}
+
+/**
+ * Read `/nodes/{node}/storage/{storage}/status` on the target connection and
+ * compare its live `avail` with requiredBytes. Never throws: a storage the
+ * node cannot report is returned as insufficient with the error text, so the
+ * caller blocks the launch and shows why instead of failing later.
+ */
+export async function checkTargetStorageSpace(
+  targetConnectionId: string,
+  node: string,
+  storage: string,
+  requiredBytes: number,
+): Promise<TargetSpaceResult> {
+  try {
+    const conn = await getConnectionById(targetConnectionId)
+    const status = await pveFetch<{ avail?: number; type?: string }>(
+      conn,
+      `/nodes/${encodeURIComponent(node)}/storage/${encodeURIComponent(storage)}/status`,
+    )
+    return evaluateTargetSpace(storage, status, requiredBytes)
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { storage, availableBytes: 0, requiredBytes, sufficient: false, error: message }
+  }
+}
+
+/** "12.2" style GiB figure for messages. */
+export function gib(bytes: number): string {
+  return (bytes / 1073741824).toFixed(1)
+}

--- a/frontend/src/lib/migration/warm/target-space.ts
+++ b/frontend/src/lib/migration/warm/target-space.ts
@@ -74,3 +74,27 @@ export async function checkTargetStorageSpace(
 export function gib(bytes: number): string {
   return (bytes / 1073741824).toFixed(1)
 }
+
+/**
+ * Planning-time guard: the same verdict as checkTargetStorageSpace, turned into
+ * the error the operator reads in the job log. Throws when the storage cannot
+ * hold the disks or cannot be read; returns the verdict otherwise so the
+ * caller can log the two figures.
+ */
+export async function assertTargetStorageSpace(
+  targetConnectionId: string,
+  node: string,
+  storage: string,
+  requiredBytes: number,
+): Promise<TargetSpaceResult> {
+  const space = await checkTargetStorageSpace(targetConnectionId, node, storage, requiredBytes)
+  if (space.error) {
+    throw new Error(`Cannot read free space on "${storage}" (node ${node}): ${space.error}`)
+  }
+  if (!space.sufficient) {
+    throw new Error(
+      `Insufficient disk space on "${storage}": ${gib(space.availableBytes)} GB free, need ${gib(space.requiredBytes)} GB plus a 10% margin. Free up space or pick another storage.`,
+    )
+  }
+  return space
+}

--- a/frontend/src/lib/migration/warm/vddk-provision.test.ts
+++ b/frontend/src/lib/migration/warm/vddk-provision.test.ts
@@ -207,6 +207,37 @@ describe("buildVddkInstallScript", () => {
     expect(s).toContain("printf 'options nbd max_part=0\\n' > /etc/modprobe.d/proxcenter-nbd.conf")
   })
 
+  it("guards the global_filter edit on an active filter without an nbd exclusion", () => {
+    const s = script()
+    expect(s).toContain("LVMCONF=/etc/lvm/lvm.conf")
+    expect(s).toContain(
+      `if grep -qE '^[[:space:]]*global_filter[[:space:]]*=[[:space:]]*\\[' "$LVMCONF" && ! grep -qE '^[[:space:]]*global_filter[[:space:]]*=.*nbd' "$LVMCONF"; then`,
+    )
+  })
+
+  it("backs up the config, prepends the nbd exclusion, and validates the filter", () => {
+    const s = script()
+    expect(s).toContain('cp -a "$LVMCONF" "$LVMCONF.proxcenter-bak"')
+    expect(s).toContain(
+      `sed -i -E 's#^([[:space:]]*global_filter[[:space:]]*=[[:space:]]*\\[)#\\1 "r|/dev/nbd.*|",#' "$LVMCONF"`,
+    )
+    expect(s).toContain('if lvmconfig --validate >/dev/null 2>&1; then\n    rm -f "$LVMCONF.proxcenter-bak"')
+  })
+
+  it("restores the original config and warns if filter validation fails", () => {
+    const s = script()
+    expect(s).toContain('else\n    mv "$LVMCONF.proxcenter-bak" "$LVMCONF"')
+    expect(s).toContain('echo "WARN: /etc/lvm/lvm.conf left unchanged (global_filter edit failed validation); add r|/dev/nbd.*| to devices/global_filter by hand" >&2')
+  })
+
+  it("edits the LVM filter after configuring the nbd kernel module", () => {
+    const s = script()
+    expect(s).toContain("modprobe nbd max_part=0")
+    expect(s).toContain("LVMCONF=/etc/lvm/lvm.conf")
+    expect(s.indexOf("LVMCONF=/etc/lvm/lvm.conf")).toBeGreaterThan(s.indexOf("modprobe nbd max_part=0"))
+    expect(s.indexOf("LVMCONF=/etc/lvm/lvm.conf")).toBeGreaterThan(s.indexOf("/etc/modprobe.d/proxcenter-nbd.conf"))
+  })
+
   it("fails fast and loud: set -eo pipefail so a broken curl cannot be masked by tar", () => {
     expect(script()).toContain("set -eo pipefail")
   })

--- a/frontend/src/lib/migration/warm/vddk-provision.ts
+++ b/frontend/src/lib/migration/warm/vddk-provision.ts
@@ -207,6 +207,27 @@ export function buildVddkInstallScript(opts: VddkInstallScriptOpts): string {
     "modprobe nbd max_part=0",
     "echo nbd > /etc/modules-load.d/proxcenter-nbd.conf",
     "printf 'options nbd max_part=0\\n' > /etc/modprobe.d/proxcenter-nbd.conf",
+    // 5. Keep the host's LVM off the transient NBD devices (#535). Without
+    // this, udev's `pvscan --cache -aay` auto-activates the GUEST volume group
+    // it finds on /dev/nbdN(pM): the dm LVs pin the device until reboot, and a
+    // guest VG named like the host's (`pve`) breaks PVE's own lvcreate for as
+    // long as the copy runs ("Multiple VGs found with the same name"). PVE
+    // already ships an active global_filter line (r|/dev/zd.*|, r|/dev/rbd.*|):
+    // prepend the nbd exclusion to that line, validate, and roll back on any
+    // parse error so the host's LVM can never be left broken. A conf without an
+    // active global_filter line is left alone: the teardown-side release in
+    // nbd-holders.ts still frees the device, only the prevention is skipped.
+    "LVMCONF=/etc/lvm/lvm.conf",
+    `if grep -qE '^[[:space:]]*global_filter[[:space:]]*=[[:space:]]*\\[' "$LVMCONF" && ! grep -qE '^[[:space:]]*global_filter[[:space:]]*=.*nbd' "$LVMCONF"; then`,
+    '  cp -a "$LVMCONF" "$LVMCONF.proxcenter-bak"',
+    `  sed -i -E 's#^([[:space:]]*global_filter[[:space:]]*=[[:space:]]*\\[)#\\1 "r|/dev/nbd.*|",#' "$LVMCONF"`,
+    "  if lvmconfig --validate >/dev/null 2>&1; then",
+    '    rm -f "$LVMCONF.proxcenter-bak"',
+    "  else",
+    '    mv "$LVMCONF.proxcenter-bak" "$LVMCONF"',
+    `    echo "WARN: /etc/lvm/lvm.conf left unchanged (global_filter edit failed validation); add r|/dev/nbd.*| to devices/global_filter by hand" >&2`,
+    "  fi",
+    "fi",
   ].join("\n")
 }
 

--- a/frontend/src/lib/migration/warm/vddk-reader.test.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.test.ts
@@ -36,7 +36,13 @@ describe("pure builders", () => {
   })
   it("tears down device, nbdkit, socket, password file", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw" })
+    expect(c).toContain("nbd_release_tree() {")
+    expect(c).toContain("nbd_release_holders() {")
+    expect(c).toContain("nbd_release_holders /dev/nbd3")
     expect(c).toContain("nbd-client -d /dev/nbd3")
+    expect(c.indexOf("nbd_release_tree() {")).toBeLessThan(c.indexOf("nbd_release_holders /dev/nbd3"))
+    expect(c.indexOf("nbd_release_holders() {")).toBeLessThan(c.indexOf("nbd_release_holders /dev/nbd3"))
+    expect(c.indexOf("nbd_release_holders /dev/nbd3")).toBeLessThan(c.indexOf("nbd-client -d /dev/nbd3"))
     expect(c).toContain("/tmp/v.sock")
     expect(c).toContain("/tmp/pw")
     // Guard against the pkill self-match: the pattern must be "[n]bdkit", not
@@ -47,12 +53,16 @@ describe("pure builders", () => {
   it("also removes the log file when present in the handle", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw", logFile: "/tmp/v.log" })
     expect(c).toContain("/tmp/v.log")
+    const lastLine = c.split("\n").at(-1)
+    expect(lastLine).toMatch(/rm -f \/tmp\/v\.sock \/tmp\/pw \/tmp\/v\.log$/)
+    expect(lastLine).toContain('pkill -f "[n]bdkit.*/tmp/v.sock"')
   })
   it("omits the device detach when no device was allocated (attach failed before a device was chosen)", () => {
     const c = buildReaderTeardownCmd({ nbdDev: "", sock: "/tmp/v.sock", pwFile: "/tmp/pw" })
     // With no owned device there is nothing to detach; a bare `nbd-client -d`
     // would error and, worse, could target an unintended device.
     expect(c).not.toContain("nbd-client -d")
+    expect(c).not.toContain("nbd_release_holders")
     // nbdkit and temp files are still cleaned up.
     expect(c).toContain('pkill -f "[n]bdkit.*/tmp/v.sock"')
     expect(c).toContain("rm -f /tmp/v.sock /tmp/pw")
@@ -132,6 +142,7 @@ describe("stopVddkReader", () => {
     mockSSH.mockResolvedValue({ success: true, output: "" })
     await stopVddkReader("conn", "10.99.99.201", { nbdDev: "/dev/nbd3", sock: "/tmp/v.sock", pwFile: "/tmp/pw", logFile: "/tmp/v.log" })
     const cmd = mockSSH.mock.calls[0][2] as string
+    expect(cmd).toContain("nbd_release_holders /dev/nbd3")
     expect(cmd).toContain("nbd-client -d /dev/nbd3")
     expect(cmd).toContain("pkill -f")
   })

--- a/frontend/src/lib/migration/warm/vddk-reader.ts
+++ b/frontend/src/lib/migration/warm/vddk-reader.ts
@@ -1,4 +1,5 @@
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
+import { NBD_RELEASE_HOLDERS_FN, nbdReleaseHoldersCall } from "../nbd-holders"
 import { buildNbdkitVddkCmd, type VddkOpts } from "./vddk-cmd"
 
 /** A running nbdkit-vddk reader: the kernel device it is attached to plus the
@@ -49,6 +50,8 @@ export function buildNbdConnectCmd(sock: string): string {
 }
 
 /**
+ * Release holders first so host-activated guest LVM volumes cannot keep the
+ * NBD device pinned after detach (#535).
  * Detach the device, kill the nbdkit serving this socket (matched by its argv,
  * not a PID, so it works even after nbdkit daemonizes), and remove the socket,
  * password file, and log. Each step is best-effort so teardown never aborts on
@@ -59,7 +62,9 @@ export function buildReaderTeardownCmd(h: VddkReaderHandle): string {
   // Only detach a device we actually own. When attach failed before any device
   // was chosen (h.nbdDev === ""), a bare `nbd-client -d` would error and could
   // target an unintended device — so skip it entirely in that case.
-  const detach = h.nbdDev ? `nbd-client -d ${h.nbdDev} 2>/dev/null; ` : ""
+  const detach = h.nbdDev
+    ? `${NBD_RELEASE_HOLDERS_FN}\n${nbdReleaseHoldersCall(h.nbdDev)}; nbd-client -d ${h.nbdDev} 2>/dev/null; `
+    : ""
   // The pkill pattern is "[n]bdkit" (a one-character class), not "nbdkit":
   // pkill -f matches against each process's FULL command line, and this teardown
   // command's own shell carries the pattern string in its argv (and the sock path

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -2,7 +2,7 @@ import { getTenantPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
-import { checkTargetStorageSpace, gib } from "./target-space"
+import { assertTargetStorageSpace, gib } from "./target-space"
 import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import {
@@ -271,15 +271,7 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     // cluster-auto node choice and direct API calls reach here unchecked, and a
     // zvol allocation that fails for space would otherwise surface only as a
     // PVE error after the node preflight said "ready".
-    const space = await checkTargetStorageSpace(
-      config.targetConnectionId, config.targetNode, config.targetStorage,
-      vmConfig.disks.reduce((s, d) => s + d.capacityBytes, 0),
-    )
-    if (!space.sufficient) {
-      throw new Error(space.error
-        ? `Cannot read free space on "${config.targetStorage}" (node ${config.targetNode}): ${space.error}`
-        : `Insufficient disk space on "${config.targetStorage}": ${gib(space.availableBytes)} GB free, need ${gib(space.requiredBytes)} GB plus a 10% margin. Free up space or pick another storage.`)
-    }
+    const space = await assertTargetStorageSpace(config.targetConnectionId, config.targetNode, config.targetStorage, vmConfig.disks.reduce((s, d) => s + d.capacityBytes, 0))
     await appendLog(jobId, `Target storage "${config.targetStorage}": ${gib(space.availableBytes)} GB free, need ${gib(space.requiredBytes)} GB`, "info")
 
     // VDDK preflight on the PVE node — actionable error before we touch anything.

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -2,6 +2,7 @@ import { getTenantPrisma } from "@/lib/tenant"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
+import { checkTargetStorageSpace, gib } from "./target-space"
 import { isFileBasedStorage } from "@/lib/proxmox/storage"
 import { executeSSH, shellEscape } from "@/lib/ssh/exec"
 import {
@@ -264,6 +265,22 @@ export async function runWarmMigration(jobId: string, config: WarmMigrationConfi
     if (isFileBasedStorage(storageInfo?.type || "dir")) {
       throw new Error(`Warm migration requires a block-storage target (LVM/LVM-thin/ZFS/Ceph RBD); "${config.targetStorage}" is file-based (${storageInfo?.type}). Pick a block storage or use a cold migration.`)
     }
+
+    // Free space backstop, same rule as the cold engine (disks' capacity plus
+    // 10 %). The dialog runs this check before enabling the launch, but the
+    // cluster-auto node choice and direct API calls reach here unchecked, and a
+    // zvol allocation that fails for space would otherwise surface only as a
+    // PVE error after the node preflight said "ready".
+    const space = await checkTargetStorageSpace(
+      config.targetConnectionId, config.targetNode, config.targetStorage,
+      vmConfig.disks.reduce((s, d) => s + d.capacityBytes, 0),
+    )
+    if (!space.sufficient) {
+      throw new Error(space.error
+        ? `Cannot read free space on "${config.targetStorage}" (node ${config.targetNode}): ${space.error}`
+        : `Insufficient disk space on "${config.targetStorage}": ${gib(space.availableBytes)} GB free, need ${gib(space.requiredBytes)} GB plus a 10% margin. Free up space or pick another storage.`)
+    }
+    await appendLog(jobId, `Target storage "${config.targetStorage}": ${gib(space.availableBytes)} GB free, need ${gib(space.requiredBytes)} GB`, "info")
 
     // VDDK preflight on the PVE node — actionable error before we touch anything.
     const pf = await checkVddkPreflight(config.targetConnectionId, nodeIp, libdir)

--- a/frontend/src/lib/migration/warm/xapi-reader.test.ts
+++ b/frontend/src/lib/migration/warm/xapi-reader.test.ts
@@ -170,6 +170,7 @@ describe("startXapiReader", () => {
     expect(teardownCmd).toContain("rm -rf '/tmp/xapi.sock.ca'")
     expect(teardownCmd).toContain("/tmp/xapi.sock.log")
     expect(teardownCmd).not.toContain("nbd-client -d")
+    expect(teardownCmd).not.toContain("nbd_release_holders")
   })
 })
 
@@ -187,8 +188,10 @@ describe("stopXapiReader", () => {
     })
 
     const cmd = mockSSH.mock.calls[0][2] as string
+    expect(cmd).toContain("nbd_release_holders /dev/nbd3")
     expect(cmd).toContain("nbd-client -d /dev/nbd3")
+    expect(cmd.indexOf("nbd_release_holders /dev/nbd3")).toBeLessThan(cmd.indexOf("nbd-client -d /dev/nbd3"))
     expect(cmd).toContain('pkill -f "[n]bdkit.*/tmp/xapi.sock"')
-    expect(cmd).toContain("; rm -rf '/tmp/xapi.sock.ca'")
+    expect(cmd.endsWith("; rm -rf '/tmp/xapi.sock.ca'")).toBe(true)
   })
 })

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -2195,6 +2195,8 @@
       "warmPreflightFailedTitle": "Zielknoten ist nicht bereit fur die Warm-Migration",
       "warmPreflightMissing": "Fehlt auf dem Knoten: {items}.",
       "warmPreflightNbdHint": "Installieren Sie die NBD-Werkzeuge auf dem Proxmox-Knoten: apt install nbdkit nbd-client libnbd-bin, und wählen Sie den Knoten anschließend erneut aus.",
+      "warmStorageInsufficient": "Nicht genügend freier Speicherplatz auf {storage}: {available} GB verfügbar, {required} GB für die Quell-Festplatten plus 10 % Reserve erforderlich. Geben Sie Speicherplatz frei oder wählen Sie einen anderen Speicher.",
+      "warmStorageCheckFailed": "Der freie Speicherplatz von {storage} auf dem Zielknoten konnte nicht gelesen werden: {error}",
       "warmPrepNeedsPve9": "Dieser Node läuft mit Proxmox VE {pve} (Debian {debian}). Die Warm-Migration erfordert Proxmox VE 9: Debian 13 ist die erste Version mit dem nbdkit-VDDK-Plugin, dieser Node kann daher weder automatisch noch manuell vorbereitet werden.",
       "warmPreflightDocsHint": "Bereiten Sie zuerst den Proxmox-Knoten vor (nbdkit, das nbdkit-VDDK-Plugin, nbd-client und das Broadcom-VDDK installieren), dann wahlen Sie den Knoten erneut aus. Siehe die <link>Anleitung zur Knotenvorbereitung fur die Warm-Migration</link>.",
       "warmSetupAction": "Diesen Knoten vorbereiten",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2208,6 +2208,8 @@
       "warmPreflightFailedTitle": "Target node is not ready for warm migration",
       "warmPreflightMissing": "Missing on the node: {items}.",
       "warmPreflightNbdHint": "Install the NBD tooling on the Proxmox node: apt install nbdkit nbd-client libnbd-bin, then reselect the node.",
+      "warmStorageInsufficient": "Not enough free space on {storage}: {available} GB available, {required} GB needed for the source disks plus a 10% margin. Free up space on it or pick another storage.",
+      "warmStorageCheckFailed": "Could not read the free space of {storage} on the target node: {error}",
       "warmPrepNeedsPve9": "This node runs Proxmox VE {pve} (Debian {debian}). Warm migration needs Proxmox VE 9: Debian 13 is the first release that ships the nbdkit VDDK plugin, so this node cannot be prepared, automatically or by hand.",
       "warmPreflightDocsHint": "Prepare the Proxmox node first (install nbdkit, the nbdkit VDDK plugin, nbd-client and the Broadcom VDDK), then reselect the node. See the <link>warm migration node setup guide</link>.",
       "warmSetupAction": "Prepare this node",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -2208,6 +2208,8 @@
       "warmPreflightFailedTitle": "El nodo destino no está listo para la migración warm",
       "warmPreflightMissing": "Falta en el nodo: {items}.",
       "warmPreflightNbdHint": "Instala las herramientas de NBD en el nodo Proxmox: apt install nbdkit nbd-client libnbd-bin y vuelve a seleccionar el nodo.",
+      "warmStorageInsufficient": "No hay suficiente espacio libre en {storage}: {available} GB disponibles, {required} GB necesarios para los discos de origen más un margen del 10 %. Libere espacio o elija otro almacenamiento.",
+      "warmStorageCheckFailed": "No se pudo leer el espacio libre de {storage} en el nodo de destino: {error}",
       "warmPrepNeedsPve9": "Este nodo ejecuta Proxmox VE {pve} (Debian {debian}). La migración warm requiere Proxmox VE 9: Debian 13 es la primera versión que incluye el plugin VDDK de nbdkit, por lo que este nodo no puede prepararse, ni automáticamente ni a mano.",
       "warmPreflightDocsHint": "Prepara primero el nodo Proxmox (instala nbdkit, el plugin nbdkit VDDK, nbd-client y Broadcom VDDK) y vuelve a seleccionar el nodo. Consulta la <link>guía de preparación del nodo para migración warm</link>.",
       "warmSetupAction": "Preparar este nodo",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -2208,6 +2208,8 @@
       "warmPreflightFailedTitle": "Le noeud cible n'est pas pret pour la migration a chaud",
       "warmPreflightMissing": "Manquant sur le noeud : {items}.",
       "warmPreflightNbdHint": "Installez les outils NBD sur le nœud Proxmox : apt install nbdkit nbd-client libnbd-bin, puis sélectionnez à nouveau le nœud.",
+      "warmStorageInsufficient": "Espace libre insuffisant sur {storage} : {available} Go disponibles, {required} Go nécessaires pour les disques source plus une marge de 10 %. Libérez de l'espace ou choisissez un autre stockage.",
+      "warmStorageCheckFailed": "Impossible de lire l'espace libre de {storage} sur le nœud cible : {error}",
       "warmPrepNeedsPve9": "Ce nœud est en Proxmox VE {pve} (Debian {debian}). La migration warm exige Proxmox VE 9 : Debian 13 est la première version à fournir le plugin VDDK de nbdkit, ce nœud ne peut donc pas être préparé, ni automatiquement ni à la main.",
       "warmPreflightDocsHint": "Preparez d'abord le noeud Proxmox (installez nbdkit, le plugin VDDK de nbdkit, nbd-client et le VDDK Broadcom), puis reselectionnez le noeud. Consultez le <link>guide de preparation du noeud pour la migration a chaud</link>.",
       "warmSetupAction": "Preparer ce noeud",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -2208,6 +2208,8 @@
       "warmPreflightFailedTitle": "대상 노드가 웜 마이그레이션 준비가 되지 않았습니다",
       "warmPreflightMissing": "노드에 없는 항목: {items}.",
       "warmPreflightNbdHint": "Proxmox 노드에 NBD 도구를 설치하세요: apt install nbdkit nbd-client libnbd-bin. 그런 다음 노드를 다시 선택하세요.",
+      "warmStorageInsufficient": "{storage}의 여유 공간이 부족합니다: {available} GB 사용 가능, 원본 디스크와 10% 여유분을 위해 {required} GB 필요. 공간을 확보하거나 다른 스토리지를 선택하세요.",
+      "warmStorageCheckFailed": "대상 노드에서 {storage}의 여유 공간을 읽을 수 없습니다: {error}",
       "warmPrepNeedsPve9": "이 노드는 Proxmox VE {pve}(Debian {debian})에서 실행 중입니다. 웜 마이그레이션에는 Proxmox VE 9가 필요합니다. Debian 13부터 nbdkit VDDK 플러그인이 제공되므로 이 노드는 자동으로도 수동으로도 준비할 수 없습니다.",
       "warmPreflightDocsHint": "먼저 Proxmox 노드를 준비한 후(nbdkit, nbdkit VDDK 플러그인, nbd-client, Broadcom VDDK 설치) 노드를 다시 선택하세요. <link>웜 마이그레이션 노드 설정 가이드</link>를 참조하세요.",
       "warmSetupAction": "이 노드 준비",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -2192,6 +2192,8 @@
       "warmPreflightFailedTitle": "目标节点尚未就绪，无法进行温迁移",
       "warmPreflightMissing": "节点上缺少：{items}。",
       "warmPreflightNbdHint": "在 Proxmox 节点上安装 NBD 工具：apt install nbdkit nbd-client libnbd-bin，然后重新选择该节点。",
+      "warmStorageInsufficient": "{storage} 上的可用空间不足：可用 {available} GB，源磁盘加 10% 余量需要 {required} GB。请释放空间或选择其他存储。",
+      "warmStorageCheckFailed": "无法读取目标节点上 {storage} 的可用空间：{error}",
       "warmPrepNeedsPve9": "此节点运行的是 Proxmox VE {pve}（Debian {debian}）。热迁移需要 Proxmox VE 9：Debian 13 是首个提供 nbdkit VDDK 插件的版本，因此无法自动或手动准备此节点。",
       "warmPreflightDocsHint": "请先准备 Proxmox 节点（安装 nbdkit、nbdkit VDDK 插件、nbd-client 以及 Broadcom VDDK），然后重新选择节点。请参阅<link>温迁移节点准备指南</link>。",
       "warmSetupAction": "准备此节点",


### PR DESCRIPTION
Closes #535.

## Why

During a warm migration of a Linux guest that uses LVM, udev's `pvscan` on the target Proxmox node auto-activates the guest's volume group on the attached `/dev/nbdN` (on a partition when the `nbd` module was loaded with `max_part>0`, which the cold UEFI-injection step does). The activated device-mapper volumes hold the device open: `nbd-client -d` returns 0 without freeing it, the pid file keeps a dead pid, `rmmod nbd` refuses, and each Linux/LVM migration wedges one more device until the node is rebooted. The cold path's `qemu-nbd --disconnect` after `partprobe` has the same failure on a Linux target disk.

## What changes

- **Holder release before detach** (`nbd-holders.ts`). The teardown walks the kernel's own holder tree under `/sys/class/block/<dev>/holders` from the device we own and its partitions, removes the leaves first (`dmsetup remove`, `mdadm --stop`), then detaches. Scoping is by construction: no VG name, no regex, so a guest VG called `pve` like the host's cannot widen the cleanup. Used by the VDDK and XCP-ng warm readers and by the cold UEFI-injection script, now extracted into `uefi-inject.ts`. The same walk also reclaims a device wedged by an earlier version, without a reboot.
- **Prevention at node preparation.** "Prepare this node" prepends `r|/dev/nbd.*|` to the `global_filter` line Proxmox already ships, validates with `lvmconfig --validate` and rolls back on any parse error. Without it the guest volumes stay visible in `lvs` for the whole copy, and a guest VG named `pve` breaks the host's own `lvcreate` ("Multiple VGs found with the same name").
- **Warm target free-space check.** The warm preflight only reported the node runtime, so a target storage too small for the source disks showed "ready" and failed at volume allocation. The check now reads the storage's live free space and compares it with the source disks plus the 10% margin the cold engine uses; the dialog shows both figures and blocks the launch, and the warm engine applies the same rule at planning time.

## Verification

Lab, Proxmox VE 9.2, LVM 2.03.31: the wedge reproduced with a partitioned LVM image served by nbdkit, then released on an already wedged device. End to end, an AlmaLinux VM migrated warm from vCenter with the filter removed: the journal shows `lvm-activate-almalinux.service` activating two volumes on `nbd0p3`, the teardown freeing the device and `nbd0` reused for the final delta. With the filter in place the journal shows `/dev/nbd0p3 excluded: device is rejected by filter config`. The free-space check blocked a 20 GB source against a 12 GB ZFS pool and let it through on Ceph.

Unit tests cover the shell builders, the teardown order, the node-prep filter step, the preflight route and the space verdict. `src/lib/migration` suite: 45 files, 503 tests green.

## For the reviewer

`pipeline.ts` only loses the inline UEFI script, moved verbatim into `uefi-inject.ts` plus the release calls. The dialog derives the required size from the VM's committed bytes, like the cold path, which includes the vSphere swap file while the VM runs; the engine uses the exact disk capacities.
