### PR TITLE
Brand a tenant from the White Label tab again, and only as a super admin

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.jsx
+++ b/frontend/src/app/(dashboard)/settings/page.jsx
@@ -3088,7 +3088,7 @@ export default function SettingsPage() {
     { label: t('settings.license'), icon: 'ri-key-2-line', component: LicenseTab, providerOnly: true },
     { label: t('settings.ai'), icon: 'ri-robot-line', component: AITab, requiredFeature: Features.AI_INSIGHTS, providerOnly: true },
     { label: 'RSE / Green IT', icon: 'ri-leaf-line', component: GreenTab, requiredFeature: Features.GREEN_METRICS, providerOnly: true },
-    { label: 'White Label', icon: 'ri-pantone-line', component: WhiteLabelTab, requiredFeature: Features.WHITE_LABEL, providerOnly: true },
+    { label: 'White Label', icon: 'ri-pantone-line', component: WhiteLabelTab, requiredFeature: Features.WHITE_LABEL, superAdminOnly: true },
     { label: t('vdc.title'), icon: 'ri-cloud-line', component: VdcTab, requiredFeature: Features.MULTI_TENANCY, providerOnly: true },
     { label: 'Tenants', icon: 'ri-building-line', component: TenantsTab, requiredFeature: Features.MULTI_TENANCY, providerOnly: true },
     { label: t('settings.sshCommands.tabLabel'), icon: 'ri-terminal-line', component: SshCommandsTab, providerOnly: true },
@@ -3096,14 +3096,24 @@ export default function SettingsPage() {
     { label: t('settings.apiTokens.tabLabel'), icon: 'ri-key-2-line', component: ApiTokensTab, providerOnly: true },
   ]
 
-  // Hide provider-only tabs (Tenants, vDC) unless super admin AND currently
-  // in provider tenant. License-gated tabs are also filtered out entirely
-  // when the feature is missing — same UX as the inventory detail tabs:
-  // the user only sees what they can actually use, no greyed-out chips.
-  // While the license is still loading we keep gated tabs visible to avoid
-  // a visible→hidden flicker once the response lands.
+  // Two different gates, deliberately:
+  //   providerOnly   — the tab configures the provider itself (connections,
+  //                    license, tenants, vDC…), so it needs a super admin
+  //                    standing in the provider tenant.
+  //   superAdminOnly — the tab configures the CURRENT tenant, whichever it
+  //                    is, and only a super admin may do it. White Label is
+  //                    the case: the branding row is keyed by tenant, so a
+  //                    super admin brands a tenant by switching onto it.
+  //                    Marking it providerOnly (a55c3856) left no UI path to
+  //                    brand a tenant at all.
+  // License-gated tabs are also filtered out entirely when the feature is
+  // missing — same UX as the inventory detail tabs: the user only sees what
+  // they can actually use, no greyed-out chips. While the license is still
+  // loading we keep gated tabs visible to avoid a visible→hidden flicker
+  // once the response lands.
   const visibleIndices = allTabs.reduce((acc, tab, idx) => {
     if (tab.providerOnly && !(isSuperAdmin && isProviderTenant)) return acc
+    if (tab.superAdminOnly && !isSuperAdmin) return acc
     if (!licenseLoading && tab.requiredFeature && !hasFeature(tab.requiredFeature)) return acc
     acc.push(idx)
     return acc

--- a/frontend/src/app/api/v1/settings/branding/logo/route.test.ts
+++ b/frontend/src/app/api/v1/settings/branding/logo/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  checkPermission: vi.fn(async () => null as any),
+  requireBrandingAdmin: vi.fn(async () => null as any),
   getCurrentTenantId: vi.fn(async () => 'default'),
   putAsset: vi.fn(async () => {}),
   deleteAsset: vi.fn(async () => {}),
 }))
 
-vi.mock('@/lib/rbac', () => ({ checkPermission: h.checkPermission, PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' } }))
+vi.mock('@/lib/branding/guard', () => ({ requireBrandingAdmin: h.requireBrandingAdmin }))
 vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId }))
 vi.mock('@/lib/branding/assetStore', () => ({ putAsset: h.putAsset, deleteAsset: h.deleteAsset }))
 
@@ -15,7 +15,7 @@ import { POST, DELETE } from './route'
 import { callRoute, readJson } from '@/__tests__/setup/route-test'
 
 beforeEach(() => {
-  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.requireBrandingAdmin.mockReset().mockResolvedValue(null)
   h.getCurrentTenantId.mockReset().mockResolvedValue('default')
   h.putAsset.mockReset().mockResolvedValue(undefined)
   h.deleteAsset.mockReset().mockResolvedValue(undefined)
@@ -30,7 +30,7 @@ function formWith(file: File, type: string) {
 
 describe('POST /settings/branding/logo', () => {
   it('403 when denied', async () => {
-    h.checkPermission.mockResolvedValue(new Response('no', { status: 403 }) as any)
+    h.requireBrandingAdmin.mockResolvedValue(new Response('no', { status: 403 }) as any)
     const res = await callRoute(POST, { body: formWith(new File(['x'], 'logo.png', { type: 'image/png' }), 'logo') })
     expect(res.status).toBe(403)
   })

--- a/frontend/src/app/api/v1/settings/branding/logo/route.ts
+++ b/frontend/src/app/api/v1/settings/branding/logo/route.ts
@@ -1,6 +1,6 @@
 export const dynamic = "force-dynamic"
 import { NextResponse } from 'next/server'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { requireBrandingAdmin } from '@/lib/branding/guard'
 import { getCurrentTenantId } from '@/lib/tenant'
 import { putAsset, deleteAsset } from '@/lib/branding/assetStore'
 
@@ -11,7 +11,7 @@ const SLOTS = ['logo', 'favicon', 'loginLogo']
 
 export async function POST(req: Request) {
   try {
-    const denied = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+    const denied = await requireBrandingAdmin()
     if (denied) return denied
 
     const tenantId = await getCurrentTenantId()
@@ -38,7 +38,7 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   try {
-    const denied = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+    const denied = await requireBrandingAdmin()
     if (denied) return denied
 
     const tenantId = await getCurrentTenantId()

--- a/frontend/src/app/api/v1/settings/branding/route.test.ts
+++ b/frontend/src/app/api/v1/settings/branding/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  checkPermission: vi.fn(async () => null as any),
+  requireBrandingAdmin: vi.fn(async () => null as any),
   getCurrentTenantId: vi.fn(async () => 'default'),
   getSetting: vi.fn(async () => null as any),
   setSetting: vi.fn(async (_key: string, _tenantId: string, _value: unknown) => {}),
 }))
 
-vi.mock('@/lib/rbac', () => ({ checkPermission: h.checkPermission, PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' } }))
+vi.mock('@/lib/branding/guard', () => ({ requireBrandingAdmin: h.requireBrandingAdmin }))
 vi.mock('@/lib/tenant', () => ({ getCurrentTenantId: h.getCurrentTenantId }))
 vi.mock('@/lib/db/settings', () => ({ getSetting: h.getSetting, setSetting: h.setSetting }))
 
@@ -15,7 +15,7 @@ import { GET, PUT } from './route'
 import { callRoute, readJson } from '@/__tests__/setup/route-test'
 
 beforeEach(() => {
-  h.checkPermission.mockReset().mockResolvedValue(null)
+  h.requireBrandingAdmin.mockReset().mockResolvedValue(null)
   h.getCurrentTenantId.mockReset().mockResolvedValue('default')
   h.getSetting.mockReset().mockResolvedValue(null)
   h.setSetting.mockReset().mockResolvedValue(undefined)
@@ -68,8 +68,8 @@ describe('PUT /settings/branding primary colour (#754)', () => {
     expect(h.setSetting).not.toHaveBeenCalled()
   })
 
-  it('denies without the admin settings permission', async () => {
-    h.checkPermission.mockResolvedValue(new Response('no', { status: 403 }) as any)
+  it('denies whoever the branding guard refuses', async () => {
+    h.requireBrandingAdmin.mockResolvedValue(new Response('no', { status: 403 }) as any)
 
     const res = await callRoute(PUT, { method: 'PUT', body: { primaryColor: '#00ECB2' } })
 

--- a/frontend/src/app/api/v1/settings/branding/route.ts
+++ b/frontend/src/app/api/v1/settings/branding/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic"
 import { NextResponse } from 'next/server'
 import { getSetting, setSetting } from '@/lib/db/settings'
-import { checkPermission, PERMISSIONS } from '@/lib/rbac'
+import { requireBrandingAdmin } from '@/lib/branding/guard'
 import { getCurrentTenantId } from '@/lib/tenant'
 import { normalizeHexColor } from '@/lib/theme/hexColor'
 
@@ -26,7 +26,7 @@ const DEFAULT_BRANDING = {
 
 export async function GET() {
   try {
-    const denied = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+    const denied = await requireBrandingAdmin()
     if (denied) return denied
 
     const tenantId = await getCurrentTenantId()
@@ -53,7 +53,7 @@ export async function GET() {
 
 export async function PUT(req: Request) {
   try {
-    const denied = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+    const denied = await requireBrandingAdmin()
     if (denied) return denied
 
     const body = await req.json()

--- a/frontend/src/components/settings/WhiteLabelTab.jsx
+++ b/frontend/src/components/settings/WhiteLabelTab.jsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material'
 import { useTranslations } from 'next-intl'
 import { useBranding } from '@/contexts/BrandingContext'
+import { useTenant } from '@/contexts/TenantContext'
 import ColorPicker from '@/components/common/ColorPicker'
 import { isHexColor, normalizeHexColor } from '@/lib/theme/hexColor'
 
@@ -17,6 +18,11 @@ export default function WhiteLabelTab() {
   const t = useTranslations()
   const theme = useTheme()
   const { branding, refresh } = useBranding()
+
+  // The branding row is keyed by the tenant the session is on, so the same
+  // form edits a different tenant depending on the tenant switcher. Name the
+  // target rather than let a super admin rebrand the provider by accident.
+  const { currentTenant } = useTenant()
 
   const [config, setConfig] = useState({
     enabled: false,
@@ -186,7 +192,9 @@ export default function WhiteLabelTab() {
         White Label / Branding
       </Typography>
       <Typography variant="body2" sx={{ mb: 3, opacity: 0.6 }}>
-        Customize the application branding for your organization. Replace the logo, name, colors and footer to match your brand.
+        {currentTenant
+          ? `Customize the branding of the ${currentTenant.name} tenant. Replace the logo, name, colors and footer to match its brand.`
+          : 'Customize the application branding for your organization. Replace the logo, name, colors and footer to match your brand.'}
       </Typography>
 
       {error && <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError('')}>{error}</Alert>}

--- a/frontend/src/lib/branding/guard.test.ts
+++ b/frontend/src/lib/branding/guard.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { sessionMock, checkPermissionMock, superAdminMock } = vi.hoisted(() => ({
+  sessionMock: vi.fn(),
+  checkPermissionMock: vi.fn(),
+  superAdminMock: vi.fn(),
+}))
+
+vi.mock('next-auth', () => ({ getServerSession: () => sessionMock() }))
+vi.mock('@/lib/auth/config', () => ({ authOptions: {} }))
+vi.mock('@/lib/rbac', () => ({
+  PERMISSIONS: { ADMIN_SETTINGS: 'admin.settings' },
+  checkPermission: (...a: any[]) => checkPermissionMock(...a),
+  isUserSuperAdmin: (...a: any[]) => superAdminMock(...a),
+}))
+
+beforeEach(() => {
+  sessionMock.mockReset().mockResolvedValue({ user: { id: 'u1', tenantId: 'default' } })
+  checkPermissionMock.mockReset().mockResolvedValue(null)
+  superAdminMock.mockReset().mockResolvedValue(true)
+})
+
+describe('requireBrandingAdmin', () => {
+  it('allows a super admin on the provider tenant', async () => {
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect(await requireBrandingAdmin()).toBeNull()
+  })
+
+  it('allows a super admin standing in another tenant, which is how a tenant gets branded', async () => {
+    sessionMock.mockResolvedValue({ user: { id: 'u1', tenantId: 'tenant-b' } })
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect(await requireBrandingAdmin()).toBeNull()
+  })
+
+  it('refuses a tenant admin, whose role carries admin.settings but who may not rebrand', async () => {
+    sessionMock.mockResolvedValue({ user: { id: 'u2', tenantId: 'tenant-b' } })
+    superAdminMock.mockResolvedValue(false)
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect((await requireBrandingAdmin())?.status).toBe(403)
+  })
+
+  it('propagates the permission refusal untouched', async () => {
+    const denial = new Response(null, { status: 403 })
+    checkPermissionMock.mockResolvedValue(denial)
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect(await requireBrandingAdmin()).toBe(denial)
+  })
+
+  it('refuses an unauthenticated caller without any RBAC work', async () => {
+    sessionMock.mockResolvedValue(null)
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect((await requireBrandingAdmin())?.status).toBe(401)
+    expect(checkPermissionMock).not.toHaveBeenCalled()
+    expect(superAdminMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses an API token, which resolves no session user', async () => {
+    sessionMock.mockResolvedValue({ user: { tenantId: 'tenant-b' } })
+    const { requireBrandingAdmin } = await import('./guard')
+
+    expect((await requireBrandingAdmin())?.status).toBe(401)
+  })
+})

--- a/frontend/src/lib/branding/guard.ts
+++ b/frontend/src/lib/branding/guard.ts
@@ -1,0 +1,48 @@
+// src/lib/branding/guard.ts
+//
+// Access guard for the tenant branding routes (White Label).
+//
+// Branding is stored per tenant — setSetting('branding', getCurrentTenantId())
+// — and a super admin brands a tenant by switching onto it, so this guard
+// deliberately does NOT pin the caller to the provider tenant the way
+// requireBroadcastAdmin does: whichever tenant the session carries is the
+// legitimate target, and getCurrentTenantId() already refuses a tenant the
+// caller is not a member of.
+//
+// What it does pin is WHO. role_tenant_admin carries admin.settings (see the
+// rolePermMap in lib/db/sqlite.ts), so checkPermission(ADMIN_SETTINGS) on its
+// own would let a tenant admin rewrite their own tenant's white label. Only a
+// super admin may, which is the rule the vDC and Tenants tabs already follow.
+//
+// Order is cheapest-first, as in lib/broadcast/guard.ts: session presence,
+// then checkPermission(), then the explicit super-admin read.
+
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+
+import { authOptions } from '@/lib/auth/config'
+import { PERMISSIONS, checkPermission, isUserSuperAdmin } from '@/lib/rbac'
+
+/**
+ * Returns a 401/403 Response when the caller may not read or write branding,
+ * or null when it may. An API token never passes: it carries no session user,
+ * and no token scope expands to admin.settings.
+ */
+export async function requireBrandingAdmin(): Promise<Response | null> {
+  const session = await getServerSession(authOptions)
+  const userId = (session as any)?.user?.id as string | undefined
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const denied = await checkPermission(PERMISSIONS.ADMIN_SETTINGS)
+
+  if (denied) return denied
+
+  if (!(await isUserSuperAdmin(userId))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return null
+}


### PR DESCRIPTION
## The problem

White Label has been unreachable for a tenant since the MSP tenant boundary pass. That change marked the tab `providerOnly`, alongside the tabs that genuinely configure the provider, and its own comment only justifies Tenants and vDC. The result is that no UI path brands a tenant: from the provider tenant the form always writes the provider's row, and from inside a tenant the tab is gone and Appearance is the only tab left.

Nothing on the server ever lost the ability. The branding row has been keyed by `getCurrentTenantId()` since multi-tenancy landed, and none of the ten routes hardened in that pass were branding routes.

## What changes

`superAdminOnly` joins `providerOnly` as a distinct gate. `providerOnly` still means "super admin standing in the provider tenant" for the tabs that configure the provider itself. `superAdminOnly` means "super admin, whichever tenant they are on", which is how vDC was gated before, and it is what White Label needs: the branding row follows the tenant switcher, so a super admin brands a tenant by switching onto it.

The write side needed the other half. The branding routes only asked for `admin.settings`, a permission `role_tenant_admin` carries, so making the tab visible again would have let a tenant admin rebrand their own tenant. `requireBrandingAdmin` adds the super-admin check. Unlike `requireProviderTenant` it deliberately does not pin the caller to the provider tenant, since the current tenant is the legitimate target here.

The tab now names what it is about to write, because the same form edits a different row depending on the tenant switcher and rebranding the provider by accident is visible to everyone.

## Verification

Driven against a running instance with two disposable accounts, both directions:

| Caller on a non-provider tenant | Settings tabs | GET | PUT | POST logo |
| --- | --- | --- | --- | --- |
| Super admin | Appearance, White Label | 200 | 200 | 200 |
| Tenant admin (holds `admin.settings`) | Appearance | 403 | 403 | 403 |

The row written landed on the tenant's id, not on `default`, and the provider row stayed absent. 215 unit tests pass across the branding, settings and broadcast suites, including six new cases on the guard.

One transient worth knowing: `isSuperAdmin` arrives from `/api/v1/rbac/effective` and starts false, so the first paint of Settings shows Appearance alone before the gated tabs appear.
