### PR TITLE
Name the conditions behind a Ceph HEALTH_ERR in connection diagnostics

### DIFF
--- a/frontend/src/lib/diagnostics/connectionDiagnostics.test.ts
+++ b/frontend/src/lib/diagnostics/connectionDiagnostics.test.ts
@@ -435,6 +435,25 @@ describe('runConnectionDiagnostics - PVE Ceph check', () => {
     expect(cephCheck?.status).toBe('error')
   })
 
+  it('names every condition behind a HEALTH_ERR, not just the status', async () => {
+    setupPveWithCeph({
+      health: {
+        status: 'HEALTH_ERR',
+        checks: {
+          OSD_FULL: { severity: 'HEALTH_ERR', summary: { message: '1 full osd(s)' } },
+          AUTH_INSECURE_SERVICE_TICKETS: { severity: 'HEALTH_ERR', summary: { message: 'Monitors are configured to issue insecure service tickets' } },
+        },
+      },
+    })
+    const meta: DiagnosticMeta = { ...pveMeta, hasCeph: true }
+    const report = await runConnectionDiagnostics(meta, pveConn)
+    const cephCheck = report.checks.find((c) => c.id === 'pve.ceph')
+    expect(cephCheck?.status).toBe('error')
+    expect(cephCheck?.detail).toBe(
+      'AUTH_INSECURE_SERVICE_TICKETS: Monitors are configured to issue insecure service tickets; OSD_FULL: 1 full osd(s)',
+    )
+  })
+
   it('does not include a ceph check when hasCeph is false', async () => {
     pveFetchMock.mockImplementation((_conn: any, path: string) => {
       if (path === '/version') return Promise.resolve({ version: '8.0.0' })

--- a/frontend/src/lib/diagnostics/connectionDiagnostics.ts
+++ b/frontend/src/lib/diagnostics/connectionDiagnostics.ts
@@ -228,17 +228,22 @@ async function pveCluster(conn: ProxmoxClientOptions, hasCeph: boolean): Promise
       if (healthStatus === 'HEALTH_OK') {
         return { status: 'ok', message: 'Ceph health is OK.' }
       }
+      // Ceph names every condition it is unhappy about, keyed by code. Report
+      // them all: a status on its own leaves the operator with nothing to act
+      // on, and the code is what `ceph health detail` is searched by.
+      const entries = Object.entries(data?.health?.checks ?? {}) as [string, any][]
+      const msgs = entries
+        .map(([code, c]) => {
+          const msg = c?.summary?.message ?? c?.message ?? ''
+          return msg ? `${code}: ${msg}` : code
+        })
+        .sort((a, b) => a.localeCompare(b))
+      const detail = msgs.length > 0 ? msgs.join('; ') : undefined
       if (healthStatus === 'HEALTH_WARN') {
-        const checks = Object.values(data?.health?.checks ?? {}) as any[]
-        const msgs = checks.map((c: any) => c?.summary?.message ?? c?.message ?? '').filter(Boolean)
-        return {
-          status: 'warn',
-          message: 'Ceph health warning.',
-          detail: msgs.length > 0 ? msgs.join('; ') : undefined,
-        }
+        return { status: 'warn', message: 'Ceph health warning.', detail }
       }
       if (healthStatus === 'HEALTH_ERR') {
-        return { status: 'error', message: 'Ceph health error.', detail: healthStatus }
+        return { status: 'error', message: 'Ceph health error.', detail: detail ?? healthStatus }
       }
       // Unexpected or empty status
       return { status: 'warn', message: `Ceph health status: "${healthStatus || 'unknown'}"` }


### PR DESCRIPTION
The connection diagnostics panel reported a Ceph health error with the status string as its only detail, so it told the operator that a cluster was in error without saying why. The warning branch right above it already listed the messages.

Both branches now share one list, each check rendered as `CODE: message` and sorted, so the panel names every condition and stays stable between two runs. Same defect class as a pre-flight fix made separately on the orchestrator side, where a Ceph HEALTH_ERR was likewise reported without its reason.
