### PR TITLE
Exclude pattern for stale-snapshot alerts, readable alert values (#875)

### DIFF
--- a/frontend/src/app/(dashboard)/operations/alerts/page.tsx
+++ b/frontend/src/app/(dashboard)/operations/alerts/page.tsx
@@ -48,6 +48,7 @@ import { resolveSelectedRowIds } from '@/utils/gridSelection'
 import EmptyState from '@/components/EmptyState'
 import { CardsSkeleton, TableSkeleton } from '@/components/skeletons'
 import { DonutStatCard, DonutTotalCard } from '@/components/charts/DonutStatCards'
+import { formatAlertValue } from '@/lib/alerts/formatAlertValue'
 
 /* --------------------------------
    Types
@@ -613,7 +614,7 @@ return true
         )
       }
     },
-    { field: 'current_value', headerName: t('alerts.value'), width: 80, renderCell: (p) => p.value ? `${p.value.toFixed(1)}${p.row.unit || ''}` : '—' },
+    { field: 'current_value', headerName: t('alerts.value'), width: 80, renderCell: (p) => p.value ? formatAlertValue(p.value, p.row.unit) : '—' },
     { field: 'last_seen_at', headerName: t('alerts.lastSeen'), width: 120, renderCell: (p) => <Tooltip title={new Date(p.value).toLocaleString()}><span>{timeAgo(p.value)}</span></Tooltip> },
     {
       field: 'actions',

--- a/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/alert-config/__tests__/route.test.ts
@@ -179,6 +179,21 @@ describe('GET /api/v1/internal/alert-config', () => {
     expect(body.thresholds.replication_rpo_grace_percent).toBe(0)
   })
 
+  it('ships the stale-snapshot exclude pattern trimmed, and empty when unset or not a string (#875)', async () => {
+    findManyMock.mockResolvedValue([])
+    getSettingMock.mockResolvedValue({ snapshot_exclude_pattern: '  (?i)replica  ' })
+    let res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect((await res.json()).thresholds.snapshot_exclude_pattern).toBe('(?i)replica')
+
+    getSettingMock.mockResolvedValue({ snapshot_max_age_days: 7 })
+    res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect((await res.json()).thresholds.snapshot_exclude_pattern).toBe('')
+
+    getSettingMock.mockResolvedValue({ snapshot_exclude_pattern: 42 })
+    res = await GET(makeReq({ 'X-API-Key': 'secret-key' }))
+    expect((await res.json()).thresholds.snapshot_exclude_pattern).toBe('')
+  })
+
   it('honors X-Tenant-ID by scoping the query', async () => {
     getSettingMock.mockResolvedValueOnce({})
     findManyMock.mockResolvedValueOnce([])

--- a/frontend/src/app/api/internal/alert-config/route.ts
+++ b/frontend/src/app/api/internal/alert-config/route.ts
@@ -15,6 +15,8 @@ const DEFAULT_THRESHOLDS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  // Stale-snapshot exclude regex (discussion #875), a string the Go side compiles.
+  snapshot_exclude_pattern: '',
   // Recovery hysteresis (#551) — see the settings route for the rationale.
   recovery_margin: 5,
   recovery_confirmations: 3,
@@ -37,15 +39,19 @@ const INT_THRESHOLD_KEYS: ReadonlySet<keyof Thresholds> = new Set([
 ])
 
 function coerceThresholds(raw: unknown): Thresholds {
-  const t = { ...DEFAULT_THRESHOLDS }
-  if (!raw || typeof raw !== 'object') return t
+  const t: Record<string, number | string> = { ...DEFAULT_THRESHOLDS }
+  if (!raw || typeof raw !== 'object') return t as Thresholds
   const obj = raw as Record<string, unknown>
   for (const key of Object.keys(DEFAULT_THRESHOLDS) as (keyof Thresholds)[]) {
     const v = obj[key]
+    if (typeof DEFAULT_THRESHOLDS[key] === 'string') {
+      if (typeof v === 'string') t[key] = v.trim()
+      continue
+    }
     if (typeof v !== 'number' || !Number.isFinite(v)) continue
     t[key] = INT_THRESHOLD_KEYS.has(key) ? Math.trunc(v) : v
   }
-  return t
+  return t as Thresholds
 }
 
 /**

--- a/frontend/src/app/api/v1/dashboard/route.ts
+++ b/frontend/src/app/api/v1/dashboard/route.ts
@@ -599,6 +599,7 @@ return null
           connId: node.connId,
           metric: 'ram',
           currentValue: node.memPct,
+          unit: '%',
           threshold: thresholds.memory_critical,
           time: new Date().toISOString()
         })
@@ -616,6 +617,7 @@ return null
           connId: node.connId,
           metric: 'ram',
           currentValue: node.memPct,
+          unit: '%',
           threshold: thresholds.memory_warning,
           time: new Date().toISOString()
         })
@@ -635,6 +637,7 @@ return null
           connId: node.connId,
           metric: 'cpu',
           currentValue: node.cpuPct,
+          unit: '%',
           threshold: thresholds.cpu_critical,
           time: new Date().toISOString()
         })
@@ -652,6 +655,7 @@ return null
           connId: node.connId,
           metric: 'cpu',
           currentValue: node.cpuPct,
+          unit: '%',
           threshold: thresholds.cpu_warning,
           time: new Date().toISOString()
         })
@@ -712,6 +716,7 @@ return null
           entityName: pbs.name,
           metric: 'storage',
           currentValue: pbs.usagePct,
+          unit: '%',
           threshold: thresholds.storage_critical,
           time: new Date().toISOString()
         })
@@ -728,6 +733,7 @@ return null
           entityName: pbs.name,
           metric: 'storage',
           currentValue: pbs.usagePct,
+          unit: '%',
           threshold: thresholds.storage_warning,
           time: new Date().toISOString()
         })

--- a/frontend/src/app/api/v1/settings/alerts/thresholds/route.test.ts
+++ b/frontend/src/app/api/v1/settings/alerts/thresholds/route.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { callRoute } from '@/__tests__/setup/route-test'
+
+const checkPermissionMock = vi.fn()
+const getSettingMock = vi.fn()
+const setSettingMock = vi.fn()
+const updateThresholdsMock = vi.fn()
+
+vi.mock('@/lib/rbac', () => ({
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' },
+}))
+vi.mock('@/lib/tenant', () => ({
+  getCurrentTenantId: async () => 'tenant-1',
+}))
+vi.mock('@/lib/db/settings', () => ({
+  getSetting: (...a: any[]) => getSettingMock(...a),
+  setSetting: (...a: any[]) => setSettingMock(...a),
+}))
+vi.mock('@/lib/demo/demo-api', () => ({
+  demoResponse: () => null,
+}))
+vi.mock('@/lib/orchestrator/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/orchestrator/client')>()
+  return {
+    ...actual,
+    alertsApi: { updateThresholds: (...a: any[]) => updateThresholdsMock(...a) },
+  }
+})
+
+import { GET, PUT } from './route'
+
+const originalOrchestratorUrl = process.env.ORCHESTRATOR_URL
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  checkPermissionMock.mockResolvedValue(null)
+  getSettingMock.mockResolvedValue(null)
+  setSettingMock.mockResolvedValue(undefined)
+  updateThresholdsMock.mockResolvedValue({ data: {}, status: 200 })
+  process.env.ORCHESTRATOR_URL = 'http://orchestrator.test'
+})
+
+afterEach(() => {
+  process.env.ORCHESTRATOR_URL = originalOrchestratorUrl
+})
+
+describe('GET /api/v1/settings/alerts/thresholds', () => {
+  it('returns the defaults with an empty exclude pattern when nothing is stored', async () => {
+    const res = await callRoute(GET as any)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.snapshot_max_age_days).toBe(7)
+    expect(body.snapshot_exclude_pattern).toBe('')
+  })
+
+  it('merges a stored pattern over the defaults and ignores a non-string one', async () => {
+    getSettingMock.mockResolvedValue({ snapshot_exclude_pattern: '(?i)replica', cpu_warning: 70 })
+    let body = await (await callRoute(GET as any)).json()
+    expect(body.snapshot_exclude_pattern).toBe('(?i)replica')
+    expect(body.cpu_warning).toBe(70)
+
+    getSettingMock.mockResolvedValue({ snapshot_exclude_pattern: 42 })
+    body = await (await callRoute(GET as any)).json()
+    expect(body.snapshot_exclude_pattern).toBe('')
+  })
+})
+
+describe('PUT /api/v1/settings/alerts/thresholds', () => {
+  it('trims the pattern, pushes it to the orchestrator and stores it', async () => {
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      body: { snapshot_max_age_days: 7, snapshot_exclude_pattern: '  (?i)replica ' },
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json()).snapshot_exclude_pattern).toBe('(?i)replica')
+    expect(updateThresholdsMock).toHaveBeenCalledWith(expect.objectContaining({ snapshot_exclude_pattern: '(?i)replica' }))
+    expect(setSettingMock).toHaveBeenCalledWith('alert_thresholds', 'tenant-1', expect.objectContaining({ snapshot_exclude_pattern: '(?i)replica' }))
+  })
+
+  it('relays the orchestrator refusal of an invalid RE2 pattern and stores nothing', async () => {
+    // The Go side rejects the regex; a JS RegExp cannot stand in for it, since
+    // JS rejects (?i) and accepts the lookahead RE2 refuses.
+    updateThresholdsMock.mockRejectedValue(new Error(
+      'Orchestrator 400: {"error":"invalid snapshot_exclude_pattern: error parsing regexp: invalid or unsupported Perl syntax: `(?!`"}',
+    ))
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      body: { snapshot_exclude_pattern: '(?!replica)' },
+    })
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/invalid snapshot_exclude_pattern/)
+    expect(setSettingMock).not.toHaveBeenCalled()
+  })
+
+  it('still stores the thresholds when the orchestrator is unreachable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    updateThresholdsMock.mockRejectedValue(new Error('fetch failed'))
+    const res = await callRoute(PUT as any, {
+      method: 'PUT',
+      body: { snapshot_exclude_pattern: '(?i)replica' },
+    })
+    expect(res.status).toBe(200)
+    expect(setSettingMock).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+  })
+
+  it('skips the orchestrator entirely without ORCHESTRATOR_URL', async () => {
+    delete process.env.ORCHESTRATOR_URL
+    const res = await callRoute(PUT as any, { method: 'PUT', body: { cpu_warning: 75 } })
+    expect(res.status).toBe(200)
+    expect(updateThresholdsMock).not.toHaveBeenCalled()
+    expect((await res.json()).cpu_warning).toBe(75)
+  })
+
+  it('denies without the settings permission', async () => {
+    checkPermissionMock.mockResolvedValue(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }))
+    const res = await callRoute(PUT as any, { method: 'PUT', body: {} })
+    expect(res.status).toBe(403)
+    expect(setSettingMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
+++ b/frontend/src/app/api/v1/settings/alerts/thresholds/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from 'next/server'
 import { getSetting, setSetting } from '@/lib/db/settings'
 import { checkPermission, PERMISSIONS } from '@/lib/rbac'
 import { getCurrentTenantId } from '@/lib/tenant'
-import { alertsApi } from '@/lib/orchestrator/client'
+import { alertsApi, parseOrchestratorError } from '@/lib/orchestrator/client'
 import { demoResponse } from '@/lib/demo/demo-api'
 
 export const runtime = 'nodejs'
@@ -17,6 +17,10 @@ const DEFAULT_THRESHOLDS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  // RE2 regex, evaluated by the orchestrator, naming the VMs and snapshots the
+  // stale-snapshot check leaves alone, e.g. `(?i)replica` for Veeam replicas
+  // and their VeeamRP restore points (discussion #875). Empty excludes nothing.
+  snapshot_exclude_pattern: '',
   // Hysteresis before an alert is declared resolved (#551): how far below the
   // warning threshold the metric must fall, and for how many consecutive
   // collections. Without it, a value oscillating around the threshold emits a
@@ -40,13 +44,17 @@ const DEFAULT_THRESHOLDS = {
 type Thresholds = typeof DEFAULT_THRESHOLDS
 
 function coerceThresholds(raw: any): Thresholds {
-  const t = { ...DEFAULT_THRESHOLDS }
-  if (!raw || typeof raw !== 'object') return t
+  const t: Record<string, number | string> = { ...DEFAULT_THRESHOLDS }
+  if (!raw || typeof raw !== 'object') return t as Thresholds
   for (const key of Object.keys(DEFAULT_THRESHOLDS) as (keyof Thresholds)[]) {
     const v = raw[key]
-    if (typeof v === 'number' && Number.isFinite(v)) t[key] = v
+    if (typeof DEFAULT_THRESHOLDS[key] === 'string') {
+      if (typeof v === 'string') t[key] = v.trim()
+    } else if (typeof v === 'number' && Number.isFinite(v)) {
+      t[key] = v
+    }
   }
-  return t
+  return t as Thresholds
 }
 
 /**
@@ -90,16 +98,23 @@ export async function PUT(req: Request) {
     const body = await req.json()
     const thresholds = coerceThresholds(body)
 
-    const tenantId = await getCurrentTenantId()
-    await setSetting('alert_thresholds', tenantId, thresholds)
-
     if (process.env.ORCHESTRATOR_URL) {
       try {
         await alertsApi.updateThresholds(thresholds)
       } catch (e) {
+        // Only the orchestrator can judge the RE2 exclude pattern: a JS RegExp
+        // rejects `(?i)` and accepts the lookaheads RE2 refuses. Its 400 is the
+        // answer the user needs, and nothing is stored on this side either.
+        const orchError = parseOrchestratorError(e)
+        if (orchError?.status === 400) {
+          return NextResponse.json({ error: orchError.message }, { status: 400 })
+        }
         console.warn('[settings/alerts/thresholds] orchestrator sync failed:', e)
       }
     }
+
+    const tenantId = await getCurrentTenantId()
+    await setSetting('alert_thresholds', tenantId, thresholds)
 
     return NextResponse.json(thresholds)
   } catch (error: any) {

--- a/frontend/src/components/dashboard/widgets/AlertsListWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/AlertsListWidget.jsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material'
 
 import { widgetColors } from './themeColors'
+import { formatAlertValue } from '@/lib/alerts/formatAlertValue'
 
 // ─── Entity icon with status dot ─────────────────────────────────────────────
 function EntityIcon({ entityType, severity, isDark }) {
@@ -97,8 +98,8 @@ return null
       : alert.entityName },
     alert.entityType && { label: t('alerts.detail.entityType'), value: alert.entityType },
     alert.metric && { label: t('alerts.detail.metric'), value: alert.metric },
-    alert.currentValue != null && { label: t('alerts.detail.currentValue'), value: `${alert.currentValue}%` },
-    alert.threshold != null && { label: t('alerts.detail.threshold'), value: `${alert.threshold}%` },
+    alert.currentValue != null && { label: t('alerts.detail.currentValue'), value: formatAlertValue(alert.currentValue, alert.unit) },
+    alert.threshold != null && { label: t('alerts.detail.threshold'), value: formatAlertValue(alert.threshold, alert.unit) },
     alert.time && { label: t('alerts.detail.time'), value: new Date(alert.time).toLocaleString() },
   ].filter(Boolean)
 

--- a/frontend/src/components/dashboard/widgets/KpiAlertsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/KpiAlertsWidget.jsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material'
 
 import { widgetColors } from './themeColors'
+import { formatAlertValue } from '@/lib/alerts/formatAlertValue'
 
 function translateAlertMessage(alert, t) {
   if (alert?.i18nKey) {
@@ -67,8 +68,8 @@ return null
     alert.entityName && { label: t('alerts.detail.entity'), value: alert.entityName },
     alert.entityType && { label: t('alerts.detail.entityType'), value: alert.entityType },
     alert.metric && { label: t('alerts.detail.metric'), value: alert.metric },
-    alert.currentValue != null && { label: t('alerts.detail.currentValue'), value: `${alert.currentValue}%` },
-    alert.threshold != null && { label: t('alerts.detail.threshold'), value: `${alert.threshold}%` },
+    alert.currentValue != null && { label: t('alerts.detail.currentValue'), value: formatAlertValue(alert.currentValue, alert.unit) },
+    alert.threshold != null && { label: t('alerts.detail.threshold'), value: formatAlertValue(alert.threshold, alert.unit) },
     alert.time && { label: t('alerts.detail.time'), value: new Date(alert.time).toLocaleString() },
   ].filter(Boolean)
 

--- a/frontend/src/components/settings/AlertThresholdsTab.jsx
+++ b/frontend/src/components/settings/AlertThresholdsTab.jsx
@@ -13,6 +13,7 @@ import {
   Slider,
   Snackbar,
   Switch,
+  TextField,
   Typography,
 } from '@mui/material'
 
@@ -26,6 +27,7 @@ const DEFAULTS = {
   storage_warning: 80,
   storage_critical: 90,
   snapshot_max_age_days: 7,
+  snapshot_exclude_pattern: '',
   recovery_margin: 5,
   recovery_confirmations: 3,
   osd_latency_warning: 0,
@@ -216,7 +218,23 @@ export default function AlertThresholdsTab() {
           enabled={thresholds.snapshot_max_age_days > 0}
           onToggle={(checked) => setThresholds(th => ({ ...th, snapshot_max_age_days: checked ? 7 : 0 }))}
           tDisabled={t('alerts.snapshotDisabled')}
-        />
+        >
+          {/* Veeam keeps a replica's restore points as PVE snapshots on a VM
+              suffixed "-replica" (discussion #875): the operator cannot act on
+              them, so they can be left out by name. RE2 on the Go side, hence
+              the (?i) example rather than a case-insensitive toggle. */}
+          <TextField
+            size='small'
+            fullWidth
+            label={t('alerts.snapshotExclude')}
+            placeholder='(?i)replica'
+            value={thresholds.snapshot_exclude_pattern || ''}
+            onChange={(e) => setThresholds(th => ({ ...th, snapshot_exclude_pattern: e.target.value }))}
+            helperText={t('alerts.snapshotExcludeDesc')}
+            slotProps={{ inputLabel: { shrink: true }, input: { sx: { fontFamily: 'monospace' } } }}
+            sx={{ mt: 1.5 }}
+          />
+        </SingleThresholdCard>
 
         <Card variant='outlined' sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 2.5, '&:last-child': { pb: 2.5 } }}>
@@ -350,7 +368,7 @@ function ThresholdCard({
 function SingleThresholdCard({
   icon, label, description, value, onChange,
   min, max, step = 1, unit = '%', formatValue, markFormat,
-  enabled, onToggle, tDisabled,
+  enabled, onToggle, tDisabled, children,
 }) {
   const format = formatValue || ((v) => `${v}${unit}`)
   const mark = markFormat || format
@@ -379,6 +397,7 @@ function SingleThresholdCard({
             ]}
             sx={edgeMarkSx}
           />
+          {children}
         </>
       ) : (
         <Typography variant='body2' color='text.disabled' sx={{ mt: 2 }}>{tDisabled}</Typography>

--- a/frontend/src/lib/alerts/__tests__/dashboardAlertMerge.test.ts
+++ b/frontend/src/lib/alerts/__tests__/dashboardAlertMerge.test.ts
@@ -31,6 +31,31 @@ describe('mergeAndFilterDashboardAlerts', () => {
     expect(result[0].entityId).toBe('pve-1')
   })
 
+  it('carries the orchestrator unit so a snapshot age is not shown as a percentage (#875)', () => {
+    const result = mergeAndFilterDashboardAlerts({
+      baseAlerts: [],
+      orchAlerts: [{
+        connection_id: 'conn-1',
+        type: 'snapshot_stale',
+        severity: 'warning',
+        resource_type: 'vm',
+        resource: 'VM 122 (app-replica) / VeeamRP-20260829-200239',
+        message: 'Snapshot is 9 days old',
+        current_value: 8.789080648219757,
+        threshold: 7,
+        unit: 'days',
+      }],
+      connectionNameById: new Map([['conn-1', 'PVE-PROD']]),
+      visibleNodeNames: visibleNodes(['pve-1']),
+      hasVisibleNodes: true,
+      silencedFingerprints: new Set(),
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].unit).toBe('days')
+    expect(result[0].currentValue).toBeCloseTo(8.789, 3)
+    expect(result[0].threshold).toBe(7)
+  })
+
   it('merges orchestrator alerts that do not duplicate a local alert', () => {
     const orchAlert = {
       connection_id: 'conn-1',

--- a/frontend/src/lib/alerts/dashboardAlertMerge.ts
+++ b/frontend/src/lib/alerts/dashboardAlertMerge.ts
@@ -18,6 +18,7 @@ export interface RawOrchestratorAlert {
   message?: string
   current_value?: number
   threshold?: number
+  unit?: string
   last_seen_at?: string
   created_at?: string
 }
@@ -39,6 +40,7 @@ export interface DashboardAlert {
   metric?: string
   currentValue?: number
   threshold?: number
+  unit?: string
   time?: string
   [key: string]: unknown
 }
@@ -107,6 +109,7 @@ export function mergeAndFilterDashboardAlerts(params: {
         metric: oa.type,
         currentValue: oa.current_value,
         threshold: oa.threshold,
+        unit: oa.unit,
         time: oa.last_seen_at || oa.created_at,
       })
     }

--- a/frontend/src/lib/alerts/formatAlertValue.test.ts
+++ b/frontend/src/lib/alerts/formatAlertValue.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatAlertValue } from '@/lib/alerts/formatAlertValue'
+
+// Discussion #875: a stale-snapshot alert showed "8.789080648219757days" in the
+// mail and "8.789080648219757%" in the dashboard dialogs.
+describe('formatAlertValue', () => {
+  it('rounds to one decimal and spaces a word unit', () => {
+    expect(formatAlertValue(8.789080648219757, 'days')).toBe('8.8 days')
+    expect(formatAlertValue(12.34, 'min')).toBe('12.3 min')
+    expect(formatAlertValue(147, 'ms')).toBe('147 ms')
+  })
+
+  it('drops a trailing .0 so a threshold reads as an integer', () => {
+    expect(formatAlertValue(7, 'days')).toBe('7 days')
+    expect(formatAlertValue(90.0, '%')).toBe('90%')
+  })
+
+  it('glues a percentage to its number', () => {
+    expect(formatAlertValue(85.25, '%')).toBe('85.3%')
+  })
+
+  it('prints the bare number when the alert has no unit', () => {
+    expect(formatAlertValue(3)).toBe('3')
+    expect(formatAlertValue(3, null)).toBe('3')
+    expect(formatAlertValue(3, '')).toBe('3')
+  })
+
+  it('returns null when there is nothing to show', () => {
+    expect(formatAlertValue(undefined, '%')).toBeNull()
+    expect(formatAlertValue(null, '%')).toBeNull()
+    expect(formatAlertValue(Number.NaN, '%')).toBeNull()
+    expect(formatAlertValue('12', '%')).toBeNull()
+  })
+})

--- a/frontend/src/lib/alerts/formatAlertValue.ts
+++ b/frontend/src/lib/alerts/formatAlertValue.ts
@@ -1,0 +1,16 @@
+/**
+ * Human form of an alert's measured value: at most one decimal, no trailing
+ * ".0", the unit glued for a percentage and spaced otherwise. A stale
+ * snapshot reads "8.8 days", not "8.789080648219757%" (discussion #875).
+ *
+ * The dashboard widgets used to append "%" to every value, which was wrong
+ * for anything the orchestrator measures in days, ms or minutes, so the unit
+ * now travels with the alert and an absent unit prints the bare number.
+ * Returns null when there is nothing to show.
+ */
+export function formatAlertValue(value: unknown, unit?: string | null): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const num = String(Math.round(value * 10) / 10)
+  if (!unit) return num
+  return unit === '%' ? `${num}%` : `${num} ${unit}`
+}

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -718,6 +718,8 @@ export interface AlertThresholds {
   storage_warning: number
   storage_critical: number
   snapshot_max_age_days: number
+  /** RE2 regex naming the VMs and snapshots the stale-snapshot check skips (discussion #875). */
+  snapshot_exclude_pattern: string
   /** Points below the warning threshold before a recovery is counted (#551). */
   recovery_margin: number
   /** Consecutive collections below the margin before the alert resolves. */

--- a/frontend/src/messages/alertsMessages.test.ts
+++ b/frontend/src/messages/alertsMessages.test.ts
@@ -44,6 +44,9 @@ describe('alerts message namespace', () => {
       'messages.nodeOffline',
       'snapshotAge',
       'snapshotDisabled',
+      // Discussion #875: exclude Veeam replicas from the stale-snapshot check.
+      'snapshotExclude',
+      'snapshotExcludeDesc',
       'recoveryTitle',
       'recoveryMargin',
       'recoveryConfirmations',

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -681,6 +681,8 @@
     "snapshotAgeDesc": "Warnung wenn Snapshots dieses Alter überschreiten",
     "snapshotDays": "Tage",
     "snapshotDisabled": "Deaktiviert",
+    "snapshotExclude": "Ausschlussmuster (Regex)",
+    "snapshotExcludeDesc": "VMs oder Snapshots, deren Name auf diese Regex passt, werden übersprungen, z. B. (?i)replica für Veeam-Replikate. RE2-Syntax, kein Lookahead.",
     "recoveryTitle": "Alarm-Entwarnung",
     "recoveryDesc": "Wie weit eine Metrik zurückgehen muss, bevor ihr Alarm als behoben gilt, damit ein schwankender Wert nicht jede Minute eine Auslösung und eine Entwarnung verschickt",
     "recoveryMargin": "Punkte unter dem Warnschwellenwert",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -692,6 +692,8 @@
     "snapshotAgeDesc": "Alert when VM snapshots exceed this age",
     "snapshotDays": "days",
     "snapshotDisabled": "Disabled",
+    "snapshotExclude": "Exclude pattern (regex)",
+    "snapshotExcludeDesc": "VMs or snapshots whose name matches this regex are skipped, e.g. (?i)replica for Veeam replicas. RE2 syntax, no lookahead.",
     "recoveryTitle": "Alert recovery",
     "recoveryDesc": "How far a metric must settle back down before its alert is declared resolved, so an unstable value does not email a firing and a recovery every minute",
     "recoveryMargin": "points below the warning threshold",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -692,6 +692,8 @@
     "snapshotAgeDesc": "Alertar cuando los snapshots de VM superen esta antigüedad",
     "snapshotDays": "días",
     "snapshotDisabled": "Deshabilitado",
+    "snapshotExclude": "Patrón de exclusión (regex)",
+    "snapshotExcludeDesc": "Las VM o snapshots cuyo nombre coincida con esta regex se omiten, p. ej. (?i)replica para réplicas de Veeam. Sintaxis RE2, sin lookahead.",
     "recoveryTitle": "Recuperación de alertas",
     "recoveryDesc": "Cuánto debe bajar una métrica antes de declarar resuelta su alerta, para evitar que un valor inestable envíe un aviso y una recuperación cada minuto",
     "recoveryMargin": "puntos por debajo del umbral de advertencia",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -692,6 +692,8 @@
     "snapshotAgeDesc": "Alerter quand les snapshots dépassent cet âge",
     "snapshotDays": "jours",
     "snapshotDisabled": "Désactivé",
+    "snapshotExclude": "Motif d'exclusion (regex)",
+    "snapshotExcludeDesc": "Les VM ou snapshots dont le nom correspond à cette regex sont ignorés, par ex. (?i)replica pour les réplicas Veeam. Syntaxe RE2, sans lookahead.",
     "recoveryTitle": "Retour à la normale",
     "recoveryDesc": "Jusqu'où une métrique doit redescendre avant que son alerte soit déclarée résolue, pour éviter qu'une valeur instable envoie un mail de déclenchement et de résolution chaque minute",
     "recoveryMargin": "points sous le seuil d'avertissement",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -692,6 +692,8 @@
     "snapshotAgeDesc": "VM 스냅샷이 이 기간을 초과하면 알림",
     "snapshotDays": "일",
     "snapshotDisabled": "비활성화됨",
+    "snapshotExclude": "제외 패턴 (정규식)",
+    "snapshotExcludeDesc": "이름이 이 정규식과 일치하는 VM 또는 스냅샷은 검사하지 않습니다. 예: Veeam 복제본은 (?i)replica. RE2 문법, 전방 탐색 미지원.",
     "recoveryTitle": "알림 해제",
     "recoveryDesc": "불안정한 값이 매분 발생 및 해제 메일을 보내지 않도록, 알림을 해제로 선언하기 전에 지표가 얼마나 안정되어야 하는지 정합니다",
     "recoveryMargin": "경고 임계값보다 낮은 포인트",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -679,6 +679,8 @@
     "snapshotAgeDesc": "当快照超过此天数时发出警报",
     "snapshotDays": "天",
     "snapshotDisabled": "已禁用",
+    "snapshotExclude": "排除模式（正则）",
+    "snapshotExcludeDesc": "名称匹配此正则的虚拟机或快照将被跳过，例如 (?i)replica 用于 Veeam 副本。RE2 语法，不支持前瞻。",
     "recoveryTitle": "告警恢复",
     "recoveryDesc": "指标需要回落到什么程度才宣告告警已解决，避免波动的数值每分钟发送一次触发和恢复邮件",
     "recoveryMargin": "低于警告阈值的百分点",


### PR DESCRIPTION
Follow-up to discussion #875, where a user wanted their Veeam replicas out of the stale-snapshot alerts. Veeam keeps a replica's restore points as PVE snapshots on VMs suffixed `-replica`, so each replica fired an alert nobody can act on, and the exclude pattern of an event rule cannot reach them: these alerts come from the threshold check, not from events.

**What changes**

- The **Stale Snapshots** card in Settings > Alert thresholds gains an **Exclude pattern** field. It is a RE2 regex matched against the VM name and the snapshot name by the orchestrator; whatever matches is skipped, and an alert already raised on it is resolved at the next pass. `(?i)replica` covers the reported case.
- The pattern is validated by the orchestrator only. A JS `RegExp` rejects `(?i)` and accepts the lookaheads RE2 refuses, so the settings route relays the orchestrator's 400 and stores nothing on refusal.
- Alert values were printed raw, `8.789080648219757` with a `%` glued to a value measured in days. They are now rounded to one decimal and carry their unit, on the alerts page and in the dashboard dialogs. The mail had the same defect; that part lives on the orchestrator side and ships separately.

**Verified in the lab** with two test VMs carrying snapshots backdated ten days: both alerted, the `(?i)replica` pattern resolved the replica's alert at the next pass and left the other one active, and an invalid pattern was refused with the RE2 message. Tests added for the settings route, the internal alert-config route, the dashboard merge and the value formatter.

Needs the orchestrator change deployed alongside: without it the field is stored but nothing evaluates it.
