### PR TITLE
Export the data behind a report as a single CSV (#906)

### DIFF
--- a/frontend/src/app/(dashboard)/operations/reports/components/ReportHistory.tsx
+++ b/frontend/src/app/(dashboard)/operations/reports/components/ReportHistory.tsx
@@ -22,6 +22,10 @@ interface Report {
   status: 'pending' | 'generating' | 'completed' | 'failed'
   file_path?: string
   file_size?: number
+
+  // Length of the report's CSV export. Reports generated before it existed
+  // have none, so the action only shows up when it is set.
+  csv_size?: number
   date_from: string
   date_to: string
   connection_ids?: string[]
@@ -53,8 +57,10 @@ function formatDate(dateStr: string): string {
 export default function ReportHistory({ reports, reportTypes, onDelete, onRefresh, loading }: ReportHistoryProps) {
   const t = useTranslations()
 
-  const handleDownload = (reportId: string) => {
-    window.open(`/api/v1/orchestrator/reports/${reportId}/download`, '_blank')
+  const handleDownload = (reportId: string, format: 'pdf' | 'csv' = 'pdf') => {
+    const query = format === 'csv' ? '?format=csv' : ''
+
+    window.open(`/api/v1/orchestrator/reports/${reportId}/download${query}`, '_blank')
   }
 
   const getStatusChip = (status: string) => {
@@ -123,14 +129,21 @@ export default function ReportHistory({ reports, reportTypes, onDelete, onRefres
     {
       field: 'actions',
       headerName: t('common.actions'),
-      width: 120,
+      width: 140,
       sortable: false,
       renderCell: (params) => (
         <Box sx={{ display: 'flex', gap: 0.5 }}>
           {params.row.status === 'completed' && (
-            <Tooltip title={t('reports.download')}>
+            <Tooltip title={t('reports.downloadPdf')}>
               <IconButton size="small" color="primary" onClick={() => handleDownload(params.row.id)}>
-                <i className="ri-download-2-line" />
+                <i className="ri-file-pdf-line" />
+              </IconButton>
+            </Tooltip>
+          )}
+          {params.row.status === 'completed' && !!params.row.csv_size && (
+            <Tooltip title={t('reports.downloadCsv')}>
+              <IconButton size="small" color="primary" onClick={() => handleDownload(params.row.id, 'csv')}>
+                <i className="ri-file-excel-2-line" />
               </IconButton>
             </Tooltip>
           )}

--- a/frontend/src/app/(dashboard)/operations/reports/page.tsx
+++ b/frontend/src/app/(dashboard)/operations/reports/page.tsx
@@ -42,6 +42,7 @@ interface Report {
   status: 'pending' | 'generating' | 'completed' | 'failed'
   file_path?: string
   file_size?: number
+  csv_size?: number
   date_from: string
   date_to: string
   connection_ids?: string[]

--- a/frontend/src/app/api/v1/orchestrator/reports/[id]/download/route.test.ts
+++ b/frontend/src/app/api/v1/orchestrator/reports/[id]/download/route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  checkPermission: vi.fn(async () => null as any),
+  getCurrentTenantId: vi.fn(async () => 'default'),
+  fetchMock: vi.fn(),
+}))
+
+vi.mock('@/lib/rbac', () => ({ checkPermission: h.checkPermission, PERMISSIONS: { REPORTS_VIEW: 'reports.view' } }))
+vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId, DEFAULT_TENANT_ID: 'default' }))
+vi.mock('@/lib/orchestrator', () => ({ orchestratorFetch: vi.fn() }))
+
+import { callRoute } from '@/__tests__/setup/route-test'
+import { GET } from './route'
+
+function orchestratorResponse(contentType: string, filename: string) {
+  return new Response(Buffer.from('payload'), {
+    status: 200,
+    headers: {
+      'Content-Type': contentType,
+      'Content-Disposition': `attachment; filename="${filename}"`,
+    },
+  })
+}
+
+beforeEach(() => {
+  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.getCurrentTenantId.mockReset().mockResolvedValue('default')
+  h.fetchMock.mockReset().mockResolvedValue(orchestratorResponse('application/pdf', 'infrastructure_3f1c8a52.pdf'))
+  vi.stubGlobal('fetch', h.fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function calledUrl(): string {
+  return h.fetchMock.mock.calls[0][0] as string
+}
+
+describe('GET /orchestrator/reports/[id]/download', () => {
+  it('asks the orchestrator for the PDF when no format is given', async () => {
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' } })
+
+    expect(res.status).toBe(200)
+    expect(calledUrl()).toMatch(/\/api\/v1\/reports\/rep-1\/download$/)
+    expect(res.headers.get('Content-Type')).toBe('application/pdf')
+  })
+
+  it('forwards format=csv and serves the single CSV the orchestrator returns', async () => {
+    h.fetchMock.mockResolvedValue(orchestratorResponse('text/csv; charset=utf-8', 'infrastructure_3f1c8a52.csv'))
+
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'csv' } })
+
+    expect(res.status).toBe(200)
+    expect(calledUrl()).toContain('/api/v1/reports/rep-1/download?format=csv')
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8')
+    expect(res.headers.get('Content-Disposition')).toContain('.csv')
+  })
+
+  it('rejects an unknown format without calling the orchestrator', async () => {
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'xlsx' } })
+
+    expect(res.status).toBe(400)
+    expect(h.fetchMock).not.toHaveBeenCalled()
+  })
+
+  // A report is one CSV, so there is nothing to select: a leftover ?table=
+  // from a bookmark must not travel to the orchestrator.
+  it('never forwards a table parameter', async () => {
+    await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'csv', table: 'vms' } })
+
+    expect(calledUrl()).toContain('format=csv')
+    expect(calledUrl()).not.toContain('table=')
+  })
+
+  it('falls back to a CSV content type when the orchestrator sends none', async () => {
+    h.fetchMock.mockResolvedValue(new Response(Buffer.from('a,b\n1,2\n'), { status: 200 }))
+
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'csv' } })
+
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8')
+    expect(res.headers.get('Content-Disposition')).toContain('report-rep-1.csv')
+  })
+
+  it('forwards an orchestrator error with its status', async () => {
+    h.fetchMock.mockResolvedValue(new Response('this report has no CSV export', { status: 404 }))
+
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'csv' } })
+
+    expect(res.status).toBe(404)
+    expect((await res.json()).error).toContain('no CSV export')
+  })
+
+  it('returns the permission denial without touching the orchestrator', async () => {
+    h.checkPermission.mockResolvedValue(new Response('no', { status: 403 }) as any)
+
+    const res = await callRoute(GET as any, { params: { id: 'rep-1' }, searchParams: { format: 'csv' } })
+
+    expect(res.status).toBe(403)
+    expect(h.fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/app/api/v1/orchestrator/reports/[id]/download/route.ts
+++ b/frontend/src/app/api/v1/orchestrator/reports/[id]/download/route.ts
@@ -10,7 +10,20 @@ const ORCHESTRATOR_API_KEY = process.env.ORCHESTRATOR_API_KEY || ''
 
 export const runtime = 'nodejs'
 
+// Formats the orchestrator can serve for a stored report. Both are built at
+// generation time from the same data, so neither re-runs any collection.
+const FORMATS = ['pdf', 'csv'] as const
+
+type Format = (typeof FORMATS)[number]
+
+// Content type to announce when the orchestrator does not send one.
+function fallbackContentType(format: Format): string {
+  return format === 'csv' ? 'text/csv; charset=utf-8' : 'application/pdf'
+}
+
 // GET /api/v1/orchestrator/reports/[id]/download — tenant-scoped
+//
+// ?format=csv downloads the report's data as one CSV instead of the PDF.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -20,11 +33,24 @@ export async function GET(
     if (denied) return denied
 
     const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const format = (searchParams.get('format') || 'pdf').toLowerCase()
+
+    if (!FORMATS.includes(format as Format)) {
+      return NextResponse.json({ error: `Unsupported format: ${format}` }, { status: 400 })
+    }
 
     // Tenant ownership is enforced by the orchestrator: orchestratorFetch
     // does not stream binary, so we hit the download URL directly here and
     // forward the X-Tenant-ID header explicitly.
-    const url = `${ORCHESTRATOR_URL}/api/v1/reports/${id}/download`
+    const query = new URLSearchParams()
+
+    if (format === 'csv') {
+      query.set('format', 'csv')
+    }
+
+    const suffix = query.toString()
+    const url = `${ORCHESTRATOR_URL}/api/v1/reports/${id}/download${suffix ? `?${suffix}` : ''}`
 
     const headers: Record<string, string> = {}
     if (ORCHESTRATOR_API_KEY) {
@@ -49,8 +75,10 @@ export async function GET(
     }
 
     // Get headers from orchestrator response
-    const contentType = response.headers.get('Content-Type') || 'application/pdf'
-    const contentDisposition = response.headers.get('Content-Disposition') || `attachment; filename="report-${id}.pdf"`
+    const fallbackType = fallbackContentType(format as Format)
+    const fallbackExt = format === 'csv' ? 'csv' : 'pdf'
+    const contentType = response.headers.get('Content-Type') || fallbackType
+    const contentDisposition = response.headers.get('Content-Disposition') || `attachment; filename="report-${id}.${fallbackExt}"`
     const contentLength = response.headers.get('Content-Length')
 
     // Stream the response

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -6809,6 +6809,8 @@
     "allSections": "Alle Abschnitte",
     "generating": "Wird generiert...",
     "download": "Herunterladen",
+    "downloadPdf": "PDF herunterladen",
+    "downloadCsv": "CSV herunterladen",
     "scheduleReport": "Zeitplan report",
     "frequency": "Häufigkeit",
     "recipients": "Empfänger",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -6862,6 +6862,8 @@
     "allSections": "All sections",
     "generating": "Generating...",
     "download": "Download",
+    "downloadPdf": "Download PDF",
+    "downloadCsv": "Download CSV",
     "scheduleReport": "Schedule report",
     "frequency": "Frequency",
     "recipients": "Recipients",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -6862,6 +6862,8 @@
     "allSections": "Todas las secciones",
     "generating": "Generando...",
     "download": "Descargar",
+    "downloadPdf": "Descargar PDF",
+    "downloadCsv": "Descargar CSV",
     "scheduleReport": "Programar informe",
     "frequency": "Frecuencia",
     "recipients": "Destinatarios",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -6863,6 +6863,8 @@
     "allSections": "Toutes les sections",
     "generating": "Génération en cours...",
     "download": "Télécharger",
+    "downloadPdf": "Télécharger le PDF",
+    "downloadCsv": "Télécharger le CSV",
     "scheduleReport": "Planifier un rapport",
     "frequency": "Fréquence",
     "recipients": "Destinataires",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -6862,6 +6862,8 @@
     "allSections": "모든 섹션",
     "generating": "생성 중...",
     "download": "다운로드",
+    "downloadPdf": "PDF 다운로드",
+    "downloadCsv": "CSV 다운로드",
     "scheduleReport": "보고서 예약",
     "frequency": "주기",
     "recipients": "수신자",

--- a/frontend/src/messages/reportsCsvExportMessages.test.ts
+++ b/frontend/src/messages/reportsCsvExportMessages.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales = { en, fr, de, es, ko, 'zh-CN': zhCN }
+const requiredKeys = ['downloadPdf', 'downloadCsv'] as const
+
+describe('report download i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} names both download formats`, () => {
+      const block = messages.reports as Record<string, unknown>
+
+      for (const key of requiredKeys) {
+        expect(block, `${locale}: missing ${key}`).toHaveProperty(key)
+        expect(block[key], `${locale}: ${key}`).toBeTypeOf('string')
+        expect((block[key] as string).trim().length, `${locale}: ${key} is empty`).toBeGreaterThan(0)
+      }
+    })
+  }
+})

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -6866,6 +6866,8 @@
     "allSections": "所有章节",
     "generating": "正在生成...",
     "download": "下载",
+    "downloadPdf": "下载 PDF",
+    "downloadCsv": "下载 CSV",
     "scheduleReport": "计划报告",
     "frequency": "频率",
     "recipients": "收件人",


### PR DESCRIPTION
Closes #906.

The reports page has only ever produced PDFs, and the request is for the same data as CSV, to load into database tools. A PDF cannot serve that: it formats every value for reading, and its tables stop at 50 CVEs and 30 alerts.

The report history now carries a CSV action next to the PDF one, and it downloads **one plain .csv file per report**. It only appears when the record actually holds an export, so the reports already in the database stay PDF-only rather than offering a broken download.

The file holds one row per object the report is about, with an `object_type` column naming what the row is (`cluster`, `node`, `vm`, `storage`, `vulnerability`, `failed_check`, ...) and the columns of a report type in union, blank where they do not apply. So `WHERE object_type = 'vm'` gives back the guest table on its own. Six columns identify the report in front of every row, which is what makes appending twelve monthly reports into one table worth doing.

Column names are stable snake_case English identifiers whatever language the report is generated in: a column that renames itself between a French and an English report breaks every recurring import built on it. Values are raw, and the PDF's display caps do not apply, which is the reason the request exists.

One decision a reviewer may want to push back on: the aggregates the PDF computes are not exported, since each is a `GROUP BY` away from the rows that are. A report whose content was only aggregates therefore has no CSV at all and hides the action, rather than serving a file with nothing in it.

The data itself is produced by the matching orchestrator change, which is in review in its own pull request; without it the action simply never shows up.

13 tests, over the download route and the six locales.
