### PR TITLE
Make the operator's cutover, hard power off and root pick reach the running migration

### DIFF
--- a/frontend/prisma/migrations/20260910130000_migration_operator_signals/migration.sql
+++ b/frontend/prisma/migrations/20260910130000_migration_operator_signals/migration.sql
@@ -1,0 +1,4 @@
+-- Durable operator decisions for a running migration (cutover, hard power off, root choice).
+ALTER TABLE "migration_jobs" ADD COLUMN "cutover_requested_at" TIMESTAMP(3);
+ALTER TABLE "migration_jobs" ADD COLUMN "force_poweroff_requested_at" TIMESTAMP(3);
+ALTER TABLE "migration_jobs" ADD COLUMN "root_choice" TEXT;

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -265,6 +265,19 @@ model MigrationJob {
   // Live estimate of the cutover downtime (seconds) at the last delta pass;
   // surfaced in the UI so the operator can decide when to trigger cutover.
   projectedDowntimeSec Int? @map("projected_downtime_sec")
+
+  // Operator decisions that reach a running pipeline from a route handler.
+  // They live on the row, not in a module-level Set, because the handler and
+  // the after() continuation running the pipeline are not guaranteed to share
+  // a module instance (a dev recompile gives the route a fresh one) nor a
+  // process (a second frontend replica). Each pipeline mirrors these back into
+  // its own registry while the job runs, see lib/migration/operator-signals.
+  // Cancellation needs no column of its own: the cancel route already writes
+  // `status = "cancelled"`, which is the durable signal.
+  cutoverRequestedAt       DateTime? @map("cutover_requested_at")
+  forcePowerOffRequestedAt DateTime? @map("force_poweroff_requested_at")
+  rootChoice               String?   @map("root_choice")
+
   error            String?
 
   // Logs

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConfirmActionButton.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/ConfirmActionButton.tsx
@@ -24,6 +24,10 @@ import { alpha, useTheme } from '@mui/material/styles'
  * what is about to happen, an optional warning, and a busy state while the
  * request is in flight. Written once so the second one cannot drift from the
  * first, and so a third does not arrive as a third copy.
+ *
+ * A failed action keeps the dialog open and states why. The dialog used to
+ * close whatever happened, which turned a rejected request into a button that
+ * did nothing at all: no message, no change on screen, nothing to report.
  */
 export default function ConfirmActionButton({
   label,
@@ -46,20 +50,25 @@ export default function ConfirmActionButton({
   body: ReactNode
   /** Shown as a warning inside the dialog when the action deserves a caveat. */
   alert?: ReactNode
+  /** Rejected by throwing: the message is shown in the dialog, which stays open. */
   onConfirm: () => Promise<void>
 }) {
   const t = useTranslations()
   const theme = useTheme()
   const [open, setOpen] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const confirm = async () => {
     setBusy(true)
+    setError(null)
     try {
       await onConfirm()
+      setOpen(false)
+    } catch (e: any) {
+      setError(e?.message || String(e))
     } finally {
       setBusy(false)
-      setOpen(false)
     }
   }
 
@@ -71,7 +80,7 @@ export default function ConfirmActionButton({
         color={color}
         disabled={busy}
         startIcon={<i className={icon} style={{ fontSize: 14 }} />}
-        onClick={() => setOpen(true)}
+        onClick={() => { setError(null); setOpen(true) }}
         sx={{ textTransform: 'none' }}
       >
         {label}
@@ -91,6 +100,7 @@ export default function ConfirmActionButton({
         <DialogContent>
           <DialogContentText>{body}</DialogContentText>
           {alert && <Alert severity="warning" sx={{ mt: 2 }}>{alert}</Alert>}
+          {error && <Alert severity="error" sx={{ mt: 2 }}>{t('common.errorWithMessage', { error })}</Alert>}
         </DialogContent>
         <DialogActions sx={{ px: 3, pb: 2 }}>
           <Button onClick={() => setOpen(false)} color="inherit">

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/ForcePowerOffButton.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/ForcePowerOffButton.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl'
 
 import ConfirmActionButton from './ConfirmActionButton'
+import { postJobAction } from './jobAction'
 
 /**
  * The way out of a refused guest shutdown.
@@ -49,7 +50,7 @@ export default function ForcePowerOffButton({
       body={t('inventoryPage.esxiMigration.forcePowerOffConfirmBody')}
       alert={t('inventoryPage.esxiMigration.forcePowerOffCrashConsistent')}
       onConfirm={async () => {
-        await fetch(`/api/v1/migrations/${job!.id}/force-poweroff`, { method: 'POST' })
+        await postJobAction(`/api/v1/migrations/${job!.id}/force-poweroff`)
         onRequested?.()
       }}
     />

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/RootChoiceButton.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/RootChoiceButton.tsx
@@ -20,6 +20,8 @@ import {
 } from '@mui/material'
 import { alpha, useTheme } from '@mui/material/styles'
 
+import { postJobAction } from './jobAction'
+
 /**
  * The way out of an ambiguous guest inspection.
  *
@@ -74,17 +76,9 @@ export default function RootChoiceButton({
     setBusy(true)
     setError(null)
     try {
-      const res = await fetch(`/api/v1/migrations/${job!.id}/root-choice`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ root: selected }),
-      })
-      if (!res.ok) {
-        // 400 carries the reason (value not a candidate, job no longer waiting).
-        const d = await res.json().catch(() => null)
-        setError(d?.error || `HTTP ${res.status}`)
-        return
-      }
+      // Throws with the route's reason on 400 (value not a candidate, job no
+      // longer waiting) or on any other rejection.
+      await postJobAction(`/api/v1/migrations/${job!.id}/root-choice`, { root: selected })
       setOpen(false)
       onRequested?.()
     } catch (e: any) {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/WarmCutoverButton.test.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/WarmCutoverButton.test.tsx
@@ -147,6 +147,34 @@ describe('WarmCutoverButton', () => {
     await waitFor(() => expect(screen.queryByText(CONFIRM_TITLE)).not.toBeInTheDocument())
   })
 
+  it('keeps the dialog open and states the reason when the route refuses', async () => {
+    // A refused request used to close the dialog like a successful one, which
+    // is what made a lost cutover look like a button that does nothing.
+    server.use(http.post('*/api/v1/migrations/:id/cutover', () =>
+      HttpResponse.json({ error: 'Cannot cut over a verify job' }, { status: 400 })))
+    const onRequested = vi.fn()
+
+    renderWithProviders(<WarmCutoverButton job={hold} onRequested={onRequested} />)
+    fireEvent.click(screen.getByRole('button', { name: CUTOVER_LABEL }))
+    const dialogButtons = await screen.findAllByRole('button', { name: CUTOVER_LABEL })
+    fireEvent.click(dialogButtons[dialogButtons.length - 1])
+
+    expect(await screen.findByText(/Cannot cut over a verify job/)).toBeInTheDocument()
+    expect(screen.getByText(CONFIRM_TITLE)).toBeInTheDocument()
+    expect(onRequested).not.toHaveBeenCalled()
+  })
+
+  it('reports the status code when the failure carries no message', async () => {
+    server.use(http.post('*/api/v1/migrations/:id/cutover', () => new HttpResponse(null, { status: 500 })))
+
+    renderWithProviders(<WarmCutoverButton job={hold} />)
+    fireEvent.click(screen.getByRole('button', { name: CUTOVER_LABEL }))
+    const dialogButtons = await screen.findAllByRole('button', { name: CUTOVER_LABEL })
+    fireEvent.click(dialogButtons[dialogButtons.length - 1])
+
+    expect(await screen.findByText(/HTTP 500/)).toBeInTheDocument()
+  })
+
   it('fires nothing when the confirmation is dismissed', async () => {
     const calls: string[] = []
     server.use(http.post('*/api/v1/migrations/:id/cutover', ({ params }) => {

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/WarmCutoverButton.tsx
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/WarmCutoverButton.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl'
 
 import ConfirmActionButton from './ConfirmActionButton'
+import { postJobAction } from './jobAction'
 
 /**
  * The operator's switchover control, with its confirmation.
@@ -73,7 +74,9 @@ export default function WarmCutoverButton({
       // warning hold: a manual hold is waiting on purpose, not diverging.
       alert={job!.status === 'awaiting_cutover' ? t('inventoryPage.esxiMigration.cutoverNotConverging') : undefined}
       onConfirm={async () => {
-        await fetch(`/api/v1/migrations/${job!.id}/cutover`, { method: 'POST' })
+        // Throws on a rejected request, which keeps the dialog open with the
+        // reason instead of closing it on a cutover that never started.
+        await postJobAction(`/api/v1/migrations/${job!.id}/cutover`)
         onRequested?.()
       }}
     />

--- a/frontend/src/app/(dashboard)/infrastructure/inventory/components/jobAction.ts
+++ b/frontend/src/app/(dashboard)/infrastructure/inventory/components/jobAction.ts
@@ -1,0 +1,24 @@
+/**
+ * POST an operator decision to a running migration and turn a rejection into a
+ * thrown Error carrying the route's own reason.
+ *
+ * The buttons that drive a running migration used to fire and forget, so a
+ * 400, a 404 or a 500 looked exactly like success: the dialog closed and
+ * nothing else happened. Everything a route can answer has a reason attached,
+ * and this is what puts that reason in front of the operator.
+ */
+export async function postJobAction(path: string, body?: unknown): Promise<any> {
+  const res = await fetch(path, {
+    method: 'POST',
+    ...(body === undefined
+      ? {}
+      : { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }),
+  })
+  // Every route in this family answers JSON, both on success ({ data }) and on
+  // failure ({ error }). A body that is not JSON at all (a proxy error page,
+  // say) still has to surface as the status code rather than as a parse crash.
+  const payload = await res.json().catch(() => null)
+  if (!res.ok) throw new Error(payload?.error || `HTTP ${res.status}`)
+
+  return payload?.data
+}

--- a/frontend/src/app/api/v1/migrations/[id]/cancel/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/cancel/route.ts
@@ -40,6 +40,12 @@ export async function POST(
     // since #738: a job parked on the multi-boot gate polls that set, so without
     // this the cancel would only change the row and leave the pipeline waiting
     // until the gate expires.
+    //
+    // These four are the fast path only. The row written just below is what
+    // actually reaches a run whose pipeline holds a different copy of those
+    // modules than this handler does: every run mirrors its own status back
+    // into its cancel set (lib/migration/operator-signals), so a cancel no
+    // longer leaves the transfer running behind a row that reads "cancelled".
     cancelMigrationJob(id)
     cancelWarmMigrationJob(id)
     cancelV2vMigrationJob(id)

--- a/frontend/src/app/api/v1/migrations/[id]/cutover/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/cutover/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 const h = vi.hoisted(() => ({
-  prisma: { migrationJob: { findUnique: vi.fn() } },
+  prisma: { migrationJob: { findUnique: vi.fn(), update: vi.fn(async () => ({})) } },
 }))
 
 vi.mock("@/lib/rbac", () => ({ checkPermission: vi.fn(async () => null), PERMISSIONS: { VM_MIGRATE: "vm.migrate" } }))
@@ -15,7 +15,12 @@ import { checkPermission } from "@/lib/rbac"
 
 const signal = requestWarmCutover as unknown as ReturnType<typeof vi.fn>
 
-beforeEach(() => { h.prisma.migrationJob.findUnique.mockReset(); signal.mockReset() })
+beforeEach(() => {
+  h.prisma.migrationJob.findUnique.mockReset()
+  h.prisma.migrationJob.update.mockReset()
+  h.prisma.migrationJob.update.mockResolvedValue({})
+  signal.mockReset()
+})
 
 describe("POST /api/v1/migrations/[id]/cutover", () => {
   it("404s when the job is missing", async () => {
@@ -23,6 +28,7 @@ describe("POST /api/v1/migrations/[id]/cutover", () => {
     const res = await callRoute(POST, { params: { id: "nope" } })
     expect(res.status).toBe(404)
     expect(signal).not.toHaveBeenCalled()
+    expect(h.prisma.migrationJob.update).not.toHaveBeenCalled()
   })
 
   it("400s when the job is not in a cutover-eligible state", async () => {
@@ -30,6 +36,7 @@ describe("POST /api/v1/migrations/[id]/cutover", () => {
     const res = await callRoute(POST, { params: { id: "j1" } })
     expect(res.status).toBe(400)
     expect(signal).not.toHaveBeenCalled()
+    expect(h.prisma.migrationJob.update).not.toHaveBeenCalled()
   })
 
   it("signals cutover for a delta_sync job", async () => {
@@ -38,6 +45,28 @@ describe("POST /api/v1/migrations/[id]/cutover", () => {
     expect(res.status).toBe(200)
     expect(await readJson<any>(res)).toEqual({ data: { status: "cutover_requested" } })
     expect(signal).toHaveBeenCalledWith("j1")
+  })
+
+  it("records the request on the row, and does so before the in-process signal", async () => {
+    // The row is what a pipeline running in another module instance (or in
+    // another replica) reads. The in-process set is only the fast path, so it
+    // must never be the only place the click landed.
+    h.prisma.migrationJob.findUnique.mockResolvedValue({ id: "j1", status: "delta_sync" })
+    await callRoute(POST, { params: { id: "j1" } })
+    expect(h.prisma.migrationJob.update).toHaveBeenCalledWith({
+      where: { id: "j1" },
+      data: { cutoverRequestedAt: expect.any(Date) },
+    })
+    expect(h.prisma.migrationJob.update.mock.invocationCallOrder[0])
+      .toBeLessThan(signal.mock.invocationCallOrder[0])
+  })
+
+  it("500s and leaves nothing signalled when the row cannot be written", async () => {
+    h.prisma.migrationJob.findUnique.mockResolvedValue({ id: "j1", status: "delta_sync" })
+    h.prisma.migrationJob.update.mockRejectedValue(new Error("db down"))
+    const res = await callRoute(POST, { params: { id: "j1" } })
+    expect(res.status).toBe(500)
+    expect(signal).not.toHaveBeenCalled()
   })
 
   it("signals cutover for an awaiting_cutover job", async () => {

--- a/frontend/src/app/api/v1/migrations/[id]/cutover/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/cutover/route.ts
@@ -30,6 +30,12 @@ export async function POST(
       return NextResponse.json({ error: `Cannot cut over a ${job.status} job` }, { status: 400 })
     }
 
+    // The row is the signal: the pipeline mirrors it back into its own
+    // registry (lib/migration/operator-signals). Writing it before the
+    // in-process call is what makes the click survive a route handler that
+    // does not share the pipeline's module instance, which is the normal case
+    // in dev and with more than one frontend replica in production.
+    await prisma.migrationJob.update({ where: { id }, data: { cutoverRequestedAt: new Date() } })
     requestWarmCutover(id)
     return NextResponse.json({ data: { status: "cutover_requested" } })
   } catch (e: any) {

--- a/frontend/src/app/api/v1/migrations/[id]/force-poweroff/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/force-poweroff/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 const h = vi.hoisted(() => ({
-  prisma: { migrationJob: { findUnique: vi.fn() } },
+  prisma: { migrationJob: { findUnique: vi.fn(), update: vi.fn(async () => ({})) } },
 }))
 
 vi.mock("@/lib/rbac", () => ({ checkPermission: vi.fn(async () => null), PERMISSIONS: { VM_MIGRATE: "vm.migrate" } }))
@@ -14,7 +14,12 @@ import { requestWarmForcePowerOff } from "@/lib/migration/warm/warm-pipeline"
 
 const signal = requestWarmForcePowerOff as unknown as ReturnType<typeof vi.fn>
 
-beforeEach(() => { h.prisma.migrationJob.findUnique.mockReset(); signal.mockReset() })
+beforeEach(() => {
+  h.prisma.migrationJob.findUnique.mockReset()
+  h.prisma.migrationJob.update.mockReset()
+  h.prisma.migrationJob.update.mockResolvedValue({})
+  signal.mockReset()
+})
 
 describe("POST /api/v1/migrations/[id]/force-poweroff", () => {
   it("404s when the job is missing", async () => {
@@ -31,6 +36,7 @@ describe("POST /api/v1/migrations/[id]/force-poweroff", () => {
     const res = await callRoute(POST, { params: { id: "j1" } })
     expect(res.status).toBe(400)
     expect(signal).not.toHaveBeenCalled()
+    expect(h.prisma.migrationJob.update).not.toHaveBeenCalled()
   })
 
   it("signals the hard power off during a cutover wait", async () => {
@@ -39,6 +45,12 @@ describe("POST /api/v1/migrations/[id]/force-poweroff", () => {
     expect(res.status).toBe(200)
     expect(await readJson<any>(res)).toEqual({ data: { status: "force_power_off_requested" } })
     expect(signal).toHaveBeenCalledWith("j1")
+    // Recorded on the row, which is what the run actually polls when the route
+    // handler does not share its module instance.
+    expect(h.prisma.migrationJob.update).toHaveBeenCalledWith({
+      where: { id: "j1" },
+      data: { forcePowerOffRequestedAt: expect.any(Date) },
+    })
   })
 
   it("signals it during the checksum fallback wait too, which runs under full_copy", async () => {

--- a/frontend/src/app/api/v1/migrations/[id]/force-poweroff/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/force-poweroff/route.ts
@@ -37,6 +37,8 @@ export async function POST(
       return NextResponse.json({ error: "This migration is not waiting for the source to power off" }, { status: 400 })
     }
 
+    // Durable first, in-process second: same reason as the cutover route.
+    await prisma.migrationJob.update({ where: { id }, data: { forcePowerOffRequestedAt: new Date() } })
     requestWarmForcePowerOff(id)
     return NextResponse.json({ data: { status: "force_power_off_requested" } })
   } catch (e: any) {

--- a/frontend/src/app/api/v1/migrations/[id]/root-choice/route.test.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/root-choice/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
 const h = vi.hoisted(() => ({
-  prisma: { migrationJob: { findUnique: vi.fn() } },
+  prisma: { migrationJob: { findUnique: vi.fn(), update: vi.fn(async () => ({})) } },
 }))
 
 vi.mock("@/lib/rbac", () => ({ checkPermission: vi.fn(async () => null), PERMISSIONS: { VM_MIGRATE: "vm.migrate" } }))
@@ -30,6 +30,8 @@ const parkedJob = (overrides: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   h.prisma.migrationJob.findUnique.mockReset()
+  h.prisma.migrationJob.update.mockReset()
+  h.prisma.migrationJob.update.mockResolvedValue({})
   signal.mockReset()
   signal.mockReturnValue(true)
 })
@@ -41,6 +43,12 @@ describe("POST /api/v1/migrations/[id]/root-choice", () => {
     expect(res.status).toBe(200)
     expect(await readJson<any>(res)).toEqual({ data: { status: "root_choice_requested", root: "/dev/sda1" } })
     expect(signal).toHaveBeenCalledWith("j1", "/dev/sda1")
+    // Same pick on the row: a parked job in another module instance reads it
+    // from there, not from the set this handler just filled.
+    expect(h.prisma.migrationJob.update).toHaveBeenCalledWith({
+      where: { id: "j1" },
+      data: { rootChoice: "/dev/sda1" },
+    })
   })
 
   it("400s when the root is missing from the body", async () => {
@@ -49,6 +57,7 @@ describe("POST /api/v1/migrations/[id]/root-choice", () => {
     expect(res.status).toBe(400)
     expect((await readJson<any>(res))?.error).toMatch(/root/i)
     expect(signal).not.toHaveBeenCalled()
+    expect(h.prisma.migrationJob.update).not.toHaveBeenCalled()
   })
 
   it("400s when the root is not a string", async () => {

--- a/frontend/src/app/api/v1/migrations/[id]/root-choice/route.ts
+++ b/frontend/src/app/api/v1/migrations/[id]/root-choice/route.ts
@@ -58,6 +58,11 @@ export async function POST(
     if (!requestV2vRootChoice(id, root)) {
       return NextResponse.json({ error: "The pipeline rejected this root device" }, { status: 400 })
     }
+    // Recorded on the row too, so the parked job reads the pick even when this
+    // handler holds its own copy of the pipeline module. The value is already
+    // allowlisted against the candidates above, and the pipeline sanitizes it
+    // again on the way in.
+    await prisma.migrationJob.update({ where: { id }, data: { rootChoice: root } })
     return NextResponse.json({ data: { status: "root_choice_requested", root } })
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || String(e) }, { status: 500 })

--- a/frontend/src/lib/migration/operator-signals.test.ts
+++ b/frontend/src/lib/migration/operator-signals.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import {
+  readOperatorSignals,
+  clearOperatorSignals,
+  startOperatorSignalWatch,
+  stopOperatorSignalWatch,
+  __watchedJobsForTest,
+  OPERATOR_SIGNAL_POLL_MS,
+} from "./operator-signals"
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+  status: "delta_sync",
+  cutoverRequestedAt: null,
+  forcePowerOffRequestedAt: null,
+  rootChoice: null,
+  ...overrides,
+})
+
+const prismaWith = (findUnique: any) => ({
+  migrationJob: { findUnique, updateMany: vi.fn(async () => ({ count: 1 })) },
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  stopOperatorSignalWatch("j1")
+  vi.useRealTimers()
+})
+
+describe("readOperatorSignals", () => {
+  it("reads each decision off the row", async () => {
+    const prisma = prismaWith(vi.fn(async () => row({
+      status: "converting_disks",
+      cutoverRequestedAt: new Date(),
+      forcePowerOffRequestedAt: new Date(),
+      rootChoice: "/dev/sda1",
+    })))
+    expect(await readOperatorSignals(prisma, "j1")).toEqual({
+      cancelled: false,
+      cutover: true,
+      forcePowerOff: true,
+      rootChoice: "/dev/sda1",
+    })
+  })
+
+  it("reports a cancelled row as cancelled, since the cancel route has no column of its own", async () => {
+    const prisma = prismaWith(vi.fn(async () => row({ status: "cancelled" })))
+    expect(await readOperatorSignals(prisma, "j1")).toMatchObject({ cancelled: true, cutover: false })
+  })
+
+  it("returns null when the row is gone", async () => {
+    const prisma = prismaWith(vi.fn(async () => null))
+    expect(await readOperatorSignals(prisma, "j1")).toBeNull()
+  })
+
+  it("treats an empty root choice as no choice", async () => {
+    const prisma = prismaWith(vi.fn(async () => row({ rootChoice: "" })))
+    expect((await readOperatorSignals(prisma, "j1"))?.rootChoice).toBeNull()
+  })
+})
+
+describe("clearOperatorSignals", () => {
+  it("nulls the three columns with updateMany, so a vanished row does not throw", async () => {
+    const prisma = prismaWith(vi.fn())
+    await clearOperatorSignals(prisma, "j1")
+    expect(prisma.migrationJob.updateMany).toHaveBeenCalledWith({
+      where: { id: "j1" },
+      data: { cutoverRequestedAt: null, forcePowerOffRequestedAt: null, rootChoice: null },
+    })
+  })
+})
+
+describe("startOperatorSignalWatch", () => {
+  it("clears anything recorded before the run, before reading the row", async () => {
+    // A run must never inherit a decision it did not see taken: a "cutover
+    // now" left on the row would fire on the first delta pass.
+    const order: string[] = []
+    const findUnique = vi.fn(async () => { order.push("read"); return row() })
+    const prisma = {
+      migrationJob: {
+        findUnique,
+        updateMany: vi.fn(async () => { order.push("clear"); return { count: 1 } }),
+      },
+    }
+    await startOperatorSignalWatch(prisma, "j1", () => {})
+    expect(order[0]).toBe("clear")
+    expect(order).toContain("read")
+  })
+
+  it("mirrors what the row says on every tick", async () => {
+    let current = row()
+    const prisma = prismaWith(vi.fn(async () => current))
+    const seen: any[] = []
+    await startOperatorSignalWatch(prisma, "j1", s => seen.push(s))
+    expect(seen.at(-1)).toMatchObject({ cutover: false })
+
+    current = row({ cutoverRequestedAt: new Date() })
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(seen.at(-1)).toMatchObject({ cutover: true })
+  })
+
+  it("stops reading once the run has ended", async () => {
+    const findUnique = vi.fn(async () => row())
+    const prisma = prismaWith(findUnique)
+    await startOperatorSignalWatch(prisma, "j1", () => {})
+    const reads = findUnique.mock.calls.length
+    stopOperatorSignalWatch("j1")
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS * 3)
+    expect(findUnique.mock.calls.length).toBe(reads)
+    expect(__watchedJobsForTest()).not.toContain("j1")
+  })
+
+  it("keeps polling after a failed read, since the row keeps the decision", async () => {
+    const findUnique = vi.fn()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValue(row({ cutoverRequestedAt: new Date() }))
+    const prisma = prismaWith(findUnique)
+    const seen: any[] = []
+    await startOperatorSignalWatch(prisma, "j1", s => seen.push(s))
+    expect(seen).toHaveLength(0)
+
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(seen.at(-1)).toMatchObject({ cutover: true })
+  })
+
+  it("replaces an earlier watch for the same job instead of stacking one", async () => {
+    const prisma = prismaWith(vi.fn(async () => row()))
+    await startOperatorSignalWatch(prisma, "j1", () => {})
+    await startOperatorSignalWatch(prisma, "j1", () => {})
+    expect(__watchedJobsForTest().filter(id => id === "j1")).toHaveLength(1)
+  })
+})

--- a/frontend/src/lib/migration/operator-signals.ts
+++ b/frontend/src/lib/migration/operator-signals.ts
@@ -1,0 +1,144 @@
+/**
+ * Operator decisions that have to reach a pipeline which is already running:
+ * "cut over now", "power the source off hard", "convert this root".
+ *
+ * Every migration pipeline used to keep these in a module-level Set, on the
+ * assumption that the POST handler and the `after()` continuation running the
+ * pipeline share one module instance. They do not, and when they do not the
+ * click is lost in silence:
+ *
+ *  - in dev, a route compiled after the pipeline started gets its own instance
+ *    of the shared module, so the route fills one Set while the pipeline polls
+ *    another (measured on a warm run: the cutover route was compiled on the
+ *    first click, twelve minutes after the pipeline began);
+ *  - in production, a second frontend replica has its own process entirely,
+ *    and only one of them owns the job (see `ownerInstanceId`).
+ *
+ * So the decision is written on the job row, which every replica and every
+ * module instance can see, and each pipeline mirrors the row back into its own
+ * registry for as long as the job runs. The in-memory Set stays as the fast
+ * path, which keeps every existing synchronous `isCancelled()` style check
+ * working unchanged.
+ *
+ * Cancellation needs no column: the cancel route already writes
+ * `status = "cancelled"` on the row, so the status is its durable signal.
+ */
+
+/**
+ * Mirror cadence. A cutover request costs at most this much extra latency,
+ * which is nothing next to the shutdown plus boot it is about to trigger, and
+ * it is one narrow indexed read per running job.
+ */
+export const OPERATOR_SIGNAL_POLL_MS = 2000
+
+export type OperatorSignalSnapshot = {
+  /** The row says the job was cancelled, whoever wrote it. */
+  cancelled: boolean
+  /** An operator asked for the cutover to run now. */
+  cutover: boolean
+  /** An operator asked to stop waiting for a clean guest shutdown. */
+  forcePowerOff: boolean
+  /** Root filesystem an operator picked for a parked v2v conversion. */
+  rootChoice: string | null
+}
+
+const SIGNAL_SELECT = {
+  status: true,
+  cutoverRequestedAt: true,
+  forcePowerOffRequestedAt: true,
+  rootChoice: true,
+} as const
+
+/** Read the decisions currently recorded for a job, or null when it is gone. */
+export async function readOperatorSignals(prisma: any, jobId: string): Promise<OperatorSignalSnapshot | null> {
+  const row = await prisma.migrationJob.findUnique({ where: { id: jobId }, select: SIGNAL_SELECT })
+  if (!row) return null
+
+  return {
+    cancelled: row.status === "cancelled",
+    cutover: row.cutoverRequestedAt != null,
+    forcePowerOff: row.forcePowerOffRequestedAt != null,
+    rootChoice: typeof row.rootChoice === "string" && row.rootChoice ? row.rootChoice : null,
+  }
+}
+
+/**
+ * Drop anything recorded before this run started. No route writes these
+ * columns outside a live run today, and a retry creates a new row rather than
+ * reusing this one, so this is a guard rather than a fix: a run must never
+ * inherit a decision it did not see taken, least of all a "cutover now" it
+ * would honour on its first delta pass. updateMany so a job whose row
+ * disappeared under us does not throw.
+ */
+export async function clearOperatorSignals(prisma: any, jobId: string): Promise<void> {
+  await prisma.migrationJob.updateMany({
+    where: { id: jobId },
+    data: { cutoverRequestedAt: null, forcePowerOffRequestedAt: null, rootChoice: null },
+  })
+}
+
+/** Stop functions of the running mirrors, keyed by job id. */
+const watchers = new Map<string, () => void>()
+
+/**
+ * Mirror a job's recorded decisions into the caller's own registries until the
+ * run ends. `apply` is called with every snapshot, including the ones that
+ * carry nothing new: callers add to a Set, which is idempotent.
+ *
+ * Runs in whichever module instance the pipeline itself runs in, since the
+ * pipeline is what calls this, so the Sets it fills are always the ones the
+ * pipeline polls. That is the whole point of the indirection.
+ */
+export async function startOperatorSignalWatch(
+  prisma: any,
+  jobId: string,
+  apply: (signals: OperatorSignalSnapshot) => void,
+  pollMs: number = OPERATOR_SIGNAL_POLL_MS,
+): Promise<void> {
+  stopOperatorSignalWatch(jobId)
+  // Clear before the first read, or the mirror could hand this run a decision
+  // that predates it. A failure here is not worth aborting on: the very next
+  // status write would fail too, and the run dies on that instead.
+  await clearOperatorSignals(prisma, jobId).catch(() => {})
+
+  let stopped = false
+  let inFlight = false
+  const tick = async () => {
+    if (stopped || inFlight) return
+    inFlight = true
+    try {
+      const signals = await readOperatorSignals(prisma, jobId)
+      if (signals && !stopped) apply(signals)
+    } catch {
+      // A failed poll is retried on the next tick. Nothing is lost: the row
+      // keeps the decision until the pipeline picks it up.
+    } finally {
+      inFlight = false
+    }
+  }
+
+  const timer = setInterval(tick, pollMs)
+  // The mirror must never be the reason the process stays alive.
+  timer.unref?.()
+  watchers.set(jobId, () => {
+    stopped = true
+    clearInterval(timer)
+  })
+  // One read before returning, so the caller can rely on the mirror being live
+  // by the time its run starts rather than one interval later.
+  await tick()
+}
+
+/** Stop mirroring a job. Safe to call for a job that was never watched. */
+export function stopOperatorSignalWatch(jobId: string): void {
+  const stop = watchers.get(jobId)
+  if (stop) {
+    stop()
+    watchers.delete(jobId)
+  }
+}
+
+/** @internal test hook */
+export function __watchedJobsForTest(): string[] {
+  return [...watchers.keys()]
+}

--- a/frontend/src/lib/migration/pipeline.ts
+++ b/frontend/src/lib/migration/pipeline.ts
@@ -17,6 +17,7 @@
  */
 
 import { getTenantPrisma } from "@/lib/tenant"
+import { startOperatorSignalWatch, stopOperatorSignalWatch } from "@/lib/migration/operator-signals"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -152,6 +153,12 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
   // Register tenant-scoped prisma for this job
   const prisma = getTenantPrisma(tenantId)
   jobPrisma.set(jobId, prisma)
+  // The cancel route fills `cancelledJobs` from whichever module instance it
+  // was compiled into, which is not necessarily this one, so mirror the row's
+  // own verdict into the set this run polls (lib/migration/operator-signals).
+  await startOperatorSignalWatch(prisma, jobId, signals => {
+    if (signals.cancelled) cancelledJobs.add(jobId)
+  })
 
   let soapSession: SoapSession | null = null
   let targetVmid: number | null = null
@@ -2959,6 +2966,7 @@ export async function runMigrationPipeline(jobId: string, config: MigrationConfi
     if (soapSession) {
       await soapLogout(soapSession)
     }
+    stopOperatorSignalWatch(jobId)
     cancelledJobs.delete(jobId)
     jobPrisma.delete(jobId)
   }

--- a/frontend/src/lib/migration/v2v-pipeline.ts
+++ b/frontend/src/lib/migration/v2v-pipeline.ts
@@ -18,6 +18,7 @@
  */
 
 import { getTenantPrisma } from "@/lib/tenant"
+import { startOperatorSignalWatch, stopOperatorSignalWatch } from "@/lib/migration/operator-signals"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -165,11 +166,12 @@ export function cancelV2vMigrationJob(jobId: string) {
 
 /**
  * Root filesystem an operator picked for a job parked on the multi-boot gate,
- * keyed by job id. In memory on purpose, mirroring the warm cutover gate: the
- * pipeline runs inside the POST request's after() continuation, so the route
- * handler and the pipeline share this module instance. A process restart loses
- * the signal, and the parked job is failed by the orphan sweep like any other
- * in-flight job.
+ * keyed by job id. This set is only the fast path: the route handler running
+ * in this very module instance fills it directly, and the signal mirror fills
+ * it from the job row for every other case, which is the common one (a route
+ * compiled after the pipeline started holds a different copy of this module).
+ * A process restart still loses the parked job, which the orphan sweep fails
+ * like any other in-flight job.
  */
 const rootChoiceRequests = new Map<string, string>()
 
@@ -948,6 +950,13 @@ export async function runV2vMigrationPipeline(
   // Register tenant-scoped prisma for this job
   const prisma = getTenantPrisma(tenantId)
   jobPrisma.set(jobId, prisma)
+  // Cancel and the multi-boot root pick both arrive from route handlers that
+  // may hold their own copy of this module, so the row is what this run reads
+  // them from (lib/migration/operator-signals).
+  await startOperatorSignalWatch(prisma, jobId, signals => {
+    if (signals.cancelled) cancelledJobs.add(jobId)
+    if (signals.rootChoice) requestV2vRootChoice(jobId, signals.rootChoice)
+  })
 
   let targetVmid: number | null = null
   /**
@@ -2971,6 +2980,7 @@ export async function runV2vMigrationPipeline(
         ).catch(() => {})
       }
     }
+    stopOperatorSignalWatch(jobId)
     cancelledJobs.delete(jobId)
     rootChoiceRequests.delete(jobId)
     jobPrisma.delete(jobId)

--- a/frontend/src/lib/migration/warm/job-control.test.ts
+++ b/frontend/src/lib/migration/warm/job-control.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+import { registerJob, unregisterJob, isCutoverRequested, isCancelled, isForcePowerOffRequested } from "./job-control"
+import { OPERATOR_SIGNAL_POLL_MS } from "@/lib/migration/operator-signals"
+
+/**
+ * The bug these cover: an operator clicks "Cutover now", the route sets the
+ * flag in its own copy of this module, and the running pipeline, holding a
+ * different copy, polls a set that stays empty forever. Measured on a warm run
+ * where the route was compiled twelve minutes after the pipeline started. The
+ * signal now travels through the job row, so what the route wrote is what this
+ * module reads, whichever instance either of them lives in.
+ */
+
+const JOB = "job-mirror-1"
+
+let row: Record<string, any>
+
+const prisma = {
+  migrationJob: {
+    findUnique: vi.fn(async () => row),
+    updateMany: vi.fn(async ({ data }: any) => {
+      Object.assign(row, data)
+
+      return { count: 1 }
+    }),
+  },
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  row = { status: "delta_sync", cutoverRequestedAt: null, forcePowerOffRequestedAt: null, rootChoice: null }
+  prisma.migrationJob.findUnique.mockClear()
+  prisma.migrationJob.updateMany.mockClear()
+})
+
+afterEach(() => {
+  unregisterJob(JOB)
+  vi.useRealTimers()
+})
+
+describe("warm job control, signals recorded on the row", () => {
+  it("picks up a cutover the route recorded, not just one signalled in-process", async () => {
+    await registerJob(JOB, prisma)
+    expect(isCutoverRequested(JOB)).toBe(false)
+
+    row.cutoverRequestedAt = new Date()
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(isCutoverRequested(JOB)).toBe(true)
+  })
+
+  it("picks up a hard power off the same way", async () => {
+    await registerJob(JOB, prisma)
+    row.forcePowerOffRequestedAt = new Date()
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(isForcePowerOffRequested(JOB)).toBe(true)
+  })
+
+  it("treats a cancelled row as a cancellation, which is how the cancel route signals", async () => {
+    await registerJob(JOB, prisma)
+    row.status = "cancelled"
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(isCancelled(JOB)).toBe(true)
+  })
+
+  it("ignores a decision that was recorded before the run started", async () => {
+    // Whatever put it there, a run must not inherit it: an old "cutover now"
+    // would fire on the first delta pass, on a copy nobody asked to switch.
+    row.cutoverRequestedAt = new Date("2026-01-01T00:00:00Z")
+    await registerJob(JOB, prisma)
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS)
+    expect(isCutoverRequested(JOB)).toBe(false)
+  })
+
+  it("stops reading the row once the run has ended", async () => {
+    await registerJob(JOB, prisma)
+    unregisterJob(JOB)
+    const reads = prisma.migrationJob.findUnique.mock.calls.length
+
+    row.cutoverRequestedAt = new Date()
+    await vi.advanceTimersByTimeAsync(OPERATOR_SIGNAL_POLL_MS * 3)
+    expect(prisma.migrationJob.findUnique.mock.calls.length).toBe(reads)
+    expect(isCutoverRequested(JOB)).toBe(false)
+  })
+})

--- a/frontend/src/lib/migration/warm/job-control.ts
+++ b/frontend/src/lib/migration/warm/job-control.ts
@@ -1,5 +1,6 @@
 import { getTenantPrisma } from "@/lib/tenant"
 import { TERMINAL_STATUSES } from "@/lib/tasks/sharedTask"
+import { startOperatorSignalWatch, stopOperatorSignalWatch } from "@/lib/migration/operator-signals"
 import type { WarmStatus, LogEntry } from "./types"
 
 // ── Job tracking (per-orchestrator, mirrors the other migration pipelines) ──
@@ -15,15 +16,29 @@ const jobPrisma = new Map<string, any>()
 // second run for a VM already migrating is rejected (design §12 concurrency lock).
 const activeWarmVms = new Set<string>()
 
-/** Bind a job to its tenant Prisma client and clear stale operator requests before a run. */
-export function registerJob(jobId: string, prisma: any): void {
+/**
+ * Bind a job to its tenant Prisma client, drop the previous attempt's operator
+ * requests, and start mirroring the durable ones from the job row.
+ *
+ * The mirror is what makes the sets above trustworthy: a route handler sets
+ * them from whichever module instance it was compiled into, which is not
+ * necessarily this one, so a click that only reached the route's copy would
+ * never be seen here. See lib/migration/operator-signals.
+ */
+export async function registerJob(jobId: string, prisma: any): Promise<void> {
   jobPrisma.set(jobId, prisma)
   cutoverRequests.delete(jobId)
   forcePowerOffRequests.delete(jobId)
+  await startOperatorSignalWatch(prisma, jobId, signals => {
+    if (signals.cancelled) cancelledJobs.add(jobId)
+    if (signals.cutover) cutoverRequests.add(jobId)
+    if (signals.forcePowerOff) forcePowerOffRequests.add(jobId)
+  })
 }
 
 /** Drop the job's Prisma binding and every per-job signal once the run has ended. */
 export function unregisterJob(jobId: string): void {
+  stopOperatorSignalWatch(jobId)
   jobPrisma.delete(jobId)
   cancelledJobs.delete(jobId)
   cutoverRequests.delete(jobId)

--- a/frontend/src/lib/migration/warm/warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/warm-pipeline.ts
@@ -191,7 +191,7 @@ export async function sweepWarmSnapshots(
  */
 export async function runWarmMigration(jobId: string, config: WarmMigrationConfig, tenantId = "default"): Promise<void> {
   const prisma = getTenantPrisma(tenantId)
-  registerJob(jobId, prisma)
+  await registerJob(jobId, prisma)
 
   const libdir = config.vddkLibdir || "/usr/lib/vmware-vix-disklib"
   const budget = config.downtimeBudgetSec ?? 300

--- a/frontend/src/lib/migration/warm/xcpng-warm-pipeline.ts
+++ b/frontend/src/lib/migration/warm/xcpng-warm-pipeline.ts
@@ -64,7 +64,7 @@ export function cbtEligibilityXcpng(disks: XoDiskInfo[]): { eligible: boolean; r
  */
 export async function runXcpngWarmMigration(jobId: string, config: WarmMigrationConfig, tenantId = "default"): Promise<void> {
   const prisma = getTenantPrisma(tenantId)
-  registerJob(jobId, prisma)
+  await registerJob(jobId, prisma)
   const budget = config.downtimeBudgetSec ?? 300
   const maxPasses = config.maxPasses ?? 5
   const cutoverMode = config.cutoverMode === "manual" ? "manual" : "auto"

--- a/frontend/src/lib/migration/xcpng-pipeline.ts
+++ b/frontend/src/lib/migration/xcpng-pipeline.ts
@@ -18,6 +18,7 @@
  */
 
 import { getTenantPrisma } from "@/lib/tenant"
+import { startOperatorSignalWatch, stopOperatorSignalWatch } from "@/lib/migration/operator-signals"
 import { decryptSecret } from "@/lib/crypto/secret"
 import { getConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
@@ -249,6 +250,11 @@ async function executeSSHWithTimeout(
 export async function runXcpngMigrationPipeline(jobId: string, config: MigrationConfig, tenantId = 'default'): Promise<void> {
   const prisma = getTenantPrisma(tenantId)
   jobPrisma.set(jobId, prisma)
+  // Same mirror as the other pipelines: the cancel route may not share this
+  // module instance (lib/migration/operator-signals).
+  await startOperatorSignalWatch(prisma, jobId, signals => {
+    if (signals.cancelled) cancelledJobs.add(jobId)
+  })
 
   let targetVmid: number | null = null
   /**
@@ -817,6 +823,7 @@ export async function runXcpngMigrationPipeline(jobId: string, config: Migration
     stopSourceKeepAlive()
     await source?.close().catch(() => {})
     stopHeartbeat()
+    stopOperatorSignalWatch(jobId)
     cancelledJobs.delete(jobId)
     jobPrisma.delete(jobId)
   }


### PR DESCRIPTION
## What was broken

Clicking "Cutover now" on a warm migration did nothing at all: no error, no message, no change on screen, and the run kept replicating as if the click had never happened.

The four migration pipelines keep their operator signals in module-level Sets, on the assumption that the POST handler and the `after()` continuation running the pipeline share one module instance. They do not. An API route is compiled on its first request, so the cutover route was compiled twelve minutes after the pipeline had started, into its own copy of the shared module: the route filled one Set, the pipeline polled another, and the two were never the same object. The same gap opens in production as soon as a second frontend replica answers the click, since only one process owns the job (see `ownerInstanceId`).

Nothing surfaced because the buttons fired and forgot the response, so a 400, a 404 and a lost signal all looked exactly like success. Cancel only appeared to work because its route also writes `status = "cancelled"` on the row.

## What changed

Three nullable columns on `migration_jobs` now carry the decisions: `cutover_requested_at`, `force_poweroff_requested_at` and `root_choice`. Cancel needs no column, its status write is already the durable signal.

`lib/migration/operator-signals.ts` mirrors the row back into the pipeline's own registry every two seconds. The pipeline is what starts the mirror, so the Sets it fills are always the ones the pipeline polls, and every existing synchronous `isCancelled()` style check keeps working unchanged. Wired into all four pipelines: warm CBT, cold and live, virt-v2v, XCP-ng.

The confirmation dialog also stays open and states the reason when a request is refused, and the three job action buttons throw on a non-OK response instead of swallowing it.

## Verification

Full suite green, 743 files and 8727 tests, with new coverage for the mirror, for the row-driven pickup in the warm job control, and for the refused-request path in the dialog.

Lab run on a VMware warm migration with manual cutover, on a build where the route and the pipeline really did hold two copies of the module: the request was picked up 492 ms after the click, the source was powered off 7 s later, and the whole cutover took 35 s of guest downtime, disks attached and verified.

## Deploying

The migration adds three nullable columns, no backfill and no data change.
