### PR TITLE
Export the change tracking timeline as CSV and dashboards as JSON

### DIFF
--- a/frontend/src/app/(dashboard)/operations/changes/page.jsx
+++ b/frontend/src/app/(dashboard)/operations/changes/page.jsx
@@ -22,12 +22,14 @@ import {
   MenuItem,
   Select,
   Slider,
-  Stack,
   TablePagination,
   TextField,
   Tooltip,
   Typography
 } from '@mui/material'
+
+import { buildChangesCsv } from '@/lib/changes/csv'
+import { dateStamp, downloadCsv } from '@/lib/export/download'
 
 import { usePageTitle } from '@/contexts/PageTitleContext'
 import { Features, useLicense } from '@/contexts/LicenseContext'
@@ -379,6 +381,29 @@ export default function ChangesPage() {
     }
   }, [mutate])
 
+  // The CSV carries what the filters select, every page of it, not just the
+  // rows currently on screen.
+  const handleExportCsv = useCallback(() => {
+    const csv = buildChangesCsv(filteredChanges, {
+      headers: [
+        t('changes.csvDate'),
+        t('changes.csvResourceType'),
+        t('changes.csvResourceId'),
+        t('changes.csvResourceName'),
+        t('changes.csvAction'),
+        t('changes.csvUser'),
+        t('changes.csvNode'),
+        t('changes.csvConnection'),
+        t('changes.csvFieldCount'),
+        t('changes.csvDetails')
+      ],
+      resourceType: type => resourceTypeConfig[type]?.label || type || '',
+      action: action => (actionConfig[action] ? t(actionConfig[action].label) : action || '')
+    })
+
+    downloadCsv(csv, `changes-${dateStamp()}.csv`)
+  }, [filteredChanges, t])
+
   const handleOpenSettings = useCallback(() => {
     setRetentionDays(currentRetention)
     setSettingsOpen(true)
@@ -410,39 +435,6 @@ export default function ChangesPage() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, flex: 1, minHeight: 0 }}>
-      {/* Header Actions */}
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, flexShrink: 0 }}>
-        <Tooltip title={t('changes.retentionInfo', { days: currentRetention })}>
-          <Button
-            variant='outlined'
-            size='small'
-            startIcon={<i className='ri-settings-3-line' />}
-            onClick={handleOpenSettings}
-          >
-            {t('changes.settings')}
-          </Button>
-        </Tooltip>
-        <Button
-          variant='outlined'
-          size='small'
-          color='error'
-          startIcon={<i className='ri-delete-bin-line' />}
-          onClick={() => setPurgeOpen(true)}
-          disabled={stats.total === 0}
-        >
-          {t('changes.purge')}
-        </Button>
-        <Button
-          variant='outlined'
-          size='small'
-          startIcon={<i className='ri-refresh-line' />}
-          onClick={() => mutate()}
-          disabled={isLoading}
-        >
-          {t('common.refresh')}
-        </Button>
-      </Box>
-
       {/* Stats row - same style as events page */}
       <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 2, flexShrink: 0 }}>
         <DonutTotalCard
@@ -461,7 +453,9 @@ export default function ChangesPage() {
       {/* Filters */}
       <Card variant='outlined' sx={{ flexShrink: 0 }}>
         <CardContent sx={{ py: 1.5, '&:last-child': { pb: 1.5 } }}>
-          <Stack direction='row' spacing={1.5} sx={{ flexWrap: 'wrap', alignItems: 'center' }}>
+          {/* A flex box rather than a Stack: Stack spaces with margins, which
+              beats the `ml: auto` that pins the actions to the right. */}
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 1.5 }}>
             <TextField
               size='small'
               placeholder={t('changes.search')}
@@ -507,7 +501,55 @@ export default function ChangesPage() {
                 <MenuItem value='migrated'>{t('changes.actionMigrated')}</MenuItem>
               </Select>
             </FormControl>
-          </Stack>
+
+            {/* Icon-only actions, pinned right. Each carries its own
+                aria-label: with no visible text, a disabled button wrapped in
+                the tooltip's <span> would otherwise have no accessible name. */}
+            <Box sx={{ display: 'flex', gap: 0.5, ml: 'auto', alignItems: 'center' }}>
+              <Tooltip title={`${t('changes.settings')} · ${t('changes.retentionInfo', { days: currentRetention })}`}>
+                <IconButton size='small' aria-label={t('changes.settings')} onClick={handleOpenSettings}>
+                  <i className='ri-settings-3-line' style={{ fontSize: 18 }} />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title={`${t('common.export')} CSV`}>
+                <span>
+                  <IconButton
+                    size='small'
+                    aria-label={`${t('common.export')} CSV`}
+                    onClick={handleExportCsv}
+                    disabled={filteredTotal === 0}
+                  >
+                    <i className='ri-download-line' style={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title={t('common.refresh')}>
+                <span>
+                  <IconButton
+                    size='small'
+                    aria-label={t('common.refresh')}
+                    onClick={() => mutate()}
+                    disabled={isLoading}
+                  >
+                    <i className='ri-refresh-line' style={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+              <Tooltip title={t('changes.purge')}>
+                <span>
+                  <IconButton
+                    size='small'
+                    color='error'
+                    aria-label={t('changes.purge')}
+                    onClick={() => setPurgeOpen(true)}
+                    disabled={stats.total === 0}
+                  >
+                    <i className='ri-delete-bin-line' style={{ fontSize: 18 }} />
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          </Box>
         </CardContent>
       </Card>
 

--- a/frontend/src/components/dashboard/WidgetGrid.jsx
+++ b/frontend/src/components/dashboard/WidgetGrid.jsx
@@ -16,6 +16,8 @@ import { computeReclaimedRows, yShiftFor } from './layoutReclaim'
 import { DEFAULT_LAYOUT, PRESET_LAYOUTS } from './types'
 import { CardsSkeleton } from '@/components/skeletons'
 import { useWidgetVisibility } from '@/hooks/useWidgetVisibility'
+import { parseDashboardFile, serializeDashboards } from '@/lib/dashboard/layoutTransfer'
+import { dateStamp, downloadJson } from '@/lib/export/download'
 import { INHERIT_ON_PRIMARY_SX } from '@/lib/theme/onPrimary'
 
 const GRID_COLS = { lg: 12, md: 12, sm: 12, xs: 12, xxs: 12 }
@@ -338,6 +340,7 @@ export default function WidgetGrid({ data, loading, onRefresh, refreshLoading })
   const [deleteDashDialog, setDeleteDashDialog] = useState(false)
   const [dragTabName, setDragTabName] = useState(null)
   const [dragOverName, setDragOverName] = useState(null)
+  const importInputRef = useRef(null)
 
   const [timeRange, setTimeRange] = useState(() => {
     if (typeof window !== 'undefined') return localStorage.getItem('dashboard-timerange') || 'hour'
@@ -409,10 +412,15 @@ return 'hour'
 
       if (res.ok) {
         const json = await res.json()
+        const list = json.data || []
 
-        setDashboards(json.data || [])
+        setDashboards(list)
+
+        return list
       }
     } catch {}
+
+    return []
   }, [])
 
   useEffect(() => {
@@ -699,6 +707,120 @@ return {
     } catch {}
   }
 
+  // Which connections this install actually exposes to this user. An imported
+  // layout names connections by id, and an id from another install resolves to
+  // nothing here, so this is what tells the two apart.
+  const knownConnectionIds = useMemo(() => {
+    const ids = new Set()
+
+    for (const cluster of data?.clusters || []) if (cluster?.id) ids.add(cluster.id)
+    for (const node of data?.nodes || []) if (node?.connId) ids.add(node.connId)
+
+    return ids
+  }, [data])
+
+  // Multi-dashboard: export every dashboard into one file. A set of monitoring
+  // views travels as a set; one file per tab only makes it harder to hand over.
+  const handleExportDashboards = async () => {
+    try {
+      const names = dashList.map(d => d.name)
+
+      const loaded = await Promise.all(
+        names.map(async name => {
+          const res = await fetch(`/api/v1/dashboard/layout?name=${encodeURIComponent(name)}`)
+
+          if (!res.ok) return null
+          const json = await res.json()
+
+          return Array.isArray(json.data?.widgets) ? { name, widgets: json.data.widgets } : null
+        })
+      )
+
+      // Exporting a subset silently would be worse than failing: the file is
+      // meant to be the whole set.
+      if (loaded.some(d => d === null)) throw new Error('incomplete')
+
+      downloadJson(serializeDashboards(loaded), `proxcenter-dashboards-${dateStamp()}.json`)
+      setSnackbar({
+        open: true,
+        message: t('dashboard.dashboardsExported', { count: loaded.length }),
+        severity: 'success',
+      })
+    } catch {
+      setSnackbar({ open: true, message: t('dashboard.exportFailed'), severity: 'error' })
+    }
+  }
+
+  // Multi-dashboard: import from a file
+  const handleImportFile = async (event) => {
+    const file = event.target.files?.[0]
+
+    // Clearing the input lets the same file be picked again after a failure.
+    event.target.value = ''
+    if (!file) return
+
+    const result = parseDashboardFile(await file.text(), {
+      isWidgetAllowed: type => Boolean(WIDGET_REGISTRY[type]) && isWidgetVisibleForScope(type, { hasInfraScope, hiddenWidgets }),
+      knownConnectionIds,
+      takenNames: dashList.map(d => d.name),
+      generateId,
+      importedSuffix: t('dashboard.importedSuffix'),
+    })
+
+    if (!result.ok) {
+      setSnackbar({ open: true, message: t(`dashboard.importError.${result.reason}`), severity: 'error' })
+
+      return
+    }
+
+    try {
+      // Sequential on purpose: the route deactivates the other dashboards on
+      // every create, so parallel writes would race over which one ends active.
+      for (const dashboard of result.dashboards) {
+        const res = await fetch('/api/v1/dashboard/layout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: dashboard.name, widgets: dashboard.widgets }),
+        })
+
+        if (!res.ok) {
+          const json = await res.json().catch(() => ({}))
+
+          throw new Error(json.error || 'import failed')
+        }
+      }
+
+      // A 200 is not proof the dashboards exist: an unhandled POST answers
+      // `{"data":[]}` in demo mode. Announce an import only once the list
+      // carries them.
+      const list = await refreshDashboardList()
+      const missing = result.dashboards.filter(d => !list.some(l => l.name === d.name))
+
+      if (missing.length > 0) throw new Error(t('dashboard.importError.not-stored'))
+
+      await loadDashboard(result.dashboards[0].name)
+
+      // Say what was left behind: a silently thinner dashboard is the failure
+      // this import is built to avoid.
+      const notes = [
+        t('dashboard.dashboardsImported', { count: result.dashboards.length }),
+        result.skipped > 0 ? t('dashboard.importSkipped', { count: result.skipped }) : null,
+        result.dropped > 0 ? t('dashboard.importDropped', { count: result.dropped }) : null,
+        result.reset > 0 ? t('dashboard.importReset', { count: result.reset }) : null,
+      ].filter(Boolean)
+
+      const incomplete = result.skipped > 0 || result.dropped > 0 || result.reset > 0
+
+      setSnackbar({
+        open: true,
+        message: notes.join(' '),
+        severity: incomplete ? 'warning' : 'success',
+      })
+    } catch (e) {
+      setSnackbar({ open: true, message: e?.message || t('dashboard.importError.invalid-json'), severity: 'error' })
+    }
+  }
+
   const dashboardRef = useRef(null)
 
   const toggleFullscreen = useCallback(() => {
@@ -832,6 +954,14 @@ return () => document.removeEventListener('fullscreenchange', handler)
           </MenuItem>
         )}
       </Menu>
+
+      <input
+        ref={importInputRef}
+        type='file'
+        accept='application/json,.json'
+        hidden
+        onChange={handleImportFile}
+      />
 
       <Box sx={{ flex: 1, display: 'flex', flexDirection: 'row', minHeight: 0 }}>
       {/* Grid avec react-grid-layout */}
@@ -990,6 +1120,20 @@ return () => document.removeEventListener('fullscreenchange', handler)
             </span>
           </Tooltip>
         )}
+        <Tooltip title={t('dashboard.exportDashboards')} placement='left'>
+          <IconButton aria-label={t('dashboard.exportDashboards')} onClick={handleExportDashboards} size='small'>
+            <i className='ri-download-line' style={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={t('dashboard.importDashboards')} placement='left'>
+          <IconButton
+            aria-label={t('dashboard.importDashboards')}
+            onClick={() => importInputRef.current?.click()}
+            size='small'
+          >
+            <i className='ri-upload-line' style={{ fontSize: 18 }} />
+          </IconButton>
+        </Tooltip>
         <Tooltip title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'} placement='left'>
           <IconButton onClick={toggleFullscreen} size='small'>
             <i className={fullscreen ? 'ri-fullscreen-exit-line' : 'ri-fullscreen-line'} style={{ fontSize: 18 }} />

--- a/frontend/src/lib/changes/csv.test.ts
+++ b/frontend/src/lib/changes/csv.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildChangesCsv, buildChangesCsvRows, formatFieldDiffs } from './csv'
+
+const labels = {
+  headers: ['Date', 'Type', 'ID', 'Name', 'Action', 'User', 'Node', 'Connection', 'Fields', 'Details'],
+  resourceType: (type?: string) => (type === 'vm' ? 'VM' : (type ?? '')),
+  action: (action?: string) => (action === 'config_changed' ? 'Configuration' : (action ?? '')),
+}
+
+const change = (over: Record<string, unknown> = {}) => ({
+  timestamp: new Date(2026, 8, 11, 8, 5, 3).toISOString(),
+  resourceType: 'vm',
+  resourceId: 101,
+  resourceName: 'web01',
+  action: 'config_changed',
+  user: 'root@pam',
+  node: 'pve1',
+  connectionName: 'PVE-PROD',
+  fields: [{ field: 'cores', oldValue: '2', newValue: '4' }],
+  ...over,
+})
+
+describe('formatFieldDiffs', () => {
+  it('writes each diff as field, old and new', () => {
+    expect(
+      formatFieldDiffs([
+        { field: 'cores', oldValue: '2', newValue: '4' },
+        { field: 'memory', oldValue: '4096', newValue: '8192' },
+      ])
+    ).toBe('cores: 2 -> 4; memory: 4096 -> 8192')
+  })
+
+  it('writes nothing when a change carries no diff', () => {
+    expect(formatFieldDiffs(undefined)).toBe('')
+    expect(formatFieldDiffs([])).toBe('')
+  })
+
+  it('leaves the missing side empty for an added or removed value', () => {
+    expect(formatFieldDiffs([{ field: 'net0', newValue: 'virtio' }])).toBe('net0:  -> virtio')
+  })
+})
+
+describe('buildChangesCsvRows', () => {
+  it('writes one row per change, with the localised labels', () => {
+    const rows = buildChangesCsvRows([change()], labels)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toEqual([
+      '2026-09-11 08:05:03',
+      'VM',
+      101,
+      'web01',
+      'Configuration',
+      'root@pam',
+      'pve1',
+      'PVE-PROD',
+      1,
+      'cores: 2 -> 4',
+    ])
+  })
+
+  it('falls back to the connection id when the name never came back', () => {
+    const rows = buildChangesCsvRows(
+      [change({ connectionName: undefined, connectionId: 'conn-a' })],
+      labels
+    )
+
+    expect(rows[0][7]).toBe('conn-a')
+  })
+
+  it('keeps a change with no diff as a row, with a count of zero', () => {
+    const rows = buildChangesCsvRows([change({ fields: undefined })], labels)
+
+    expect(rows[0][8]).toBe(0)
+    expect(rows[0][9]).toBe('')
+  })
+})
+
+describe('buildChangesCsv', () => {
+  it('quotes a diff holding the separator and a quote, so the row stays one row', () => {
+    const csv = buildChangesCsv(
+      [change({ fields: [{ field: 'description', oldValue: 'a,b', newValue: 'say "hi"' }] })],
+      labels
+    )
+    const lines = csv.split('\r\n')
+
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toContain('"description: a,b -> say ""hi"""')
+  })
+
+  it('emits the header alone when the filters select nothing', () => {
+    expect(buildChangesCsv([], labels).split('\r\n')).toHaveLength(1)
+  })
+})

--- a/frontend/src/lib/changes/csv.ts
+++ b/frontend/src/lib/changes/csv.ts
@@ -1,0 +1,69 @@
+/**
+ * The change tracking timeline as a CSV.
+ *
+ * One row per change, so the row count matches the number the page announces.
+ * The field diffs a row carries are flattened into a single readable column
+ * rather than spread over extra rows, which keeps a change and its count on the
+ * same line.
+ */
+
+import { timestampCell, toCsv } from '@/lib/export/download'
+
+export type ChangeFieldDiff = {
+  field?: string
+  oldValue?: string | null
+  newValue?: string | null
+}
+
+export type ChangeRecord = {
+  timestamp?: string | number | Date
+  resourceType?: string
+  resourceId?: string | number
+  resourceName?: string
+  action?: string
+  user?: string
+  node?: string
+  connectionName?: string
+  connectionId?: string
+  fields?: ChangeFieldDiff[]
+}
+
+export type ChangesCsvLabels = {
+  headers: readonly string[]
+  resourceType: (type: string | undefined) => string
+  action: (action: string | undefined) => string
+}
+
+/** `cores: 2 -> 4; memory: 4096 -> 8192`, in the timeline's own order. */
+export function formatFieldDiffs(fields: ChangeFieldDiff[] | undefined): string {
+  if (!Array.isArray(fields) || fields.length === 0) return ''
+
+  return fields
+    .map(f => `${f?.field ?? ''}: ${f?.oldValue ?? ''} -> ${f?.newValue ?? ''}`)
+    .join('; ')
+}
+
+export function buildChangesCsvRows(
+  changes: readonly ChangeRecord[],
+  labels: ChangesCsvLabels
+): unknown[][] {
+  return changes.map(change => [
+    timestampCell(change.timestamp ?? ''),
+    labels.resourceType(change.resourceType),
+    change.resourceId ?? '',
+    change.resourceName ?? '',
+    labels.action(change.action),
+    change.user ?? '',
+    change.node ?? '',
+    change.connectionName || change.connectionId || '',
+    Array.isArray(change.fields) ? change.fields.length : 0,
+    formatFieldDiffs(change.fields),
+  ])
+}
+
+export function buildChangesCsv(
+  changes: readonly ChangeRecord[],
+  labels: ChangesCsvLabels
+): string {
+  return toCsv(labels.headers, buildChangesCsvRows(changes, labels))
+}

--- a/frontend/src/lib/dashboard/layoutTransfer.test.ts
+++ b/frontend/src/lib/dashboard/layoutTransfer.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DASHBOARD_FILE_KIND,
+  DASHBOARD_FILE_VERSION,
+  clampToGrid,
+  parseDashboardFile,
+  portSettings,
+  resolveImportName,
+  serializeDashboards,
+} from './layoutTransfer'
+
+const allowAll = () => true
+
+let seq = 0
+
+const generateId = () => `gen-${++seq}`
+
+const options = (over: Partial<Parameters<typeof parseDashboardFile>[1]> = {}) => ({
+  isWidgetAllowed: allowAll,
+  knownConnectionIds: new Set<string>(['conn-a']),
+  generateId,
+  ...over,
+})
+
+const file = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    kind: DASHBOARD_FILE_KIND,
+    version: DASHBOARD_FILE_VERSION,
+    exportedAt: '2026-09-11T06:00:00.000Z',
+    dashboards: [{ name: 'Site A', widgets: [{ id: 'w1', type: 'kpi-vms', x: 0, y: 0, w: 2, h: 3 }] }],
+    ...over,
+  })
+
+describe('serializeDashboards', () => {
+  it('stamps the envelope readers check before importing', () => {
+    const out = serializeDashboards(
+      [{ name: 'Site A', widgets: [{ type: 'kpi-vms' }] }],
+      new Date('2026-09-11T06:00:00Z')
+    )
+
+    expect(out.kind).toBe(DASHBOARD_FILE_KIND)
+    expect(out.version).toBe(DASHBOARD_FILE_VERSION)
+    expect(out.exportedAt).toBe('2026-09-11T06:00:00.000Z')
+  })
+
+  it('carries every dashboard in one file, in order', () => {
+    const out = serializeDashboards([
+      { name: 'Site A', widgets: [{ type: 'kpi-vms' }] },
+      { name: 'Ops', widgets: [{ type: 'kpi-lxc' }, { type: 'kpi-alerts' }] },
+    ])
+
+    expect(out.dashboards.map(d => d.name)).toEqual(['Site A', 'Ops'])
+    expect(out.dashboards[1].widgets).toHaveLength(2)
+  })
+
+  it('copies the widgets so a later edit cannot reach the exported file', () => {
+    const widget = { type: 'kpi-vms', settings: { a: 1 } }
+    const out = serializeDashboards([{ name: 'D', widgets: [widget] }])
+
+    widget.type = 'mutated'
+    expect(out.dashboards[0].widgets[0].type).toBe('kpi-vms')
+  })
+
+  it('survives a dashboard whose widgets never loaded', () => {
+    const out = serializeDashboards([{ name: 'D', widgets: undefined as never }])
+
+    expect(out.dashboards[0].widgets).toEqual([])
+  })
+})
+
+describe('parseDashboardFile rejections', () => {
+  it.each([
+    ['not JSON at all', 'this is not json', 'invalid-json'],
+    ['a JSON array', '[]', 'not-a-dashboard'],
+    ['someone else’s JSON', '{"foo":1}', 'not-a-dashboard'],
+    ['a dashboards field that is not a list', file({ dashboards: 'nope' }), 'not-a-dashboard'],
+    ['a future schema', file({ version: 99 }), 'unsupported-version'],
+  ])('refuses %s', (_label, raw, reason) => {
+    const result = parseDashboardFile(raw as string, options())
+
+    expect(result).toEqual({ ok: false, reason })
+  })
+
+  it('refuses a file whose every widget was dropped rather than creating empty dashboards', () => {
+    const result = parseDashboardFile(file(), options({ isWidgetAllowed: () => false }))
+
+    expect(result).toEqual({ ok: false, reason: 'no-widgets' })
+  })
+})
+
+describe('parseDashboardFile across several dashboards', () => {
+  it('imports every dashboard the file carries', () => {
+    const raw = file({
+      dashboards: [
+        { name: 'Site A', widgets: [{ type: 'kpi-vms' }] },
+        { name: 'Ops', widgets: [{ type: 'kpi-lxc' }] },
+      ],
+    })
+
+    const result = parseDashboardFile(raw, options())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards.map(d => d.name)).toEqual(['Site A', 'Ops'])
+  })
+
+  it('skips a dashboard left with no widget but keeps the others', () => {
+    const raw = file({
+      dashboards: [
+        { name: 'Site A', widgets: [{ type: 'kpi-vms' }] },
+        { name: 'Ceph only', widgets: [{ type: 'ceph-status' }] },
+      ],
+    })
+
+    const result = parseDashboardFile(raw, options({ isWidgetAllowed: t => t !== 'ceph-status' }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards.map(d => d.name)).toEqual(['Site A'])
+    expect(result.skipped).toBe(1)
+    expect(result.dropped).toBe(1)
+  })
+
+  it('totals what was left behind across the whole file', () => {
+    const raw = file({
+      dashboards: [
+        { name: 'A', widgets: [{ type: 'kpi-vms' }, { type: 'unknown-1' }] },
+        { name: 'B', widgets: [{ type: 'kpi-lxc', settings: { selectedConnections: ['gone'] } }] },
+      ],
+    })
+
+    const result = parseDashboardFile(raw, options({ isWidgetAllowed: t => !t.startsWith('unknown') }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dropped).toBe(1)
+    expect(result.reset).toBe(1)
+  })
+
+  it('keeps two dashboards of the same name apart instead of colliding', () => {
+    const raw = file({
+      dashboards: [
+        { name: 'Site A', widgets: [{ type: 'kpi-vms' }] },
+        { name: 'Site A', widgets: [{ type: 'kpi-lxc' }] },
+      ],
+    })
+
+    const result = parseDashboardFile(raw, options({ takenNames: ['Site A'] }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards.map(d => d.name)).toEqual(['Site A (imported)', 'Site A (imported 2)'])
+  })
+
+  it('skips a malformed entry without losing the rest of the file', () => {
+    const raw = file({ dashboards: [null, { name: 'Ops', widgets: [{ type: 'kpi-vms' }] }] })
+    const result = parseDashboardFile(raw, options())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards.map(d => d.name)).toEqual(['Ops'])
+    expect(result.skipped).toBe(1)
+  })
+})
+
+describe('parseDashboardFile widget filtering', () => {
+  it('drops a widget type this install does not know and counts it', () => {
+    const raw = file({
+      dashboards: [{ name: 'A', widgets: [{ type: 'kpi-vms' }, { type: 'widget-from-the-future' }] }],
+    })
+
+    const result = parseDashboardFile(raw, options({ isWidgetAllowed: t => t === 'kpi-vms' }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards[0].widgets).toHaveLength(1)
+    expect(result.dashboards[0].dropped).toBe(1)
+  })
+
+  it('drops a widget RBAC hides from this user, so an import is not a way around the overrides', () => {
+    const raw = file({
+      dashboards: [{ name: 'A', widgets: [{ type: 'kpi-vms' }, { type: 'ceph-status' }] }],
+    })
+
+    const result = parseDashboardFile(raw, options({ isWidgetAllowed: t => t !== 'ceph-status' }))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards[0].widgets.map(w => w.type)).toEqual(['kpi-vms'])
+  })
+
+  it('drops a malformed widget instead of importing one with no type', () => {
+    const raw = file({ dashboards: [{ name: 'A', widgets: [null, { x: 1 }, { type: 'kpi-vms' }] }] })
+    const result = parseDashboardFile(raw, options())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards[0].widgets).toHaveLength(1)
+    expect(result.dashboards[0].dropped).toBe(2)
+  })
+
+  it('gives every imported widget a fresh id, so it cannot collide with a live one', () => {
+    const raw = file({
+      dashboards: [{ name: 'A', widgets: [{ id: 'w1', type: 'kpi-vms' }, { id: 'w1', type: 'kpi-lxc' }] }],
+    })
+
+    const result = parseDashboardFile(raw, options())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const ids = result.dashboards[0].widgets.map(w => w.id)
+
+    expect(new Set(ids).size).toBe(2)
+    expect(ids).not.toContain('w1')
+  })
+})
+
+describe('portSettings', () => {
+  const known = new Set(['conn-a', 'conn-b'])
+
+  it('keeps the connections the target install has', () => {
+    const { settings, changed } = portSettings({ selectedConnections: ['conn-a'] }, known)
+
+    expect(settings).toEqual({ selectedConnections: ['conn-a'] })
+    expect(changed).toBe(false)
+  })
+
+  it('keeps the half of a selection that resolves and reports the loss', () => {
+    const { settings, changed } = portSettings({ selectedConnections: ['conn-a', 'conn-gone'] }, known)
+
+    expect(settings).toEqual({ selectedConnections: ['conn-a'] })
+    expect(changed).toBe(true)
+  })
+
+  it('removes a selector nothing resolves, which is how a widget falls back to all', () => {
+    const { settings, changed } = portSettings({ selectedConnections: ['conn-gone'] }, known)
+
+    expect(settings).toBeUndefined()
+    expect(changed).toBe(true)
+  })
+
+  it('reads a node selector by its connection half', () => {
+    const { settings } = portSettings({ selectedNodes: ['conn-a:pve1', 'conn-gone:pve1'] }, known)
+
+    expect(settings).toEqual({ selectedNodes: ['conn-a:pve1'] })
+  })
+
+  it('treats selectedClusters as connection ids too', () => {
+    const { settings } = portSettings({ selectedClusters: ['conn-b', 'conn-gone'] }, known)
+
+    expect(settings).toEqual({ selectedClusters: ['conn-b'] })
+  })
+
+  it('drops the unfolded-rows state, which describes a tree the target does not have', () => {
+    const { settings } = portSettings({ expanded: ['conn-a:pve1'], title: 'General' }, known)
+
+    expect(settings).toEqual({ title: 'General' })
+  })
+
+  it('leaves a setting that names nothing in the environment alone', () => {
+    const { settings, changed } = portSettings({ title: 'Cluster / Ceph' }, known)
+
+    expect(settings).toEqual({ title: 'Cluster / Ceph' })
+    expect(changed).toBe(false)
+  })
+})
+
+describe('parseDashboardFile settings porting', () => {
+  it('counts the widgets whose selectors named a connection this install lacks', () => {
+    const raw = file({
+      dashboards: [
+        {
+          name: 'A',
+          widgets: [
+            { type: 'zfs-arc', settings: { selectedConnections: ['conn-from-site-b'] } },
+            { type: 'kpi-vms', settings: { selectedConnections: ['conn-a'] } },
+          ],
+        },
+      ],
+    })
+
+    const result = parseDashboardFile(raw, options())
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.dashboards[0].reset).toBe(1)
+    expect(result.dashboards[0].widgets[0].settings).toBeUndefined()
+    expect(result.dashboards[0].widgets[1].settings).toEqual({ selectedConnections: ['conn-a'] })
+  })
+})
+
+describe('clampToGrid', () => {
+  it('pulls a widget wider than the grid back inside it', () => {
+    expect(clampToGrid({ type: 'x', x: 0, y: 0, w: 40, h: 2 })).toMatchObject({ w: 12, x: 0 })
+  })
+
+  it('slides a widget starting past the last column back into view', () => {
+    expect(clampToGrid({ type: 'x', x: 30, y: 0, w: 3, h: 2 })).toMatchObject({ x: 9, w: 3 })
+  })
+
+  it('replaces a missing or absurd geometry with a usable one', () => {
+    expect(clampToGrid({ type: 'x' })).toMatchObject({ x: 0, y: 0, w: 1, h: 1 })
+    expect(clampToGrid({ type: 'x', x: -5, y: -5, w: 0, h: 0 })).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 1,
+      h: 1,
+    })
+  })
+})
+
+describe('resolveImportName', () => {
+  it('keeps the exported name when nothing holds it', () => {
+    expect(resolveImportName('Site A', ['Default'])).toBe('Site A')
+  })
+
+  it('never overwrites an existing dashboard', () => {
+    expect(resolveImportName('Site A', ['Site A'])).toBe('Site A (imported)')
+    expect(resolveImportName('Site A', ['Site A', 'Site A (imported)'])).toBe('Site A (imported 2)')
+  })
+
+  it('names a file that carries no name', () => {
+    expect(resolveImportName('   ', [])).toBe('imported')
+  })
+
+  it('uses the caller’s word, so the name is not English in a French UI', () => {
+    expect(resolveImportName('Site A', ['Site A'], 'importé')).toBe('Site A (importé)')
+    expect(resolveImportName('Site A', ['Site A', 'Site A (importé)'], 'importé')).toBe('Site A (importé 2)')
+  })
+})

--- a/frontend/src/lib/dashboard/layoutTransfer.ts
+++ b/frontend/src/lib/dashboard/layoutTransfer.ts
@@ -1,0 +1,300 @@
+/**
+ * Moving dashboards between accounts and between ProxCenter installs.
+ *
+ * One file carries every dashboard the user has, never an archive: a set of
+ * monitoring views travels as a set, and splitting it into one file per tab
+ * only makes a standard view harder to hand to a colleague.
+ *
+ * A layout is portable, but a few widget settings are not: `selectedConnections`,
+ * `selectedClusters` and `selectedNodes` name things by id, and those ids belong
+ * to the install the dashboards were exported from. Carried over verbatim they
+ * point at nothing on the target and the widget renders empty with no
+ * explanation, which is the failure this module exists to prevent. Every
+ * selector is therefore checked against the connections the target actually has:
+ * what resolves is kept (re-importing your own backup keeps your filters), what
+ * does not is dropped, and a selector left empty means "all", the widgets' own
+ * documented fallback.
+ */
+
+export const DASHBOARD_FILE_KIND = 'proxcenter.dashboards'
+export const DASHBOARD_FILE_VERSION = 1
+
+/** Widest grid the dashboard renders at (GRID_COLS in WidgetGrid). */
+const GRID_COLUMNS = 12
+
+export type TransferWidget = {
+  id?: string
+  type: string
+  x?: number
+  y?: number
+  w?: number
+  h?: number
+  settings?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+export type TransferDashboard = {
+  name: string
+  widgets: TransferWidget[]
+}
+
+export type DashboardFile = {
+  kind: string
+  version: number
+  exportedAt: string
+  dashboards: TransferDashboard[]
+}
+
+export type ParseFailure =
+  | 'invalid-json'
+  | 'not-a-dashboard'
+  | 'unsupported-version'
+  | 'no-widgets'
+
+export type ImportedDashboard = {
+  name: string
+  widgets: TransferWidget[]
+  /** Widgets the target does not know, or that RBAC hides from this user. */
+  dropped: number
+  /** Widgets whose selectors named connections this install does not have. */
+  reset: number
+}
+
+export type ParseResult =
+  | {
+      ok: true
+      dashboards: ImportedDashboard[]
+      /** Dashboards whose every widget was dropped, so nothing was left to create. */
+      skipped: number
+      dropped: number
+      reset: number
+    }
+  | { ok: false; reason: ParseFailure }
+
+export type ParseOptions = {
+  /** Whether this user may hold this widget type here (registry + RBAC + scope). */
+  isWidgetAllowed: (type: string) => boolean
+  /** Connection ids the target install exposes to this user. */
+  knownConnectionIds: Set<string>
+  /** Dashboard names already taken for this user. */
+  takenNames?: Iterable<string>
+  generateId: () => string
+  /** Localised word appended when an exported name is taken, e.g. "imported". */
+  importedSuffix?: string
+}
+
+export function serializeDashboards(
+  dashboards: readonly TransferDashboard[],
+  now: Date = new Date()
+): DashboardFile {
+  return {
+    kind: DASHBOARD_FILE_KIND,
+    version: DASHBOARD_FILE_VERSION,
+    exportedAt: now.toISOString(),
+    dashboards: dashboards.map(d => ({
+      name: d.name,
+      widgets: (d.widgets || []).map(widget => ({ ...widget })),
+    })),
+  }
+}
+
+/**
+ * Free name for an import: the file's own name when nothing holds it, then
+ * `<name> (imported)`, then a counter. Never silently overwrites a dashboard
+ * the user already built.
+ */
+export function resolveImportName(
+  base: string,
+  takenNames: Iterable<string> = [],
+  importedSuffix = 'imported'
+): string {
+  const taken = new Set(takenNames)
+  const trimmed = base.trim() || importedSuffix
+
+  if (!taken.has(trimmed)) return trimmed
+
+  const candidate = `${trimmed} (${importedSuffix})`
+
+  if (!taken.has(candidate)) return candidate
+
+  for (let n = 2; n <= 99; n++) {
+    const numbered = `${trimmed} (${importedSuffix} ${n})`
+
+    if (!taken.has(numbered)) return numbered
+  }
+
+  return `${trimmed} (${importedSuffix} ${Date.now()})`
+}
+
+/** Lists of connection ids. `selectedClusters` holds connection ids too. */
+const CONNECTION_ID_SETTINGS = ['selectedConnections', 'selectedClusters'] as const
+
+/** `<connectionId>:<nodeName>`, so the connection half is what can go stale. */
+const CONNECTION_SCOPED_SETTINGS = ['selectedNodes'] as const
+
+/** Which tree rows were unfolded. Pure view state, never worth carrying over. */
+const VIEW_STATE_SETTINGS = ['expanded'] as const
+
+function keepResolvable(
+  values: unknown,
+  isKnown: (id: string) => boolean
+): { kept: string[]; changed: boolean } {
+  if (!Array.isArray(values)) return { kept: [], changed: false }
+
+  const kept = values.filter(v => typeof v === 'string' && isKnown(v))
+
+  return { kept, changed: kept.length !== values.length }
+}
+
+/**
+ * Strips the environment out of a widget's settings. Returns the settings to
+ * keep and whether anything was dropped, so the import can say so out loud.
+ */
+export function portSettings(
+  settings: Record<string, unknown> | undefined,
+  knownConnectionIds: Set<string>
+): { settings: Record<string, unknown> | undefined; changed: boolean } {
+  if (!settings || typeof settings !== 'object') return { settings, changed: false }
+
+  const next: Record<string, unknown> = { ...settings }
+  let changed = false
+
+  for (const key of CONNECTION_ID_SETTINGS) {
+    if (!(key in next)) continue
+    const { kept, changed: lost } = keepResolvable(next[key], id => knownConnectionIds.has(id))
+
+    changed = changed || lost
+    if (kept.length > 0) next[key] = kept
+    else delete next[key]
+  }
+
+  for (const key of CONNECTION_SCOPED_SETTINGS) {
+    if (!(key in next)) continue
+    const { kept, changed: lost } = keepResolvable(next[key], id =>
+      knownConnectionIds.has(id.split(':')[0])
+    )
+
+    changed = changed || lost
+    if (kept.length > 0) next[key] = kept
+    else delete next[key]
+  }
+
+  for (const key of VIEW_STATE_SETTINGS) {
+    if (key in next) delete next[key]
+  }
+
+  return { settings: Object.keys(next).length > 0 ? next : undefined, changed }
+}
+
+function clampInt(value: unknown, fallback: number, min: number, max: number): number {
+  const n = Math.round(Number(value))
+
+  if (!Number.isFinite(n)) return fallback
+
+  return Math.min(max, Math.max(min, n))
+}
+
+/** Keeps an imported widget inside the 12-column grid whatever the file claims. */
+export function clampToGrid(widget: TransferWidget): TransferWidget {
+  const w = clampInt(widget.w, 1, 1, GRID_COLUMNS)
+  const h = clampInt(widget.h, 1, 1, 200)
+  const x = clampInt(widget.x, 0, 0, GRID_COLUMNS - w)
+  const y = clampInt(widget.y, 0, 0, 10_000)
+
+  return { ...widget, x, y, w, h }
+}
+
+function portWidgets(
+  candidates: unknown,
+  opts: ParseOptions
+): { widgets: TransferWidget[]; dropped: number; reset: number } {
+  const widgets: TransferWidget[] = []
+  let dropped = 0
+  let reset = 0
+
+  for (const candidate of Array.isArray(candidates) ? candidates : []) {
+    if (!candidate || typeof candidate !== 'object' || typeof candidate.type !== 'string') {
+      dropped++
+      continue
+    }
+
+    // An imported file must not be a way around the widget overrides: a type
+    // this user may not hold here is dropped, not merely hidden at render.
+    if (!opts.isWidgetAllowed(candidate.type)) {
+      dropped++
+      continue
+    }
+
+    const { settings, changed } = portSettings(candidate.settings, opts.knownConnectionIds)
+
+    if (changed) reset++
+
+    const widget = clampToGrid({ ...candidate, id: opts.generateId() })
+
+    if (settings) widget.settings = settings
+    else delete widget.settings
+
+    widgets.push(widget)
+  }
+
+  return { widgets, dropped, reset }
+}
+
+export function parseDashboardFile(raw: string, opts: ParseOptions): ParseResult {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { ok: false, reason: 'invalid-json' }
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, reason: 'not-a-dashboard' }
+  }
+
+  const file = parsed as Partial<DashboardFile>
+
+  if (file.kind !== DASHBOARD_FILE_KIND) return { ok: false, reason: 'not-a-dashboard' }
+  if (file.version !== DASHBOARD_FILE_VERSION) return { ok: false, reason: 'unsupported-version' }
+  if (!Array.isArray(file.dashboards)) return { ok: false, reason: 'not-a-dashboard' }
+
+  // Names are resolved against the live ones AND against the names this same
+  // file already claimed, so two dashboards in one file cannot collide.
+  const taken = new Set(opts.takenNames || [])
+  const dashboards: ImportedDashboard[] = []
+  let skipped = 0
+  let dropped = 0
+  let reset = 0
+
+  for (const entry of file.dashboards) {
+    if (!entry || typeof entry !== 'object') {
+      skipped++
+      continue
+    }
+
+    const ported = portWidgets(entry.widgets, opts)
+
+    dropped += ported.dropped
+    reset += ported.reset
+
+    // A dashboard with nothing left to show is not worth creating.
+    if (ported.widgets.length === 0) {
+      skipped++
+      continue
+    }
+
+    const name = resolveImportName(
+      typeof entry.name === 'string' ? entry.name : '',
+      taken,
+      opts.importedSuffix
+    )
+
+    taken.add(name)
+    dashboards.push({ name, widgets: ported.widgets, dropped: ported.dropped, reset: ported.reset })
+  }
+
+  if (dashboards.length === 0) return { ok: false, reason: 'no-widgets' }
+
+  return { ok: true, dashboards, skipped, dropped, reset }
+}

--- a/frontend/src/lib/export/download.test.ts
+++ b/frontend/src/lib/export/download.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { csvCell, dateStamp, filenameSlug, timestampCell, toCsv } from './download'
+
+describe('csvCell', () => {
+  it('doubles an embedded quote instead of ending the cell', () => {
+    expect(csvCell('name "web01"')).toBe('"name ""web01"""')
+  })
+
+  it('keeps a comma and a newline inside one cell', () => {
+    expect(csvCell('a,b')).toBe('"a,b"')
+    expect(csvCell('line1\nline2')).toBe('"line1\nline2"')
+  })
+
+  it('writes an empty cell for null and undefined rather than the word', () => {
+    expect(csvCell(null)).toBe('""')
+    expect(csvCell(undefined)).toBe('""')
+  })
+
+  it('keeps a zero, which is a value and not an absence', () => {
+    expect(csvCell(0)).toBe('"0"')
+  })
+})
+
+describe('toCsv', () => {
+  it('writes the header row then the data rows', () => {
+    expect(toCsv(['a', 'b'], [[1, 2], [3, 4]])).toBe('"a","b"\r\n"1","2"\r\n"3","4"')
+  })
+
+  it('emits the header alone when there is no data', () => {
+    expect(toCsv(['a'], [])).toBe('"a"')
+  })
+
+  it('survives a value holding the separator and the row terminator', () => {
+    const csv = toCsv(['v'], [['x","y\r\nz']])
+
+    expect(csv).toBe('"v"\r\n"x"",""y\r\nz"')
+  })
+})
+
+describe('timestampCell', () => {
+  it('writes local time a spreadsheet parses as a date', () => {
+    expect(timestampCell(new Date(2026, 8, 11, 8, 5, 3))).toBe('2026-09-11 08:05:03')
+  })
+
+  it('writes nothing for a timestamp it cannot read', () => {
+    expect(timestampCell('not a date')).toBe('')
+    expect(timestampCell('')).toBe('')
+  })
+})
+
+describe('dateStamp', () => {
+  it('pads the month and the day', () => {
+    expect(dateStamp(new Date(2026, 0, 5))).toBe('2026-01-05')
+  })
+})
+
+describe('filenameSlug', () => {
+  it('replaces what a filesystem refuses', () => {
+    expect(filenameSlug('Site A / prod')).toBe('Site-A-prod')
+  })
+
+  it('falls back rather than producing an empty name', () => {
+    expect(filenameSlug('///')).toBe('export')
+  })
+
+  it('caps the length so the filename stays usable', () => {
+    expect(filenameSlug('a'.repeat(200))).toHaveLength(60)
+  })
+})

--- a/frontend/src/lib/export/download.ts
+++ b/frontend/src/lib/export/download.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared export primitives.
+ *
+ * Every export built on this hands the browser exactly one file: there is no
+ * archive to unzip and no format to pick.
+ */
+
+/**
+ * One RFC 4180 cell: always quoted, embedded quotes doubled. Config diffs hold
+ * commas, quotes and newlines, all three of which split a naively quoted cell
+ * into garbage.
+ */
+export function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return '""'
+
+  return `"${String(value).replace(/"/g, '""')}"`
+}
+
+export function toCsv(headers: readonly string[], rows: readonly (readonly unknown[])[]): string {
+  return [headers, ...rows].map(row => row.map(csvCell).join(',')).join('\r\n')
+}
+
+export function downloadTextFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Excel reads a UTF-8 CSV as the local codepage unless the file opens with a
+ * BOM, which turns every accented or CJK label our six locales produce into
+ * mojibake. The BOM is not part of the CSV, so it is added here and never in
+ * toCsv().
+ */
+export function downloadCsv(csv: string, filename: string): void {
+  downloadTextFile(`\uFEFF${csv}`, filename, 'text/csv;charset=utf-8')
+}
+
+export function downloadJson(value: unknown, filename: string): void {
+  downloadTextFile(JSON.stringify(value, null, 2), filename, 'application/json')
+}
+
+/** Local date, so the filename carries the user's day and not UTC's. */
+export function dateStamp(date: Date = new Date()): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+/** Local `YYYY-MM-DD HH:MM:SS`, which spreadsheets parse and sort as a date. */
+export function timestampCell(value: string | number | Date): string {
+  const d = new Date(value)
+
+  if (Number.isNaN(d.getTime())) return ''
+
+  const pad = (n: number) => String(n).padStart(2, '0')
+
+  return `${dateStamp(d)} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+/** Strips what a filesystem refuses, so a dashboard name can become a filename. */
+export function filenameSlug(value: string): string {
+  return (
+    String(value)
+      .normalize('NFKD')
+      .replace(/[^\w.-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'export'
+  )
+}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -565,7 +565,23 @@
       "guests": "{count} Guests",
       "running": "{count} aktiv",
       "nodes": "{count} Nodes"
-    }
+    },
+    "importDropped": "{count, plural, one {# Widget wurde ausgelassen: hier unbekannt oder für Sie nicht verfügbar.} other {# Widgets wurden ausgelassen: hier unbekannt oder für Sie nicht verfügbar.}}",
+    "importReset": "{count, plural, one {# Widget zeigt jetzt alle Verbindungen: die benannten fehlen in dieser Installation.} other {# Widgets zeigen jetzt alle Verbindungen: die benannten fehlen in dieser Installation.}}",
+    "exportFailed": "Dieses Dashboard konnte nicht exportiert werden.",
+    "importError": {
+      "invalid-json": "Diese Datei ist kein gültiges JSON.",
+      "not-a-dashboard": "Diese Datei ist kein ProxCenter-Dashboard-Export.",
+      "unsupported-version": "Diese Datei stammt aus einer neueren ProxCenter-Version.",
+      "no-widgets": "Nichts zu importieren: keines der Widgets dieser Datei ist hier verfügbar.",
+      "not-stored": "Der Import wurde angenommen, die Dashboards aber nicht gespeichert."
+    },
+    "importedSuffix": "importiert",
+    "exportDashboards": "Alle Dashboards exportieren",
+    "importDashboards": "Dashboards importieren…",
+    "dashboardsExported": "{count, plural, one {# Dashboard exportiert.} other {# Dashboards in eine Datei exportiert.}}",
+    "dashboardsImported": "{count, plural, one {# Dashboard importiert.} other {# Dashboards importiert.}}",
+    "importSkipped": "{count, plural, one {# Dashboard wurde übersprungen: keines seiner Widgets ist hier verfügbar.} other {# Dashboards wurden übersprungen: keines ihrer Widgets ist hier verfügbar.}}"
   },
   "alerts": {
     "title": "Warnmeldungen",
@@ -7365,7 +7381,17 @@
     "retentionDescription": "Änderungen, die älter als der Aufbewahrungszeitraum sind, werden automatisch gelöscht.",
     "retentionDays": "Aufbewahrung",
     "retentionInfo": "Aufbewahrung: {days} Tage",
-    "days": "Tage"
+    "days": "Tage",
+    "csvDate": "Datum",
+    "csvResourceType": "Ressourcentyp",
+    "csvResourceId": "Ressourcen-ID",
+    "csvResourceName": "Ressourcenname",
+    "csvAction": "Aktion",
+    "csvUser": "Benutzer",
+    "csvNode": "Knoten",
+    "csvConnection": "Verbindung",
+    "csvFieldCount": "Geänderte Felder",
+    "csvDetails": "Details"
   },
   "tenants": {
     "title": "Mandanten",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -576,7 +576,23 @@
       "guests": "{count} guests",
       "running": "{count} running",
       "nodes": "{count} nodes"
-    }
+    },
+    "importDropped": "{count, plural, one {# widget was left out: unknown here, or not available to you.} other {# widgets were left out: unknown here, or not available to you.}}",
+    "importReset": "{count, plural, one {# widget now shows all connections: the ones it named are not on this install.} other {# widgets now show all connections: the ones they named are not on this install.}}",
+    "exportFailed": "This dashboard could not be exported.",
+    "importError": {
+      "invalid-json": "This file is not valid JSON.",
+      "not-a-dashboard": "This file is not a ProxCenter dashboard export.",
+      "unsupported-version": "This dashboard file comes from a newer version of ProxCenter.",
+      "no-widgets": "Nothing to import: none of the widgets in this file are available here.",
+      "not-stored": "The import was accepted but the dashboards were not stored."
+    },
+    "importedSuffix": "imported",
+    "exportDashboards": "Export all dashboards",
+    "importDashboards": "Import dashboards…",
+    "dashboardsExported": "{count, plural, one {# dashboard exported.} other {# dashboards exported to one file.}}",
+    "dashboardsImported": "{count, plural, one {# dashboard imported.} other {# dashboards imported.}}",
+    "importSkipped": "{count, plural, one {# dashboard was skipped: none of its widgets are available here.} other {# dashboards were skipped: none of their widgets are available here.}}"
   },
   "alerts": {
     "title": "Alerts",
@@ -7421,7 +7437,17 @@
     "retentionDescription": "Changes older than the retention period will be automatically deleted.",
     "retentionDays": "Retention",
     "retentionInfo": "Retention: {days} days",
-    "days": "days"
+    "days": "days",
+    "csvDate": "Date",
+    "csvResourceType": "Resource type",
+    "csvResourceId": "Resource ID",
+    "csvResourceName": "Resource name",
+    "csvAction": "Action",
+    "csvUser": "User",
+    "csvNode": "Node",
+    "csvConnection": "Connection",
+    "csvFieldCount": "Fields changed",
+    "csvDetails": "Details"
   },
   "tenants": {
     "title": "Tenants",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -576,7 +576,23 @@
       "guests": "{count} guests",
       "running": "{count} en ejecución",
       "nodes": "{count} nodos"
-    }
+    },
+    "importDropped": "{count, plural, one {Se ha omitido # widget: desconocido aquí o no disponible para su cuenta.} other {Se han omitido # widgets: desconocidos aquí o no disponibles para su cuenta.}}",
+    "importReset": "{count, plural, one {# widget muestra ahora todas las conexiones: las que indicaba no existen en esta instalación.} other {# widgets muestran ahora todas las conexiones: las que indicaban no existen en esta instalación.}}",
+    "exportFailed": "No se ha podido exportar este dashboard.",
+    "importError": {
+      "invalid-json": "Este archivo no es JSON válido.",
+      "not-a-dashboard": "Este archivo no es una exportación de dashboards de ProxCenter.",
+      "unsupported-version": "Este archivo procede de una versión más reciente de ProxCenter.",
+      "no-widgets": "Nada que importar: ninguno de los widgets de este archivo está disponible aquí.",
+      "not-stored": "La importación se aceptó pero los dashboards no se han guardado."
+    },
+    "importedSuffix": "importado",
+    "exportDashboards": "Exportar todos los dashboards",
+    "importDashboards": "Importar dashboards…",
+    "dashboardsExported": "{count, plural, one {# dashboard exportado.} other {# dashboards exportados en un solo archivo.}}",
+    "dashboardsImported": "{count, plural, one {# dashboard importado.} other {# dashboards importados.}}",
+    "importSkipped": "{count, plural, one {Se ha omitido # dashboard: ninguno de sus widgets está disponible aquí.} other {Se han omitido # dashboards: ninguno de sus widgets está disponible aquí.}}"
   },
   "alerts": {
     "title": "Alertas",
@@ -7421,7 +7437,17 @@
     "retentionDescription": "Los cambios anteriores al período de retención se eliminarán automáticamente.",
     "retentionDays": "Retención",
     "retentionInfo": "Retención: {days} días",
-    "days": "días"
+    "days": "días",
+    "csvDate": "Fecha",
+    "csvResourceType": "Tipo de recurso",
+    "csvResourceId": "ID del recurso",
+    "csvResourceName": "Nombre del recurso",
+    "csvAction": "Acción",
+    "csvUser": "Usuario",
+    "csvNode": "Nodo",
+    "csvConnection": "Conexión",
+    "csvFieldCount": "Campos modificados",
+    "csvDetails": "Detalles"
   },
   "tenants": {
     "title": "Tenants",

--- a/frontend/src/messages/exportMessages.test.ts
+++ b/frontend/src/messages/exportMessages.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import ko from './ko.json'
+import zhCN from './zh-CN.json'
+
+const locales = { en, fr, de, es, ko, 'zh-CN': zhCN }
+
+const CHANGES_CSV_KEYS = [
+  'csvDate',
+  'csvResourceType',
+  'csvResourceId',
+  'csvResourceName',
+  'csvAction',
+  'csvUser',
+  'csvNode',
+  'csvConnection',
+  'csvFieldCount',
+  'csvDetails',
+] as const
+
+const DASHBOARD_TRANSFER_KEYS = [
+  'exportDashboards',
+  'importDashboards',
+  'dashboardsExported',
+  'dashboardsImported',
+  'importSkipped',
+  'importDropped',
+  'importReset',
+  'exportFailed',
+  'importedSuffix',
+] as const
+
+/** Every rejection parseDashboardFile can return needs a sentence in every locale. */
+const IMPORT_ERROR_KEYS = [
+  'invalid-json',
+  'not-a-dashboard',
+  'unsupported-version',
+  'no-widgets',
+  'not-stored',
+] as const
+
+function expectStrings(block: unknown, keys: readonly string[], locale: string, label: string) {
+  const record = block as Record<string, unknown>
+
+  expect(record, `${locale}: missing ${label} block`).toBeTypeOf('object')
+
+  for (const key of keys) {
+    expect(record, `${locale}: missing ${label}.${key}`).toHaveProperty(key)
+    expect(record[key], `${locale}: ${label}.${key}`).toBeTypeOf('string')
+    expect((record[key] as string).trim().length, `${locale}: ${label}.${key} is empty`).toBeGreaterThan(0)
+  }
+}
+
+describe('export i18n parity across the 6 served locales', () => {
+  for (const [locale, messages] of Object.entries(locales)) {
+    it(`${locale} names every change tracking CSV column`, () => {
+      expectStrings(messages.changes, CHANGES_CSV_KEYS, locale, 'changes')
+    })
+
+    it(`${locale} names the dashboard transfer actions and their outcomes`, () => {
+      expectStrings(messages.dashboard, DASHBOARD_TRANSFER_KEYS, locale, 'dashboard')
+    })
+
+    it(`${locale} explains every reason an import can be refused`, () => {
+      const dashboard = messages.dashboard as Record<string, unknown>
+
+      expectStrings(dashboard.importError, IMPORT_ERROR_KEYS, locale, 'dashboard.importError')
+    })
+
+    it(`${locale} keeps the placeholders the code passes`, () => {
+      const dashboard = messages.dashboard as unknown as Record<string, string>
+
+      // ICU plurals spell it `{count, plural, ...}`, so match the placeholder name.
+      const counted = [
+        'dashboardsExported',
+        'dashboardsImported',
+        'importSkipped',
+        'importDropped',
+        'importReset',
+      ]
+
+      for (const key of counted) {
+        expect(dashboard[key], `${locale}: ${key}`).toMatch(/\{count[,}]/)
+      }
+    })
+  }
+})

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -576,7 +576,23 @@
       "guests": "{count} guests",
       "running": "{count} en cours",
       "nodes": "{count} nœuds"
-    }
+    },
+    "importDropped": "{count, plural, one {# widget a été écarté : inconnu ici, ou non accessible à votre compte.} other {# widgets ont été écartés : inconnus ici, ou non accessibles à votre compte.}}",
+    "importReset": "{count, plural, one {# widget affiche désormais toutes les connexions : celles qu’il désignait sont absentes de cette installation.} other {# widgets affichent désormais toutes les connexions : celles qu’ils désignaient sont absentes de cette installation.}}",
+    "exportFailed": "Ce dashboard n’a pas pu être exporté.",
+    "importError": {
+      "invalid-json": "Ce fichier n’est pas du JSON valide.",
+      "not-a-dashboard": "Ce fichier n’est pas un export de dashboards ProxCenter.",
+      "unsupported-version": "Ce fichier provient d’une version plus récente de ProxCenter.",
+      "no-widgets": "Rien à importer : aucun widget de ce fichier n’est disponible ici.",
+      "not-stored": "L'import a été accepté mais les dashboards n'ont pas été enregistrés."
+    },
+    "importedSuffix": "importé",
+    "exportDashboards": "Exporter tous les dashboards",
+    "importDashboards": "Importer des dashboards…",
+    "dashboardsExported": "{count, plural, one {# dashboard exporté.} other {# dashboards exportés dans un seul fichier.}}",
+    "dashboardsImported": "{count, plural, one {# dashboard importé.} other {# dashboards importés.}}",
+    "importSkipped": "{count, plural, one {# dashboard a été ignoré : aucun de ses widgets n’est disponible ici.} other {# dashboards ont été ignorés : aucun de leurs widgets n’est disponible ici.}}"
   },
   "alerts": {
     "title": "Alertes",
@@ -7422,7 +7438,17 @@
     "retentionDescription": "Les changements plus anciens que la période de rétention seront automatiquement supprimés.",
     "retentionDays": "Rétention",
     "retentionInfo": "Rétention : {days} jours",
-    "days": "jours"
+    "days": "jours",
+    "csvDate": "Date",
+    "csvResourceType": "Type de ressource",
+    "csvResourceId": "ID de ressource",
+    "csvResourceName": "Nom de la ressource",
+    "csvAction": "Action",
+    "csvUser": "Utilisateur",
+    "csvNode": "Nœud",
+    "csvConnection": "Connexion",
+    "csvFieldCount": "Champs modifiés",
+    "csvDetails": "Détail"
   },
   "tenants": {
     "title": "Tenants",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -576,7 +576,23 @@
       "guests": "게스트 {count}개",
       "running": "실행 중 {count}개",
       "nodes": "노드 {count}개"
-    }
+    },
+    "importDropped": "위젯 {count}개를 제외했습니다. 이 설치에 없거나 계정에서 사용할 수 없습니다.",
+    "importReset": "위젯 {count}개가 이제 모든 연결을 표시합니다. 지정된 연결이 이 설치에 없습니다.",
+    "exportFailed": "이 대시보드를 내보내지 못했습니다.",
+    "importError": {
+      "invalid-json": "이 파일은 올바른 JSON이 아닙니다.",
+      "not-a-dashboard": "이 파일은 ProxCenter 대시보드 내보내기 파일이 아닙니다.",
+      "unsupported-version": "이 파일은 더 새로운 ProxCenter 버전에서 만들어졌습니다.",
+      "no-widgets": "가져올 항목이 없습니다. 이 파일의 위젯 중 여기에서 사용할 수 있는 것이 없습니다.",
+      "not-stored": "가져오기는 수락되었지만 대시보드가 저장되지 않았습니다."
+    },
+    "importedSuffix": "가져옴",
+    "exportDashboards": "모든 대시보드 내보내기",
+    "importDashboards": "대시보드 가져오기…",
+    "dashboardsExported": "대시보드 {count}개를 파일 하나로 내보냈습니다.",
+    "dashboardsImported": "대시보드 {count}개를 가져왔습니다.",
+    "importSkipped": "대시보드 {count}개를 건너뛰었습니다. 해당 위젯이 이 설치에 없습니다."
   },
   "alerts": {
     "title": "알림",
@@ -7421,7 +7437,17 @@
     "retentionDescription": "보존 기간보다 오래된 변경 사항은 자동으로 삭제됩니다.",
     "retentionDays": "보존 기간",
     "retentionInfo": "보존 기간: {days}일",
-    "days": "일"
+    "days": "일",
+    "csvDate": "날짜",
+    "csvResourceType": "리소스 유형",
+    "csvResourceId": "리소스 ID",
+    "csvResourceName": "리소스 이름",
+    "csvAction": "작업",
+    "csvUser": "사용자",
+    "csvNode": "노드",
+    "csvConnection": "연결",
+    "csvFieldCount": "변경된 필드",
+    "csvDetails": "상세"
   },
   "tenants": {
     "title": "테넌트",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -580,7 +580,23 @@
       "guests": "{count} 个客户机",
       "running": "{count} 个运行中",
       "nodes": "{count} 个节点"
-    }
+    },
+    "importDropped": "已略过 {count} 个小部件：此处不存在，或您的账号无权使用。",
+    "importReset": "{count} 个小部件现在显示全部连接：它们指定的连接不在此安装中。",
+    "exportFailed": "无法导出此仪表盘。",
+    "importError": {
+      "invalid-json": "此文件不是有效的 JSON。",
+      "not-a-dashboard": "此文件不是 ProxCenter 仪表盘导出文件。",
+      "unsupported-version": "此文件来自更新版本的 ProxCenter。",
+      "no-widgets": "没有可导入的内容：此文件中的小部件在此处均不可用。",
+      "not-stored": "导入已被接受，但仪表盘未保存。"
+    },
+    "importedSuffix": "导入",
+    "exportDashboards": "导出全部仪表盘",
+    "importDashboards": "导入仪表盘…",
+    "dashboardsExported": "已将 {count} 个仪表盘导出为一个文件。",
+    "dashboardsImported": "已导入 {count} 个仪表盘。",
+    "importSkipped": "已跳过 {count} 个仪表盘：其小部件在此处均不可用。"
   },
   "alerts": {
     "title": "告警",
@@ -7427,7 +7443,17 @@
     "retentionDescription": "超过保留期的变更将被自动删除。",
     "retentionDays": "保留期",
     "retentionInfo": "保留期：{days} 天",
-    "days": "天"
+    "days": "天",
+    "csvDate": "日期",
+    "csvResourceType": "资源类型",
+    "csvResourceId": "资源 ID",
+    "csvResourceName": "资源名称",
+    "csvAction": "操作",
+    "csvUser": "用户",
+    "csvNode": "节点",
+    "csvConnection": "连接",
+    "csvFieldCount": "变更字段数",
+    "csvDetails": "详情"
   },
   "tenants": {
     "title": "租户",


### PR DESCRIPTION
Closes #918, closes #913.

## Change tracking export (#918)

The timeline gains an export action that writes what the filters select, every page of it, not just the rows on screen. One row per change, so the count matches what the page announces, with the field diffs flattened into a readable column.

Values are quoted per RFC 4180 instead of wrapped in bare quotes. Config diffs routinely carry commas, quotes and newlines, and any of those splits a naively quoted cell into garbage: on the test cluster, 46 of 61 changes hold a comma inside a value. The file also opens with a BOM, without which Excel reads UTF-8 as the local codepage and mangles every accented or CJK column header.

The page's four actions move into the filter row as icons, giving the timeline back a full row of height. Each carries its own `aria-label`, since a disabled icon button wrapped in a tooltip's `span` would otherwise have no accessible name.

## Dashboard export and import (#913)

The dashboard toolbar gains export and import, above the fullscreen control. Export writes **every** dashboard the user has into a single JSON file: a standard monitoring view travels as a set, and one file per tab only makes it harder to hand to a colleague. If any dashboard fails to load the export fails rather than hand over a file that silently claims to be the whole set.

The part worth reviewing is what import does to widget settings. `selectedConnections`, `selectedClusters` and `selectedNodes` name things by id, and those ids belong to the install the file came from. Carried over verbatim into another install they resolve to nothing and the widget renders empty with no explanation, which is exactly the failure the feature is meant to avoid. Import checks every selector against the connections the target actually has: what resolves is kept, so re-importing your own backup keeps your filters, and what does not is dropped, which falls the widget back to "all". Unfolded-tree state is dropped outright.

Three other rules: widget types the user may not hold here are dropped rather than merely hidden, so an imported file cannot work around the RBAC widget overrides; geometry is clamped back into the 12-column grid; and names never overwrite an existing dashboard, resolving to `<name> (imported)` instead, including between two same-named dashboards inside one file.

A 200 from the create route is not proof anything was stored, so the import confirms the dashboards against the list before announcing success. Every outcome is reported, including how many widgets were dropped or reset.

## Testing

748 files, 8813 tests green. Recette on the lab cluster covered both exports end to end in the browser, including a file built to look like it came from another install: 3 dashboards imported, 1 skipped, 2 widgets dropped, 3 reset, and no foreign connection id surviving in the database.
