### PR TITLE
Scan every installed package for CVEs, and report what the scan actually covered (#905)

### DIFF
--- a/frontend/src/components/CveTab.test.tsx
+++ b/frontend/src/components/CveTab.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+import { renderWithProviders, screen, waitFor } from '@/__tests__/setup/renderWithProviders'
+import CveTab from './CveTab'
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+function mockScan(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const entry = (over: Record<string, unknown> = {}) => ({
+  cveId: 'CVE-2026-38076',
+  package: 'jbig2dec',
+  installedVersion: '0.20-1',
+  fixedVersion: '0.20-1+deb13u1',
+  fixAvailable: true,
+  severity: 'medium',
+  description: 'A heap overflow',
+  node: 'pve1',
+  publishedAt: '',
+  ...over,
+})
+
+describe('CveTab', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('reports a failed scan instead of showing the clean-node message', async () => {
+    // The ui#905 symptom: the tab swallowed every backend error and rendered
+    // the green "No vulnerabilities detected" state, so a cluster with no
+    // outbound access to the Debian tracker looked perfectly healthy.
+    mockScan({ error: 'refresh CVE db: fetch debian tracker: no such host' }, false, 500)
+
+    renderWithProviders(<CveTab connectionId="conn1" node="pve1" available />)
+
+    await waitFor(() => expect(screen.getByText('Scan failed')).toBeTruthy())
+    expect(screen.queryByText('No vulnerabilities detected')).toBeNull()
+    expect(screen.getByText(/no such host/)).toBeTruthy()
+  })
+
+  it('calls an empty result partial when the node was only read through the API', async () => {
+    mockScan({
+      vulnerabilities: [],
+      nodes: [{ node: 'pve1', release: 'trixie', source: 'api', packagesScanned: 62, packagesTracked: 12, fixable: 0, noFix: 0, warning: 'ssh-not-configured' }],
+      lastScan: '2026-09-09T12:00:00Z',
+    })
+
+    renderWithProviders(<CveTab connectionId="conn1" node="pve1" available />)
+
+    await waitFor(() => expect(screen.getByText('Partial scan')).toBeTruthy())
+    expect(screen.getByText(/62 packages scanned, 12 known/)).toBeTruthy()
+    expect(screen.getByText(/SSH is not configured/)).toBeTruthy()
+  })
+
+  it('keeps the clean-node message for a full inventory with nothing to patch', async () => {
+    mockScan({
+      vulnerabilities: [],
+      nodes: [{ node: 'pve1', release: 'trixie', source: 'ssh', packagesScanned: 929, packagesTracked: 297, fixable: 0, noFix: 0 }],
+      lastScan: '2026-09-09T12:00:00Z',
+    })
+
+    renderWithProviders(<CveTab connectionId="conn1" node="pve1" available />)
+
+    await waitFor(() => expect(screen.getByText('No vulnerabilities detected')).toBeTruthy())
+    expect(screen.getByText(/929 packages scanned, 297 known/)).toBeTruthy()
+  })
+
+  it('shows fixable findings first and keeps the unfixed ones behind their filter', async () => {
+    mockScan({
+      vulnerabilities: [
+        entry(),
+        entry({ cveId: 'CVE-2026-54369', package: 'acl', fixedVersion: '', fixAvailable: false, installedVersion: '2.3.2-2' }),
+        entry({ cveId: 'CVE-2026-54370', package: 'attr', fixedVersion: '', fixAvailable: false, installedVersion: '1:2.5.2-3' }),
+      ],
+      nodes: [{ node: 'pve1', release: 'trixie', source: 'ssh', packagesScanned: 929, packagesTracked: 297, fixable: 1, noFix: 2 }],
+      lastScan: '2026-09-09T12:00:00Z',
+    })
+
+    renderWithProviders(<CveTab connectionId="conn1" node="pve1" available />)
+
+    await waitFor(() => expect(screen.getByText('CVE-2026-38076')).toBeTruthy())
+    expect(screen.queryByText('CVE-2026-54369')).toBeNull()
+
+    // The unfixed class is announced with its count and one click away.
+    const filter = screen.getByText('No fix yet (2)')
+    filter.click()
+
+    await waitFor(() => expect(screen.getByText('CVE-2026-54369')).toBeTruthy())
+    expect(screen.getByText('CVE-2026-54370')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/CveTab.tsx
+++ b/frontend/src/components/CveTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   Box,
@@ -12,7 +12,9 @@ import {
   TableCell,
   TableContainer,
   TableHead,
+  TablePagination,
   TableRow,
+  Tooltip,
   Typography,
   alpha,
   useTheme,
@@ -23,10 +25,25 @@ interface CveEntry {
   package: string
   installedVersion: string
   fixedVersion: string
+  fixAvailable: boolean
+  noDsaReason?: string
   severity: 'critical' | 'high' | 'medium' | 'low'
   description: string
   node: string
   publishedAt: string
+}
+
+interface NodeScan {
+  node: string
+  release: string
+  source: 'ssh' | 'api' | ''
+  packagesScanned: number
+  packagesTracked: number
+  fixable: number
+  noFix: number
+  error?: string
+  warning?: string
+  warningDetail?: string
 }
 
 interface CveTabProps {
@@ -34,6 +51,8 @@ interface CveTabProps {
   node?: string
   available: boolean
 }
+
+const SEVERITIES = ['critical', 'high', 'medium', 'low'] as const
 
 const SEVERITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 }
 
@@ -46,57 +65,66 @@ const SEVERITY_COLORS: Record<string, string> = {
 
 export default function CveTab({ connectionId, node, available }: CveTabProps) {
   const t = useTranslations('cve')
+  const tCommon = useTranslations('common')
   const theme = useTheme()
   const [cves, setCves] = useState<CveEntry[]>([])
+  const [nodes, setNodes] = useState<NodeScan[]>([])
   const [loading, setLoading] = useState(true)
   const [scanning, setScanning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [lastScan, setLastScan] = useState<string | null>(null)
-  const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set(['critical', 'high', 'medium', 'low']))
+  const [activeFilters, setActiveFilters] = useState<Set<string>>(new Set(SEVERITIES))
+  // CVEs Debian has not fixed yet are real findings but there is nothing to
+  // act on today, and they outnumber the actionable ones by two orders of
+  // magnitude. They stay one click away instead of burying the fixable list.
+  const [showNoFix, setShowNoFix] = useState(false)
+  const [page, setPage] = useState(0)
+  const [rowsPerPage, setRowsPerPage] = useState(20)
 
-  const fetchCves = async () => {
-    setLoading(true)
+  const url = node
+    ? `/api/v1/cve/${connectionId}?node=${encodeURIComponent(node)}`
+    : `/api/v1/cve/${connectionId}`
+
+  const load = useCallback(async (method: 'GET' | 'POST') => {
     try {
-      const url = node
-        ? `/api/v1/cve/${connectionId}?node=${encodeURIComponent(node)}`
-        : `/api/v1/cve/${connectionId}`
-      const res = await fetch(url)
-      if (res.ok) {
-        const data = await res.json()
-        setCves(data.vulnerabilities || [])
-        setLastScan(data.lastScan || null)
+      const res = await fetch(url, { method })
+      const data = await res.json().catch(() => null)
+
+      if (!res.ok) {
+        // An empty table used to be shown for a failed scan too, so a
+        // connection with no outbound access to the Debian tracker looked
+        // exactly like a cluster with nothing to patch.
+        setError(data?.error || `HTTP ${res.status}`)
+        setCves([])
+        setNodes([])
+        return
       }
-    } catch (e) {
-      console.error('Failed to fetch CVEs:', e)
-    } finally {
-      setLoading(false)
+
+      setError(null)
+      setCves(data?.vulnerabilities || [])
+      setNodes(data?.nodes || [])
+      setLastScan(data?.lastScan || null)
+      setPage(0)
+    } catch (e: any) {
+      setError(e?.message || 'Network error')
+      setCves([])
+      setNodes([])
     }
-  }
+  }, [url])
 
   useEffect(() => {
-    if (available) {
-      fetchCves()
-    } else {
+    if (!available) {
       setLoading(false)
+      return
     }
-  }, [connectionId, node, available])
+    setLoading(true)
+    load('GET').finally(() => setLoading(false))
+  }, [available, load])
 
   const handleScan = async () => {
     setScanning(true)
-    try {
-      const url = node
-        ? `/api/v1/cve/${connectionId}?node=${encodeURIComponent(node)}`
-        : `/api/v1/cve/${connectionId}`
-      const res = await fetch(url, { method: 'POST' })
-      if (res.ok) {
-        const data = await res.json()
-        setCves(data.vulnerabilities || [])
-        setLastScan(data.lastScan || null)
-      }
-    } catch (e) {
-      console.error('Failed to scan CVEs:', e)
-    } finally {
-      setScanning(false)
-    }
+    await load('POST')
+    setScanning(false)
   }
 
   const toggleFilter = (severity: string) => {
@@ -109,21 +137,60 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
       }
       return next
     })
+    setPage(0)
   }
 
+  const visibleByFix = useMemo(
+    () => cves.filter(cve => showNoFix || cve.fixAvailable),
+    [cves, showNoFix]
+  )
+
   const counts = useMemo(() => {
-    const c = { critical: 0, high: 0, medium: 0, low: 0 }
-    for (const cve of cves) {
+    const c: Record<string, number> = { critical: 0, high: 0, medium: 0, low: 0 }
+    for (const cve of visibleByFix) {
       c[cve.severity]++
     }
     return c
+  }, [visibleByFix])
+
+  const fixCounts = useMemo(() => {
+    let fixable = 0
+    for (const cve of cves) {
+      if (cve.fixAvailable) fixable++
+    }
+    return { fixable, noFix: cves.length - fixable }
   }, [cves])
 
   const filteredCves = useMemo(() => {
-    return cves
+    return visibleByFix
       .filter(cve => activeFilters.has(cve.severity))
-      .sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 4) - (SEVERITY_ORDER[b.severity] ?? 4))
-  }, [cves, activeFilters])
+      .sort((a, b) => {
+        // Actionable findings first, then by severity.
+        if (a.fixAvailable !== b.fixAvailable) return a.fixAvailable ? -1 : 1
+        return (SEVERITY_ORDER[a.severity] ?? 4) - (SEVERITY_ORDER[b.severity] ?? 4)
+      })
+  }, [visibleByFix, activeFilters])
+
+  const pagedCves = useMemo(
+    () => filteredCves.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [filteredCves, page, rowsPerPage]
+  )
+
+  // Coverage tells a clean cluster apart from a scan that saw almost nothing.
+  const coverage = useMemo(() => {
+    const scanned = nodes.reduce((sum, n) => sum + (n.packagesScanned || 0), 0)
+    const tracked = nodes.reduce((sum, n) => sum + (n.packagesTracked || 0), 0)
+    const degraded = nodes.filter(n => n.warning || n.error)
+    const release = nodes.find(n => n.release)?.release || ''
+    const full = nodes.length > 0 && nodes.every(n => n.source === 'ssh' && !n.error)
+    return { scanned, tracked, degraded, release, full }
+  }, [nodes])
+
+  const degradedNode = coverage.degraded[0]
+  const degradedCode = degradedNode?.error || degradedNode?.warning || ''
+  const degradedLabel = degradedCode
+    ? t(`status.${degradedCode}`, { node: degradedNode.node, release: degradedNode.release || '?' })
+    : ''
 
   if (!available) {
     return (
@@ -171,38 +238,69 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
     )
   }
 
-  if (cves.length === 0) {
+  const scanButton = (
+    <Button
+      variant="outlined"
+      size="small"
+      startIcon={<i className="ri-radar-line" />}
+      onClick={handleScan}
+      disabled={scanning}
+    >
+      {scanning ? t('scanning') : t('scanNow')}
+    </Button>
+  )
+
+  if (error) {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8 }}>
-        <i className="ri-checkbox-circle-line" style={{ fontSize: 48, color: theme.palette.success.main, marginBottom: 16 }} />
+        <Box sx={{ color: 'error.main', mb: 2, display: 'flex' }}>
+          <i className="ri-error-warning-line" style={{ fontSize: 48 }} />
+        </Box>
         <Typography variant="body1" fontWeight={600}>
-          {t('noVulnerabilities')}
+          {t('scanFailed')}
         </Typography>
+        <Typography variant="body2" sx={{ mt: 1, opacity: 0.7, maxWidth: 560, textAlign: 'center' }}>
+          {error}
+        </Typography>
+        <Box sx={{ mt: 2 }}>{scanButton}</Box>
+      </Box>
+    )
+  }
+
+  if (cves.length === 0) {
+    const partial = !coverage.full
+    return (
+      <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8 }}>
+        <Box sx={{ color: partial ? 'warning.main' : 'success.main', mb: 2, display: 'flex' }}>
+          <i className={partial ? 'ri-shield-keyhole-line' : 'ri-checkbox-circle-line'} style={{ fontSize: 48 }} />
+        </Box>
+        <Typography variant="body1" fontWeight={600}>
+          {partial ? t('partialScan') : t('noVulnerabilities')}
+        </Typography>
+        <Typography variant="body2" sx={{ mt: 1, opacity: 0.7, maxWidth: 620, textAlign: 'center' }}>
+          {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
+        </Typography>
+        {degradedLabel && (
+          <Typography variant="body2" sx={{ mt: 0.5, opacity: 0.7, maxWidth: 620, textAlign: 'center' }}>
+            {degradedLabel}
+          </Typography>
+        )}
         {lastScan && (
           <Typography variant="caption" sx={{ mt: 1, opacity: 0.6 }}>
             {t('lastScan', { date: new Date(lastScan).toLocaleString() })}
           </Typography>
         )}
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<i className="ri-radar-line" />}
-          onClick={handleScan}
-          disabled={scanning}
-          sx={{ mt: 2 }}
-        >
-          {scanning ? t('scanning') : t('scanNow')}
-        </Button>
+        <Box sx={{ mt: 2 }}>{scanButton}</Box>
       </Box>
     )
   }
 
   return (
     <Box>
-      {/* Header: severity chips + scan button */}
+      {/* Header: severity chips, fix filter, coverage and scan button */}
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2, flexWrap: 'wrap', gap: 1 }}>
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {(['critical', 'high', 'medium', 'low'] as const).map(sev => (
+          {SEVERITIES.map(sev => (
             <Chip
               key={sev}
               label={`${t(`severity.${sev}`)} (${counts[sev]})`}
@@ -221,22 +319,40 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
               }}
             />
           ))}
+          {fixCounts.noFix > 0 && (
+            <Chip
+              label={t('noFixFilter', { count: fixCounts.noFix })}
+              size="small"
+              onClick={() => { setShowNoFix(v => !v); setPage(0) }}
+              sx={{
+                height: 28,
+                fontSize: 12,
+                fontWeight: 600,
+                bgcolor: showNoFix ? 'action.selected' : 'action.hover',
+                color: showNoFix ? 'text.primary' : 'text.disabled',
+                border: '1px solid',
+                borderColor: 'divider',
+                cursor: 'pointer',
+              }}
+            />
+          )}
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Tooltip title={degradedLabel || ''} disableHoverListener={!degradedLabel}>
+            <Typography
+              variant="caption"
+              sx={{ opacity: degradedLabel ? 0.9 : 0.5, color: degradedLabel ? 'warning.main' : 'inherit', display: 'flex', alignItems: 'center', gap: 0.5 }}
+            >
+              {degradedLabel && <i className="ri-error-warning-line" style={{ fontSize: 14 }} />}
+              {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
+            </Typography>
+          </Tooltip>
           {lastScan && (
             <Typography variant="caption" sx={{ opacity: 0.5 }}>
               {t('lastScan', { date: new Date(lastScan).toLocaleString() })}
             </Typography>
           )}
-          <Button
-            variant="outlined"
-            size="small"
-            startIcon={<i className="ri-radar-line" />}
-            onClick={handleScan}
-            disabled={scanning}
-          >
-            {scanning ? t('scanning') : t('scanNow')}
-          </Button>
+          {scanButton}
         </Box>
       </Box>
 
@@ -255,7 +371,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
             </TableRow>
           </TableHead>
           <TableBody>
-            {filteredCves.map(cve => (
+            {pagedCves.map(cve => (
               <TableRow
                 key={`${cve.cveId}-${cve.package}-${cve.node}`}
                 sx={{
@@ -271,7 +387,6 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
                     rel="noopener noreferrer"
                     sx={{
                       fontSize: 12,
-                      fontFamily: 'monospace',
                       fontWeight: 600,
                       color: 'primary.main',
                       textDecoration: 'none',
@@ -285,14 +400,22 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
                   <Typography variant="body2" sx={{ fontSize: 12 }}>{cve.package}</Typography>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2" sx={{ fontSize: 11, fontFamily: 'monospace', opacity: 0.7 }}>
+                  <Typography variant="body2" sx={{ fontSize: 11, opacity: 0.7 }}>
                     {cve.installedVersion}
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="body2" sx={{ fontSize: 11, fontFamily: 'monospace', color: 'success.main', fontWeight: 600 }}>
-                    {cve.fixedVersion}
-                  </Typography>
+                  {cve.fixAvailable ? (
+                    <Typography variant="body2" sx={{ fontSize: 11, color: 'success.main', fontWeight: 600 }}>
+                      {cve.fixedVersion}
+                    </Typography>
+                  ) : (
+                    <Tooltip title={cve.noDsaReason || ''} disableHoverListener={!cve.noDsaReason}>
+                      <Typography variant="body2" sx={{ fontSize: 11, opacity: 0.6 }}>
+                        {t('noFix')}
+                      </Typography>
+                    </Tooltip>
+                  )}
                 </TableCell>
                 <TableCell>
                   <Chip
@@ -330,6 +453,17 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <TablePagination
+        component="div"
+        count={filteredCves.length}
+        page={page}
+        rowsPerPage={rowsPerPage}
+        rowsPerPageOptions={[20, 50, 100]}
+        labelRowsPerPage={tCommon('rowsPerPage')}
+        onPageChange={(_, value) => setPage(value)}
+        onRowsPerPageChange={e => { setRowsPerPage(parseInt(e.target.value, 10)); setPage(0) }}
+      />
     </Box>
   )
 }

--- a/frontend/src/components/CveTab.tsx
+++ b/frontend/src/components/CveTab.tsx
@@ -25,7 +25,9 @@ interface CveEntry {
   package: string
   installedVersion: string
   fixedVersion: string
-  fixAvailable: boolean
+  // Absent when the orchestrator predates the ui#905 fix; a published fixed
+  // version is then the only signal that the finding is actionable.
+  fixAvailable?: boolean
   noDsaReason?: string
   severity: 'critical' | 'high' | 'medium' | 'low'
   description: string
@@ -53,6 +55,8 @@ interface CveTabProps {
 }
 
 const SEVERITIES = ['critical', 'high', 'medium', 'low'] as const
+
+const hasFix = (cve: CveEntry) => cve.fixAvailable ?? Boolean(cve.fixedVersion)
 
 const SEVERITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 }
 
@@ -141,7 +145,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
   }
 
   const visibleByFix = useMemo(
-    () => cves.filter(cve => showNoFix || cve.fixAvailable),
+    () => cves.filter(cve => showNoFix || hasFix(cve)),
     [cves, showNoFix]
   )
 
@@ -156,7 +160,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
   const fixCounts = useMemo(() => {
     let fixable = 0
     for (const cve of cves) {
-      if (cve.fixAvailable) fixable++
+      if (hasFix(cve)) fixable++
     }
     return { fixable, noFix: cves.length - fixable }
   }, [cves])
@@ -166,7 +170,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
       .filter(cve => activeFilters.has(cve.severity))
       .sort((a, b) => {
         // Actionable findings first, then by severity.
-        if (a.fixAvailable !== b.fixAvailable) return a.fixAvailable ? -1 : 1
+        if (hasFix(a) !== hasFix(b)) return hasFix(a) ? -1 : 1
         return (SEVERITY_ORDER[a.severity] ?? 4) - (SEVERITY_ORDER[b.severity] ?? 4)
       })
   }, [visibleByFix, activeFilters])
@@ -182,8 +186,8 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
     const tracked = nodes.reduce((sum, n) => sum + (n.packagesTracked || 0), 0)
     const degraded = nodes.filter(n => n.warning || n.error)
     const release = nodes.find(n => n.release)?.release || ''
-    const full = nodes.length > 0 && nodes.every(n => n.source === 'ssh' && !n.error)
-    return { scanned, tracked, degraded, release, full }
+    const full = nodes.every(n => n.source === 'ssh' && !n.error)
+    return { scanned, tracked, degraded, release, full, known: nodes.length > 0 }
   }, [nodes])
 
   const degradedNode = coverage.degraded[0]
@@ -268,7 +272,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
   }
 
   if (cves.length === 0) {
-    const partial = !coverage.full
+    const partial = coverage.known && !coverage.full
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', py: 8 }}>
         <Box sx={{ color: partial ? 'warning.main' : 'success.main', mb: 2, display: 'flex' }}>
@@ -277,9 +281,11 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
         <Typography variant="body1" fontWeight={600}>
           {partial ? t('partialScan') : t('noVulnerabilities')}
         </Typography>
-        <Typography variant="body2" sx={{ mt: 1, opacity: 0.7, maxWidth: 620, textAlign: 'center' }}>
-          {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
-        </Typography>
+        {coverage.known && (
+          <Typography variant="body2" sx={{ mt: 1, opacity: 0.7, maxWidth: 620, textAlign: 'center' }}>
+            {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
+          </Typography>
+        )}
         {degradedLabel && (
           <Typography variant="body2" sx={{ mt: 0.5, opacity: 0.7, maxWidth: 620, textAlign: 'center' }}>
             {degradedLabel}
@@ -338,15 +344,17 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
           )}
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Tooltip title={degradedLabel || ''} disableHoverListener={!degradedLabel}>
-            <Typography
-              variant="caption"
-              sx={{ opacity: degradedLabel ? 0.9 : 0.5, color: degradedLabel ? 'warning.main' : 'inherit', display: 'flex', alignItems: 'center', gap: 0.5 }}
-            >
-              {degradedLabel && <i className="ri-error-warning-line" style={{ fontSize: 14 }} />}
-              {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
-            </Typography>
-          </Tooltip>
+          {coverage.known && (
+            <Tooltip title={degradedLabel || ''} disableHoverListener={!degradedLabel}>
+              <Typography
+                variant="caption"
+                sx={{ opacity: degradedLabel ? 0.9 : 0.5, color: degradedLabel ? 'warning.main' : 'inherit', display: 'flex', alignItems: 'center', gap: 0.5 }}
+              >
+                {degradedLabel && <i className="ri-error-warning-line" style={{ fontSize: 14 }} />}
+                {t('coverage', { scanned: coverage.scanned, tracked: coverage.tracked })}
+              </Typography>
+            </Tooltip>
+          )}
           {lastScan && (
             <Typography variant="caption" sx={{ opacity: 0.5 }}>
               {t('lastScan', { date: new Date(lastScan).toLocaleString() })}
@@ -405,7 +413,7 @@ export default function CveTab({ connectionId, node, available }: CveTabProps) {
                   </Typography>
                 </TableCell>
                 <TableCell>
-                  {cve.fixAvailable ? (
+                  {hasFix(cve) ? (
                     <Typography variant="body2" sx={{ fontSize: 11, color: 'success.main', fontWeight: 600 }}>
                       {cve.fixedVersion}
                     </Typography>

--- a/frontend/src/messages/cveMessages.test.ts
+++ b/frontend/src/messages/cveMessages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+// The scan status codes the orchestrator sends (internal/cve/service.go). A
+// code with no message throws at render time, so the tab would break exactly
+// when it has something important to say about a degraded scan.
+const statusCodes = [
+  'ssh-not-configured',
+  'ssh-failed',
+  'credentials-failed',
+  'release-not-tracked',
+  'node-offline',
+  'inventory-empty',
+] as const
+
+const flatKeys = ['scanFailed', 'partialScan', 'coverage', 'noFix', 'noFixFilter'] as const
+
+describe('CVE scanner i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    const cve = messages.cve as Record<string, any>
+
+    it(`${locale} declares every scan-coverage string`, () => {
+      for (const key of flatKeys) {
+        expect(cve, `${locale}: missing ${key}`).toHaveProperty(key)
+        expect(cve[key], `${locale}: ${key}`).toBeTypeOf('string')
+        expect((cve[key] as string).trim().length, `${locale}: ${key} is empty`).toBeGreaterThan(0)
+      }
+    })
+
+    it(`${locale} declares a message for every scan status code`, () => {
+      for (const code of statusCodes) {
+        expect(cve.status, `${locale}: missing status.${code}`).toHaveProperty(code)
+        expect((cve.status[code] as string).trim().length, `${locale}: status.${code} is empty`).toBeGreaterThan(0)
+      }
+    })
+
+    it(`${locale} preserves the placeholders the tab passes`, () => {
+      expect(cve.coverage, locale).toContain('{scanned}')
+      expect(cve.coverage, locale).toContain('{tracked}')
+      expect(cve.noFixFilter, locale).toContain('{count}')
+      expect(cve.status['node-offline'], locale).toContain('{node}')
+      expect(cve.status['inventory-empty'], locale).toContain('{node}')
+      expect(cve.status['release-not-tracked'], locale).toContain('{release}')
+    })
+  }
+})

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -7008,7 +7008,20 @@
       "description": "Beschreibung"
     },
     "lastScan": "Letzter Scan: {date}",
-    "filterBySeverity": "Nach Schweregrad filtern"
+    "filterBySeverity": "Nach Schweregrad filtern",
+    "scanFailed": "Scan fehlgeschlagen",
+    "partialScan": "Teilweiser Scan",
+    "coverage": "{scanned} Pakete gescannt, {tracked} im Debian-Security-Tracker bekannt",
+    "noFix": "Noch kein Fix",
+    "noFixFilter": "Ohne Fix ({count})",
+    "status": {
+      "ssh-not-configured": "SSH ist für diese Verbindung nicht konfiguriert, daher wurden nur die von der Proxmox-API gemeldeten Pakete gescannt. Der größte Teil des Debian-Basissystems bleibt außen vor.",
+      "ssh-failed": "Die Paketinventur über SSH ist auf {node} fehlgeschlagen. Der Scan ist auf die Proxmox-API zurückgefallen und deckt nur einen Teil der installierten Pakete ab.",
+      "credentials-failed": "Die SSH-Zugangsdaten dieser Verbindung konnten nicht gelesen werden. Der Scan ist auf die Proxmox-API zurückgefallen und deckt nur einen Teil der installierten Pakete ab.",
+      "release-not-tracked": "Der Debian-Security-Tracker veröffentlicht keine Daten mehr für {release}, {node} kann daher nicht gescannt werden.",
+      "node-offline": "{node} ist offline und wurde nicht gescannt.",
+      "inventory-empty": "Von {node} konnte keine Paketliste gelesen werden."
+    }
   },
   "emptyState": {
     "noEvents": "Keine Ereignisse",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -7064,7 +7064,20 @@
       "description": "Description"
     },
     "lastScan": "Last scan: {date}",
-    "filterBySeverity": "Filter by severity"
+    "filterBySeverity": "Filter by severity",
+    "scanFailed": "Scan failed",
+    "partialScan": "Partial scan",
+    "coverage": "{scanned} packages scanned, {tracked} known to the Debian security tracker",
+    "noFix": "No fix yet",
+    "noFixFilter": "No fix yet ({count})",
+    "status": {
+      "ssh-not-configured": "SSH is not configured on this connection, so only the packages the Proxmox API reports were scanned. Most of the Debian base system is left out.",
+      "ssh-failed": "The package inventory over SSH failed on {node}. The scan fell back to the Proxmox API and covers only part of the installed packages.",
+      "credentials-failed": "The SSH credentials of this connection could not be read. The scan fell back to the Proxmox API and covers only part of the installed packages.",
+      "release-not-tracked": "The Debian security tracker no longer publishes data for {release}, so {node} cannot be scanned.",
+      "node-offline": "{node} is offline and was not scanned.",
+      "inventory-empty": "No package list could be read from {node}."
+    }
   },
   "emptyState": {
     "noEvents": "No events",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -7064,7 +7064,20 @@
       "description": "Descripción"
     },
     "lastScan": "Último escaneo: {date}",
-    "filterBySeverity": "Filtrar por gravedad"
+    "filterBySeverity": "Filtrar por gravedad",
+    "scanFailed": "El escaneo ha fallado",
+    "partialScan": "Escaneo parcial",
+    "coverage": "{scanned} paquetes analizados, {tracked} conocidos por el rastreador de seguridad de Debian",
+    "noFix": "Sin corrección aún",
+    "noFixFilter": "Sin corrección ({count})",
+    "status": {
+      "ssh-not-configured": "SSH no está configurado en esta conexión, por lo que solo se han analizado los paquetes que informa la API de Proxmox. La mayor parte del sistema base de Debian queda fuera.",
+      "ssh-failed": "El inventario de paquetes por SSH ha fallado en {node}. El escaneo ha recurrido a la API de Proxmox y solo cubre parte de los paquetes instalados.",
+      "credentials-failed": "No se han podido leer las credenciales SSH de esta conexión. El escaneo ha recurrido a la API de Proxmox y solo cubre parte de los paquetes instalados.",
+      "release-not-tracked": "El rastreador de seguridad de Debian ya no publica datos para {release}, por lo que {node} no puede analizarse.",
+      "node-offline": "{node} está sin conexión y no se ha analizado.",
+      "inventory-empty": "No se ha podido leer ninguna lista de paquetes de {node}."
+    }
   },
   "emptyState": {
     "noEvents": "Sin eventos",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -7065,7 +7065,20 @@
       "description": "Description"
     },
     "lastScan": "Dernier scan : {date}",
-    "filterBySeverity": "Filtrer par sévérité"
+    "filterBySeverity": "Filtrer par sévérité",
+    "scanFailed": "Échec du scan",
+    "partialScan": "Scan partiel",
+    "coverage": "{scanned} paquets analysés, {tracked} connus du tracker de sécurité Debian",
+    "noFix": "Pas encore de correctif",
+    "noFixFilter": "Sans correctif ({count})",
+    "status": {
+      "ssh-not-configured": "SSH n'est pas configuré sur cette connexion : seuls les paquets remontés par l'API Proxmox ont été analysés. L'essentiel du système Debian est hors du scan.",
+      "ssh-failed": "L'inventaire des paquets par SSH a échoué sur {node}. Le scan est retombé sur l'API Proxmox et ne couvre qu'une partie des paquets installés.",
+      "credentials-failed": "Les identifiants SSH de cette connexion n'ont pas pu être lus. Le scan est retombé sur l'API Proxmox et ne couvre qu'une partie des paquets installés.",
+      "release-not-tracked": "Le tracker de sécurité Debian ne publie plus de données pour {release}, {node} ne peut donc pas être analysé.",
+      "node-offline": "{node} est hors ligne et n’a pas été analysé.",
+      "inventory-empty": "Aucune liste de paquets n'a pu être lue sur {node}."
+    }
   },
   "emptyState": {
     "noEvents": "Aucun événement",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -7064,7 +7064,20 @@
       "description": "설명"
     },
     "lastScan": "마지막 스캔: {date}",
-    "filterBySeverity": "심각도로 필터"
+    "filterBySeverity": "심각도로 필터",
+    "scanFailed": "스캔 실패",
+    "partialScan": "부분 스캔",
+    "coverage": "패키지 {scanned}개 스캔, 그중 {tracked}개가 Debian 보안 트래커에 등록됨",
+    "noFix": "아직 수정본 없음",
+    "noFixFilter": "수정본 없음 ({count})",
+    "status": {
+      "ssh-not-configured": "이 연결에 SSH가 구성되어 있지 않아 Proxmox API가 보고하는 패키지만 스캔했습니다. Debian 기본 시스템의 대부분이 제외됩니다.",
+      "ssh-failed": "{node}에서 SSH 패키지 인벤토리에 실패했습니다. 스캔은 Proxmox API로 대체되어 설치된 패키지의 일부만 포함합니다.",
+      "credentials-failed": "이 연결의 SSH 자격 증명을 읽을 수 없습니다. 스캔은 Proxmox API로 대체되어 설치된 패키지의 일부만 포함합니다.",
+      "release-not-tracked": "Debian 보안 트래커가 더 이상 {release}에 대한 데이터를 게시하지 않으므로 {node}는 스캔할 수 없습니다.",
+      "node-offline": "{node}가 오프라인이어서 스캔하지 않았습니다.",
+      "inventory-empty": "{node}에서 패키지 목록을 읽을 수 없습니다."
+    }
   },
   "emptyState": {
     "noEvents": "이벤트 없음",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -7070,7 +7070,20 @@
       "description": "描述"
     },
     "lastScan": "上次扫描：{date}",
-    "filterBySeverity": "按严重程度筛选"
+    "filterBySeverity": "按严重程度筛选",
+    "scanFailed": "扫描失败",
+    "partialScan": "部分扫描",
+    "coverage": "已扫描 {scanned} 个软件包，其中 {tracked} 个在 Debian 安全跟踪器中",
+    "noFix": "尚无修复",
+    "noFixFilter": "无修复（{count}）",
+    "status": {
+      "ssh-not-configured": "此连接未配置 SSH，因此仅扫描了 Proxmox API 报告的软件包，Debian 基础系统的大部分内容未被覆盖。",
+      "ssh-failed": "{node} 上通过 SSH 获取软件包清单失败。扫描回退到 Proxmox API，仅覆盖部分已安装的软件包。",
+      "credentials-failed": "无法读取此连接的 SSH 凭据。扫描回退到 Proxmox API，仅覆盖部分已安装的软件包。",
+      "release-not-tracked": "Debian 安全跟踪器不再发布 {release} 的数据，因此无法扫描 {node}。",
+      "node-offline": "{node} 处于离线状态，未进行扫描。",
+      "inventory-empty": "无法从 {node} 读取软件包列表。"
+    }
   },
   "emptyState": {
     "noEvents": "暂无事件",


### PR DESCRIPTION
Closes #905.

The CVE tab always answered "No vulnerabilities detected". Two independent causes, one in this repo and one in the orchestrator.

**The scan looked at almost nothing.** The package inventory came from the Proxmox apt endpoints: `/apt/versions`, which lists the ~60 packages `pveversion -v` covers, nearly all of them Proxmox's own and absent from the Debian security tracker, and `/apt/update`, which only returns packages that have a *pending* update. On a lab node that is 62 packages out of the 929 installed, of which 12 are known to the tracker. A cluster that keeps its hosts patched has nothing pending, so the scan had nothing left to match and reported zero by construction, exactly what the reporter describes. The orchestrator now reads the real list with dpkg over SSH, which also yields the source package and the source version a tracker `fixed_version` is expressed in. Same node after the change: 929 packages scanned, 297 tracked, 2 fixable CVEs and 1020 with no published fix.

**The tab hid every failure.** `if (res.ok)` with no `else` meant a scan that could not reach the tracker, or one refused by the licence gate, rendered exactly like a healthy cluster: the green check and "No vulnerabilities detected". That is now an error state carrying its cause.

What the screen gains:

- the header says how many packages were scanned and how many the tracker knows, so a clean cluster is distinguishable from a blind one;
- the empty state says whether the node was read in full or only through the Proxmox API, and why it was degraded;
- CVEs with no published fix get their own counted chip and stay out of the default view, keeping the actionable findings first;
- the table is paginated and the versions lose their monospace.

Degraded-scan reasons travel as codes, so the wording lives in the six locales rather than in the route. The second commit keeps the tab correct against an orchestrator that predates the fix: a missing `fixAvailable` falls back to whether a fixed version was published, and the coverage line only appears when per-node data was actually reported.

Tests: `CveTab.test.tsx` covers the failed scan, the partial scan, the clean scan and the fix filter; `cveMessages.test.ts` checks the six locales declare every status code and keep their placeholders. Verified end to end against a 3-node PVE 9.2 lab cluster.

Needs the matching orchestrator change to be released alongside.
