### PR TITLE
Grow the Prometheus exposition to 53 families and ship five Grafana dashboards

### DIFF
--- a/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
@@ -1,0 +1,1480 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "The Prometheus that scrapes /api/v1/public/metrics on your ProxCenter.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "Which Proxmox guests are actually protected, how stale their backups are, and whether the Proxmox Backup Server datastores behind them have room left. Counts guests that have NEVER been backed up, which a dashboard built on backup age alone cannot see. Requires ProxCenter Enterprise with the API option.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Protected guests",
+      "id": 1,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(proxcenter_backup_protected{connection=~\"$connection\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No guest in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Share of guests holding at least one backup. Guests with none are counted here, which is what proxcenter_backup_protected exists for: an age series alone cannot see them."
+    },
+    {
+      "type": "stat",
+      "title": "Guests with no backup",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_protected{connection=~\"$connection\"} == 0) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Never backed up once. These are invisible to any dashboard built on backup age alone."
+    },
+    {
+      "type": "stat",
+      "title": "Guests past the threshold",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_age_seconds{connection=~\"$connection\"} > ${stale_hours} * 3600) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Backed up at some point, but not within the staleness threshold selected above."
+    },
+    {
+      "type": "stat",
+      "title": "Oldest backup",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(proxcenter_backup_age_seconds{connection=~\"$connection\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "noValue": "No backup found"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
+      "type": "row",
+      "title": "Compliance over time",
+      "id": 100,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Guests past each staleness bucket",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_age_seconds{connection=~\"$connection\"} > 86400) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Older than 24h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_age_seconds{connection=~\"$connection\"} > 172800) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "Older than 48h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_age_seconds{connection=~\"$connection\"} > 604800) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "C",
+          "legendFormat": "Older than 7d"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_backup_protected{connection=~\"$connection\"} == 0) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "D",
+          "legendFormat": "Never backed up"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Fixed buckets rather than the selected threshold, so the trend stays comparable when someone changes the threshold above. All four series are guest counts, so they share one axis."
+    },
+    {
+      "type": "row",
+      "title": "Offenders",
+      "id": 101,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Guests never backed up",
+      "id": 20,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_backup_protected{connection=~\"$connection\"} == 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "Every guest has at least one backup",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Guests past the staleness threshold",
+      "id": 21,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_backup_age_seconds{connection=~\"$connection\"} > ${stale_hours} * 3600",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "noValue": "No guest is past the threshold",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "PBS capacity",
+      "id": 102,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "panels": []
+    },
+    {
+      "type": "bargauge",
+      "title": "Datastore usage",
+      "id": 30,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 23
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_usage_ratio{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{datastore}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No datastore in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Served pre-computed by ProxCenter, so a datastore whose backend reports no capacity, such as one backed by S3, still charts instead of dividing by zero."
+    },
+    {
+      "type": "timeseries",
+      "title": "Datastore space in use",
+      "id": 31,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 23
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{datastore}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "The slope here is what tells you when a datastore runs out, which a usage percentage alone never does."
+    },
+    {
+      "type": "table",
+      "title": "Datastore capacity",
+      "id": 32,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 31
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_total_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_available_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "noValue": "No datastore in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A capacity and an available figure of 0 mean the backend does not report them, which is normal for an S3-backed datastore. The space in use is still real.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "datastore",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Snapshots per datastore",
+      "id": 33,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 10,
+        "y": 31
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_datastore_snapshots{connection=~\"$pbs\",datastore=~\"$datastore\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{datastore}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "A count that stops growing is a backup job that stopped running. A count that falls is pruning."
+    },
+    {
+      "type": "piechart",
+      "title": "Backup sources by kind",
+      "id": 34,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 31
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind) (proxcenter_pbs_datastore_guests{connection=~\"$pbs\",datastore=~\"$datastore\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No backup source in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "description": "Distinct sources, by kind: vm, ct and host."
+    },
+    {
+      "type": "row",
+      "title": "PBS availability",
+      "id": 103,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "panels": []
+    },
+    {
+      "type": "state-timeline",
+      "title": "PBS reachability",
+      "id": 40,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 0,
+        "y": 40
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_up{connection=~\"$pbs\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false,
+            "insertNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Offline",
+                  "color": "red",
+                  "index": 0
+                },
+                "1": {
+                  "text": "Online",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1,
+          "noValue": "No PBS server in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "description": "A gap in this timeline is a window in which no backup could have been taken or verified."
+    },
+    {
+      "type": "table",
+      "title": "PBS servers",
+      "id": 41,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_pbs_info{connection=~\"$pbs\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No PBS server reporting a version",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A server whose version is unknown is omitted rather than shown blank, which on this panel means it was unreachable when ProxCenter last read it.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "proxmox",
+    "proxcenter",
+    "pbs",
+    "backup",
+    "compliance"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "connection",
+        "label": "PVE connection",
+        "description": "The PVE connection a guest belongs to. This is NOT the PBS server name.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_backup_protected, connection)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_backup_protected, connection)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "pbs",
+        "label": "PBS server",
+        "description": "The PBS server. A separate label space from the PVE connection above.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_pbs_up, connection)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_pbs_up, connection)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "datastore",
+        "label": "Datastore",
+        "description": "Datastores of the selected PBS servers.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_pbs_datastore_usage_ratio{connection=~\"$pbs\"}, datastore)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_pbs_datastore_usage_ratio{connection=~\"$pbs\"}, datastore)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "stale_hours",
+        "label": "Staleness threshold (hours)",
+        "description": "How old a backup has to be before this dashboard calls a guest stale.",
+        "type": "custom",
+        "query": "12,24,48,72,168",
+        "options": [
+          {
+            "selected": false,
+            "text": "12",
+            "value": "12"
+          },
+          {
+            "selected": true,
+            "text": "24",
+            "value": "24"
+          },
+          {
+            "selected": false,
+            "text": "48",
+            "value": "48"
+          },
+          {
+            "selected": false,
+            "text": "72",
+            "value": "72"
+          },
+          {
+            "selected": false,
+            "text": "168",
+            "value": "168"
+          }
+        ],
+        "current": {
+          "selected": true,
+          "text": "24",
+          "value": "24"
+        },
+        "includeAll": false,
+        "multi": false,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ProxCenter Backup Compliance",
+  "uid": "proxcenter-backups",
+  "version": 1,
+  "weekStart": ""
+}

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
@@ -324,7 +324,7 @@
         "overrides": []
       },
       "options": {
-        "colorMode": "value",
+        "colorMode": "none",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -337,7 +337,8 @@
         },
         "textMode": "auto",
         "wideLayout": true
-      }
+      },
+      "description": "Neutral on purpose: with nothing backed up there is no age to report, and colouring that green would read as good news."
     },
     {
       "type": "row",
@@ -561,7 +562,8 @@
               "Time": true,
               "__name__": true,
               "job": true,
-              "instance": true
+              "instance": true,
+              "Value": true
             },
             "indexByName": {},
             "renameByName": {}
@@ -647,7 +649,9 @@
               "instance": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value": "Backup age"
+            }
           }
         },
         {
@@ -656,7 +660,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "Value",
+                "field": "Backup age",
                 "desc": true
               }
             ]
@@ -736,7 +740,7 @@
         "overrides": []
       },
       "options": {
-        "displayMode": "gradient",
+        "displayMode": "basic",
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -954,13 +958,28 @@
           "id": "organize",
           "options": {
             "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true,
-              "instance": true
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "connection 2": true,
+              "connection 3": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true
             },
-            "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "connection 1": "PBS server",
+              "Value #A": "Capacity",
+              "Value #B": "In use",
+              "Value #C": "Available"
+            },
+            "indexByName": {}
           }
         }
       ]
@@ -1170,7 +1189,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "custom": {
             "fillOpacity": 70,
@@ -1205,8 +1224,7 @@
             ]
           },
           "min": 0,
-          "max": 1,
-          "noValue": "No PBS server in this selection"
+          "max": 1
         },
         "overrides": []
       },
@@ -1302,7 +1320,8 @@
               "Time": true,
               "__name__": true,
               "job": true,
-              "instance": true
+              "instance": true,
+              "Value": true
             },
             "indexByName": {},
             "renameByName": {}

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
@@ -354,6 +354,80 @@
       "panels": []
     },
     {
+      "type": "stat",
+      "title": "Coverage over the window",
+      "id": 50,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 5
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(avg_over_time(proxcenter_backup_protected{connection=~\"$connection\"}[$__range]))",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No guest in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Average coverage across the selected window rather than at this instant, which is what a compliance report is actually claiming when it quotes a percentage. The outer avg() is not decoration: avg_over_time is a window function applied per series, so without it this tile renders one number per guest."
+    },
+    {
       "type": "timeseries",
       "title": "Guests past each staleness bucket",
       "id": 10,
@@ -363,8 +437,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 18,
+        "x": 6,
         "y": 5
       },
       "targets": [
@@ -669,6 +743,90 @@
       ]
     },
     {
+      "type": "table",
+      "title": "Backups that stopped running",
+      "id": 51,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "deriv(proxcenter_backup_age_seconds{connection=~\"$connection\"}[$__range]) > 0.9",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "Every protected guest was backed up during this window",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A backup age that grows one second per second means no backup ran during the window. This catches a job that silently stopped, which a staleness threshold only reveals once the threshold is finally crossed.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    },
+    {
       "type": "row",
       "title": "PBS capacity",
       "id": 102,
@@ -677,7 +835,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 29
       },
       "panels": []
     },
@@ -693,7 +851,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 23
+        "y": 30
       },
       "targets": [
         {
@@ -777,7 +935,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 23
+        "y": 30
       },
       "targets": [
         {
@@ -866,7 +1024,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "targets": [
         {
@@ -996,7 +1154,7 @@
         "h": 8,
         "w": 8,
         "x": 10,
-        "y": 31
+        "y": 38
       },
       "targets": [
         {
@@ -1082,7 +1240,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 31
+        "y": 38
       },
       "targets": [
         {
@@ -1146,6 +1304,275 @@
       "description": "Distinct sources, by kind: vm, ct and host."
     },
     {
+      "type": "bargauge",
+      "title": "Time before a datastore is full",
+      "id": 52,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 46
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(proxcenter_pbs_datastore_total_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"} - proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}) / deriv(proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}[6h]) > 0",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{datastore}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 2592000
+              }
+            ]
+          },
+          "unit": "s",
+          "min": 0,
+          "max": 7776000,
+          "noValue": "No datastore is growing"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "At the current trend. The bar is capped at 90 days so that a datastore with days left reads as a short red bar rather than as an invisible sliver next to one with years left. A datastore that is not growing is absent rather than shown as infinite. Needs several hours of history, so read it as a direction and not as a date."
+    },
+    {
+      "type": "table",
+      "title": "Space in use in seven days",
+      "id": 53,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 46
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "predict_linear(proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}[6h], 7*86400)",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "noValue": "Not enough history yet",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "Projected from the current trend, to read against the capacity in the table above.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Projected"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Projected",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Backups added per day",
+      "id": 54,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 46
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "delta(proxcenter_pbs_datastore_snapshots{connection=~\"$pbs\",datastore=~\"$datastore\"}[24h])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{datastore}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No datastore in this selection",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Snapshots added over a rolling 24 hours. A line falling to zero is a backup job that stopped, which the snapshot count itself never shows because it simply stays high."
+    },
+    {
       "type": "row",
       "title": "PBS availability",
       "id": 103,
@@ -1154,9 +1581,83 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 53
       },
       "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "PBS availability over the window",
+      "id": 55,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 54
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "min(avg_over_time(proxcenter_pbs_up{connection=~\"$pbs\"}[$__range]))",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.999
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No PBS server in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Share of the selected window during which PBS answered, for the WORST server in the selection, which is the figure a compliance claim rests on. A gap here is a window in which no backup could have been taken or verified."
     },
     {
       "type": "state-timeline",
@@ -1168,9 +1669,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 16,
-        "x": 0,
-        "y": 40
+        "w": 12,
+        "x": 6,
+        "y": 54
       },
       "targets": [
         {
@@ -1255,9 +1756,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 40
+        "w": 6,
+        "x": 18,
+        "y": 54
       },
       "targets": [
         {

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
@@ -66,7 +66,22 @@
   "editable": true,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "proxcenter"
+      ],
+      "targetBlank": false,
+      "title": "ProxCenter dashboards",
+      "tooltip": "The other ProxCenter dashboards, with the time range and filters carried over",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
   "panels": [
     {
       "type": "stat",
@@ -1345,7 +1360,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "(proxcenter_pbs_datastore_total_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"} - proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}) / deriv(proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}[6h]) > 0",
+          "expr": "(proxcenter_pbs_datastore_total_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"} - proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}) / (deriv(proxcenter_pbs_datastore_used_bytes{connection=~\"$pbs\",datastore=~\"$datastore\"}[6h]) > 0)",
           "range": true,
           "instant": false,
           "refId": "A",
@@ -1406,7 +1421,7 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "description": "At the current trend. The bar is capped at 90 days so that a datastore with days left reads as a short red bar rather than as an invisible sliver next to one with years left. A datastore that is not growing is absent rather than shown as infinite. Needs several hours of history, so read it as a direction and not as a date."
+      "description": "At the current trend. The filter sits on the derivative and not on the quotient: a storage that is not growing divides by zero, and an infinite result passes a `> 0` test on the quotient, which is how a row reading ∞ years appears. The bar is capped at 90 days so that a datastore with days left reads as a short red bar rather than as an invisible sliver next to one with years left. A datastore that is not growing is absent rather than shown as infinite. Needs several hours of history, so read it as a direction and not as a date."
     },
     {
       "type": "table",
@@ -1867,6 +1882,7 @@
   "tags": [
     "proxmox",
     "proxcenter",
+    "pve",
     "pbs",
     "backup",
     "compliance"

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-backups.json
@@ -343,7 +343,7 @@
     {
       "type": "row",
       "title": "Compliance over time",
-      "id": 100,
+      "id": 5,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -356,7 +356,7 @@
     {
       "type": "stat",
       "title": "Coverage over the window",
-      "id": 50,
+      "id": 6,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -430,7 +430,7 @@
     {
       "type": "timeseries",
       "title": "Guests past each staleness bucket",
-      "id": 10,
+      "id": 7,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -552,7 +552,7 @@
     {
       "type": "row",
       "title": "Offenders",
-      "id": 101,
+      "id": 8,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -565,7 +565,7 @@
     {
       "type": "table",
       "title": "Guests never backed up",
-      "id": 20,
+      "id": 9,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -648,7 +648,7 @@
     {
       "type": "table",
       "title": "Guests past the staleness threshold",
-      "id": 21,
+      "id": 10,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -688,7 +688,6 @@
               }
             ]
           },
-          "unit": "s",
           "noValue": "No guest is past the threshold",
           "custom": {
             "align": "auto",
@@ -698,7 +697,20 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Backup age"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -722,7 +734,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Backup age"
             }
@@ -745,7 +766,7 @@
     {
       "type": "table",
       "title": "Backups that stopped running",
-      "id": 51,
+      "id": 11,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -829,7 +850,7 @@
     {
       "type": "row",
       "title": "PBS capacity",
-      "id": 102,
+      "id": 12,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -842,7 +863,7 @@
     {
       "type": "bargauge",
       "title": "Datastore usage",
-      "id": 30,
+      "id": 13,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -926,7 +947,7 @@
     {
       "type": "timeseries",
       "title": "Datastore space in use",
-      "id": 31,
+      "id": 14,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1015,7 +1036,7 @@
     {
       "type": "table",
       "title": "Datastore capacity",
-      "id": 32,
+      "id": 15,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1145,7 +1166,7 @@
     {
       "type": "timeseries",
       "title": "Snapshots per datastore",
-      "id": 33,
+      "id": 16,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1231,7 +1252,7 @@
     {
       "type": "piechart",
       "title": "Backup sources by kind",
-      "id": 34,
+      "id": 17,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1306,7 +1327,7 @@
     {
       "type": "bargauge",
       "title": "Time before a datastore is full",
-      "id": 52,
+      "id": 18,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1390,7 +1411,7 @@
     {
       "type": "table",
       "title": "Space in use in seven days",
-      "id": 53,
+      "id": 19,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1465,7 +1486,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Projected"
             }
@@ -1488,7 +1518,7 @@
     {
       "type": "timeseries",
       "title": "Backups added per day",
-      "id": 54,
+      "id": 20,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1575,7 +1605,7 @@
     {
       "type": "row",
       "title": "PBS availability",
-      "id": 103,
+      "id": 21,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1588,7 +1618,7 @@
     {
       "type": "stat",
       "title": "PBS availability over the window",
-      "id": 55,
+      "id": 22,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1662,7 +1692,7 @@
     {
       "type": "state-timeline",
       "title": "PBS reachability",
-      "id": 40,
+      "id": 23,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1749,7 +1779,7 @@
     {
       "type": "table",
       "title": "PBS servers",
-      "id": 41,
+      "id": 24,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-guests.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-guests.json
@@ -1,0 +1,1361 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "The Prometheus that scrapes /api/v1/public/metrics on your ProxCenter.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "What are the virtual machines and containers actually doing? Running state over time, the guests consuming the most CPU and memory, allocation against real use, and disk and network throughput derived from Proxmox's own counters. Names every guest across every cluster. Requires ProxCenter Enterprise with the API option.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "proxcenter"
+      ],
+      "targetBlank": false,
+      "title": "ProxCenter dashboards",
+      "tooltip": "The other ProxCenter dashboards, with the time range and filters carried over",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Load",
+      "id": 1,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Guests running and stopped",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Running"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"}) - sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "Stopped"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest memory, allocated against in use",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Allocated"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "In use"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "description": "The gap between the two lines is the overcommit a balloon driver is expected to absorb."
+    },
+    {
+      "type": "stat",
+      "title": "vCPU overcommit",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_cpu_cores{connection=~\"$connection\",node=~\"$node\"}) / sum(proxcenter_node_cpu_cores{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No core count reported"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Virtual cores handed out against physical cores present. Overcommit is normal on a hypervisor, which is why the thresholds only warn past three to one."
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest memory as the host accounts it",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 9
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_host_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Host accounting"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "Guest reported"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "noValue": "No guest reporting memory",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "description": "PVE 9 accounts a guest's memory twice, once as the guest reports it and once as the host sees it. The host figure is the one that decides whether a node runs out. Containers report no host figure, so they sit at zero in the first series."
+    },
+    {
+      "type": "row",
+      "title": "Top consumers",
+      "id": 6,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Top guests by CPU",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, proxcenter_vm_cpu_usage_ratio{connection=~\"$connection\",node=~\"$node\"})",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest reporting CPU",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
+            "renameByName": {
+              "Value": "CPU"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "CPU",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top guests by memory",
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, proxcenter_vm_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"})",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest reporting memory",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
+            "renameByName": {
+              "Value": "Memory"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Memory",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Guest uptime, longest first",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_vm_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest reporting uptime",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
+            "renameByName": {
+              "Value": "Uptime"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Uptime",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Disk and network",
+      "id": 10,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest disk read",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_disk_read_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting disk I/O",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Derived with rate() from a cumulative counter, which is why a guest restart shows as a gap rather than as an enormous negative spike. The window is an explicit 5m rather than $__rate_interval on purpose: that macro is computed from the scrape interval DECLARED on the reader's datasource, and an undeclared one makes Grafana assume 15s, pick a 60s window, and return nothing at all against ProxCenter's 60s scrape."
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest disk write",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_disk_written_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting disk I/O",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest network in",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_network_receive_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting network traffic",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest network out",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_network_transmit_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting network traffic",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "row",
+      "title": "Guest agent inventory",
+      "id": 15,
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "panels": [
+        {
+          "type": "table",
+          "title": "Guests without the guest agent enabled",
+          "id": 16,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 48
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "proxcenter_vm_agent_enabled{connection=~\"$connection\",node=~\"$node\"} == 0",
+              "range": false,
+              "instant": true,
+              "refId": "A",
+              "format": "table"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "noValue": "No data yet on this install",
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "description": "No data yet on most installs, and that is expected rather than broken. ProxCenter builds its inventory from /cluster/resources, which carries no guest agent config flag, so the flag is unknown and the series is deliberately omitted rather than published as a misleading zero. It fills in once the agent flag has a source, which means a capped pass over /config.",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "job": true,
+                  "instance": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "proxmox",
+    "proxcenter",
+    "pve",
+    "guests",
+    "vm",
+    "lxc"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "connection",
+        "label": "Connection",
+        "description": "One PVE connection as ProxCenter names it: a cluster or a standalone node.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_cluster_up, connection)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_cluster_up, connection)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node",
+        "label": "Node",
+        "description": "Nodes of the selected connections.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ProxCenter Guest Workload",
+  "uid": "proxcenter-guests",
+  "version": 1,
+  "weekStart": ""
+}

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-nodes.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-nodes.json
@@ -1,0 +1,1497 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "The Prometheus that scrapes /api/v1/public/metrics on your ProxCenter.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "How hard are the Proxmox hosts working, and what is about to run out? Load average, CPU, memory headroom, I/O wait, swap, the host root filesystem with a seven day projection, and an inventory of which PVE and kernel each node runs. Covers every cluster from one Prometheus job. Requires ProxCenter Enterprise with the API option.",
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "proxcenter"
+      ],
+      "targetBlank": false,
+      "title": "ProxCenter dashboards",
+      "tooltip": "The other ProxCenter dashboards, with the time range and filters carried over",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Load",
+      "id": 1,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average, 1 minute",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load1{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Runnable processes averaged over one minute, the figure that moves first when a node is about to be in trouble. Read it against the core count, not against other nodes."
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average, 5 minutes",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load5{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average, 15 minutes",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load15{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "The slow average. A 15 minute load that stays high while the 1 minute one has come down is a node that has been loaded for a while, not a node that just spiked."
+    },
+    {
+      "type": "row",
+      "title": "CPU and memory",
+      "id": 5,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Node CPU usage",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_cpu_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Node memory usage",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Memory free per node",
+      "id": 8,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"} - proxcenter_node_mem_bytes{connection=~\"$connection\",node=~\"$node\"}) / proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "green",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node reporting memory"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Free memory as a share of the node's own capacity. A ratio rather than a byte count on purpose: 20 GiB free is comfortable on a 24 GiB node and critical on a 1 TiB one, so an absolute threshold cannot be right for both."
+    },
+    {
+      "type": "bargauge",
+      "title": "Peak memory per node",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max_over_time(proxcenter_node_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"}[$__range])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node reporting memory"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "The peak over the selected window. A node sitting at 60 per cent that peaked at 95 nearly ran out, and the current value never shows it."
+    },
+    {
+      "type": "stat",
+      "title": "Memory overcommit",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"}) / sum(proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No node reporting memory"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Memory promised to guests against memory that exists. Above 1 the fleet depends on the balloon driver handing memory back, which a Windows guest without free page reporting will not do."
+    },
+    {
+      "type": "row",
+      "title": "Disk, swap and I/O",
+      "id": 11,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "type": "bargauge",
+      "title": "Root filesystem usage",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "The HOST root filesystem, not cluster storage. A full root filesystem is what stops a node accepting migrations."
+    },
+    {
+      "type": "bargauge",
+      "title": "Root filesystem in seven days",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "predict_linear(proxcenter_node_rootfs_usage_ratio{connection=~\"$connection\",node=~\"$node\"}[6h], 7*86400)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "Not enough history yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Where each root filesystem lands in seven days at the current trend. Needs several hours of history to mean anything, so read it as a direction and not as a date."
+    },
+    {
+      "type": "bargauge",
+      "title": "Swap in use per node",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_swap_bytes{connection=~\"$connection\",node=~\"$node\"} / proxcenter_node_swap_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node has swap configured"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "A hypervisor that swaps is a hypervisor that has already run out of memory, so the thresholds here are deliberately harsh: amber at a tenth of the swap used."
+    },
+    {
+      "type": "timeseries",
+      "title": "I/O wait per node",
+      "id": 15,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_iowait_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No node reporting I/O wait",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "CPU time spent waiting on storage. High I/O wait with low CPU usage means the storage is the bottleneck, not the processor, which is the opposite conclusion from the CPU panel alone."
+    },
+    {
+      "type": "table",
+      "title": "Node uptime, longest first",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No node reporting uptime",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A node up far longer than its peers is a node that has missed the reboots its peers took.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
+            "renameByName": {
+              "Value": "Uptime"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Uptime",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Inventory",
+      "id": 17,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Node inventory",
+      "id": 18,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_info",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_cpu_cores{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "D",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No node in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "Which Proxmox VE and which kernel each node runs, with its core count and root filesystem in bytes. A fleet running three different point releases is a fleet with three different bug sets.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "node",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "connection 2": true,
+              "connection 3": true,
+              "connection 4": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "pve_version": "PVE",
+              "kernel": "Kernel",
+              "Value #B": "Cores",
+              "Value #C": "Root used",
+              "Value #D": "Root size"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "proxmox",
+    "proxcenter",
+    "pve",
+    "nodes",
+    "capacity"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "connection",
+        "label": "Connection",
+        "description": "One PVE connection as ProxCenter names it: a cluster or a standalone node.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_cluster_up, connection)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_cluster_up, connection)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node",
+        "label": "Node",
+        "description": "Nodes of the selected connections.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ProxCenter Node Performance",
+  "uid": "proxcenter-nodes",
+  "version": 1,
+  "weekStart": ""
+}

--- a/frontend/public/integrations/grafana-dashboard-proxcenter-storage.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter-storage.json
@@ -42,21 +42,21 @@
     },
     {
       "type": "panel",
-      "id": "state-timeline",
-      "name": "State timeline",
+      "id": "table",
+      "name": "Table",
       "version": ""
     },
     {
       "type": "panel",
-      "id": "table",
-      "name": "Table",
+      "id": "timeseries",
+      "name": "Time series",
       "version": ""
     }
   ],
   "annotations": {
     "list": []
   },
-  "description": "Is every Proxmox cluster reachable, and has it been? Multi-cluster reachability, Ceph health, high availability state and the changes that an instantaneous count hides, such as a node that bounced overnight. One Prometheus job covers every cluster, with no agent on any node. Start here, then follow the dashboard links to nodes, guests, storage or backups. Requires ProxCenter Enterprise with the API option.",
+  "description": "Where is the space going across every Proxmox cluster? Capacity and usage per storage, split the way Proxmox splits it: a shared storage such as a Ceph pool or an NFS export counted ONCE for the cluster, and non-shared storages broken down per node, which is where a single full host hides behind a comfortable cluster average. Requires ProxCenter Enterprise with the API option.",
   "editable": true,
   "graphTooltip": 1,
   "id": null,
@@ -79,7 +79,7 @@
   "panels": [
     {
       "type": "stat",
-      "title": "Clusters",
+      "title": "Fleet capacity",
       "id": 1,
       "datasource": {
         "type": "prometheus",
@@ -87,7 +87,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 6,
         "x": 0,
         "y": 0
       },
@@ -98,7 +98,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(proxcenter_cluster_up{connection=~\"$connection\"})",
+          "expr": "sum(proxcenter_storage_total_bytes{connection=~\"$connection\"})",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -119,7 +119,8 @@
               }
             ]
           },
-          "noValue": "0"
+          "unit": "bytes",
+          "noValue": "No storage in this selection"
         },
         "overrides": []
       },
@@ -138,11 +139,11 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "description": "Every PVE connection ProxCenter manages, clustered or standalone."
+      "description": "Every storage of every selected cluster, shared ones counted once."
     },
     {
       "type": "stat",
-      "title": "Nodes online",
+      "title": "Fleet space in use",
       "id": 2,
       "datasource": {
         "type": "prometheus",
@@ -150,8 +151,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 6,
+        "x": 6,
         "y": 0
       },
       "targets": [
@@ -161,7 +162,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"})",
+          "expr": "sum(proxcenter_storage_used_bytes{connection=~\"$connection\"})",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -182,7 +183,8 @@
               }
             ]
           },
-          "noValue": "0"
+          "unit": "bytes",
+          "noValue": "No storage in this selection"
         },
         "overrides": []
       },
@@ -204,7 +206,7 @@
     },
     {
       "type": "stat",
-      "title": "Nodes offline",
+      "title": "Fleet usage",
       "id": 3,
       "datasource": {
         "type": "prometheus",
@@ -212,74 +214,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
-        "y": 0
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "count(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"}) - sum(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"})",
-          "range": true,
-          "instant": false,
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "description": "The actionable half of the pair: anything above zero is a node the fleet lost."
-    },
-    {
-      "type": "stat",
-      "title": "Guests running",
-      "id": 4,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
+        "w": 6,
         "x": 12,
         "y": 0
       },
@@ -290,70 +225,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
-          "range": true,
-          "instant": false,
-          "refId": "A"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "noValue": "0"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "description": "Templates are excluded upstream, so this counts real workloads only."
-    },
-    {
-      "type": "stat",
-      "title": "Nodes in maintenance",
-      "id": 5,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 0
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(proxcenter_node_maintenance{connection=~\"$connection\",node=~\"$node\"})",
+          "expr": "sum(proxcenter_storage_used_bytes{connection=~\"$connection\"}) / sum(proxcenter_storage_total_bytes{connection=~\"$connection\"})",
           "range": true,
           "instant": false,
           "refId": "A"
@@ -369,7 +241,80 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No storage in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Storages disabled",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_storage_enabled{connection=~\"$connection\"} == 0) or vector(0)",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
                 "value": null
               },
               {
@@ -396,75 +341,13 @@
         },
         "textMode": "auto",
         "wideLayout": true
-      }
-    },
-    {
-      "type": "stat",
-      "title": "ProxCenter",
-      "id": 6,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
       },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 0
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "proxcenter_build_info",
-          "range": true,
-          "instant": false,
-          "refId": "A",
-          "legendFormat": "{{version}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "name",
-        "wideLayout": true
-      },
-      "description": "Version of the ProxCenter being scraped."
+      "description": "A disabled storage still reports its capacity, so it inflates the fleet total above while accepting no new volume."
     },
     {
       "type": "row",
-      "title": "Cluster health",
-      "id": 7,
+      "title": "Usage",
+      "id": 5,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -475,254 +358,18 @@
       "panels": []
     },
     {
-      "type": "state-timeline",
-      "title": "Cluster health",
-      "id": 8,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 0,
-        "y": 5
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "proxcenter_cluster_degraded{connection=~\"$connection\"}",
-          "range": true,
-          "instant": false,
-          "refId": "A",
-          "legendFormat": "{{connection}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 70,
-            "lineWidth": 0,
-            "spanNulls": false,
-            "insertNulls": false
-          },
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "Healthy",
-                  "color": "green",
-                  "index": 0
-                },
-                "1": {
-                  "text": "Degraded",
-                  "color": "red",
-                  "index": 1
-                }
-              }
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "min": 0,
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "alignValue": "left",
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "mergeValues": true,
-        "rowHeight": 0.9,
-        "showValue": "never",
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "description": "A degraded cluster has lost quorum or a node. Green is the healthy state, so a coloured band here is always something to look at."
-    },
-    {
-      "type": "piechart",
-      "title": "Ceph health across clusters",
-      "id": 9,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 5
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (health) (proxcenter_cluster_ceph_health{connection=~\"$connection\"} == 1)",
-          "range": true,
-          "instant": false,
-          "refId": "A",
-          "legendFormat": "{{health}}"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "noValue": "No Ceph cluster in this selection"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ok"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "green"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "warn"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "orange"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "err"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "red"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "unknown"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "text"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "description": "Clusters without Ceph emit nothing, so they are absent rather than counted as unknown."
-    },
-    {
-      "type": "row",
-      "title": "Stability",
-      "id": 10,
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
-      },
-      "panels": []
-    },
-    {
       "type": "bargauge",
-      "title": "Cluster availability over the window",
-      "id": 11,
+      "title": "Storage usage",
+      "id": 6,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
-        "h": 7,
-        "w": 8,
+        "h": 12,
+        "w": 12,
         "x": 0,
-        "y": 14
+        "y": 5
       },
       "targets": [
         {
@@ -731,11 +378,11 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(proxcenter_cluster_up{connection=~\"$connection\"}[$__range])",
+          "expr": "proxcenter_storage_usage_ratio{connection=~\"$connection\"}",
           "range": true,
           "instant": false,
           "refId": "A",
-          "legendFormat": "{{connection}}"
+          "legendFormat": "{{connection}} / {{storage}} ({{type}})"
         }
       ],
       "fieldConfig": {
@@ -748,23 +395,23 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "green",
                 "value": null
               },
               {
                 "color": "orange",
-                "value": 0.99
+                "value": 0.8
               },
               {
-                "color": "green",
-                "value": 0.999
+                "color": "red",
+                "value": 0.9
               }
             ]
           },
           "unit": "percentunit",
           "min": 0,
           "max": 1,
-          "noValue": "No cluster in this selection"
+          "noValue": "No storage in this selection"
         },
         "overrides": []
       },
@@ -792,21 +439,21 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "description": "Share of the selected window during which each cluster answered. Anything short of 1 is a gap the instantaneous tiles at the top cannot show."
+      "description": "One bar per storage, shared ones counted ONCE for the whole cluster rather than once per node, which is how a Ceph pool otherwise appears to have three times its real capacity."
     },
     {
-      "type": "table",
-      "title": "Nodes that changed state",
-      "id": 12,
+      "type": "bargauge",
+      "title": "Local storage, per node",
+      "id": 7,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 14
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 5
       },
       "targets": [
         {
@@ -815,323 +462,176 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "changes(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
-          "range": false,
-          "instant": true,
+          "expr": "proxcenter_storage_node_usage_ratio{connection=~\"$connection\"}",
+          "range": true,
+          "instant": false,
           "refId": "A",
-          "format": "table"
+          "legendFormat": "{{storage}} ({{node}})"
         }
       ],
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
               }
             ]
           },
-          "noValue": "No node changed state in this window",
-          "decimals": 0,
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          }
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No non-shared storage in this selection"
         },
         "overrides": []
       },
       "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
           ],
-          "countRows": false,
-          "fields": ""
-        }
-      },
-      "description": "A node that bounced overnight reads as online on the tile above, exactly like one that never moved. This counts the transitions.",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true,
-              "instance": true
-            },
-            "indexByName": {
-              "name": 0,
-              "Value": 1,
-              "node": 2,
-              "connection": 3,
-              "type": 4,
-              "vmid": 5,
-              "storage": 6,
-              "datastore": 7
-            },
-            "renameByName": {
-              "Value": "Transitions"
-            }
-          }
+          "fields": "",
+          "values": false
         },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Transitions",
-                "desc": true
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "type": "table",
-      "title": "Nodes that rebooted",
-      "id": 13,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
       },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 14
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "resets(proxcenter_node_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
-          "range": false,
-          "instant": true,
-          "refId": "A",
-          "format": "table"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "noValue": "No node rebooted in this window",
-          "decimals": 0,
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        }
-      },
-      "description": "An uptime that goes backwards is a reboot. Counted over the window without going through the task log.",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true,
-              "instance": true
-            },
-            "indexByName": {
-              "name": 0,
-              "Value": 1,
-              "node": 2,
-              "connection": 3,
-              "type": 4,
-              "vmid": 5,
-              "storage": 6,
-              "datastore": 7
-            },
-            "renameByName": {
-              "Value": "Reboots"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Reboots",
-                "desc": true
-              }
-            ]
-          }
-        }
-      ]
-    },
-    {
-      "type": "table",
-      "title": "Guests that changed state",
-      "id": 14,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "changes(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
-          "range": false,
-          "instant": true,
-          "refId": "A",
-          "format": "table"
-        }
-      ],
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          },
-          "noValue": "No guest changed state in this window",
-          "decimals": 0,
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm",
-        "footer": {
-          "show": false,
-          "reducer": [
-            "sum"
-          ],
-          "countRows": false,
-          "fields": ""
-        }
-      },
-      "description": "Guests that stopped and restarted on their own. A guest in a crash loop shows the same running state as a stable one on any instantaneous count.",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "job": true,
-              "instance": true
-            },
-            "indexByName": {
-              "name": 0,
-              "Value": 1,
-              "node": 2,
-              "connection": 3,
-              "type": 4,
-              "vmid": 5,
-              "storage": 6,
-              "datastore": 7
-            },
-            "renameByName": {
-              "Value": "Transitions"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Transitions",
-                "desc": true
-              }
-            ]
-          }
-        }
-      ]
+      "description": "Non-shared storages only. A shared storage has one capacity for the cluster, so it emits nothing here on purpose rather than repeating itself once per node."
     },
     {
       "type": "row",
-      "title": "High availability",
-      "id": 15,
+      "title": "Trend",
+      "id": 8,
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 17
       },
       "panels": []
     },
     {
+      "type": "timeseries",
+      "title": "Space in use over time",
+      "id": 9,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 18
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_used_bytes{connection=~\"$connection\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{storage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "noValue": "No storage in this selection",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "The slope is what tells you when a storage runs out, which a usage percentage never does."
+    },
+    {
       "type": "piechart",
-      "title": "Guests by HA state",
-      "id": 16,
+      "title": "Capacity by storage type",
+      "id": 10,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1139,8 +639,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 29
+        "x": 16,
+        "y": 18
       },
       "targets": [
         {
@@ -1149,11 +649,11 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (state) (proxcenter_vm_ha_state{connection=~\"$connection\",node=~\"$node\"} == 1)",
+          "expr": "sum by (type) (proxcenter_storage_total_bytes{connection=~\"$connection\"})",
           "range": true,
           "instant": false,
           "refId": "A",
-          "legendFormat": "{{state}}"
+          "legendFormat": "{{type}}"
         }
       ],
       "fieldConfig": {
@@ -1171,40 +671,10 @@
               }
             ]
           },
-          "noValue": "No guest is managed by HA"
+          "unit": "bytes",
+          "noValue": "No storage in this selection"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "started"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "green"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "mode": "fixed",
-                  "fixedColor": "red"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "options": {
         "displayLabels": [
@@ -1232,21 +702,21 @@
           "sort": "none"
         }
       },
-      "description": "Guests HA does not manage emit nothing at all, so this counts only the HA estate."
+      "description": "How the fleet's capacity is split across Proxmox storage plugins: rbd, zfspool, dir, lvmthin and the rest."
     },
     {
-      "type": "table",
-      "title": "Guests in HA error",
-      "id": 17,
+      "type": "bargauge",
+      "title": "Time before a storage is full",
+      "id": 11,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
       "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 8,
-        "y": 29
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 26
       },
       "targets": [
         {
@@ -1255,10 +725,119 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "proxcenter_vm_ha_state{connection=~\"$connection\",node=~\"$node\",state=\"error\"} == 1",
+          "expr": "(proxcenter_storage_total_bytes{connection=~\"$connection\"} - proxcenter_storage_used_bytes{connection=~\"$connection\"}) / (deriv(proxcenter_storage_used_bytes{connection=~\"$connection\"}[6h]) > 0)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{storage}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 2592000
+              }
+            ]
+          },
+          "unit": "s",
+          "min": 0,
+          "max": 7776000,
+          "noValue": "No storage is growing"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "At the current trend, with the filter on the derivative rather than on the quotient so a storage that is not growing is absent instead of reading as infinite. Capped at 90 days so a storage with days left reads as a short red bar rather than an invisible sliver. Needs several hours of history."
+    },
+    {
+      "type": "row",
+      "title": "Detail",
+      "id": 12,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "panels": []
+    },
+    {
+      "type": "table",
+      "title": "Storage capacity",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_total_bytes{connection=~\"$connection\"}",
           "range": false,
           "instant": true,
           "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_used_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
           "format": "table"
         }
       ],
@@ -1277,7 +856,8 @@
               }
             ]
           },
-          "noValue": "No guest is in HA error",
+          "unit": "bytes",
+          "noValue": "No storage in this selection",
           "custom": {
             "align": "auto",
             "cellOptions": {
@@ -1300,7 +880,224 @@
           "fields": ""
         }
       },
-      "description": "An HA resource in error has stopped being managed: HA will not restart or relocate it until an operator clears the state.",
+      "description": "Capacity and space in use per storage, with its Proxmox type and whether the cluster shares it.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "storage",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "connection 2": true,
+              "type 2": true,
+              "shared 2": true,
+              "job 1": true,
+              "job 2": true,
+              "instance 1": true,
+              "instance 2": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "type 1": "Type",
+              "shared 1": "Shared",
+              "Value #A": "Capacity",
+              "Value #B": "In use"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Local storage per node, in bytes",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_node_used_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_node_total_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "noValue": "No non-shared storage in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "The absolute figures behind the per-node bars, for the moment a percentage is not enough.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "node",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "connection 2": true,
+              "storage 2": true,
+              "job 1": true,
+              "job 2": true,
+              "instance 1": true,
+              "instance 2": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "storage 1": "Storage",
+              "Value #A": "In use",
+              "Value #B": "Capacity"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Disabled storages",
+      "id": 15,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_enabled{connection=~\"$connection\"} == 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "Every storage is enabled",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A disabled storage still reports its capacity, so it inflates any fleet total while accepting no new volume. Worth knowing before planning against that capacity.",
       "transformations": [
         {
           "id": "organize",
@@ -1326,8 +1123,9 @@
     "proxmox",
     "proxcenter",
     "pve",
-    "fleet",
-    "virtualization"
+    "storage",
+    "ceph",
+    "zfs"
   ],
   "templating": {
     "list": [
@@ -1363,39 +1161,6 @@
         "sort": 1,
         "hide": 0,
         "skipUrlSync": false
-      },
-      {
-        "name": "node",
-        "label": "Node",
-        "description": "Nodes of the selected connections.",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
-        "query": {
-          "qryType": 1,
-          "query": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "includeAll": true,
-        "allValue": ".*",
-        "multi": true,
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "options": [],
-        "sort": 1,
-        "hide": 0,
-        "skipUrlSync": false
       }
     ]
   },
@@ -1405,8 +1170,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "ProxCenter Fleet Overview",
-  "uid": "proxcenter-fleet",
+  "title": "ProxCenter Storage",
+  "uid": "proxcenter-storage",
   "version": 1,
   "weekStart": ""
 }

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -1132,6 +1132,637 @@
       ]
     },
     {
+      "type": "stat",
+      "title": "Memory overcommit",
+      "id": 17,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 27
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"}) / sum(proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 1.5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No node reporting memory"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Memory promised to guests against memory that exists. Above 1 the fleet depends on the balloon driver handing memory back, which a Windows guest without free page reporting will not do."
+    },
+    {
+      "type": "bargauge",
+      "title": "Peak memory per node",
+      "id": 18,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 6,
+        "y": 27
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max_over_time(proxcenter_node_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"}[$__range])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node reporting memory"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "The peak over the selected window. A node sitting at 60 per cent that peaked at 95 nearly ran out, and the current value never shows it."
+    },
+    {
+      "type": "bargauge",
+      "title": "Root filesystem in seven days",
+      "id": 19,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 27
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "predict_linear(proxcenter_node_rootfs_usage_ratio{connection=~\"$connection\",node=~\"$node\"}[6h], 7*86400)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "Not enough history yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Where each root filesystem lands in seven days at the current trend. Needs several hours of history to mean anything, so read it as a direction and not as a date."
+    },
+    {
+      "type": "row",
+      "title": "Stability",
+      "id": 104,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "type": "bargauge",
+      "title": "Cluster availability over the window",
+      "id": 50,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg_over_time(proxcenter_cluster_up{connection=~\"$connection\"}[$__range])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.99
+              },
+              {
+                "color": "green",
+                "value": 0.999
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No cluster in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Share of the selected window during which each cluster answered. Anything short of 1 is a gap the instantaneous tiles at the top cannot show."
+    },
+    {
+      "type": "table",
+      "title": "Nodes that changed state",
+      "id": 51,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "changes(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No node changed state in this window",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A node that bounced overnight reads as online on the tile above, exactly like one that never moved. This counts the transitions.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Transitions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Transitions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Nodes that rebooted",
+      "id": 52,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "resets(proxcenter_node_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No node rebooted in this window",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "An uptime that goes backwards is a reboot. Counted over the window without going through the task log.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Reboots"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Reboots",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Guests that changed state",
+      "id": 53,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "changes(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"}[$__range]) > 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest changed state in this window",
+          "decimals": 0,
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "Guests that stopped and restarted on their own. A guest in a crash loop shows the same running state as a stable one on any instantaneous count.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Transitions"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Transitions",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
       "type": "row",
       "title": "Guests",
       "id": 101,
@@ -1140,7 +1771,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 49
       },
       "panels": []
     },
@@ -1156,7 +1787,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 50
       },
       "targets": [
         {
@@ -1252,7 +1883,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 50
       },
       "targets": [
         {
@@ -1350,7 +1981,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 58
       },
       "targets": [
         {
@@ -1447,7 +2078,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 58
       },
       "targets": [
         {
@@ -1544,7 +2175,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 66
       },
       "targets": [
         {
@@ -1638,7 +2269,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 74
       },
       "panels": []
     },
@@ -1654,7 +2285,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 53
+        "y": 75
       },
       "targets": [
         {
@@ -1760,7 +2391,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 53
+        "y": 75
       },
       "targets": [
         {
@@ -1841,7 +2472,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 83
       },
       "panels": [
         {
@@ -1856,7 +2487,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 62
+            "y": 84
           },
           "targets": [
             {

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -2870,7 +2870,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(proxcenter_vm_disk_read_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(proxcenter_vm_disk_read_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
           "range": true,
           "instant": false,
           "refId": "A",
@@ -2934,7 +2934,7 @@
           "sort": "desc"
         }
       },
-      "description": "Derived with rate() from a cumulative counter, which is why a guest restart shows as a gap rather than as an enormous negative spike."
+      "description": "Derived with rate() from a cumulative counter, which is why a guest restart shows as a gap rather than as an enormous negative spike. The window is an explicit 5m rather than $__rate_interval on purpose: that macro is computed from the scrape interval DECLARED on the reader's datasource, and an undeclared one makes Grafana assume 15s, pick a 60s window, and return nothing at all against ProxCenter's 60s scrape."
     },
     {
       "type": "timeseries",
@@ -2957,7 +2957,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(proxcenter_vm_disk_written_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(proxcenter_vm_disk_written_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
           "range": true,
           "instant": false,
           "refId": "A",
@@ -3043,7 +3043,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(proxcenter_vm_network_receive_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(proxcenter_vm_network_receive_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
           "range": true,
           "instant": false,
           "refId": "A",
@@ -3129,7 +3129,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(proxcenter_vm_network_transmit_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "expr": "rate(proxcenter_vm_network_transmit_bytes_total{connection=~\"$connection\",node=~\"$node\"}[5m])",
           "range": true,
           "instant": false,
           "refId": "A",

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -455,7 +455,7 @@
     {
       "type": "row",
       "title": "Capacity",
-      "id": 100,
+      "id": 7,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -468,7 +468,7 @@
     {
       "type": "timeseries",
       "title": "Node CPU usage",
-      "id": 10,
+      "id": 8,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -557,7 +557,7 @@
     {
       "type": "timeseries",
       "title": "Node memory usage",
-      "id": 11,
+      "id": 9,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -646,7 +646,7 @@
     {
       "type": "bargauge",
       "title": "Memory free per node",
-      "id": 12,
+      "id": 10,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -730,7 +730,7 @@
     {
       "type": "bargauge",
       "title": "Root filesystem usage",
-      "id": 13,
+      "id": 11,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -813,7 +813,7 @@
     {
       "type": "piechart",
       "title": "Ceph health across clusters",
-      "id": 14,
+      "id": 12,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -949,7 +949,7 @@
     {
       "type": "state-timeline",
       "title": "Cluster health",
-      "id": 15,
+      "id": 13,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1036,7 +1036,7 @@
     {
       "type": "table",
       "title": "Node uptime, longest first",
-      "id": 16,
+      "id": 14,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1076,7 +1076,6 @@
               }
             ]
           },
-          "unit": "s",
           "noValue": "No node reporting uptime",
           "custom": {
             "align": "auto",
@@ -1086,7 +1085,20 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -1111,7 +1123,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Uptime"
             }
@@ -1134,7 +1155,7 @@
     {
       "type": "stat",
       "title": "Memory overcommit",
-      "id": 17,
+      "id": 15,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1207,7 +1228,7 @@
     {
       "type": "bargauge",
       "title": "Peak memory per node",
-      "id": 18,
+      "id": 16,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1291,7 +1312,7 @@
     {
       "type": "bargauge",
       "title": "Root filesystem in seven days",
-      "id": 19,
+      "id": 17,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1374,7 +1395,7 @@
     {
       "type": "timeseries",
       "title": "Load average, 1 minute",
-      "id": 20,
+      "id": 18,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1460,7 +1481,7 @@
     {
       "type": "timeseries",
       "title": "Load average, 5 minutes",
-      "id": 21,
+      "id": 19,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1545,7 +1566,7 @@
     {
       "type": "timeseries",
       "title": "Load average, 15 minutes",
-      "id": 22,
+      "id": 20,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1631,7 +1652,7 @@
     {
       "type": "timeseries",
       "title": "I/O wait per node",
-      "id": 23,
+      "id": 21,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1718,7 +1739,7 @@
     {
       "type": "bargauge",
       "title": "Swap in use per node",
-      "id": 24,
+      "id": 22,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1802,7 +1823,7 @@
     {
       "type": "table",
       "title": "Node inventory",
-      "id": 25,
+      "id": 23,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -1950,7 +1971,7 @@
     {
       "type": "row",
       "title": "Stability",
-      "id": 104,
+      "id": 24,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1963,7 +1984,7 @@
     {
       "type": "bargauge",
       "title": "Cluster availability over the window",
-      "id": 50,
+      "id": 25,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2047,7 +2068,7 @@
     {
       "type": "table",
       "title": "Nodes that changed state",
-      "id": 51,
+      "id": 26,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2122,7 +2143,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Transitions"
             }
@@ -2145,7 +2175,7 @@
     {
       "type": "table",
       "title": "Nodes that rebooted",
-      "id": 52,
+      "id": 27,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2220,7 +2250,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Reboots"
             }
@@ -2243,7 +2282,7 @@
     {
       "type": "table",
       "title": "Guests that changed state",
-      "id": 53,
+      "id": 28,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2318,7 +2357,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Transitions"
             }
@@ -2341,7 +2389,7 @@
     {
       "type": "row",
       "title": "Guests",
-      "id": 101,
+      "id": 29,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -2354,7 +2402,7 @@
     {
       "type": "timeseries",
       "title": "Guests running and stopped",
-      "id": 20,
+      "id": 30,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2450,7 +2498,7 @@
     {
       "type": "timeseries",
       "title": "Guest memory, allocated against in use",
-      "id": 21,
+      "id": 31,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2548,7 +2596,7 @@
     {
       "type": "table",
       "title": "Top guests by CPU",
-      "id": 22,
+      "id": 32,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2588,7 +2636,6 @@
               }
             ]
           },
-          "unit": "percentunit",
           "noValue": "No guest reporting CPU",
           "custom": {
             "align": "auto",
@@ -2598,7 +2645,20 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -2622,7 +2682,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "CPU"
             }
@@ -2645,7 +2714,7 @@
     {
       "type": "table",
       "title": "Top guests by memory",
-      "id": 23,
+      "id": 33,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2685,7 +2754,6 @@
               }
             ]
           },
-          "unit": "percentunit",
           "noValue": "No guest reporting memory",
           "custom": {
             "align": "auto",
@@ -2695,7 +2763,20 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -2719,7 +2800,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Memory"
             }
@@ -2742,7 +2832,7 @@
     {
       "type": "table",
       "title": "Guest uptime, longest first",
-      "id": 24,
+      "id": 34,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2782,7 +2872,6 @@
               }
             ]
           },
-          "unit": "s",
           "noValue": "No guest reporting uptime",
           "custom": {
             "align": "auto",
@@ -2792,7 +2881,20 @@
             "inspect": false
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Uptime"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "showHeader": true,
@@ -2816,7 +2918,16 @@
               "job": true,
               "instance": true
             },
-            "indexByName": {},
+            "indexByName": {
+              "name": 0,
+              "Value": 1,
+              "node": 2,
+              "connection": 3,
+              "type": 4,
+              "vmid": 5,
+              "storage": 6,
+              "datastore": 7
+            },
             "renameByName": {
               "Value": "Uptime"
             }
@@ -2839,7 +2950,7 @@
     {
       "type": "row",
       "title": "Guest I/O",
-      "id": 105,
+      "id": 35,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -2852,7 +2963,7 @@
     {
       "type": "timeseries",
       "title": "Guest disk read",
-      "id": 60,
+      "id": 36,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -2939,7 +3050,7 @@
     {
       "type": "timeseries",
       "title": "Guest disk write",
-      "id": 61,
+      "id": 37,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3025,7 +3136,7 @@
     {
       "type": "timeseries",
       "title": "Guest network in",
-      "id": 62,
+      "id": 38,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3111,7 +3222,7 @@
     {
       "type": "timeseries",
       "title": "Guest network out",
-      "id": 63,
+      "id": 39,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3197,7 +3308,7 @@
     {
       "type": "stat",
       "title": "vCPU overcommit",
-      "id": 64,
+      "id": 40,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3270,7 +3381,7 @@
     {
       "type": "timeseries",
       "title": "Guest memory as the host accounts it",
-      "id": 65,
+      "id": 41,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3369,7 +3480,7 @@
     {
       "type": "row",
       "title": "Storage",
-      "id": 106,
+      "id": 42,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -3382,7 +3493,7 @@
     {
       "type": "bargauge",
       "title": "Storage usage",
-      "id": 70,
+      "id": 43,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3466,7 +3577,7 @@
     {
       "type": "bargauge",
       "title": "Local storage, per node",
-      "id": 71,
+      "id": 44,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3550,7 +3661,7 @@
     {
       "type": "table",
       "title": "Storage capacity",
-      "id": 72,
+      "id": 45,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3666,7 +3777,7 @@
     {
       "type": "table",
       "title": "Local storage per node, in bytes",
-      "id": 73,
+      "id": 46,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3780,7 +3891,7 @@
     {
       "type": "table",
       "title": "Disabled storages",
-      "id": 74,
+      "id": 47,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3864,7 +3975,7 @@
     {
       "type": "row",
       "title": "High availability",
-      "id": 102,
+      "id": 48,
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -3877,7 +3988,7 @@
     {
       "type": "piechart",
       "title": "Guests by HA state",
-      "id": 30,
+      "id": 49,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -3983,7 +4094,7 @@
     {
       "type": "table",
       "title": "Guests in HA error",
-      "id": 31,
+      "id": 50,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -4067,7 +4178,7 @@
     {
       "type": "row",
       "title": "Guest agent inventory",
-      "id": 103,
+      "id": 51,
       "collapsed": true,
       "gridPos": {
         "h": 1,
@@ -4079,7 +4190,7 @@
         {
           "type": "table",
           "title": "Guests without the guest agent enabled",
-          "id": 40,
+          "id": 52,
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -1372,6 +1372,582 @@
       "description": "Where each root filesystem lands in seven days at the current trend. Needs several hours of history to mean anything, so read it as a direction and not as a date."
     },
     {
+      "type": "timeseries",
+      "title": "Load average, 1 minute",
+      "id": 20,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load1{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Runnable processes averaged over one minute, the figure that moves first when a node is about to be in trouble. Read it against the core count, not against other nodes."
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average, 5 minutes",
+      "id": 21,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load5{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Load average, 15 minutes",
+      "id": 22,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 34
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_load15{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "noValue": "No node reporting load",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "The slow average. A 15 minute load that stays high while the 1 minute one has come down is a node that has been loaded for a while, not a node that just spiked."
+    },
+    {
+      "type": "timeseries",
+      "title": "I/O wait per node",
+      "id": 23,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 41
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_iowait_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No node reporting I/O wait",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "CPU time spent waiting on storage. High I/O wait with low CPU usage means the storage is the bottleneck, not the processor, which is the opposite conclusion from the CPU panel alone."
+    },
+    {
+      "type": "bargauge",
+      "title": "Swap in use per node",
+      "id": 24,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 41
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_swap_bytes{connection=~\"$connection\",node=~\"$node\"} / proxcenter_node_swap_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.1
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node has swap configured"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "A hypervisor that swaps is a hypervisor that has already run out of memory, so the thresholds here are deliberately harsh: amber at a tenth of the swap used."
+    },
+    {
+      "type": "table",
+      "title": "Node inventory",
+      "id": 25,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 41
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_info",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_cpu_cores{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "D",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No node in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "Which Proxmox VE and which kernel each node runs, with its core count and root filesystem in bytes. A fleet running three different point releases is a fleet with three different bug sets.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "node",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "__name__ 4": true,
+              "connection 2": true,
+              "connection 3": true,
+              "connection 4": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "job 4": true,
+              "instance 1": true,
+              "instance 2": true,
+              "instance 3": true,
+              "instance 4": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "pve_version": "PVE",
+              "kernel": "Kernel",
+              "Value #B": "Cores",
+              "Value #C": "Root used",
+              "Value #D": "Root size"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    },
+    {
       "type": "row",
       "title": "Stability",
       "id": 104,
@@ -1380,7 +1956,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 48
       },
       "panels": []
     },
@@ -1396,7 +1972,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 35
+        "y": 49
       },
       "targets": [
         {
@@ -1480,7 +2056,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 35
+        "y": 49
       },
       "targets": [
         {
@@ -1578,7 +2154,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 35
+        "y": 49
       },
       "targets": [
         {
@@ -1676,7 +2252,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 56
       },
       "targets": [
         {
@@ -1771,7 +2347,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 63
       },
       "panels": []
     },
@@ -1787,7 +2363,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 50
+        "y": 64
       },
       "targets": [
         {
@@ -1883,7 +2459,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 50
+        "y": 64
       },
       "targets": [
         {
@@ -1981,7 +2557,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 58
+        "y": 72
       },
       "targets": [
         {
@@ -2078,7 +2654,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 58
+        "y": 72
       },
       "targets": [
         {
@@ -2175,7 +2751,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 80
       },
       "targets": [
         {
@@ -2262,6 +2838,1031 @@
     },
     {
       "type": "row",
+      "title": "Guest I/O",
+      "id": 105,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest disk read",
+      "id": 60,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_disk_read_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting disk I/O",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "description": "Derived with rate() from a cumulative counter, which is why a guest restart shows as a gap rather than as an enormous negative spike."
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest disk write",
+      "id": 61,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_disk_written_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting disk I/O",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest network in",
+      "id": 62,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 96
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_network_receive_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting network traffic",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest network out",
+      "id": 63,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 96
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(proxcenter_vm_network_transmit_bytes_total{connection=~\"$connection\",node=~\"$node\"}[$__rate_interval])",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0,
+          "noValue": "No guest reporting network traffic",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "vCPU overcommit",
+      "id": 64,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 103
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_cpu_cores{connection=~\"$connection\",node=~\"$node\"}) / sum(proxcenter_node_cpu_cores{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "noValue": "No core count reported"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Virtual cores handed out against physical cores present. Overcommit is normal on a hypervisor, which is why the thresholds only warn past three to one."
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest memory as the host accounts it",
+      "id": 65,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 103
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_host_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Host accounting"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "Guest reported"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "noValue": "No guest reporting memory",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "description": "PVE 9 accounts a guest's memory twice, once as the guest reports it and once as the host sees it. The host figure is the one that decides whether a node runs out. Containers report no host figure, so they sit at zero in the first series."
+    },
+    {
+      "type": "row",
+      "title": "Storage",
+      "id": 106,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 109
+      },
+      "panels": []
+    },
+    {
+      "type": "bargauge",
+      "title": "Storage usage",
+      "id": 70,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 110
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_usage_ratio{connection=~\"$connection\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{storage}} ({{type}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No storage in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "One bar per storage, shared ones counted ONCE for the whole cluster rather than once per node, which is how a Ceph pool otherwise appears to have three times its real capacity."
+    },
+    {
+      "type": "bargauge",
+      "title": "Local storage, per node",
+      "id": 71,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 110
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_node_usage_ratio{connection=~\"$connection\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{storage}} ({{node}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No non-shared storage in this selection"
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "basic",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Non-shared storages only. A shared storage has one capacity for the cluster, so it emits nothing here on purpose rather than repeating itself once per node."
+    },
+    {
+      "type": "table",
+      "title": "Storage capacity",
+      "id": 72,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 110
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_total_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_used_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "noValue": "No storage in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "Capacity and space in use per storage, with its Proxmox type and whether the cluster shares it.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "storage",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "connection 2": true,
+              "type 2": true,
+              "shared 2": true,
+              "job 1": true,
+              "job 2": true,
+              "instance 1": true,
+              "instance 2": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "type 1": "Type",
+              "shared 1": "Shared",
+              "Value #A": "Capacity",
+              "Value #B": "In use"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Local storage per node, in bytes",
+      "id": 73,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 118
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_node_used_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_node_total_bytes{connection=~\"$connection\"}",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "noValue": "No non-shared storage in this selection",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "The absolute figures behind the per-node bars, for the moment a percentage is not enough.",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "node",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "connection 2": true,
+              "storage 2": true,
+              "job 1": true,
+              "job 2": true,
+              "instance 1": true,
+              "instance 2": true
+            },
+            "renameByName": {
+              "connection 1": "Connection",
+              "storage 1": "Storage",
+              "Value #A": "In use",
+              "Value #B": "Capacity"
+            },
+            "indexByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Disabled storages",
+      "id": 74,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 118
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_storage_enabled{connection=~\"$connection\"} == 0",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "Every storage is enabled",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A disabled storage still reports its capacity, so it inflates any fleet total while accepting no new volume. Worth knowing before planning against that capacity.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true,
+              "Value": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
       "title": "High availability",
       "id": 102,
       "collapsed": false,
@@ -2269,7 +3870,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 125
       },
       "panels": []
     },
@@ -2285,7 +3886,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 75
+        "y": 126
       },
       "targets": [
         {
@@ -2391,7 +3992,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 75
+        "y": 126
       },
       "targets": [
         {
@@ -2472,7 +4073,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 134
       },
       "panels": [
         {
@@ -2487,7 +4088,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 84
+            "y": 135
           },
           "targets": [
             {

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -645,7 +645,7 @@
     },
     {
       "type": "bargauge",
-      "title": "Memory headroom per node",
+      "title": "Memory free per node",
       "id": 12,
       "datasource": {
         "type": "prometheus",
@@ -664,7 +664,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"} - proxcenter_node_mem_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "expr": "(proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"} - proxcenter_node_mem_bytes{connection=~\"$connection\",node=~\"$node\"}) / proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"}",
           "range": true,
           "instant": false,
           "refId": "A",
@@ -686,21 +686,23 @@
               },
               {
                 "color": "orange",
-                "value": 8589934592
+                "value": 0.1
               },
               {
                 "color": "green",
-                "value": 34359738368
+                "value": 0.2
               }
             ]
           },
-          "unit": "bytes",
-          "min": 0
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "No node reporting memory"
         },
         "overrides": []
       },
       "options": {
-        "displayMode": "gradient",
+        "displayMode": "basic",
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -723,7 +725,7 @@
         "sizing": "auto",
         "valueMode": "color"
       },
-      "description": "Bytes still free. Low is bad here, so the thresholds run the other way: red under 8 GiB, amber under 32 GiB."
+      "description": "Free memory as a share of the node's own capacity. A ratio rather than a byte count on purpose: 20 GiB free is comfortable on a 24 GiB node and critical on a 1 TiB one, so an absolute threshold cannot be right for both."
     },
     {
       "type": "bargauge",
@@ -783,7 +785,7 @@
         "overrides": []
       },
       "options": {
-        "displayMode": "gradient",
+        "displayMode": "basic",
         "legend": {
           "calcs": [],
           "displayMode": "list",
@@ -946,7 +948,7 @@
     },
     {
       "type": "state-timeline",
-      "title": "Cluster degraded",
+      "title": "Cluster health",
       "id": 15,
       "datasource": {
         "type": "prometheus",
@@ -977,7 +979,29 @@
           "color": {
             "mode": "palette-classic"
           },
-          "mappings": [],
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false,
+            "insertNulls": false
+          },
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "Healthy",
+                  "color": "green",
+                  "index": 0
+                },
+                "1": {
+                  "text": "Degraded",
+                  "color": "red",
+                  "index": 1
+                }
+              }
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -988,13 +1012,7 @@
             ]
           },
           "min": 0,
-          "max": 1,
-          "custom": {
-            "fillOpacity": 70,
-            "lineWidth": 0,
-            "spanNulls": false,
-            "insertNulls": false
-          }
+          "max": 1
         },
         "overrides": []
       },
@@ -1012,7 +1030,8 @@
           "mode": "single",
           "sort": "none"
         }
-      }
+      },
+      "description": "A degraded cluster has lost quorum or a node. Green is the healthy state, so a coloured band here is always something to look at."
     },
     {
       "type": "table",
@@ -1093,7 +1112,9 @@
               "instance": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value": "Uptime"
+            }
           }
         },
         {
@@ -1102,7 +1123,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "Value",
+                "field": "Uptime",
                 "desc": true
               }
             ]
@@ -1327,7 +1348,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
         "y": 36
       },
@@ -1395,7 +1416,9 @@
               "instance": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value": "CPU"
+            }
           }
         },
         {
@@ -1404,7 +1427,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "Value",
+                "field": "CPU",
                 "desc": true
               }
             ]
@@ -1422,8 +1445,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 8,
+        "w": 12,
+        "x": 12,
         "y": 36
       },
       "targets": [
@@ -1490,7 +1513,9 @@
               "instance": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value": "Memory"
+            }
           }
         },
         {
@@ -1499,7 +1524,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "Value",
+                "field": "Memory",
                 "desc": true
               }
             ]
@@ -1517,9 +1542,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 36
+        "w": 24,
+        "x": 0,
+        "y": 44
       },
       "targets": [
         {
@@ -1585,7 +1610,9 @@
               "instance": true
             },
             "indexByName": {},
-            "renameByName": {}
+            "renameByName": {
+              "Value": "Uptime"
+            }
           }
         },
         {
@@ -1594,7 +1621,7 @@
             "fields": {},
             "sort": [
               {
-                "field": "Value",
+                "field": "Uptime",
                 "desc": true
               }
             ]
@@ -1611,7 +1638,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 52
       },
       "panels": []
     },
@@ -1627,7 +1654,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "targets": [
         {
@@ -1733,7 +1760,7 @@
         "h": 8,
         "w": 16,
         "x": 8,
-        "y": 45
+        "y": 53
       },
       "targets": [
         {
@@ -1796,7 +1823,8 @@
               "Time": true,
               "__name__": true,
               "job": true,
-              "instance": true
+              "instance": true,
+              "Value": true
             },
             "indexByName": {},
             "renameByName": {}
@@ -1813,7 +1841,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 61
       },
       "panels": [
         {
@@ -1828,7 +1856,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 54
+            "y": 62
           },
           "targets": [
             {

--- a/frontend/public/integrations/grafana-dashboard-proxcenter.json
+++ b/frontend/public/integrations/grafana-dashboard-proxcenter.json
@@ -1,94 +1,1996 @@
 {
-  "title": "ProxCenter fleet",
-  "uid": "proxcenter-fleet",
-  "schemaVersion": 39,
-  "version": 1,
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "The Prometheus that scrapes /api/v1/public/metrics on your ProxCenter.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "piechart",
+      "name": "Pie chart",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "state-timeline",
+      "name": "State timeline",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "Multi-cluster Proxmox VE fleet: reachability, capacity headroom, guest load and HA state, across every cluster one ProxCenter manages. Scrapes ProxCenter's own aggregated exposition, so a single Prometheus job covers every cluster without an agent on any node. Requires ProxCenter Enterprise with the API option.",
   "editable": true,
-  "time": { "from": "now-24h", "to": "now" },
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Clusters",
+      "id": 1,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_cluster_up{connection=~\"$connection\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Every PVE connection ProxCenter manages, clustered or standalone."
+    },
+    {
+      "type": "stat",
+      "title": "Nodes online",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Nodes offline",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"}) - sum(proxcenter_node_online{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "The actionable half of the pair: anything above zero is a node the fleet lost."
+    },
+    {
+      "type": "stat",
+      "title": "Guests running",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "description": "Templates are excluded upstream, so this counts real workloads only."
+    },
+    {
+      "type": "stat",
+      "title": "Nodes in maintenance",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_node_maintenance{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      }
+    },
+    {
+      "type": "stat",
+      "title": "ProxCenter",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_build_info",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{version}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name",
+        "wideLayout": true
+      },
+      "description": "Version of the ProxCenter being scraped."
+    },
+    {
+      "type": "row",
+      "title": "Capacity",
+      "id": 100,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Node CPU usage",
+      "id": 10,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_cpu_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Node memory usage",
+      "id": 11,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Memory headroom per node",
+      "id": 12,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 13
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"} - proxcenter_node_mem_bytes{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 8589934592
+              },
+              {
+                "color": "green",
+                "value": 34359738368
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "Bytes still free. Low is bad here, so the thresholds run the other way: red under 8 GiB, amber under 32 GiB."
+    },
+    {
+      "type": "bargauge",
+      "title": "Root filesystem usage",
+      "id": 13,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 13
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_rootfs_usage_ratio{connection=~\"$connection\",node=~\"$node\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}} / {{node}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "description": "The HOST root filesystem, not cluster storage. A full root filesystem is what stops a node accepting migrations."
+    },
+    {
+      "type": "piechart",
+      "title": "Ceph health across clusters",
+      "id": 14,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 13
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (health) (proxcenter_cluster_ceph_health{connection=~\"$connection\"} == 1)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{health}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No Ceph cluster in this selection"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ok"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "warn"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "err"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "description": "Clusters without Ceph emit nothing, so they are absent rather than counted as unknown."
+    },
+    {
+      "type": "state-timeline",
+      "title": "Cluster degraded",
+      "id": 15,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 0,
+        "y": 21
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_cluster_degraded{connection=~\"$connection\"}",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{connection}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1,
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0,
+            "spanNulls": false,
+            "insertNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "type": "table",
+      "title": "Node uptime, longest first",
+      "id": 16,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_node_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "noValue": "No node reporting uptime",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "A node up far longer than its peers is a node that has missed the reboots its peers took.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Guests",
+      "id": 101,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Guests running and stopped",
+      "id": 20,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Running"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"}) - sum(proxcenter_vm_status{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "Stopped"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Guest memory, allocated against in use",
+      "id": 21,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_total_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "Allocated"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(proxcenter_vm_mem_bytes{connection=~\"$connection\",node=~\"$node\"})",
+          "range": true,
+          "instant": false,
+          "refId": "B",
+          "legendFormat": "In use"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "fillOpacity": 8,
+            "gradientMode": "none",
+            "showPoints": "never",
+            "pointSize": 8,
+            "spanNulls": true,
+            "axisBorderShow": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "description": "The gap between the two lines is the overcommit a balloon driver is expected to absorb."
+    },
+    {
+      "type": "table",
+      "title": "Top guests by CPU",
+      "id": 22,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 36
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, proxcenter_vm_cpu_usage_ratio{connection=~\"$connection\",node=~\"$node\"})",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "No guest reporting CPU",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Top guests by memory",
+      "id": 23,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 36
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(10, proxcenter_vm_mem_usage_ratio{connection=~\"$connection\",node=~\"$node\"})",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "noValue": "No guest reporting memory",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Guest uptime, longest first",
+      "id": 24,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 36
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_vm_uptime_seconds{connection=~\"$connection\",node=~\"$node\"}",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "noValue": "No guest reporting uptime",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Value",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "High availability",
+      "id": 102,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "panels": []
+    },
+    {
+      "type": "piechart",
+      "title": "Guests by HA state",
+      "id": 30,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (state) (proxcenter_vm_ha_state{connection=~\"$connection\",node=~\"$node\"} == 1)",
+          "range": true,
+          "instant": false,
+          "refId": "A",
+          "legendFormat": "{{state}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest is managed by HA"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "started"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "red"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "description": "Guests HA does not manage emit nothing at all, so this counts only the HA estate."
+    },
+    {
+      "type": "table",
+      "title": "Guests in HA error",
+      "id": 31,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 45
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "proxcenter_vm_ha_state{connection=~\"$connection\",node=~\"$node\",state=\"error\"} == 1",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "No guest is in HA error",
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "description": "An HA resource in error has stopped being managed: HA will not restart or relocate it until an operator clears the state.",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "job": true,
+              "instance": true
+            },
+            "indexByName": {},
+            "renameByName": {}
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Guest agent inventory",
+      "id": 103,
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "panels": [
+        {
+          "type": "table",
+          "title": "Guests without the guest agent enabled",
+          "id": 40,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 54
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "proxcenter_vm_agent_enabled{connection=~\"$connection\",node=~\"$node\"} == 0",
+              "range": false,
+              "instant": true,
+              "refId": "A",
+              "format": "table"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  }
+                ]
+              },
+              "noValue": "No data yet on this install",
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "showHeader": true,
+            "cellHeight": "sm",
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "description": "No data yet on most installs, and that is expected rather than broken. ProxCenter builds its inventory from /cluster/resources, which carries no guest agent config flag, so the flag is unknown and the series is deliberately omitted rather than published as a misleading zero. It fills in once the agent flag has a source, which means a capped pass over /config.",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "job": true,
+                  "instance": true
+                },
+                "indexByName": {},
+                "renameByName": {}
+              }
+            }
+          ]
+        }
+      ],
+      "description": "Collapsed on purpose: the series behind it is empty on most installs today. Open the row to read why."
+    }
+  ],
+  "preload": false,
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "proxmox",
+    "proxcenter",
+    "pve",
+    "fleet",
+    "virtualization"
+  ],
   "templating": {
     "list": [
       {
-        "type": "datasource",
-        "name": "datasource",
-        "label": "Prometheus",
-        "query": "prometheus",
-        "current": {},
-        "hide": 0
+        "name": "connection",
+        "label": "Connection",
+        "description": "One PVE connection as ProxCenter names it: a cluster or a standalone node.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_cluster_up, connection)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_cluster_up, connection)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node",
+        "label": "Node",
+        "description": "Nodes of the selected connections.",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(proxcenter_node_online{connection=~\"$connection\"}, node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "sort": 1,
+        "hide": 0,
+        "skipUrlSync": false
       }
     ]
   },
-  "panels": [
-    {
-      "id": 1,
-      "type": "table",
-      "title": "Guests without a backup in the last 48h",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
-      "options": { "showHeader": true },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "format": "table",
-          "expr": "proxcenter_backup_age_seconds > 172800"
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "type": "table",
-      "title": "Guests pinned at 100% CPU",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
-      "options": { "showHeader": true },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "format": "table",
-          "expr": "proxcenter_vm_cpu_usage_ratio >= 0.95 and proxcenter_vm_status == 1"
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "type": "table",
-      "title": "Guests without the guest agent enabled",
-      "description": "No data yet on a fresh install. The agent config flag is omitted whenever it is unknown, and today it is unknown for every guest: the inventory cache is built from /cluster/resources, which carries no agent flag at all. Sourcing it would need a per-guest /config pass (see VmsResponse's agentEnabled field on GET /api/v1/vms, or the ?include=agent probe); wiring that into this metric family is an open product decision (issue #254), not implemented yet. Kept here rather than dropped so the use case stays visible instead of silently disappearing.",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
-      "options": { "showHeader": true },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "format": "table",
-          "expr": "proxcenter_vm_agent_enabled == 0"
-        }
-      ]
-    },
-    {
-      "id": 4,
-      "type": "timeseries",
-      "title": "Node capacity (CPU and memory)",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
-      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 }, "overrides": [] },
-      "targets": [
-        { "refId": "A", "legendFormat": "{{connection}}/{{node}} CPU", "expr": "proxcenter_node_cpu_usage_ratio" },
-        { "refId": "B", "legendFormat": "{{connection}}/{{node}} RAM", "expr": "proxcenter_node_mem_usage_ratio" }
-      ]
-    },
-    {
-      "id": 5,
-      "type": "stat",
-      "title": "Nodes online",
-      "datasource": { "type": "prometheus", "uid": "${datasource}" },
-      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 18 },
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "refId": "A", "legendFormat": "online", "expr": "sum(proxcenter_node_online)" }
-      ]
-    }
-  ]
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ProxCenter Fleet Overview",
+  "uid": "proxcenter-fleet",
+  "version": 1,
+  "weekStart": ""
 }

--- a/frontend/public/integrations/prometheus-scrape-config.yml
+++ b/frontend/public/integrations/prometheus-scrape-config.yml
@@ -1,7 +1,28 @@
 # ProxCenter public read-only API: Prometheus scrape configuration.
-# Create the token in ProxCenter under Settings > API with at least the
+#
+# Requires ProxCenter Enterprise with the API option. Without it every call
+# on this path answers 403 "Feature not licensed".
+#
+# Create the token in ProxCenter under Settings > API with all three of the
 # nodes:read, vms:read and backups:read scopes, then paste the secret below.
 # The token is shown once at creation and never again.
+#
+# A token short of one scope still gets HTTP 200: the families it may not see
+# are filtered out of the response rather than refused. On a dashboard that
+# looks exactly like a broken panel, so grant all three.
+#
+# One job covers every cluster. ProxCenter serves its own aggregated view, so
+# there is nothing to install on any Proxmox node, and the scrape is answered
+# from ProxCenter's inventory cache rather than fanning out to the
+# hypervisor. Keep the 60s interval: a tighter one buys no fresher data.
+#
+# Two dashboards read this exposition, both published on grafana.com:
+#   proxcenter-fleet     ProxCenter Fleet Overview
+#                        reachability, capacity headroom, guest load, HA state
+#   proxcenter-backups   ProxCenter Backup Compliance
+#                        protection coverage, staleness, PBS datastore capacity
+# They also ship beside this file, as
+# grafana-dashboard-proxcenter.json and grafana-dashboard-proxcenter-backups.json.
 scrape_configs:
   - job_name: proxcenter
     scheme: https

--- a/frontend/src/app/api/v1/public/metrics/route.ts
+++ b/frontend/src/app/api/v1/public/metrics/route.ts
@@ -3,15 +3,25 @@ import { NextResponse } from "next/server"
 import { withPublicApiGuard } from "@/lib/api-tokens/routeGuard"
 import { loadPublicView, loadBackupFreshnessForView } from "@/lib/api-tokens/publicRoutePrologue"
 import { isFamilyAllowed, renderExposition, type MetricFamily } from "@/lib/metrics/prometheus"
+import { buildBackupFamilies } from "@/lib/metrics/families/backup"
+import { buildClusterFamilies } from "@/lib/metrics/families/cluster"
+import { buildGuestFamilies } from "@/lib/metrics/families/guest"
+import { buildMetaFamilies } from "@/lib/metrics/families/meta"
+import { buildNodeFamilies } from "@/lib/metrics/families/node"
+import { buildPbsFamilies } from "@/lib/metrics/families/pbs"
 import { PERMISSIONS } from "@/lib/rbac"
 import type { Principal } from "@/lib/auth/principal"
 
 export const runtime = "nodejs"
 
-function ratio(used: number, total: number): number {
-  return total > 0 ? Math.round((used / total) * 10_000) / 10_000 : 0
-}
-
+/**
+ * Assembly only (#925). Every sample is built by a PURE per-domain module
+ * under lib/metrics/families/, which takes the fleet view and returns
+ * families whose HELP text comes from the single registry. Five near
+ * identical builders inline here is what the Sonar duplication gate flags,
+ * and it is also what let the 3 August exposition drift away from the
+ * dashboard shipped beside it.
+ */
 async function handler(_req: Request, ctx: { principal?: Principal }) {
   const principal = ctx?.principal
   const result = await loadPublicView(principal, PERMISSIONS.NODE_VIEW)
@@ -24,114 +34,25 @@ async function handler(_req: Request, ctx: { principal?: Principal }) {
   const scopes = principal?.kind === "token" ? principal.scopes ?? [] : []
   const allowed = (name: string) => principal?.kind !== "token" || isFamilyAllowed(name, scopes)
 
-  const families: MetricFamily[] = []
+  const families: MetricFamily[] = [
+    ...buildMetaFamilies(),
+    ...buildClusterFamilies(view),
+    ...buildNodeFamilies(view),
+    ...buildGuestFamilies(view),
+    ...buildPbsFamilies(view),
+  ]
 
-  if (allowed("proxcenter_node_online")) {
-    families.push(
-      {
-        name: "proxcenter_node_online",
-        help: "Node online state (1 online, 0 otherwise)",
-        type: "gauge",
-        samples: view.nodes.map(node => ({
-          name: "proxcenter_node_online",
-          labels: { connection: node.connectionName, node: node.node },
-          value: node.status === "online" ? 1 : 0,
-        })),
-      },
-      {
-        name: "proxcenter_node_cpu_usage_ratio",
-        help: "Node CPU usage ratio (0 to 1)",
-        type: "gauge",
-        samples: view.nodes.map(node => ({
-          name: "proxcenter_node_cpu_usage_ratio",
-          labels: { connection: node.connectionName, node: node.node },
-          value: Math.round(node.cpu * 10_000) / 10_000,
-        })),
-      },
-      {
-        name: "proxcenter_node_mem_usage_ratio",
-        help: "Node memory usage ratio (0 to 1)",
-        type: "gauge",
-        samples: view.nodes.map(node => ({
-          name: "proxcenter_node_mem_usage_ratio",
-          labels: { connection: node.connectionName, node: node.node },
-          value: ratio(node.mem, node.maxmem),
-        })),
-      },
-    )
-  }
-
-  if (allowed("proxcenter_vm_status")) {
-    families.push(
-      {
-        name: "proxcenter_vm_status",
-        help: "Guest running state (1 running, 0 otherwise)",
-        type: "gauge",
-        samples: view.guests.map(guest => ({
-          name: "proxcenter_vm_status",
-          labels: {
-            connection: guest.connectionName,
-            node: guest.node,
-            vmid: guest.vmid,
-            name: guest.name,
-            type: guest.type,
-          },
-          value: guest.status === "running" ? 1 : 0,
-        })),
-      },
-      {
-        name: "proxcenter_vm_cpu_usage_ratio",
-        help: "Guest CPU usage ratio (0 to 1)",
-        type: "gauge",
-        samples: view.guests.map(guest => ({
-          name: "proxcenter_vm_cpu_usage_ratio",
-          labels: {
-            connection: guest.connectionName,
-            node: guest.node,
-            vmid: guest.vmid,
-            name: guest.name,
-            type: guest.type,
-          },
-          value: Math.round(guest.cpu * 10_000) / 10_000,
-        })),
-      },
-      {
-        name: "proxcenter_vm_agent_enabled",
-        help: "Guest agent config flag (1 enabled, 0 otherwise)",
-        type: "gauge",
-        // agentEnabled is tri-state: null means "we do not know", and the
-        // metric's whole purpose is finding agent-less VMs, so a null is
-        // OMITTED here rather than published as a misleading 0.
-        samples: view.guests
-          .filter(guest => guest.agentEnabled !== null)
-          .map(guest => ({
-            name: "proxcenter_vm_agent_enabled",
-            labels: { connection: guest.connectionName, node: guest.node, vmid: guest.vmid, name: guest.name },
-            value: guest.agentEnabled ? 1 : 0,
-          })),
-      },
-    )
-  }
-
+  // The backup aggregation walks every visible PBS connection, so it is the
+  // expensive part of this handler and stays BEHIND the family check: a
+  // token without backups:read must not pay for an aggregation whose output
+  // it is not allowed to see. Every other family is cheap enough to build
+  // and then drop in the filter below.
   if (allowed("proxcenter_backup_age_seconds")) {
-    // Only computed when the family is exposed: the aggregation touches the
-    // PBS cache, so skipping it is a real saving, not cosmetics.
     const freshness = await loadBackupFreshnessForView(view)
-    families.push({
-      name: "proxcenter_backup_age_seconds",
-      help: "Seconds since the most recent backup of this guest",
-      type: "gauge",
-      samples: freshness.guests
-        .filter(guest => guest.ageSeconds !== null)
-        .map(guest => ({
-          name: "proxcenter_backup_age_seconds",
-          labels: { connection: guest.connectionName, vmid: guest.vmid, datastore: guest.datastore },
-          value: guest.ageSeconds as number,
-        })),
-    })
+    families.push(...buildBackupFamilies(view, freshness))
   }
 
-  return new NextResponse(renderExposition(families), {
+  return new NextResponse(renderExposition(families.filter(family => allowed(family.name))), {
     status: 200,
     headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" },
   })

--- a/frontend/src/app/api/v1/public/metrics/route.ts
+++ b/frontend/src/app/api/v1/public/metrics/route.ts
@@ -9,6 +9,7 @@ import { buildGuestFamilies } from "@/lib/metrics/families/guest"
 import { buildMetaFamilies } from "@/lib/metrics/families/meta"
 import { buildNodeFamilies } from "@/lib/metrics/families/node"
 import { buildPbsFamilies } from "@/lib/metrics/families/pbs"
+import { buildStorageFamilies } from "@/lib/metrics/families/storage"
 import { PERMISSIONS } from "@/lib/rbac"
 import type { Principal } from "@/lib/auth/principal"
 
@@ -40,6 +41,7 @@ async function handler(_req: Request, ctx: { principal?: Principal }) {
     ...buildNodeFamilies(view),
     ...buildGuestFamilies(view),
     ...buildPbsFamilies(view),
+    ...buildStorageFamilies(view),
   ]
 
   // The backup aggregation walks every visible PBS connection, so it is the

--- a/frontend/src/app/api/v1/public/publicEndpoints.test.ts
+++ b/frontend/src/app/api/v1/public/publicEndpoints.test.ts
@@ -44,10 +44,16 @@ const VIEW = {
     {
       connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000,
       disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: false,
+      load1: 1.3, load5: 1.27, load15: 1.23, iowait: 0.02,
+      swapUsed: 28672, swapTotal: 2550132736, rootfsUsed: 7818567680, rootfsTotal: 17983504384,
+      cores: 8, pveVersion: '9.2.11', kernel: '7.0.2-6-pve',
     },
     {
       connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0,
       disk: 0, maxdisk: 0, uptime: 0, maintenance: true,
+      load1: 0, load5: 0, load15: 0, iowait: 0,
+      swapUsed: 0, swapTotal: 0, rootfsUsed: 0, rootfsTotal: 0,
+      cores: 0, pveVersion: null, kernel: null,
     },
   ],
   guests: [
@@ -55,6 +61,19 @@ const VIEW = {
       connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '100', name: 'web-01', type: 'qemu',
       status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, agentEnabled: true, template: false,
       maxdisk: 32000, uptime: 3600, hastate: 'started',
+      netIn: 292131298, netOut: 3046818, diskRead: 154857472, diskWritten: 639959040,
+      cores: 2, memHost: 700,
+    },
+  ],
+  storages: [
+    {
+      connId: 'pve-1', connectionName: 'PVE One', storage: 'CephPool', type: 'rbd', shared: true,
+      used: 100, total: 1000, enabled: true, nodes: [{ node: 'n1', used: 100, total: 1000 }],
+    },
+    {
+      connId: 'pve-1', connectionName: 'PVE One', storage: 'local', type: 'dir', shared: false,
+      used: 30, total: 90, enabled: true,
+      nodes: [{ node: 'n1', used: 10, total: 30 }, { node: 'n2', used: 20, total: 60 }],
     },
   ],
   pbsServers: [
@@ -107,7 +126,7 @@ beforeEach(() => {
 
 describe('GET /api/v1/public/metrics', () => {
   it('emits every family for a full-scope token, in Prometheus format', async () => {
-    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read', 'storage:read'])
     const { GET } = await import('./metrics/route')
     const res = await callRoute(GET)
     expect(res.status).toBe(200)
@@ -286,7 +305,7 @@ describe('GET /api/v1/public/metrics after the family extraction (#925)', () => 
    * headers, not merely that the names appear somewhere.
    */
   it('renders the seven pre-existing families with their original headers', async () => {
-    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read', 'storage:read'])
     const { GET } = await import('./metrics/route')
     const body = await (await callRoute(GET)).text()
     for (const [name, help] of [
@@ -304,7 +323,7 @@ describe('GET /api/v1/public/metrics after the family extraction (#925)', () => 
   })
 
   it('serves every registered family to a full-scope token', async () => {
-    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read', 'storage:read'])
     const { GET } = await import('./metrics/route')
     const body = await (await callRoute(GET)).text()
     const rendered = new Set(
@@ -388,7 +407,7 @@ describe('GET /api/v1/public/metrics after the family extraction (#925)', () => 
       nodes: [{ connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0, mem: 0, maxmem: 0 }],
       guests: [{ connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '1', name: 'a', type: 'qemu', status: 'running', cpu: 0, mem: 0, maxmem: 0, agentEnabled: null, template: false }],
     })
-    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read', 'storage:read'])
     const { GET } = await import('./metrics/route')
     const res = await callRoute(GET)
     expect(res.status).toBe(200)
@@ -397,5 +416,59 @@ describe('GET /api/v1/public/metrics after the family extraction (#925)', () => 
     expect(body).not.toContain('proxcenter_pbs_up')
     expect(body).not.toContain('proxcenter_vm_ha_state')
     expect(body).not.toContain('NaN')
+  })
+})
+
+describe('GET /api/v1/public/metrics, the storage and counter families (#925)', () => {
+  it('serves the storage families to a storage:read token, and nothing else', async () => {
+    currentPrincipal.value = tokenPrincipal(['storage:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toContain('proxcenter_storage_total_bytes{connection="PVE One",storage="CephPool",type="rbd",shared="true"} 1000')
+    expect(body).toContain('proxcenter_storage_usage_ratio{connection="PVE One",storage="local",type="dir",shared="false"} 0.3333')
+    expect(body).not.toContain('proxcenter_node_online{')
+    expect(body).not.toContain('proxcenter_vm_status{')
+  })
+
+  /**
+   * A shared storage has ONE capacity for the cluster. Upstream Proxmox
+   * reports it once per node, so a per-node sample here would let any sum()
+   * triple an RBD pool on a three node cluster.
+   */
+  it('emits no per-node sample for a shared storage', async () => {
+    currentPrincipal.value = tokenPrincipal(['storage:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toContain('proxcenter_storage_node_used_bytes{connection="PVE One",storage="local",node="n1"} 10')
+    expect(body).not.toContain('storage="CephPool",node=')
+  })
+
+  /**
+   * The TYPE line is the whole point of declaring these as counters: it tells
+   * Prometheus to handle a guest restart as a reset rather than read it as an
+   * enormous negative rate.
+   */
+  it('renders the four guest byte totals as counters, not gauges', async () => {
+    currentPrincipal.value = tokenPrincipal(['vms:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    for (const name of [
+      'proxcenter_vm_network_receive_bytes_total',
+      'proxcenter_vm_network_transmit_bytes_total',
+      'proxcenter_vm_disk_read_bytes_total',
+      'proxcenter_vm_disk_written_bytes_total',
+    ]) {
+      expect(body).toContain(`# TYPE ${name} counter`)
+    }
+    expect(body).toContain('# TYPE proxcenter_vm_cpu_cores gauge')
+  })
+
+  it('serves the node load average and root filesystem bytes', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toContain('proxcenter_node_load1{connection="PVE One",node="n1"} 1.3')
+    expect(body).toContain('proxcenter_node_rootfs_total_bytes{connection="PVE One",node="n1"} 17983504384')
+    expect(body).toContain('proxcenter_node_info{connection="PVE One",node="n1",pve_version="9.2.11",kernel="7.0.2-6-pve"} 1')
   })
 })

--- a/frontend/src/app/api/v1/public/publicEndpoints.test.ts
+++ b/frontend/src/app/api/v1/public/publicEndpoints.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/rbac', () => ({
 }))
 
 import { callRoute, readJson } from '@/__tests__/setup/route-test'
+import { FAMILY_REGISTRY } from '@/lib/metrics/families/registry'
 
 const VIEW = {
   tenantId: 'default',
@@ -40,16 +41,41 @@ const VIEW = {
     },
   ],
   nodes: [
-    { connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000 },
-    { connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0 },
+    {
+      connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000,
+      disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: false,
+    },
+    {
+      connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0,
+      disk: 0, maxdisk: 0, uptime: 0, maintenance: true,
+    },
   ],
   guests: [
     {
       connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '100', name: 'web-01', type: 'qemu',
       status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, agentEnabled: true, template: false,
+      maxdisk: 32000, uptime: 3600, hastate: 'started',
+    },
+  ],
+  pbsServers: [
+    {
+      connId: 'pbs-1', connectionName: 'PBS Main', status: 'online', version: '4.2.1',
+      datastores: [
+        {
+          name: 'ds', total: 8000, used: 2000, available: 6000, usagePercent: 25,
+          backupCount: 12, vmCount: 3, ctCount: 2, hostCount: 1,
+        },
+      ],
     },
   ],
 }
+
+/**
+ * Families the VIEW fixture above genuinely cannot populate, so the
+ * "serves every registered family" loop skips them rather than being
+ * weakened: the fixture's single cluster carries no `cephHealth`.
+ */
+const EMPTY_ON_THIS_FIXTURE = ['proxcenter_cluster_ceph_health']
 
 function tokenPrincipal(scopes: string[]) {
   return { kind: 'token', tokenId: 't', tenantId: 'default', connectionIds: null, scopes }
@@ -95,7 +121,9 @@ describe('GET /api/v1/public/metrics', () => {
     expect(body).toContain('proxcenter_vm_status{connection="PVE One",node="n1",vmid="100",name="web-01",type="qemu"} 1')
     expect(body).toContain('proxcenter_vm_cpu_usage_ratio{connection="PVE One",node="n1",vmid="100",name="web-01",type="qemu"} 0.5')
     expect(body).toContain('proxcenter_vm_agent_enabled{connection="PVE One",node="n1",vmid="100",name="web-01"} 1')
-    expect(body).toContain('proxcenter_backup_age_seconds{connection="PVE One",vmid="100",datastore="ds"} 3600')
+    // #925: the ONE authorised label break. node, name and type are added so
+    // the offenders table can name a guest without a group_left join.
+    expect(body).toContain('proxcenter_backup_age_seconds{connection="PVE One",node="n1",vmid="100",name="web-01",type="qemu",datastore="ds"} 3600')
     // D12: the backup family, once allowed, must still forward nonBlocking
     // so a scrape never blocks on a cold PBS cache.
     expect(buildFleetBackupFreshnessMock).toHaveBeenCalledWith(expect.objectContaining({ nonBlocking: true }))
@@ -247,5 +275,127 @@ describe('GET /api/v1/public/health', () => {
     const res = await callRoute(GET)
     expect(res.status).toBe(200)
     expect(checkPermissionMock).toHaveBeenCalledWith('node.view')
+  })
+})
+
+describe('GET /api/v1/public/metrics after the family extraction (#925)', () => {
+  /**
+   * The seven families shipped on 3 August are a published contract. Moving
+   * them out of the route into per-domain modules must not change one
+   * character of their output, so this asserts the rendered HELP and TYPE
+   * headers, not merely that the names appear somewhere.
+   */
+  it('renders the seven pre-existing families with their original headers', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    for (const [name, help] of [
+      ['proxcenter_node_online', 'Node online state (1 online, 0 otherwise)'],
+      ['proxcenter_node_cpu_usage_ratio', 'Node CPU usage ratio (0 to 1)'],
+      ['proxcenter_node_mem_usage_ratio', 'Node memory usage ratio (0 to 1)'],
+      ['proxcenter_vm_status', 'Guest running state (1 running, 0 otherwise)'],
+      ['proxcenter_vm_cpu_usage_ratio', 'Guest CPU usage ratio (0 to 1)'],
+      ['proxcenter_vm_agent_enabled', 'Guest agent config flag (1 enabled, 0 otherwise)'],
+      ['proxcenter_backup_age_seconds', 'Seconds since the most recent backup of this guest'],
+    ]) {
+      expect(body).toContain(`# HELP ${name} ${help}`)
+      expect(body).toContain(`# TYPE ${name} gauge`)
+    }
+  })
+
+  it('serves every registered family to a full-scope token', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    const rendered = new Set(
+      body.split(String.fromCharCode(10))
+        .filter(line => line.startsWith('# TYPE '))
+        .map(line => line.split(' ')[2]),
+    )
+    for (const declaration of FAMILY_REGISTRY) {
+      if (EMPTY_ON_THIS_FIXTURE.includes(declaration.name)) continue
+      expect(rendered, `missing family ${declaration.name}`).toContain(declaration.name)
+    }
+  })
+
+  /**
+   * Per-family filtering, never a route-level gate: a token holding only
+   * nodes:read gets a 200 carrying the node and cluster families and
+   * nothing else.
+   */
+  it('filters the new families by token scope, one family at a time', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read'])
+    const { GET } = await import('./metrics/route')
+    const res = await callRoute(GET)
+    const body = await res.text()
+    expect(res.status).toBe(200)
+    expect(body).toContain('proxcenter_cluster_up{')
+    expect(body).toContain('proxcenter_node_mem_bytes{')
+    expect(body).toContain('proxcenter_node_rootfs_usage_ratio{')
+    expect(body).not.toContain('proxcenter_vm_mem_bytes{')
+    expect(body).not.toContain('proxcenter_pbs_up{')
+    expect(body).not.toContain('proxcenter_backup_protected{')
+  })
+
+  it('serves the PBS and backup families to a backups:read token, and no node series', async () => {
+    currentPrincipal.value = tokenPrincipal(['backups:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toContain('proxcenter_pbs_up{connection="PBS Main"} 1')
+    expect(body).toContain('proxcenter_pbs_datastore_usage_ratio{connection="PBS Main",datastore="ds"} 0.25')
+    expect(body).toContain('proxcenter_backup_protected{connection="PVE One",node="n1",vmid="100",name="web-01",type="qemu"} 1')
+    expect(body).not.toContain('proxcenter_node_online{')
+    expect(body).not.toContain('proxcenter_cluster_up{')
+  })
+
+  it('always serves the build info, whatever the token holds', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toMatch(/proxcenter_build_info\{version="[0-9]+\.[0-9]+\.[0-9]+"\} 1/)
+  })
+
+  /**
+   * The backup aggregation walks every visible PBS connection, so it is the
+   * expensive part of this handler. A token that cannot see its output must
+   * not pay for it.
+   */
+  it('does not compute backup freshness for a nodes:read token', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read'])
+    const { GET } = await import('./metrics/route')
+    await callRoute(GET)
+    expect(buildFleetBackupFreshnessMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a node in maintenance and one that is not', async () => {
+    currentPrincipal.value = tokenPrincipal(['nodes:read'])
+    const { GET } = await import('./metrics/route')
+    const body = await (await callRoute(GET)).text()
+    expect(body).toContain('proxcenter_node_maintenance{connection="PVE One",node="n1"} 0')
+    expect(body).toContain('proxcenter_node_maintenance{connection="PVE One",node="n2"} 1')
+  })
+
+  /**
+   * A view missing a collection entirely, which is what a caller written
+   * before #925 hands over, must yield empty families rather than a throw:
+   * one missing optional field must never take the whole scrape down and
+   * blind every panel.
+   */
+  it('survives a fleet view with no PBS servers and no HA state at all', async () => {
+    loadPublicFleetViewMock.mockResolvedValue({
+      tenantId: 'default', visible: new Set(['pve-1']), cached: true,
+      clusters: [{ id: 'pve-1', name: 'PVE One', nodes: [] }],
+      nodes: [{ connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0, mem: 0, maxmem: 0 }],
+      guests: [{ connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '1', name: 'a', type: 'qemu', status: 'running', cpu: 0, mem: 0, maxmem: 0, agentEnabled: null, template: false }],
+    })
+    currentPrincipal.value = tokenPrincipal(['nodes:read', 'vms:read', 'backups:read'])
+    const { GET } = await import('./metrics/route')
+    const res = await callRoute(GET)
+    expect(res.status).toBe(200)
+    const body = await res.text()
+    expect(body).toContain('proxcenter_node_online{connection="PVE One",node="n1"} 1')
+    expect(body).not.toContain('proxcenter_pbs_up')
+    expect(body).not.toContain('proxcenter_vm_ha_state')
+    expect(body).not.toContain('NaN')
   })
 })

--- a/frontend/src/lib/api-tokens/publicData.test.ts
+++ b/frontend/src/lib/api-tokens/publicData.test.ts
@@ -37,8 +37,17 @@ const RAW = {
           maxdisk: 10000,
           uptime: 86400,
           maintenance: 'migrate',
+          loadavg: [1.3, 1.27, 1.23],
+          iowait: 0.02,
+          swapUsed: 28672,
+          swapTotal: 2550132736,
+          rootfsUsed: 7818567680,
+          rootfsTotal: 17983504384,
+          cores: 8,
+          pveVersion: 'pve-manager/9.2.11/f6997e698c7933ea',
+          kernel: '7.0.2-6-pve',
           guests: [
-            { vmid: 100, name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true },
+            { vmid: 100, name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true, netin: 292131298, netout: 3046818, diskread: 154857472, diskwrite: 639959040, cores: 2, memhost: 700 },
             { vmid: 900, name: 'tpl', type: 'qemu', status: 'stopped', template: 1 },
           ],
         },
@@ -46,6 +55,22 @@ const RAW = {
       ],
     },
     { id: 'pve-hidden', name: 'Hidden', nodes: [{ node: 'x', status: 'online', guests: [{ vmid: 5, type: 'qemu', status: 'running' }] }] },
+  ],
+  storages: [
+    {
+      connId: 'pve-1', connName: 'PVE One', storage: 'CephPool', type: 'rbd', shared: true,
+      used: 100, total: 1000, enabled: true,
+      nodeBreakdown: [{ node: 'n1', used: 100, total: 1000 }],
+    },
+    {
+      connId: 'pve-1', connName: 'PVE One', storage: 'local', type: 'dir', shared: false,
+      used: 30, total: 90, enabled: true,
+      nodeBreakdown: [{ node: 'n1', used: 10, total: 30 }, { node: 'n2', used: 20, total: 60 }],
+    },
+    {
+      connId: 'pve-hidden', connName: 'Hidden', storage: 'secret', type: 'dir', shared: false,
+      used: 1, total: 2, enabled: true, nodeBreakdown: [{ node: 'x', used: 1, total: 2 }],
+    },
   ],
   pbsServers: [
     {
@@ -62,7 +87,6 @@ const RAW = {
     },
   ],
   externalHypervisors: [],
-  storages: [],
   stats: {
     totalClusters: 2, totalNodes: 3, totalGuests: 2, onlineNodes: 2,
     runningGuests: 1, totalPbsServers: 0, totalDatastores: 0, totalBackups: 0,
@@ -87,14 +111,28 @@ describe('loadPublicFleetView', () => {
     expect(view.tenantId).toBe('default')
     expect(view.clusters.map(c => c.id)).toEqual(['pve-1'])
     expect(view.nodes).toEqual([
-      { connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000, disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true },
-      { connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0, disk: 0, maxdisk: 0, uptime: 0, maintenance: false },
+      {
+        connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000,
+        disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true,
+        load1: 1.3, load5: 1.27, load15: 1.23, iowait: 0.02,
+        swapUsed: 28672, swapTotal: 2550132736, rootfsUsed: 7818567680, rootfsTotal: 17983504384,
+        cores: 8, pveVersion: '9.2.11', kernel: '7.0.2-6-pve',
+      },
+      {
+        connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0,
+        disk: 0, maxdisk: 0, uptime: 0, maintenance: false,
+        load1: 0, load5: 0, load15: 0, iowait: 0,
+        swapUsed: 0, swapTotal: 0, rootfsUsed: 0, rootfsTotal: 0,
+        cores: 0, pveVersion: null, kernel: null,
+      },
     ])
     expect(view.guests).toHaveLength(1)
     expect(view.guests[0]).toEqual({
       connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '100', name: 'web', type: 'qemu',
       status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started',
       agentEnabled: true, template: false,
+      netIn: 292131298, netOut: 3046818, diskRead: 154857472, diskWritten: 639959040,
+      cores: 2, memHost: 700,
     })
     expect(view.cached).toBe(true)
     expect(view.visible).toEqual(new Set(['pve-1', 'pbs-1']))
@@ -289,5 +327,67 @@ describe('loadPublicFleetView, widened projections (#925)', () => {
     const view = await loadPublicFleetView(undefined)
     expect(view.pbsServers[0].version).toBeNull()
     expect(view.pbsServers[0].datastores).toEqual([])
+  })
+})
+
+describe('loadPublicFleetView, node status and guest counters (#925)', () => {
+  it('parses the load average, which Proxmox sends as an array of strings', async () => {
+    const view = await loadPublicFleetView(undefined)
+    const n1 = view.nodes.find(node => node.node === 'n1')
+    expect(n1).toMatchObject({ load1: 1.3, load5: 1.27, load15: 1.23 })
+    expect(typeof n1?.load1).toBe('number')
+  })
+
+  /**
+   * The raw value is `pve-manager/9.2.11/<commit>`. Carrying the commit into a
+   * metric label would churn it on every point release rebuild, for no gain.
+   */
+  it('keeps only the version number out of the pve-manager string', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.nodes.find(node => node.node === 'n1')?.pveVersion).toBe('9.2.11')
+  })
+
+  it('carries the four cumulative counters off cluster/resources', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.guests[0]).toMatchObject({
+      netIn: 292131298, netOut: 3046818, diskRead: 154857472, diskWritten: 639959040,
+    })
+  })
+
+  it('defaults every new field to 0 rather than undefined, so a ratio never divides by NaN', async () => {
+    const view = await loadPublicFleetView(undefined)
+    const n2 = view.nodes.find(node => node.node === 'n2')
+    for (const value of [n2?.load1, n2?.iowait, n2?.swapTotal, n2?.rootfsTotal, n2?.cores]) {
+      expect(Number.isFinite(value)).toBe(true)
+    }
+  })
+})
+
+describe('loadPublicFleetView, storages (#925)', () => {
+  it('projects the aggregated storages and filters them on the tenant perimeter', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.storages.map(s => s.storage)).toEqual(['CephPool', 'local'])
+  })
+
+  /**
+   * The point of reusing aggregateStorage upstream: a shared storage arrives
+   * already collapsed to ONE entry, so summing `total` across the view cannot
+   * triple an RBD pool that appears once per node in the raw Proxmox data.
+   */
+  it('carries a shared storage once, with its own capacity, not once per node', async () => {
+    const view = await loadPublicFleetView(undefined)
+    const ceph = view.storages.find(s => s.storage === 'CephPool')
+    expect(ceph).toMatchObject({ shared: true, used: 100, total: 1000 })
+    expect(ceph?.nodes).toHaveLength(1)
+  })
+
+  it('keeps the per-node breakdown of a local storage, which is where it means something', async () => {
+    const view = await loadPublicFleetView(undefined)
+    const local = view.storages.find(s => s.storage === 'local')
+    expect(local).toMatchObject({ shared: false, used: 30, total: 90 })
+    expect(local?.nodes).toEqual([
+      { node: 'n1', used: 10, total: 30 },
+      { node: 'n2', used: 20, total: 60 },
+    ])
   })
 })

--- a/frontend/src/lib/api-tokens/publicData.test.ts
+++ b/frontend/src/lib/api-tokens/publicData.test.ts
@@ -33,8 +33,12 @@ const RAW = {
           cpu: 0.25,
           mem: 1000,
           maxmem: 4000,
+          disk: 3000,
+          maxdisk: 10000,
+          uptime: 86400,
+          maintenance: 'migrate',
           guests: [
-            { vmid: 100, name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, agentEnabled: true },
+            { vmid: 100, name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true },
             { vmid: 900, name: 'tpl', type: 'qemu', status: 'stopped', template: 1 },
           ],
         },
@@ -43,7 +47,20 @@ const RAW = {
     },
     { id: 'pve-hidden', name: 'Hidden', nodes: [{ node: 'x', status: 'online', guests: [{ vmid: 5, type: 'qemu', status: 'running' }] }] },
   ],
-  pbsServers: [],
+  pbsServers: [
+    {
+      id: 'pbs-1', name: 'PBS One', type: 'pbs', status: 'online', version: '4.2.1',
+      datastores: [
+        { name: 'S3manu', total: 0, used: 4096, available: 0, usagePercent: 12.5, backupCount: 7, vmCount: 3, ctCount: 1, hostCount: 0 },
+      ],
+      stats: { totalSize: 0, totalUsed: 4096, datastoreCount: 1, backupCount: 7 },
+    },
+    {
+      id: 'pbs-hidden', name: 'PBS Hidden', type: 'pbs', status: 'online', version: '4.2.1',
+      datastores: [{ name: 'secret', total: 10, used: 1, available: 9, usagePercent: 10, backupCount: 1, vmCount: 1, ctCount: 0, hostCount: 0 }],
+      stats: { totalSize: 10, totalUsed: 1, datastoreCount: 1, backupCount: 1 },
+    },
+  ],
   externalHypervisors: [],
   storages: [],
   stats: {
@@ -59,7 +76,7 @@ beforeEach(() => {
   // resetAllMocks wipes the implementation too, so every default below is
   // re-established explicitly and nothing bleeds in from another test.
   vi.resetAllMocks()
-  resolvePublicRequestScopeMock.mockResolvedValue({ tenantId: 'default', visible: new Set(['pve-1']) })
+  resolvePublicRequestScopeMock.mockResolvedValue({ tenantId: 'default', visible: new Set(['pve-1', 'pbs-1']) })
   getTenantInfrastructureScopeMock.mockResolvedValue({ kind: 'provider' })
   getInventorySWRMock.mockResolvedValue({ raw: RAW, cached: true })
 })
@@ -70,16 +87,17 @@ describe('loadPublicFleetView', () => {
     expect(view.tenantId).toBe('default')
     expect(view.clusters.map(c => c.id)).toEqual(['pve-1'])
     expect(view.nodes).toEqual([
-      { connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000 },
-      { connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0 },
+      { connId: 'pve-1', connectionName: 'PVE One', node: 'n1', status: 'online', cpu: 0.25, mem: 1000, maxmem: 4000, disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true },
+      { connId: 'pve-1', connectionName: 'PVE One', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0, disk: 0, maxdisk: 0, uptime: 0, maintenance: false },
     ])
     expect(view.guests).toHaveLength(1)
     expect(view.guests[0]).toEqual({
       connId: 'pve-1', connectionName: 'PVE One', node: 'n1', vmid: '100', name: 'web', type: 'qemu',
-      status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, agentEnabled: true, template: false,
+      status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started',
+      agentEnabled: true, template: false,
     })
     expect(view.cached).toBe(true)
-    expect(view.visible).toEqual(new Set(['pve-1']))
+    expect(view.visible).toEqual(new Set(['pve-1', 'pbs-1']))
   })
 
   it('carries the VM name through: Task 17 must be able to label proxcenter_vm_* series without re-walking clusters', async () => {
@@ -196,5 +214,80 @@ describe('loadPublicFleetView', () => {
     getInventorySWRMock.mockResolvedValue({ raw: RAW, cached: false })
     const view = await loadPublicFleetView({ kind: 'token', tenantId: 'default', connectionIds: ['pve-1'] } as any)
     expect(view.cached).toBe(false)
+  })
+})
+
+describe('loadPublicFleetView, widened projections (#925)', () => {
+  it('carries the node capacity, uptime and maintenance fields the exposition needs', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.nodes.find(node => node.node === 'n1')).toMatchObject({
+      disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true,
+    })
+    expect(view.nodes.find(node => node.node === 'n2')).toMatchObject({
+      disk: 0, maxdisk: 0, uptime: 0, maintenance: false,
+    })
+  })
+
+  /**
+   * `maintenance` is projected as a BOOLEAN, never the raw string: the raw
+   * value is a free-form Proxmox mode name, so letting it through would
+   * hand an unbounded label value to `proxcenter_node_maintenance`.
+   */
+  it('reduces the maintenance mode to a boolean rather than leaking the raw mode name', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.nodes.find(node => node.node === 'n1')?.maintenance).toBe(true)
+  })
+
+  it('carries the guest capacity, uptime and HA state', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.guests[0]).toMatchObject({ maxdisk: 32000, uptime: 3600, hastate: 'started' })
+  })
+
+  it('leaves hastate null rather than inventing a state for a guest HA does not manage', async () => {
+    getInventorySWRMock.mockResolvedValue({
+      raw: {
+        ...RAW,
+        clusters: [
+          {
+            id: 'pve-1',
+            name: 'PVE One',
+            nodes: [{ node: 'n1', status: 'online', guests: [{ vmid: 1, type: 'qemu', status: 'running' }] }],
+          },
+        ],
+      },
+      cached: true,
+    })
+    const view = await loadPublicFleetView(undefined)
+    expect(view.guests[0].hastate).toBeNull()
+  })
+
+  /**
+   * The PBS filter is a TENANT BOUNDARY, not a display filter. A projection
+   * that accepts the perimeter and never reads it is exactly the
+   * resolveVisibleConnectionIds bug this chantier already shipped once, so
+   * `pbs-hidden` sits in the fixture purely to fail that regression.
+   */
+  it('projects PBS servers and filters them on the tenant perimeter', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.pbsServers.map(server => server.connectionName)).toEqual(['PBS One'])
+    expect(view.pbsServers[0]).toMatchObject({ connId: 'pbs-1', status: 'online', version: '4.2.1' })
+  })
+
+  it('projects every datastore field the PBS families need, including a zero capacity', async () => {
+    const view = await loadPublicFleetView(undefined)
+    expect(view.pbsServers[0].datastores[0]).toEqual({
+      name: 'S3manu', total: 0, used: 4096, available: 0, usagePercent: 12.5,
+      backupCount: 7, vmCount: 3, ctCount: 1, hostCount: 0,
+    })
+  })
+
+  it('reports a version-less PBS server as null rather than an empty string', async () => {
+    getInventorySWRMock.mockResolvedValue({
+      raw: { ...RAW, pbsServers: [{ id: 'pbs-1', name: 'PBS One', type: 'pbs', status: 'offline', datastores: [] }] },
+      cached: true,
+    })
+    const view = await loadPublicFleetView(undefined)
+    expect(view.pbsServers[0].version).toBeNull()
+    expect(view.pbsServers[0].datastores).toEqual([])
   })
 })

--- a/frontend/src/lib/api-tokens/publicData.ts
+++ b/frontend/src/lib/api-tokens/publicData.ts
@@ -19,6 +19,16 @@ export type PublicNode = {
   cpu: number
   mem: number
   maxmem: number
+  /** Root filesystem of the HOST, not cluster storage capacity (#925). */
+  disk: number
+  maxdisk: number
+  uptime: number
+  /**
+   * Reduced to a boolean on purpose: the raw Proxmox value is a free-form
+   * mode name, and letting it through would hand an unbounded label value
+   * to `proxcenter_node_maintenance`.
+   */
+  maintenance: boolean
 }
 
 export type PublicGuest = {
@@ -43,6 +53,32 @@ export type PublicGuest = {
    */
   agentEnabled: boolean | null
   template: boolean
+  /** Provisioned disk size; `disk` itself is only meaningful for LXC (#925). */
+  maxdisk: number
+  uptime: number
+  /** null when HA does not manage this guest, never a fabricated state (#925). */
+  hastate: string | null
+}
+
+export type PublicPbsDatastore = {
+  name: string
+  /** 0 when the backend does not report a capacity, as with an S3-backed datastore. */
+  total: number
+  used: number
+  available: number
+  usagePercent: number
+  backupCount: number
+  vmCount: number
+  ctCount: number
+  hostCount: number
+}
+
+export type PublicPbsServer = {
+  connId: string
+  connectionName: string
+  status: string
+  version: string | null
+  datastores: PublicPbsDatastore[]
 }
 
 export type PublicFleetView = {
@@ -51,6 +87,7 @@ export type PublicFleetView = {
   clusters: ClusterData[]
   nodes: PublicNode[]
   guests: PublicGuest[]
+  pbsServers: PublicPbsServer[]
   cached: boolean
 }
 
@@ -93,6 +130,10 @@ export async function loadPublicFleetView(principal?: Principal): Promise<Public
         cpu: Number(node.cpu || 0),
         mem: Number(node.mem || 0),
         maxmem: Number(node.maxmem || 0),
+        disk: Number(node.disk || 0),
+        maxdisk: Number(node.maxdisk || 0),
+        uptime: Number(node.uptime || 0),
+        maintenance: typeof node.maintenance === "string" && node.maintenance !== "",
       })
       for (const guest of node.guests as any[]) {
         if (isTemplate(guest)) continue
@@ -109,10 +150,36 @@ export async function loadPublicFleetView(principal?: Principal): Promise<Public
           maxmem: Number(guest.maxmem || 0),
           agentEnabled: typeof guest.agentEnabled === "boolean" ? guest.agentEnabled : null,
           template: false,
+          maxdisk: Number(guest.maxdisk || 0),
+          uptime: Number(guest.uptime || 0),
+          hastate: typeof guest.hastate === "string" && guest.hastate !== "" ? guest.hastate : null,
         })
       }
     }
   }
 
-  return { tenantId, visible, clusters, nodes, guests, cached }
+  // Same TENANT BOUNDARY as `clusters` above, never a display filter: a
+  // helper that accepts this argument and never reads it is exactly the
+  // `resolveVisibleConnectionIds` bug this chantier already shipped once.
+  const pbsServers: PublicPbsServer[] = (raw.pbsServers ?? [])
+    .filter(server => visible.has(server.id))
+    .map(server => ({
+      connId: server.id,
+      connectionName: server.name,
+      status: server.status,
+      version: typeof server.version === "string" && server.version !== "" ? server.version : null,
+      datastores: (server.datastores ?? []).map(datastore => ({
+        name: datastore.name,
+        total: Number(datastore.total || 0),
+        used: Number(datastore.used || 0),
+        available: Number(datastore.available || 0),
+        usagePercent: Number(datastore.usagePercent || 0),
+        backupCount: Number(datastore.backupCount || 0),
+        vmCount: Number(datastore.vmCount || 0),
+        ctCount: Number(datastore.ctCount || 0),
+        hostCount: Number(datastore.hostCount || 0),
+      })),
+    }))
+
+  return { tenantId, visible, clusters, nodes, guests, pbsServers, cached }
 }

--- a/frontend/src/lib/api-tokens/publicData.ts
+++ b/frontend/src/lib/api-tokens/publicData.ts
@@ -29,6 +29,19 @@ export type PublicNode = {
    * to `proxcenter_node_maintenance`.
    */
   maintenance: boolean
+  /** From /nodes/{node}/status, the call the fan-out already makes (#925). */
+  load1: number
+  load5: number
+  load15: number
+  iowait: number
+  swapUsed: number
+  swapTotal: number
+  rootfsUsed: number
+  rootfsTotal: number
+  cores: number
+  /** Short version only: the raw value is `pve-manager/9.2.11/<commit>`, whose commit would churn the label. */
+  pveVersion: string | null
+  kernel: string | null
 }
 
 export type PublicGuest = {
@@ -58,6 +71,14 @@ export type PublicGuest = {
   uptime: number
   /** null when HA does not manage this guest, never a fabricated state (#925). */
   hastate: string | null
+  /** Cumulative COUNTERS since guest start, not gauges (#925). */
+  netIn: number
+  netOut: number
+  diskRead: number
+  diskWritten: number
+  cores: number
+  /** PVE 9 host-side memory. 0 on an LXC, which reports none. */
+  memHost: number
 }
 
 export type PublicPbsDatastore = {
@@ -81,6 +102,26 @@ export type PublicPbsServer = {
   datastores: PublicPbsDatastore[]
 }
 
+export type PublicStorageNode = { node: string; used: number; total: number }
+
+export type PublicStorage = {
+  connId: string
+  connectionName: string
+  storage: string
+  type: string
+  /**
+   * A shared storage appears once PER NODE upstream, so summing raw rows
+   * triples an RBD pool on a three node cluster. `aggregateStorage` has
+   * already collapsed those, which is why this carries no node of its own:
+   * per-node figures live in `nodes`, and only for non-shared storages.
+   */
+  shared: boolean
+  used: number
+  total: number
+  enabled: boolean
+  nodes: PublicStorageNode[]
+}
+
 export type PublicFleetView = {
   tenantId: string
   visible: Set<string>
@@ -88,6 +129,7 @@ export type PublicFleetView = {
   nodes: PublicNode[]
   guests: PublicGuest[]
   pbsServers: PublicPbsServer[]
+  storages: PublicStorage[]
   cached: boolean
 }
 
@@ -134,6 +176,19 @@ export async function loadPublicFleetView(principal?: Principal): Promise<Public
         maxdisk: Number(node.maxdisk || 0),
         uptime: Number(node.uptime || 0),
         maintenance: typeof node.maintenance === "string" && node.maintenance !== "",
+        load1: Number(node.loadavg?.[0] || 0),
+        load5: Number(node.loadavg?.[1] || 0),
+        load15: Number(node.loadavg?.[2] || 0),
+        iowait: Number(node.iowait || 0),
+        swapUsed: Number(node.swapUsed || 0),
+        swapTotal: Number(node.swapTotal || 0),
+        rootfsUsed: Number(node.rootfsUsed || 0),
+        rootfsTotal: Number(node.rootfsTotal || 0),
+        cores: Number(node.cores || 0),
+        // `pve-manager/9.2.11/<commit>` -> `9.2.11`. The commit would make the
+        // label churn on every point release rebuild.
+        pveVersion: typeof node.pveVersion === "string" ? (node.pveVersion.split("/")[1] || node.pveVersion) : null,
+        kernel: typeof node.kernel === "string" && node.kernel !== "" ? node.kernel : null,
       })
       for (const guest of node.guests as any[]) {
         if (isTemplate(guest)) continue
@@ -152,6 +207,12 @@ export async function loadPublicFleetView(principal?: Principal): Promise<Public
           template: false,
           maxdisk: Number(guest.maxdisk || 0),
           uptime: Number(guest.uptime || 0),
+          netIn: Number(guest.netin || 0),
+          netOut: Number(guest.netout || 0),
+          diskRead: Number(guest.diskread || 0),
+          diskWritten: Number(guest.diskwrite || 0),
+          cores: Number(guest.cores || 0),
+          memHost: Number(guest.memhost || 0),
           hastate: typeof guest.hastate === "string" && guest.hastate !== "" ? guest.hastate : null,
         })
       }
@@ -181,5 +242,24 @@ export async function loadPublicFleetView(principal?: Principal): Promise<Public
       })),
     }))
 
-  return { tenantId, visible, clusters, nodes, guests, pbsServers, cached }
+  // Same TENANT BOUNDARY as clusters and PBS servers.
+  const storages: PublicStorage[] = (raw.storages ?? [])
+    .filter(entry => visible.has(entry.connId))
+    .map(entry => ({
+      connId: entry.connId,
+      connectionName: entry.connName,
+      storage: entry.storage,
+      type: entry.type,
+      shared: !!entry.shared,
+      used: Number(entry.used || 0),
+      total: Number(entry.total || 0),
+      enabled: entry.enabled !== false,
+      nodes: (entry.nodeBreakdown ?? []).map(n => ({
+        node: n.node,
+        used: Number(n.used || 0),
+        total: Number(n.total || 0),
+      })),
+    }))
+
+  return { tenantId, visible, clusters, nodes, guests, pbsServers, storages, cached }
 }

--- a/frontend/src/lib/inventory/fetchRawInventory.ts
+++ b/frontend/src/lib/inventory/fetchRawInventory.ts
@@ -11,6 +11,7 @@ import { getSessionPrisma } from "@/lib/tenant"
 import { prisma as globalPrisma } from "@/lib/db/prisma"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
+import { aggregateStorage, type AggregatedStorage, type RawStorageEntry } from "@/lib/proxmox/storage"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { collectNodeAddresses, resolveManagementIp } from "@/lib/proxmox/resolveManagementIp"
 import {
@@ -30,6 +31,21 @@ export type NodeData = {
   disk?: number
   maxdisk?: number
   uptime?: number
+  /**
+   * Everything below comes from the per-node `/nodes/{node}/status` call this
+   * module ALREADY makes for its memory figures (#925). The payload carries
+   * load, iowait, swap and the exact root filesystem bytes, and all of it used
+   * to be discarded. `/nodes` and `/cluster/resources` carry none of them.
+   */
+  loadavg?: number[]
+  iowait?: number
+  swapUsed?: number
+  swapTotal?: number
+  rootfsUsed?: number
+  rootfsTotal?: number
+  cores?: number
+  pveVersion?: string
+  kernel?: string
   ip?: string
   /** All non-loopback addresses of the host, for the IP search of the palette (#861). */
   ips?: string[]
@@ -53,6 +69,18 @@ export type GuestData = {
   template?: number | boolean
   hastate?: string
   hagroup?: string
+  /**
+   * Cumulative byte COUNTERS since guest start, straight off
+   * `/cluster/resources?type=vm` (#925). Measured present on PVE 9. They were
+   * fetched and dropped by this projection.
+   */
+  netin?: number
+  netout?: number
+  diskread?: number
+  diskwrite?: number
+  cores?: number
+  /** PVE 9 host-side memory of the guest, distinct from the guest-side `mem`. */
+  memhost?: number
 }
 
 export type HaResource = {
@@ -121,7 +149,7 @@ export type RawInventory = {
   clusters: ClusterData[]
   pbsServers: PbsServerData[]
   externalHypervisors: ExternalHypervisor[]
-  storages: any[]
+  storages: AggregatedStorage[]
   stats: { totalClusters: number; totalNodes: number; totalGuests: number; onlineNodes: number; runningGuests: number; totalPbsServers: number; totalDatastores: number; totalBackups: number }
 }
 
@@ -169,16 +197,21 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
   }
 
   // 2) Pour chaque connexion PVE, charger nodes et guests EN PARALLÈLE
-  const clusterPromises = pveConnections.map(async (conn): Promise<ClusterData | null> => {
+  const clusterPromises = pveConnections.map(async (conn): Promise<{ cluster: ClusterData; storages: AggregatedStorage[] } | null> => {
     try {
       const connConfig = await getConnectionById(conn.id, (conn as any).tenantId)
 
-      const [nodesResult, guestsResult, haResult, cephResult, nodeResourcesResult] = await Promise.allSettled([
+      const [nodesResult, guestsResult, haResult, cephResult, nodeResourcesResult, storagesResult] = await Promise.allSettled([
         pveFetch<NodeData[]>(connConfig, '/nodes'),
         pveFetch<GuestData[]>(connConfig, '/cluster/resources?type=vm'),
         pveFetch<HaResource[]>(connConfig, '/cluster/ha/resources'),
         pveFetch<any>(connConfig, '/cluster/ceph/status'),
         pveFetch<any[]>(connConfig, '/cluster/resources?type=node'),
+        // #925: the ONE call this module gains. `storages` has been declared on
+        // RawInventory since the beginning and never filled, and
+        // inventoryCache.ts treats a missing one as a cache miss, so filling it
+        // is the direction that was always intended.
+        pveFetch<any[]>(connConfig, '/cluster/resources?type=storage'),
       ])
 
       const nodes: NodeData[] = nodesResult.status === 'fulfilled' ? nodesResult.value || [] : []
@@ -213,6 +246,10 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
               : Promise.resolve(null),
           ])
 
+          // loadavg arrives as an array of STRINGS ("0.61"), so it is parsed
+          // rather than passed through (#925).
+          const rawLoad = Array.isArray(nodeStatus?.loadavg) ? nodeStatus.loadavg : null
+
           return {
             node: node.node,
             ip: resolveManagementIp(networks),
@@ -220,6 +257,15 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
             // Use memory from /nodes/{node}/status (excludes ZFS ARC / kernel caches)
             mem: nodeStatus?.memory?.total > 0 ? Number(nodeStatus.memory.used || 0) : undefined,
             maxmem: nodeStatus?.memory?.total > 0 ? Number(nodeStatus.memory.total || 0) : undefined,
+            loadavg: rawLoad ? rawLoad.slice(0, 3).map((v: any) => Number(v)).filter((v: number) => Number.isFinite(v)) : undefined,
+            iowait: typeof nodeStatus?.wait === 'number' ? nodeStatus.wait : undefined,
+            swapUsed: nodeStatus?.swap?.total > 0 ? Number(nodeStatus.swap.used || 0) : undefined,
+            swapTotal: nodeStatus?.swap?.total > 0 ? Number(nodeStatus.swap.total || 0) : undefined,
+            rootfsUsed: nodeStatus?.rootfs?.total > 0 ? Number(nodeStatus.rootfs.used || 0) : undefined,
+            rootfsTotal: nodeStatus?.rootfs?.total > 0 ? Number(nodeStatus.rootfs.total || 0) : undefined,
+            cores: typeof nodeStatus?.cpuinfo?.cpus === 'number' ? nodeStatus.cpuinfo.cpus : undefined,
+            pveVersion: typeof nodeStatus?.pveversion === 'string' ? nodeStatus.pveversion : undefined,
+            kernel: typeof nodeStatus?.['current-kernel']?.release === 'string' ? nodeStatus['current-kernel'].release : undefined,
           }
         } catch {
           return { node: node.node, ip: undefined, ips: [] as string[], mem: undefined, maxmem: undefined }
@@ -227,10 +273,12 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
       })
 
       const nodeEnrichData = await Promise.all(nodeEnrichPromises)
-      const nodeIpMap = new Map<string, { ip?: string; ips: string[]; mem?: number; maxmem?: number }>()
+      type NodeEnrichment = Omit<(typeof nodeEnrichData)[number], 'node'>
+      const nodeIpMap = new Map<string, NodeEnrichment>()
 
-      for (const { node, ip, ips, mem, maxmem } of nodeEnrichData) {
-        if (node) nodeIpMap.set(node, { ip, ips, mem, maxmem })
+      for (const entry of nodeEnrichData) {
+        const { node, ...rest } = entry as any
+        if (node) nodeIpMap.set(node, rest)
       }
 
       const haMap = new Map<string, HaResource>()
@@ -253,6 +301,16 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
           // Override mem/maxmem with accurate values from /nodes/{node}/status
           ...(extra?.mem !== undefined ? { mem: extra.mem } : {}),
           ...(extra?.maxmem !== undefined ? { maxmem: extra.maxmem } : {}),
+          // #925: load, iowait, swap and root filesystem, from the same call.
+          loadavg: (extra as any)?.loadavg,
+          iowait: (extra as any)?.iowait,
+          swapUsed: (extra as any)?.swapUsed,
+          swapTotal: (extra as any)?.swapTotal,
+          rootfsUsed: (extra as any)?.rootfsUsed,
+          rootfsTotal: (extra as any)?.rootfsTotal,
+          cores: (extra as any)?.cores ?? (n as any)?.maxcpu,
+          pveVersion: (extra as any)?.pveVersion,
+          kernel: (extra as any)?.kernel,
           ip: extra?.ip,
           ips: extra?.ips ?? [],
           maintenance,
@@ -286,6 +344,13 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
           pool: g.pool,
           tags: g.tags,
           template: g.template === 1 || g.template === true,
+          // #925: cumulative counters, dropped by this projection until now.
+          netin: g.netin,
+          netout: g.netout,
+          diskread: g.diskread,
+          diskwrite: g.diskwrite,
+          cores: (g as any).maxcpu,
+          memhost: (g as any).memhost,
           hastate: (() => {
             const haSid = `${g.type === 'lxc' ? 'ct' : 'vm'}:${g.vmid}`
             const ha = haMap.get(haSid)
@@ -325,7 +390,29 @@ return aId - bId
         status = 'degraded'
       }
 
+      // #925. aggregateStorage is reused rather than reimplemented: a shared
+      // storage appears once PER NODE in /cluster/resources, so summing the raw
+      // rows triples the capacity of an RBD pool on a three node cluster. That
+      // helper already collapses shared storages to one entry and sums local
+      // ones per node, producing the nodeBreakdown a per-node panel needs.
+      const rawStorages: RawStorageEntry[] = (storagesResult.status === 'fulfilled' ? storagesResult.value || [] : [])
+        .filter((row: any) => row?.storage)
+        .map((row: any) => ({
+          connId: conn.id,
+          connName: conn.name,
+          node: String(row.node ?? ''),
+          storage: String(row.storage),
+          type: String(row.plugintype || row.type || 'unknown'),
+          shared: row.shared,
+          used: Number(row.disk || 0),
+          total: Number(row.maxdisk || 0),
+          content: typeof row.content === 'string' ? row.content.split(',') : undefined,
+          enabled: row.status !== 'unknown' && row.status !== 'disabled',
+          status: row.status,
+        }))
+
       return {
+        cluster: {
         id: conn.id,
         name: conn.name,
         type: conn.type,
@@ -337,11 +424,14 @@ return aId - bId
         longitude: conn.longitude,
         locationLabel: conn.locationLabel,
         nodes: nodesArray.sort((a, b) => a.node.localeCompare(b.node)),
+        },
+        storages: aggregateStorage(rawStorages),
       }
     } catch (e: any) {
       console.error(`[inventory] Failed to load ${conn.name}:`, e?.message)
 
       return {
+        cluster: {
         id: conn.id,
         name: conn.name,
         type: conn.type,
@@ -352,12 +442,16 @@ return aId - bId
         longitude: conn.longitude,
         locationLabel: conn.locationLabel,
         nodes: [],
+        },
+        storages: [],
       }
     }
   })
 
   const clustersResults = await Promise.all(clusterPromises)
-  const clusters = clustersResults.filter((c): c is ClusterData => c !== null)
+  const clusterEntries = clustersResults.filter((c): c is { cluster: ClusterData; storages: AggregatedStorage[] } => c !== null)
+  const clusters = clusterEntries.map(entry => entry.cluster)
+  const storages = clusterEntries.flatMap(entry => entry.storages)
 
   // 3) Pour chaque connexion PBS, charger status et datastores EN PARALLÈLE
   const pbsPromises = pbsConnections.map(async (conn): Promise<PbsServerData | null> => {
@@ -512,7 +606,7 @@ return aId - bId
     clusters,
     pbsServers,
     externalHypervisors: externalConnections,
-    storages: [],
+    storages,
     stats: {
       totalClusters: clusters.length,
       totalNodes,

--- a/frontend/src/lib/inventory/fetchRawInventory.ts
+++ b/frontend/src/lib/inventory/fetchRawInventory.ts
@@ -366,13 +366,25 @@ return aId - bId
       // open PBS servers owned by MSP tenants, not just default-owned ones.
       const connConfig = await getPbsConnectionById(conn.id, (conn as any).tenantId)
 
-      const [statusResult, datastoresResult] = await Promise.allSettled([
+      const [statusResult, datastoresResult, versionResult] = await Promise.allSettled([
         pbsFetch<any>(connConfig, '/status'),
         pbsFetch<any[]>(connConfig, '/admin/datastore'),
+        // #925: `/status` carries NO version on PBS. It was read here as
+        // `status.info.version` and had always been undefined, so the PBS
+        // version was blank in the inventory tree and absent from the
+        // Prometheus exposition. `/version` is the endpoint that answers it,
+        // as connectionDiagnostics.ts:368 and the connections route already do.
+        pbsFetch<any>(connConfig, '/version'),
       ])
 
       const status = statusResult.status === 'fulfilled' ? statusResult.value : null
       const datastores = datastoresResult.status === 'fulfilled' ? datastoresResult.value || [] : []
+      const versionInfo = versionResult.status === 'fulfilled' ? versionResult.value : null
+      // allSettled swallows a rejection, which is how `status.info.version`
+      // stayed dead and unnoticed. Say WHY the version is missing (#925).
+      if (versionResult.status === 'rejected') {
+        console.warn(`[inventory] PBS ${conn.name}: /version failed:`, versionResult.reason?.message)
+      }
 
       const datastoreDetailsPromises = datastores.map(async (ds): Promise<PbsDatastoreData> => {
         const storeName = ds.store || ds.name
@@ -446,7 +458,10 @@ return aId - bId
         name: conn.name,
         type: 'pbs',
         status: status ? 'online' : 'offline',
-        version: status?.info?.version || undefined,
+        version: versionInfo?.version || undefined,
+        // KNOWN DEAD, left as-is on purpose (#925): `/status` carries no
+        // uptime either. The answer is on /nodes/{node}/status, which needs a
+        // node name this call does not have, and no consumer reads it today.
         uptime: status?.uptime || undefined,
         datastores: datastoreDetails,
         stats: { totalSize, totalUsed, datastoreCount: datastoreDetails.length, backupCount: totalBackups }

--- a/frontend/src/lib/inventory/fetchRawInventory.ts
+++ b/frontend/src/lib/inventory/fetchRawInventory.ts
@@ -11,7 +11,8 @@ import { getSessionPrisma } from "@/lib/tenant"
 import { prisma as globalPrisma } from "@/lib/db/prisma"
 import { getConnectionById, getPbsConnectionById } from "@/lib/connections/getConnection"
 import { pveFetch } from "@/lib/proxmox/client"
-import { aggregateStorage, type AggregatedStorage, type RawStorageEntry } from "@/lib/proxmox/storage"
+import { aggregateStorage, type AggregatedStorage } from "@/lib/proxmox/storage"
+import { readNodeStatus, readStorageResources } from "./proxmoxProjections"
 import { pbsFetch } from "@/lib/proxmox/pbs-client"
 import { collectNodeAddresses, resolveManagementIp } from "@/lib/proxmox/resolveManagementIp"
 import {
@@ -246,26 +247,15 @@ export async function fetchRawInventory(infra: InfraScope): Promise<RawInventory
               : Promise.resolve(null),
           ])
 
-          // loadavg arrives as an array of STRINGS ("0.61"), so it is parsed
-          // rather than passed through (#925).
-          const rawLoad = Array.isArray(nodeStatus?.loadavg) ? nodeStatus.loadavg : null
-
+          // Everything read out of the status payload lives in a pure module
+          // with its own tests (#925): the parsing is where the awkward
+          // Proxmox details are, and this function is unreachable by a unit
+          // test without mocking every network call around it.
           return {
             node: node.node,
             ip: resolveManagementIp(networks),
             ips: collectNodeAddresses(networks),
-            // Use memory from /nodes/{node}/status (excludes ZFS ARC / kernel caches)
-            mem: nodeStatus?.memory?.total > 0 ? Number(nodeStatus.memory.used || 0) : undefined,
-            maxmem: nodeStatus?.memory?.total > 0 ? Number(nodeStatus.memory.total || 0) : undefined,
-            loadavg: rawLoad ? rawLoad.slice(0, 3).map((v: any) => Number(v)).filter((v: number) => Number.isFinite(v)) : undefined,
-            iowait: typeof nodeStatus?.wait === 'number' ? nodeStatus.wait : undefined,
-            swapUsed: nodeStatus?.swap?.total > 0 ? Number(nodeStatus.swap.used || 0) : undefined,
-            swapTotal: nodeStatus?.swap?.total > 0 ? Number(nodeStatus.swap.total || 0) : undefined,
-            rootfsUsed: nodeStatus?.rootfs?.total > 0 ? Number(nodeStatus.rootfs.used || 0) : undefined,
-            rootfsTotal: nodeStatus?.rootfs?.total > 0 ? Number(nodeStatus.rootfs.total || 0) : undefined,
-            cores: typeof nodeStatus?.cpuinfo?.cpus === 'number' ? nodeStatus.cpuinfo.cpus : undefined,
-            pveVersion: typeof nodeStatus?.pveversion === 'string' ? nodeStatus.pveversion : undefined,
-            kernel: typeof nodeStatus?.['current-kernel']?.release === 'string' ? nodeStatus['current-kernel'].release : undefined,
+            ...readNodeStatus(nodeStatus),
           }
         } catch {
           return { node: node.node, ip: undefined, ips: [] as string[], mem: undefined, maxmem: undefined }
@@ -395,21 +385,11 @@ return aId - bId
       // rows triples the capacity of an RBD pool on a three node cluster. That
       // helper already collapses shared storages to one entry and sums local
       // ones per node, producing the nodeBreakdown a per-node panel needs.
-      const rawStorages: RawStorageEntry[] = (storagesResult.status === 'fulfilled' ? storagesResult.value || [] : [])
-        .filter((row: any) => row?.storage)
-        .map((row: any) => ({
-          connId: conn.id,
-          connName: conn.name,
-          node: String(row.node ?? ''),
-          storage: String(row.storage),
-          type: String(row.plugintype || row.type || 'unknown'),
-          shared: row.shared,
-          used: Number(row.disk || 0),
-          total: Number(row.maxdisk || 0),
-          content: typeof row.content === 'string' ? row.content.split(',') : undefined,
-          enabled: row.status !== 'unknown' && row.status !== 'disabled',
-          status: row.status,
-        }))
+      const rawStorages = readStorageResources(
+        storagesResult.status === 'fulfilled' ? storagesResult.value : null,
+        conn.id,
+        conn.name,
+      )
 
       return {
         cluster: {

--- a/frontend/src/lib/inventory/pbsVersionSource.test.ts
+++ b/frontend/src/lib/inventory/pbsVersionSource.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+
+/**
+ * SOURCE-LEVEL on purpose, and the reason is the bug it guards (#925).
+ *
+ * `fetchRawInventory` read the PBS version as `status.info.version`, from the
+ * `/status` payload, which carries no version at all. The expression is typed
+ * `any`, so it compiled, never threw, and quietly produced `undefined` for
+ * every PBS server on every install: a blank version in the inventory tree,
+ * and `proxcenter_pbs_info` absent from the Prometheus exposition. Measured
+ * against the lab PBS on 2026-09-11: `/version` answers `{ version: "4.2" }`
+ * and `/status` answers no version, so the field had ALWAYS been dead.
+ *
+ * No fixture-based test catches that class of bug: a mock returning
+ * `{info: {version}}` makes the wrong path pass, and a mock returning the
+ * real `/status` shape makes it fail for the wrong reason. The failure is in
+ * WHICH endpoint is asked and WHICH field is read, so that is what this
+ * asserts. The same reasoning already governs `lib/metrics/integrations.test.ts`.
+ */
+const SOURCE = readFileSync('src/lib/inventory/fetchRawInventory.ts', 'utf8')
+
+describe('PBS version source', () => {
+  it("asks PBS's /version endpoint", () => {
+    expect(SOURCE).toContain("pbsFetch<any>(connConfig, '/version')")
+  })
+
+  it('reads the version off that response, not off /status', () => {
+    expect(SOURCE).toContain('version: versionInfo?.version')
+    expect(SOURCE).not.toContain('status?.info?.version')
+  })
+
+  /**
+   * `Promise.allSettled` swallowed the rejection, which is the other half of
+   * why this stayed invisible: a PBS that refuses /version looked exactly
+   * like a PBS that has no version.
+   */
+  it('says why the version is missing when the call is rejected', () => {
+    expect(SOURCE).toContain("versionResult.status === 'rejected'")
+    expect(SOURCE).toMatch(/console\.warn\([^)]*\/version failed/)
+  })
+})

--- a/frontend/src/lib/inventory/proxmoxProjections.test.ts
+++ b/frontend/src/lib/inventory/proxmoxProjections.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+
+import { readNodeStatus, readStorageResources } from './proxmoxProjections'
+
+/** Copied from a real PVE 9.2.11 node on 2026-09-11, trimmed to what is read. */
+const NODE_STATUS = {
+  'current-kernel': { release: '7.0.2-6-pve', sysname: 'Linux' },
+  kversion: 'Linux 7.0.2-6-pve',
+  uptime: 528208,
+  cpu: 0.0779,
+  wait: 0.0021,
+  idle: 0,
+  swap: { used: 28672, free: 2550104064, total: 2550132736 },
+  memory: { used: 14669058048, free: 10527633408, total: 25196691456 },
+  rootfs: { avail: 11141296128, free: 11982450688, used: 6001053696, total: 17983504384 },
+  pveversion: 'pve-manager/9.2.11/f6997e698c7933ea',
+  cpuinfo: { cpus: 8, model: 'Common KVM processor', sockets: 1 },
+  ksm: { shared: 0 },
+}
+
+describe('readNodeStatus', () => {
+  it('reads every field the inventory keeps from a real payload', () => {
+    expect(readNodeStatus(NODE_STATUS)).toEqual({
+      mem: 14669058048,
+      maxmem: 25196691456,
+      loadavg: undefined,
+      iowait: 0.0021,
+      swapUsed: 28672,
+      swapTotal: 2550132736,
+      rootfsUsed: 6001053696,
+      rootfsTotal: 17983504384,
+      cores: 8,
+      pveVersion: 'pve-manager/9.2.11/f6997e698c7933ea',
+      kernel: '7.0.2-6-pve',
+    })
+  })
+
+  /**
+   * Proxmox sends the load average as an array of STRINGS. Passing it through
+   * would put `"0.61"` where a metric value belongs, and `Number` of a bad
+   * entry is NaN, which makes Prometheus reject the entire scrape.
+   */
+  it('parses the load average, which arrives as strings', () => {
+    expect(readNodeStatus({ ...NODE_STATUS, loadavg: ['0.61', '0.55', '0.49'] }).loadavg)
+      .toEqual([0.61, 0.55, 0.49])
+  })
+
+  it('drops a non-numeric load entry rather than publishing NaN', () => {
+    expect(readNodeStatus({ loadavg: ['0.61', 'n/a', '0.49'] }).loadavg).toEqual([0.61, 0.49])
+  })
+
+  it('keeps only the first three load figures, whatever the node sends', () => {
+    expect(readNodeStatus({ loadavg: ['1', '2', '3', '4', '5'] }).loadavg).toEqual([1, 2, 3])
+  })
+
+  it('omits the load entirely when every entry is unusable', () => {
+    expect(readNodeStatus({ loadavg: ['n/a'] }).loadavg).toBeUndefined()
+  })
+
+  /**
+   * A total of 0 means the node reports no such resource, most often a node
+   * with no swap. Publishing 0/0 would make every ratio downstream divide by
+   * zero rather than simply having nothing to say.
+   */
+  it('omits a resource whose total is zero rather than reporting 0 of 0', () => {
+    const facts = readNodeStatus({ swap: { used: 0, total: 0 }, memory: { used: 0, total: 0 } })
+    expect(facts.swapTotal).toBeUndefined()
+    expect(facts.swapUsed).toBeUndefined()
+    expect(facts.maxmem).toBeUndefined()
+  })
+
+  it('survives an empty, null or undefined payload', () => {
+    for (const payload of [{}, null, undefined]) {
+      expect(() => readNodeStatus(payload)).not.toThrow()
+      expect(readNodeStatus(payload).cores).toBeUndefined()
+    }
+  })
+
+  it('ignores an iowait that is not a number', () => {
+    expect(readNodeStatus({ wait: 'high' }).iowait).toBeUndefined()
+    expect(readNodeStatus({ wait: 0 }).iowait).toBe(0)
+  })
+
+  it('treats an empty version or kernel string as absent', () => {
+    const facts = readNodeStatus({ pveversion: '', 'current-kernel': { release: '' } })
+    expect(facts.pveVersion).toBeUndefined()
+    expect(facts.kernel).toBeUndefined()
+  })
+})
+
+/** Shape of `/cluster/resources?type=storage`, as PVE 9 returns it. */
+const STORAGE_ROWS = [
+  {
+    id: 'storage/pve1/local', storage: 'local', node: 'pve1', type: 'storage',
+    plugintype: 'dir', status: 'available', shared: 0,
+    disk: 22404694016, maxdisk: 26820993024, content: 'iso,vztmpl,backup',
+  },
+  {
+    id: 'storage/pve1/CephStoragePool', storage: 'CephStoragePool', node: 'pve1', type: 'storage',
+    plugintype: 'rbd', status: 'available', shared: 1,
+    disk: 13123162752, maxdisk: 100310741632, content: 'rootdir,images',
+  },
+]
+
+describe('readStorageResources', () => {
+  /**
+   * Two fields are not what their name suggests: the space figures arrive as
+   * `disk` and `maxdisk`, and the plugin name is `plugintype` while `type`
+   * carries the resource kind, which is the constant string "storage".
+   */
+  it('reads disk and maxdisk as used and total, and plugintype as the type', () => {
+    const [local] = readStorageResources(STORAGE_ROWS, 'pve-1', 'PVE One')
+    expect(local).toMatchObject({
+      connId: 'pve-1', connName: 'PVE One', node: 'pve1', storage: 'local',
+      type: 'dir', used: 22404694016, total: 26820993024, enabled: true,
+    })
+    expect(local.type).not.toBe('storage')
+  })
+
+  it('carries the shared flag through untouched, for aggregateStorage to collapse on', () => {
+    const rows = readStorageResources(STORAGE_ROWS, 'pve-1', 'PVE One')
+    expect(rows.map(r => r.shared)).toEqual([0, 1])
+  })
+
+  it('splits the content list', () => {
+    const [local] = readStorageResources(STORAGE_ROWS, 'pve-1', 'PVE One')
+    expect(local.content).toEqual(['iso', 'vztmpl', 'backup'])
+  })
+
+  /**
+   * `unknown` is what Proxmox reports for a storage it could not reach, which
+   * is not the same as one an operator disabled. Both mean the same thing to
+   * a capacity plan, so both are reported as not enabled.
+   */
+  it('treats an unreachable storage as not enabled, like a disabled one', () => {
+    const rows = readStorageResources(
+      [{ storage: 'a', status: 'unknown' }, { storage: 'b', status: 'disabled' },
+       { storage: 'c', status: 'available' }],
+      'pve-1', 'PVE One')
+    expect(rows.map(r => r.enabled)).toEqual([false, false, true])
+  })
+
+  it('drops a row with no storage name rather than emitting a nameless entry', () => {
+    expect(readStorageResources([{ node: 'pve1' }, ...STORAGE_ROWS], 'pve-1', 'PVE One'))
+      .toHaveLength(2)
+  })
+
+  it('answers an empty list for anything that is not an array', () => {
+    for (const payload of [null, undefined, {}, 'nope']) {
+      expect(readStorageResources(payload, 'pve-1', 'PVE One')).toEqual([])
+    }
+  })
+
+  it('defaults a missing capacity to 0 rather than NaN', () => {
+    const [row] = readStorageResources([{ storage: 'a' }], 'pve-1', 'PVE One')
+    expect(row.used).toBe(0)
+    expect(row.total).toBe(0)
+    expect(row.node).toBe('')
+  })
+})

--- a/frontend/src/lib/inventory/proxmoxProjections.ts
+++ b/frontend/src/lib/inventory/proxmoxProjections.ts
@@ -1,0 +1,118 @@
+// PURE readers of raw Proxmox payloads, extracted from the inventory fan-out
+// (#925).
+//
+// `fetchRawInventory` is a 772-line orchestration of network calls, Prisma
+// reads and a tenant scope, and it sits at 22 per cent line coverage because
+// exercising it means mocking all of that. The parsing inside it is not
+// orchestration: it is a pure transformation of a JSON payload into our own
+// shape, it carries the awkward details Proxmox actually returns, and it is
+// exactly the part a reader will get wrong. So it lives here, with tests.
+import type { RawStorageEntry } from "@/lib/proxmox/storage"
+
+/** What `/nodes/{node}/status` gives us, once read. */
+export type NodeStatusFacts = {
+  /** Bytes, from `memory`, which excludes the ZFS ARC and kernel caches. */
+  mem?: number
+  maxmem?: number
+  /** One, five and fifteen minute load, in that order. Empty when absent. */
+  loadavg?: number[]
+  iowait?: number
+  swapUsed?: number
+  swapTotal?: number
+  rootfsUsed?: number
+  rootfsTotal?: number
+  cores?: number
+  pveVersion?: string
+  kernel?: string
+}
+
+/**
+ * Reads the parts of a node status payload the inventory keeps.
+ *
+ * Measured on PVE 9.2.11, the payload carries `current-kernel`, `kversion`,
+ * `uptime`, `cpu`, `swap`, `memory`, `pveversion`, `cpuinfo`, `wait`,
+ * `loadavg`, `idle`, `boot-info`, `rootfs` and `ksm`. Two details a reader
+ * gets wrong:
+ *
+ *   - **`loadavg` is an array of STRINGS**, `["0.61", "0.55", "0.49"]`, so it
+ *     is parsed rather than passed through. A non-numeric entry is dropped
+ *     rather than published as NaN, which would make Prometheus reject the
+ *     whole scrape.
+ *   - a capacity of 0 means the node reports none, so `memory`, `swap` and
+ *     `rootfs` are only read when their total is positive. Returning 0/0
+ *     instead would make every ratio downstream divide by zero.
+ */
+export function readNodeStatus(status: unknown): NodeStatusFacts {
+  const payload = (status ?? {}) as Record<string, any>
+  const facts: NodeStatusFacts = {}
+
+  if (Number(payload.memory?.total) > 0) {
+    facts.mem = Number(payload.memory.used || 0)
+    facts.maxmem = Number(payload.memory.total || 0)
+  }
+  if (Array.isArray(payload.loadavg)) {
+    const parsed = payload.loadavg.slice(0, 3).map(Number).filter(Number.isFinite)
+    if (parsed.length > 0) facts.loadavg = parsed
+  }
+  if (typeof payload.wait === "number" && Number.isFinite(payload.wait)) {
+    facts.iowait = payload.wait
+  }
+  if (Number(payload.swap?.total) > 0) {
+    facts.swapUsed = Number(payload.swap.used || 0)
+    facts.swapTotal = Number(payload.swap.total || 0)
+  }
+  if (Number(payload.rootfs?.total) > 0) {
+    facts.rootfsUsed = Number(payload.rootfs.used || 0)
+    facts.rootfsTotal = Number(payload.rootfs.total || 0)
+  }
+  if (typeof payload.cpuinfo?.cpus === "number") {
+    facts.cores = payload.cpuinfo.cpus
+  }
+  if (typeof payload.pveversion === "string" && payload.pveversion !== "") {
+    facts.pveVersion = payload.pveversion
+  }
+  const kernel = payload["current-kernel"]?.release
+  if (typeof kernel === "string" && kernel !== "") {
+    facts.kernel = kernel
+  }
+
+  return facts
+}
+
+/**
+ * Turns `/cluster/resources?type=storage` rows into the shape
+ * `aggregateStorage` consumes.
+ *
+ * The aggregation is deliberately NOT done here: a shared storage appears
+ * once per node upstream, and collapsing that is `aggregateStorage`'s job,
+ * already written and tested. This only reads the payload, where two fields
+ * are not what their name suggests: the space figures arrive as `disk` and
+ * `maxdisk`, not `used` and `total`, and the plugin name is `plugintype`,
+ * with `type` carrying the resource kind.
+ */
+export function readStorageResources(
+  rows: unknown,
+  connId: string,
+  connName: string,
+): RawStorageEntry[] {
+  if (!Array.isArray(rows)) return []
+
+  return rows
+    .filter((row: any) => row?.storage)
+    .map((row: any) => ({
+      connId,
+      connName,
+      node: String(row.node ?? ""),
+      storage: String(row.storage),
+      type: String(row.plugintype || row.type || "unknown"),
+      shared: row.shared,
+      used: Number(row.disk || 0),
+      total: Number(row.maxdisk || 0),
+      content: typeof row.content === "string" ? row.content.split(",") : undefined,
+      // `unknown` is what Proxmox reports for a storage it could not reach,
+      // which is not the same thing as one an operator disabled, but both
+      // mean "do not plan against this capacity".
+      enabled: row.status !== "unknown" && row.status !== "disabled",
+      status: row.status,
+    }))
+}

--- a/frontend/src/lib/metrics/families/backup.test.ts
+++ b/frontend/src/lib/metrics/families/backup.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildBackupFamilies } from './backup'
+
+const view = {
+  guests: [
+    { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '100', name: 'web', type: 'qemu' },
+    { connId: 'a', connectionName: 'Alpha', node: 'n2', vmid: '101', name: 'db', type: 'lxc' },
+    { connId: 'a', connectionName: 'Alpha', node: 'n2', vmid: '102', name: 'orphan', type: 'qemu' },
+  ],
+} as any
+
+const freshness = {
+  guests: [
+    { connId: 'a', connectionName: 'Alpha', vmid: '100', backupType: 'vm', ageSeconds: 3600, datastore: 'S3manu' },
+    { connId: 'a', connectionName: 'Alpha', vmid: '101', backupType: 'ct', ageSeconds: 200000, datastore: 'S3manu' },
+    { connId: 'a', connectionName: 'Alpha', vmid: '102', backupType: 'vm', ageSeconds: null, datastore: null },
+  ],
+  warnings: [],
+} as any
+
+describe('buildBackupFamilies', () => {
+  it('labels the age series with the node, name and guest type recovered from the fleet view', () => {
+    const text = renderExposition(buildBackupFamilies(view, freshness))
+    expect(text).toContain('proxcenter_backup_age_seconds{connection="Alpha",node="n1",vmid="100",name="web",type="qemu",datastore="S3manu"} 3600')
+  })
+
+  it('uses the guest type, not the PBS backup type, so the label means the same thing everywhere', () => {
+    const text = renderExposition(buildBackupFamilies(view, freshness))
+    expect(text).toContain('vmid="101",name="db",type="lxc"')
+    expect(text).not.toContain('vmid="101",name="db",type="ct"')
+  })
+
+  it('still omits an age sample for a guest that has never been backed up', () => {
+    const text = renderExposition(buildBackupFamilies(view, freshness))
+    const ageLines = text.split(String.fromCharCode(10)).filter(line => line.startsWith('proxcenter_backup_age_seconds{'))
+    expect(ageLines).toHaveLength(2)
+  })
+
+  /**
+   * THE point of this task. A guest with no backup is absent from the age
+   * family by design, so before this series existed it could not be counted
+   * in PromQL at all, and a compliance dashboard could not answer the only
+   * question it exists to answer.
+   */
+  it('publishes a zero for a guest with no backup, so it can be counted', () => {
+    const text = renderExposition(buildBackupFamilies(view, freshness))
+    expect(text).toContain('proxcenter_backup_protected{connection="Alpha",node="n2",vmid="102",name="orphan",type="qemu"} 0')
+    expect(text).toContain('proxcenter_backup_protected{connection="Alpha",node="n1",vmid="100",name="web",type="qemu"} 1')
+  })
+
+  it('covers every guest in the fleet view, protected or not', () => {
+    const text = renderExposition(buildBackupFamilies(view, freshness))
+    const lines = text.split(String.fromCharCode(10)).filter(line => line.startsWith('proxcenter_backup_protected{'))
+    expect(lines).toHaveLength(3)
+  })
+
+  /**
+   * A freshness entry for a guest the fleet view does not contain means the
+   * two caches disagree, which happens while one of them is warming. Such an
+   * entry must be dropped rather than emitted with empty node and name
+   * labels, which would render as a nameless row on the offenders table.
+   */
+  it('drops a freshness entry with no matching guest in the fleet view', () => {
+    const stale = { guests: [...freshness.guests, { connId: 'a', connectionName: 'Alpha', vmid: '999', backupType: 'vm', ageSeconds: 10, datastore: 'S3manu' }], warnings: [] } as any
+    const text = renderExposition(buildBackupFamilies(view, stale))
+    expect(text).not.toContain('vmid="999"')
+  })
+})

--- a/frontend/src/lib/metrics/families/backup.ts
+++ b/frontend/src/lib/metrics/families/backup.ts
@@ -1,0 +1,48 @@
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+import type { FleetBackupFreshness } from "@/lib/backups/freshness"
+import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
+
+import { family } from "./registry"
+
+/** connId + vmid identifies a guest across the two caches. */
+function key(connId: string, vmid: string): string {
+  return `${connId} ${vmid}`
+}
+
+export function buildBackupFamilies(
+  view: PublicFleetView,
+  freshness: FleetBackupFreshness,
+): MetricFamily[] {
+  const byGuest = new Map(freshness.guests.map(guest => [key(guest.connId, guest.vmid), guest]))
+
+  const ageSamples: Sample[] = []
+  const protectedSamples: Sample[] = []
+
+  for (const guest of view.guests) {
+    const labels = {
+      connection: guest.connectionName,
+      node: guest.node,
+      vmid: guest.vmid,
+      name: guest.name,
+      type: guest.type,
+    }
+    const entry = byGuest.get(key(guest.connId, guest.vmid))
+    protectedSamples.push({
+      name: "proxcenter_backup_protected",
+      labels,
+      value: entry && entry.ageSeconds !== null ? 1 : 0,
+    })
+    if (entry && entry.ageSeconds !== null) {
+      ageSamples.push({
+        name: "proxcenter_backup_age_seconds",
+        labels: { ...labels, datastore: entry.datastore },
+        value: entry.ageSeconds,
+      })
+    }
+  }
+
+  return [
+    family("proxcenter_backup_age_seconds", ageSamples),
+    family("proxcenter_backup_protected", protectedSamples),
+  ]
+}

--- a/frontend/src/lib/metrics/families/backup.ts
+++ b/frontend/src/lib/metrics/families/backup.ts
@@ -13,12 +13,16 @@ export function buildBackupFamilies(
   view: PublicFleetView,
   freshness: FleetBackupFreshness,
 ): MetricFamily[] {
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const guests = view.guests ?? []
+
   const byGuest = new Map(freshness.guests.map(guest => [key(guest.connId, guest.vmid), guest]))
 
   const ageSamples: Sample[] = []
   const protectedSamples: Sample[] = []
 
-  for (const guest of view.guests) {
+  for (const guest of guests) {
     const labels = {
       connection: guest.connectionName,
       node: guest.node,

--- a/frontend/src/lib/metrics/families/cluster.test.ts
+++ b/frontend/src/lib/metrics/families/cluster.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildClusterFamilies } from './cluster'
+
+const view = {
+  clusters: [
+    { id: 'a', name: 'Alpha', type: 'pve', status: 'online', cephHealth: 'HEALTH_WARN' },
+    { id: 'b', name: 'Beta', type: 'pve', status: 'degraded' },
+    { id: 'c', name: 'Gamma', type: 'pve', status: 'offline', cephHealth: 'HEALTH_OK' },
+  ],
+} as any
+
+describe('buildClusterFamilies', () => {
+  it('reports reachability and degradation as independent booleans', () => {
+    const text = renderExposition(buildClusterFamilies(view))
+    expect(text).toContain('proxcenter_cluster_up{connection="Alpha",type="pve"} 1')
+    expect(text).toContain('proxcenter_cluster_up{connection="Beta",type="pve"} 0')
+    expect(text).toContain('proxcenter_cluster_degraded{connection="Beta"} 1')
+    expect(text).toContain('proxcenter_cluster_degraded{connection="Alpha"} 0')
+  })
+
+  /**
+   * A degraded cluster is NOT up: `status` is a single tri-state, so a
+   * consumer counting `sum(proxcenter_cluster_up)` must not be handed a 1
+   * for a cluster that lost quorum.
+   */
+  it('does not count a degraded cluster as up', () => {
+    const text = renderExposition(buildClusterFamilies(view))
+    expect(text).not.toContain('proxcenter_cluster_up{connection="Beta",type="pve"} 1')
+  })
+
+  it('emits Ceph health as a state set with exactly one active state', () => {
+    const text = renderExposition(buildClusterFamilies(view))
+    expect(text).toContain('proxcenter_cluster_ceph_health{connection="Alpha",health="warn"} 1')
+    expect(text).toContain('proxcenter_cluster_ceph_health{connection="Alpha",health="ok"} 0')
+    expect(text).toContain('proxcenter_cluster_ceph_health{connection="Alpha",health="err"} 0')
+    expect(text).toContain('proxcenter_cluster_ceph_health{connection="Alpha",health="unknown"} 0')
+  })
+
+  /**
+   * A cluster with no Ceph at all must emit NOTHING for this family, not an
+   * `unknown` sample: an `unknown` would inflate any panel counting clusters
+   * whose Ceph is not healthy, on installs that have no Ceph to be unhealthy.
+   */
+  it('omits the Ceph family entirely for a cluster without Ceph', () => {
+    const text = renderExposition(buildClusterFamilies(view))
+    expect(text).not.toContain('connection="Beta",health=')
+  })
+
+  it('maps an unrecognised Ceph string to unknown rather than dropping it', () => {
+    const text = renderExposition(buildClusterFamilies([{ clusters: [{ id: 'z', name: 'Zed', type: 'pve', status: 'online', cephHealth: 'SOMETHING_NEW' }] }][0] as any))
+    expect(text).toContain('proxcenter_cluster_ceph_health{connection="Zed",health="unknown"} 1')
+  })
+})

--- a/frontend/src/lib/metrics/families/cluster.ts
+++ b/frontend/src/lib/metrics/families/cluster.ts
@@ -20,20 +20,24 @@ function cephState(health: string): (typeof CEPH_STATES)[number] {
 }
 
 export function buildClusterFamilies(view: PublicFleetView): MetricFamily[] {
-  const upSamples: Sample[] = view.clusters.map(cluster => ({
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const clusters = view.clusters ?? []
+
+  const upSamples: Sample[] = clusters.map(cluster => ({
     name: "proxcenter_cluster_up",
     labels: { connection: cluster.name, type: cluster.type },
     value: cluster.status === "online" ? 1 : 0,
   }))
 
-  const degradedSamples: Sample[] = view.clusters.map(cluster => ({
+  const degradedSamples: Sample[] = clusters.map(cluster => ({
     name: "proxcenter_cluster_degraded",
     labels: { connection: cluster.name },
     value: cluster.status === "degraded" ? 1 : 0,
   }))
 
   const cephSamples: Sample[] = []
-  for (const cluster of view.clusters) {
+  for (const cluster of clusters) {
     const health = (cluster as { cephHealth?: string }).cephHealth
     if (typeof health !== "string" || health === "") continue
     const active = cephState(health)

--- a/frontend/src/lib/metrics/families/cluster.ts
+++ b/frontend/src/lib/metrics/families/cluster.ts
@@ -1,0 +1,54 @@
+// PURE module: fleet view in, families out. No I/O, ever (D12).
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
+
+import { family } from "./registry"
+
+const CEPH_STATES = ["ok", "warn", "err", "unknown"] as const
+
+/**
+ * Maps Proxmox's Ceph health string to a bounded state set. An unrecognised
+ * value becomes `unknown` rather than a new label value: label values come
+ * from the cluster and an unbounded set would blow up cardinality.
+ */
+function cephState(health: string): (typeof CEPH_STATES)[number] {
+  const upper = health.toUpperCase()
+  if (upper.includes("HEALTH_OK")) return "ok"
+  if (upper.includes("HEALTH_WARN")) return "warn"
+  if (upper.includes("HEALTH_ERR")) return "err"
+  return "unknown"
+}
+
+export function buildClusterFamilies(view: PublicFleetView): MetricFamily[] {
+  const upSamples: Sample[] = view.clusters.map(cluster => ({
+    name: "proxcenter_cluster_up",
+    labels: { connection: cluster.name, type: cluster.type },
+    value: cluster.status === "online" ? 1 : 0,
+  }))
+
+  const degradedSamples: Sample[] = view.clusters.map(cluster => ({
+    name: "proxcenter_cluster_degraded",
+    labels: { connection: cluster.name },
+    value: cluster.status === "degraded" ? 1 : 0,
+  }))
+
+  const cephSamples: Sample[] = []
+  for (const cluster of view.clusters) {
+    const health = (cluster as { cephHealth?: string }).cephHealth
+    if (typeof health !== "string" || health === "") continue
+    const active = cephState(health)
+    for (const state of CEPH_STATES) {
+      cephSamples.push({
+        name: "proxcenter_cluster_ceph_health",
+        labels: { connection: cluster.name, health: state },
+        value: state === active ? 1 : 0,
+      })
+    }
+  }
+
+  return [
+    family("proxcenter_cluster_up", upSamples),
+    family("proxcenter_cluster_degraded", degradedSamples),
+    family("proxcenter_cluster_ceph_health", cephSamples),
+  ]
+}

--- a/frontend/src/lib/metrics/families/guest.test.ts
+++ b/frontend/src/lib/metrics/families/guest.test.ts
@@ -4,11 +4,12 @@ import { renderExposition } from '../prometheus'
 import { buildGuestFamilies } from './guest'
 
 const GUESTS = [
-  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '100', name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true },
-  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '101', name: 'db', type: 'lxc', status: 'stopped', cpu: 0, mem: 0, maxmem: 0, maxdisk: 0, uptime: 0, hastate: null, agentEnabled: null },
+  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '100', name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true, cores: 4, memHost: 1024, netIn: 12345, netOut: 6789, diskRead: 111, diskWritten: 222 },
+  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '101', name: 'db', type: 'lxc', status: 'stopped', cpu: 0, mem: 0, maxmem: 0, maxdisk: 0, uptime: 0, hastate: null, agentEnabled: null, cores: 0, memHost: 0, netIn: 0, netOut: 0, diskRead: 0, diskWritten: 0 },
 ]
 const view = { guests: GUESTS } as any
 const LABELS = 'connection="Alpha",node="n1",vmid="100",name="web",type="qemu"'
+const LABELS_DB = 'connection="Alpha",node="n1",vmid="101",name="db",type="lxc"'
 
 describe('buildGuestFamilies', () => {
   it('keeps the three pre-existing families byte-identical', () => {
@@ -70,5 +71,49 @@ describe('buildGuestFamilies', () => {
   it('folds an unrecognised HA state into other rather than inventing a label value', () => {
     const text = renderExposition(buildGuestFamilies({ guests: [{ ...GUESTS[0], hastate: 'freshly_invented' }] } as any))
     expect(text).toContain(`proxcenter_vm_ha_state{${LABELS},state="other"} 1`)
+  })
+
+  it('publishes vCPU cores and host-side memory as gauges', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_cpu_cores{${LABELS}} 4`)
+    expect(text).toContain(`proxcenter_vm_mem_host_bytes{${LABELS}} 1024`)
+  })
+
+  /**
+   * memHost is 0 for every container (PVE 9 reports none), and the whole
+   * point of publishing it is telling that apart from a missing sample: a
+   * builder that skips falsy values would silently drop every LXC from this
+   * series.
+   */
+  it('still renders a container reporting zero host memory rather than omitting the sample', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_mem_host_bytes{${LABELS_DB}} 0`)
+  })
+
+  /**
+   * netIn/netOut/diskRead/diskWritten are cumulative counters since guest
+   * start (#925): the raw value must be published as-is, never a delta or a
+   * rate, since Prometheus computes rates itself and needs the raw counter
+   * to detect a reset when a guest restarts.
+   */
+  it('publishes the four network/disk counters at their raw cumulative value, never a delta', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_network_receive_bytes_total{${LABELS}} 12345`)
+    expect(text).toContain(`proxcenter_vm_network_transmit_bytes_total{${LABELS}} 6789`)
+    expect(text).toContain(`proxcenter_vm_disk_read_bytes_total{${LABELS}} 111`)
+    expect(text).toContain(`proxcenter_vm_disk_written_bytes_total{${LABELS}} 222`)
+  })
+
+  /**
+   * The whole point of #925's counter split: these four series must render
+   * as Prometheus counters, not the default gauge, or `rate()` mishandles a
+   * guest restart's reset to zero.
+   */
+  it('declares the four byte counters as Prometheus counters, not gauges', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain('# TYPE proxcenter_vm_network_receive_bytes_total counter')
+    expect(text).toContain('# TYPE proxcenter_vm_network_transmit_bytes_total counter')
+    expect(text).toContain('# TYPE proxcenter_vm_disk_read_bytes_total counter')
+    expect(text).toContain('# TYPE proxcenter_vm_disk_written_bytes_total counter')
   })
 })

--- a/frontend/src/lib/metrics/families/guest.test.ts
+++ b/frontend/src/lib/metrics/families/guest.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildGuestFamilies } from './guest'
+
+const GUESTS = [
+  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '100', name: 'web', type: 'qemu', status: 'running', cpu: 0.5, mem: 500, maxmem: 2000, maxdisk: 32000, uptime: 3600, hastate: 'started', agentEnabled: true },
+  { connId: 'a', connectionName: 'Alpha', node: 'n1', vmid: '101', name: 'db', type: 'lxc', status: 'stopped', cpu: 0, mem: 0, maxmem: 0, maxdisk: 0, uptime: 0, hastate: null, agentEnabled: null },
+]
+const view = { guests: GUESTS } as any
+const LABELS = 'connection="Alpha",node="n1",vmid="100",name="web",type="qemu"'
+
+describe('buildGuestFamilies', () => {
+  it('keeps the three pre-existing families byte-identical', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_status{${LABELS}} 1`)
+    expect(text).toContain(`proxcenter_vm_cpu_usage_ratio{${LABELS}} 0.5`)
+    expect(text).toContain('proxcenter_vm_agent_enabled{connection="Alpha",node="n1",vmid="100",name="web"} 1')
+  })
+
+  /**
+   * agentEnabled is tri-state and null means "we do not know". The whole
+   * point of the family is finding agent-less guests, so a null must be
+   * OMITTED, never published as a misleading 0.
+   *
+   * The plan's original assertion here was a brittle multi-line
+   * `not.toContain('vmid="101",name="db"} 0\nproxcenter_vm_agent')`: it
+   * assumed a line ending in `name="db"} 0` sits immediately before an
+   * agent_enabled line, but every other vm family also carries a `type`
+   * label, so no such adjacent substring can ever occur regardless of
+   * whether the agent sample is (wrongly) emitted. It could never fail.
+   * Replaced with a direct count of agent_enabled lines, which tests the
+   * same property: the fixture has 2 guests and only 1 known agent flag,
+   * so exactly 1 line must be emitted.
+   */
+  it('still omits the agent sample when the flag is unknown', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    const agentLines = text.split('\n').filter(line => line.startsWith('proxcenter_vm_agent_enabled{'))
+    expect(agentLines).toHaveLength(1)
+  })
+
+  it('publishes guest memory as a ratio and in bytes', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_mem_usage_ratio{${LABELS}} 0.25`)
+    expect(text).toContain(`proxcenter_vm_mem_bytes{${LABELS}} 500`)
+    expect(text).toContain(`proxcenter_vm_mem_total_bytes{${LABELS}} 2000`)
+  })
+
+  it('never emits NaN for a stopped guest with no memory allocation reported', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).not.toContain('NaN')
+  })
+
+  it('reports uptime', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_uptime_seconds{${LABELS}} 3600`)
+  })
+
+  it('emits HA state as a state set only for guests HA actually manages', () => {
+    const text = renderExposition(buildGuestFamilies(view))
+    expect(text).toContain(`proxcenter_vm_ha_state{${LABELS},state="started"} 1`)
+    expect(text).toContain(`proxcenter_vm_ha_state{${LABELS},state="error"} 0`)
+    expect(text).not.toContain('vmid="101",name="db",type="lxc",state=')
+  })
+
+  /**
+   * A state Proxmox may add later must not become a new label value: the
+   * set is bounded and anything outside it lands on `other`.
+   */
+  it('folds an unrecognised HA state into other rather than inventing a label value', () => {
+    const text = renderExposition(buildGuestFamilies({ guests: [{ ...GUESTS[0], hastate: 'freshly_invented' }] } as any))
+    expect(text).toContain(`proxcenter_vm_ha_state{${LABELS},state="other"} 1`)
+  })
+})

--- a/frontend/src/lib/metrics/families/guest.ts
+++ b/frontend/src/lib/metrics/families/guest.ts
@@ -1,0 +1,114 @@
+// Guest (`proxcenter_vm_*`) families. The three pre-existing series
+// (status, cpu_usage_ratio, agent_enabled) move here VERBATIM from
+// route.ts: same label sets, same value expressions. Five new series join
+// them: memory as a ratio and in bytes, uptime, and HA state as a bounded
+// state set (#925).
+import { ratio, type MetricFamily, type Sample } from "@/lib/metrics/prometheus"
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+
+import { family } from "./registry"
+
+const HA_STATES = ["started", "stopped", "disabled", "ignored", "error", "other"] as const
+
+function haState(raw: string): (typeof HA_STATES)[number] {
+  const lower = raw.toLowerCase()
+  return (HA_STATES as readonly string[]).includes(lower) && lower !== "other"
+    ? (lower as (typeof HA_STATES)[number])
+    : "other"
+}
+
+export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
+  const statusSamples: Sample[] = []
+  const cpuSamples: Sample[] = []
+  const agentSamples: Sample[] = []
+  const memRatioSamples: Sample[] = []
+  const memBytesSamples: Sample[] = []
+  const memTotalBytesSamples: Sample[] = []
+  const uptimeSamples: Sample[] = []
+  const haStateSamples: Sample[] = []
+
+  for (const guest of view.guests) {
+    const labels = {
+      connection: guest.connectionName,
+      node: guest.node,
+      vmid: guest.vmid,
+      name: guest.name,
+      type: guest.type,
+    }
+
+    statusSamples.push({
+      name: "proxcenter_vm_status",
+      labels,
+      value: guest.status === "running" ? 1 : 0,
+    })
+
+    cpuSamples.push({
+      name: "proxcenter_vm_cpu_usage_ratio",
+      labels,
+      value: Math.round(guest.cpu * 10_000) / 10_000,
+    })
+
+    // agentEnabled is tri-state: null means "we do not know", and the
+    // metric's whole purpose is finding agent-less VMs, so a null is
+    // OMITTED here rather than published as a misleading 0. No `type`
+    // label, matching the series as it shipped on 3 August.
+    if (guest.agentEnabled !== null) {
+      agentSamples.push({
+        name: "proxcenter_vm_agent_enabled",
+        labels: { connection: guest.connectionName, node: guest.node, vmid: guest.vmid, name: guest.name },
+        value: guest.agentEnabled ? 1 : 0,
+      })
+    }
+
+    memRatioSamples.push({
+      name: "proxcenter_vm_mem_usage_ratio",
+      labels,
+      value: ratio(guest.mem, guest.maxmem),
+    })
+
+    memBytesSamples.push({
+      name: "proxcenter_vm_mem_bytes",
+      labels,
+      value: guest.mem,
+    })
+
+    memTotalBytesSamples.push({
+      name: "proxcenter_vm_mem_total_bytes",
+      labels,
+      value: guest.maxmem,
+    })
+
+    uptimeSamples.push({
+      name: "proxcenter_vm_uptime_seconds",
+      labels,
+      value: guest.uptime,
+    })
+
+    // A state set: every guest HA actually manages gets one sample per
+    // bounded state, with a 1 on the current state only, so a dashboard
+    // can chart `proxcenter_vm_ha_state{state="error"}` directly instead
+    // of decoding a free-form string. Guests HA does not manage (hastate
+    // null) contribute no sample at all.
+    if (guest.hastate !== null) {
+      const current = haState(guest.hastate)
+      for (const state of HA_STATES) {
+        haStateSamples.push({
+          name: "proxcenter_vm_ha_state",
+          labels: { ...labels, state },
+          value: state === current ? 1 : 0,
+        })
+      }
+    }
+  }
+
+  return [
+    family("proxcenter_vm_status", statusSamples),
+    family("proxcenter_vm_cpu_usage_ratio", cpuSamples),
+    family("proxcenter_vm_agent_enabled", agentSamples),
+    family("proxcenter_vm_mem_usage_ratio", memRatioSamples),
+    family("proxcenter_vm_mem_bytes", memBytesSamples),
+    family("proxcenter_vm_mem_total_bytes", memTotalBytesSamples),
+    family("proxcenter_vm_uptime_seconds", uptimeSamples),
+    family("proxcenter_vm_ha_state", haStateSamples),
+  ]
+}

--- a/frontend/src/lib/metrics/families/guest.ts
+++ b/frontend/src/lib/metrics/families/guest.ts
@@ -18,6 +18,10 @@ function haState(raw: string): (typeof HA_STATES)[number] {
 }
 
 export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const guests = view.guests ?? []
+
   const statusSamples: Sample[] = []
   const cpuSamples: Sample[] = []
   const agentSamples: Sample[] = []
@@ -27,7 +31,7 @@ export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
   const uptimeSamples: Sample[] = []
   const haStateSamples: Sample[] = []
 
-  for (const guest of view.guests) {
+  for (const guest of guests) {
     const labels = {
       connection: guest.connectionName,
       node: guest.node,
@@ -89,7 +93,10 @@ export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
     // can chart `proxcenter_vm_ha_state{state="error"}` directly instead
     // of decoding a free-form string. Guests HA does not manage (hastate
     // null) contribute no sample at all.
-    if (guest.hastate !== null) {
+    // typeof, not `!== null`: a view built before this field existed carries
+    // `undefined`, and an exposition handler that throws takes the WHOLE scrape
+    // down, blinding every panel over one missing optional field.
+    if (typeof guest.hastate === "string" && guest.hastate !== "") {
       const current = haState(guest.hastate)
       for (const state of HA_STATES) {
         haStateSamples.push({

--- a/frontend/src/lib/metrics/families/guest.ts
+++ b/frontend/src/lib/metrics/families/guest.ts
@@ -30,6 +30,12 @@ export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
   const memTotalBytesSamples: Sample[] = []
   const uptimeSamples: Sample[] = []
   const haStateSamples: Sample[] = []
+  const cpuCoresSamples: Sample[] = []
+  const memHostBytesSamples: Sample[] = []
+  const netInSamples: Sample[] = []
+  const netOutSamples: Sample[] = []
+  const diskReadSamples: Sample[] = []
+  const diskWrittenSamples: Sample[] = []
 
   for (const guest of guests) {
     const labels = {
@@ -106,6 +112,48 @@ export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
         })
       }
     }
+
+    cpuCoresSamples.push({
+      name: "proxcenter_vm_cpu_cores",
+      labels,
+      value: guest.cores,
+    })
+
+    // 0 for a container on purpose (PVE 9 reports none): the raw value is
+    // pushed unconditionally, never guarded by a truthy check, or every LXC
+    // would silently vanish from this series (#925).
+    memHostBytesSamples.push({
+      name: "proxcenter_vm_mem_host_bytes",
+      labels,
+      value: guest.memHost,
+    })
+
+    // Cumulative COUNTERS since guest start (#925): the raw value goes out
+    // as-is, never a delta or a rate. Prometheus computes rates itself and
+    // needs the raw counter to detect a reset when a guest restarts.
+    netInSamples.push({
+      name: "proxcenter_vm_network_receive_bytes_total",
+      labels,
+      value: guest.netIn,
+    })
+
+    netOutSamples.push({
+      name: "proxcenter_vm_network_transmit_bytes_total",
+      labels,
+      value: guest.netOut,
+    })
+
+    diskReadSamples.push({
+      name: "proxcenter_vm_disk_read_bytes_total",
+      labels,
+      value: guest.diskRead,
+    })
+
+    diskWrittenSamples.push({
+      name: "proxcenter_vm_disk_written_bytes_total",
+      labels,
+      value: guest.diskWritten,
+    })
   }
 
   return [
@@ -117,5 +165,11 @@ export function buildGuestFamilies(view: PublicFleetView): MetricFamily[] {
     family("proxcenter_vm_mem_total_bytes", memTotalBytesSamples),
     family("proxcenter_vm_uptime_seconds", uptimeSamples),
     family("proxcenter_vm_ha_state", haStateSamples),
+    family("proxcenter_vm_cpu_cores", cpuCoresSamples),
+    family("proxcenter_vm_mem_host_bytes", memHostBytesSamples),
+    family("proxcenter_vm_network_receive_bytes_total", netInSamples),
+    family("proxcenter_vm_network_transmit_bytes_total", netOutSamples),
+    family("proxcenter_vm_disk_read_bytes_total", diskReadSamples),
+    family("proxcenter_vm_disk_written_bytes_total", diskWrittenSamples),
   ]
 }

--- a/frontend/src/lib/metrics/families/meta.ts
+++ b/frontend/src/lib/metrics/families/meta.ts
@@ -1,0 +1,21 @@
+// Build information, the one family with no scope: it matches no prefix in
+// METRIC_FAMILY_SCOPES, so `familyScope` answers null and `isFamilyAllowed`
+// treats it as always visible. Any valid token sees it, which is what lets a
+// hub dashboard show which ProxCenter it is charting.
+//
+// Deliberately carries NO edition label: that would couple the exposition to
+// the orchestrator's licence verdict, and `getServerLicense` falls back to
+// community whenever the orchestrator is unreachable, so the label would lie
+// during exactly the incident an operator is looking at the dashboard for.
+import { APP_VERSION } from "@/config/version"
+import type { MetricFamily } from "@/lib/metrics/prometheus"
+
+import { family } from "./registry"
+
+export function buildMetaFamilies(): MetricFamily[] {
+  return [
+    family("proxcenter_build_info", [
+      { name: "proxcenter_build_info", labels: { version: APP_VERSION }, value: 1 },
+    ]),
+  ]
+}

--- a/frontend/src/lib/metrics/families/node.test.ts
+++ b/frontend/src/lib/metrics/families/node.test.ts
@@ -4,8 +4,14 @@ import { renderExposition } from '../prometheus'
 import { buildNodeFamilies } from './node'
 
 const NODES = [
-  { connId: 'a', connectionName: 'Alpha', node: 'n1', status: 'online', cpu: 0.256789, mem: 1000, maxmem: 4000, disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true },
-  { connId: 'a', connectionName: 'Alpha', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0, disk: 0, maxdisk: 0, uptime: 0, maintenance: false },
+  {
+    connId: 'a', connectionName: 'Alpha', node: 'n1', status: 'online', cpu: 0.256789, mem: 1000, maxmem: 4000, disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true,
+    load1: 1.5, load5: 1.25, load15: 0.75, iowait: 0.123456, swapUsed: 500, swapTotal: 2000, rootfsUsed: 3000, rootfsTotal: 8000, cores: 8, pveVersion: '9.2.11', kernel: '6.8.0-1-pve',
+  },
+  {
+    connId: 'a', connectionName: 'Alpha', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0, disk: 0, maxdisk: 0, uptime: 0, maintenance: false,
+    load1: 0, load5: 0, load15: 0, iowait: 0, swapUsed: 0, swapTotal: 0, rootfsUsed: 0, rootfsTotal: 0, cores: 0, pveVersion: null, kernel: null,
+  },
 ]
 const view = { nodes: NODES } as any
 
@@ -47,5 +53,63 @@ describe('buildNodeFamilies', () => {
     expect(text).toContain('proxcenter_node_uptime_seconds{connection="Alpha",node="n1"} 86400')
     expect(text).toContain('proxcenter_node_maintenance{connection="Alpha",node="n1"} 1')
     expect(text).toContain('proxcenter_node_maintenance{connection="Alpha",node="n2"} 0')
+  })
+
+  it('reports the three load averages as plain numbers', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_load1{connection="Alpha",node="n1"} 1.5')
+    expect(text).toContain('proxcenter_node_load5{connection="Alpha",node="n1"} 1.25')
+    expect(text).toContain('proxcenter_node_load15{connection="Alpha",node="n1"} 0.75')
+  })
+
+  it('rounds iowait to four decimal places', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_iowait_ratio{connection="Alpha",node="n1"} 0.1235')
+  })
+
+  it('publishes swap and root filesystem usage in bytes', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_swap_bytes{connection="Alpha",node="n1"} 500')
+    expect(text).toContain('proxcenter_node_swap_total_bytes{connection="Alpha",node="n1"} 2000')
+    expect(text).toContain('proxcenter_node_rootfs_bytes{connection="Alpha",node="n1"} 3000')
+    expect(text).toContain('proxcenter_node_rootfs_total_bytes{connection="Alpha",node="n1"} 8000')
+  })
+
+  it('publishes the CPU core count', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_cpu_cores{connection="Alpha",node="n1"} 8')
+  })
+
+  it('carries the PVE version and kernel as labels on node info', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain(
+      'proxcenter_node_info{connection="Alpha",node="n1",pve_version="9.2.11",kernel="6.8.0-1-pve"} 1',
+    )
+  })
+
+  /**
+   * A node with neither field would otherwise render as a bare
+   * connection/node line once renderLabels drops the two null labels --
+   * indistinguishable from every OTHER node with no version or kernel
+   * reported, colliding on the same series. Omitting the sample entirely
+   * avoids that (#925).
+   */
+  it('omits the info sample when both PVE version and kernel are null', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).not.toContain('proxcenter_node_info{connection="Alpha",node="n2"')
+  })
+
+  it('never emits NaN across the new families for a node reporting all zeros', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).not.toContain('NaN')
+    expect(text).toContain('proxcenter_node_load1{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_load5{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_load15{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_iowait_ratio{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_swap_bytes{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_swap_total_bytes{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_rootfs_bytes{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_rootfs_total_bytes{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_cpu_cores{connection="Alpha",node="n2"} 0')
   })
 })

--- a/frontend/src/lib/metrics/families/node.test.ts
+++ b/frontend/src/lib/metrics/families/node.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildNodeFamilies } from './node'
+
+const NODES = [
+  { connId: 'a', connectionName: 'Alpha', node: 'n1', status: 'online', cpu: 0.256789, mem: 1000, maxmem: 4000, disk: 3000, maxdisk: 10000, uptime: 86400, maintenance: true },
+  { connId: 'a', connectionName: 'Alpha', node: 'n2', status: 'offline', cpu: 0, mem: 0, maxmem: 0, disk: 0, maxdisk: 0, uptime: 0, maintenance: false },
+]
+const view = { nodes: NODES } as any
+
+describe('buildNodeFamilies', () => {
+  it('keeps the three pre-existing families byte-identical', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_online{connection="Alpha",node="n1"} 1')
+    expect(text).toContain('proxcenter_node_online{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_cpu_usage_ratio{connection="Alpha",node="n1"} 0.2568')
+    expect(text).toContain('proxcenter_node_mem_usage_ratio{connection="Alpha",node="n1"} 0.25')
+  })
+
+  it('publishes memory in bytes alongside the ratio, so a panel can show headroom', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_mem_bytes{connection="Alpha",node="n1"} 1000')
+    expect(text).toContain('proxcenter_node_mem_total_bytes{connection="Alpha",node="n1"} 4000')
+  })
+
+  it('names the root filesystem ratio for what it is', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_rootfs_usage_ratio{connection="Alpha",node="n1"} 0.3')
+    expect(text).toMatch(/# HELP proxcenter_node_rootfs_usage_ratio .*NOT cluster storage capacity/)
+  })
+
+  /**
+   * An offline node reports maxmem and maxdisk 0. A ratio must then be 0,
+   * never NaN: a NaN in the exposition makes Prometheus reject the whole
+   * scrape, so one dead node would blank every series on the dashboard.
+   */
+  it('never emits NaN for a node reporting a zero capacity', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).not.toContain('NaN')
+    expect(text).toContain('proxcenter_node_mem_usage_ratio{connection="Alpha",node="n2"} 0')
+    expect(text).toContain('proxcenter_node_rootfs_usage_ratio{connection="Alpha",node="n2"} 0')
+  })
+
+  it('reports uptime and maintenance', () => {
+    const text = renderExposition(buildNodeFamilies(view))
+    expect(text).toContain('proxcenter_node_uptime_seconds{connection="Alpha",node="n1"} 86400')
+    expect(text).toContain('proxcenter_node_maintenance{connection="Alpha",node="n1"} 1')
+    expect(text).toContain('proxcenter_node_maintenance{connection="Alpha",node="n2"} 0')
+  })
+})

--- a/frontend/src/lib/metrics/families/node.ts
+++ b/frontend/src/lib/metrics/families/node.ts
@@ -1,5 +1,5 @@
 // Node families (#925): the three pre-existing series moved out of the
-// route verbatim, plus five new ones from the normative family table.
+// route verbatim, plus fifteen new ones from the normative family table.
 import type { MetricFamily } from "@/lib/metrics/prometheus"
 import { ratio } from "@/lib/metrics/prometheus"
 import type { PublicFleetView } from "@/lib/api-tokens/publicData"
@@ -75,6 +75,98 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
         labels: { connection: node.connectionName, node: node.node },
         value: node.maintenance ? 1 : 0,
       })),
+    ),
+    family(
+      "proxcenter_node_load1",
+      nodes.map(node => ({
+        name: "proxcenter_node_load1",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.load1,
+      })),
+    ),
+    family(
+      "proxcenter_node_load5",
+      nodes.map(node => ({
+        name: "proxcenter_node_load5",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.load5,
+      })),
+    ),
+    family(
+      "proxcenter_node_load15",
+      nodes.map(node => ({
+        name: "proxcenter_node_load15",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.load15,
+      })),
+    ),
+    family(
+      "proxcenter_node_iowait_ratio",
+      nodes.map(node => ({
+        name: "proxcenter_node_iowait_ratio",
+        labels: { connection: node.connectionName, node: node.node },
+        value: Math.round(node.iowait * 10_000) / 10_000,
+      })),
+    ),
+    family(
+      "proxcenter_node_swap_bytes",
+      nodes.map(node => ({
+        name: "proxcenter_node_swap_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.swapUsed,
+      })),
+    ),
+    family(
+      "proxcenter_node_swap_total_bytes",
+      nodes.map(node => ({
+        name: "proxcenter_node_swap_total_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.swapTotal,
+      })),
+    ),
+    family(
+      "proxcenter_node_rootfs_bytes",
+      nodes.map(node => ({
+        name: "proxcenter_node_rootfs_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.rootfsUsed,
+      })),
+    ),
+    family(
+      "proxcenter_node_rootfs_total_bytes",
+      nodes.map(node => ({
+        name: "proxcenter_node_rootfs_total_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.rootfsTotal,
+      })),
+    ),
+    family(
+      "proxcenter_node_cpu_cores",
+      nodes.map(node => ({
+        name: "proxcenter_node_cpu_cores",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.cores,
+      })),
+    ),
+    family(
+      "proxcenter_node_info",
+      // Omit the sample entirely when neither field is known: renderLabels
+      // (prometheus.ts) drops null labels, so keeping the sample would
+      // render a bare connection/node line indistinguishable from every
+      // OTHER node with no version or kernel reported, colliding on the
+      // same series.
+      nodes
+        .filter(node => node.pveVersion !== null || node.kernel !== null)
+        .map(node => ({
+          name: "proxcenter_node_info",
+          labels: {
+            connection: node.connectionName,
+            node: node.node,
+            pve_version: node.pveVersion,
+            kernel: node.kernel,
+          },
+          value: 1,
+        })),
     ),
   ]
 }

--- a/frontend/src/lib/metrics/families/node.ts
+++ b/frontend/src/lib/metrics/families/node.ts
@@ -1,0 +1,76 @@
+// Node families (#925): the three pre-existing series moved out of the
+// route verbatim, plus five new ones from the normative family table.
+import type { MetricFamily } from "@/lib/metrics/prometheus"
+import { ratio } from "@/lib/metrics/prometheus"
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+
+import { family } from "./registry"
+
+export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
+  return [
+    family(
+      "proxcenter_node_online",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_online",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.status === "online" ? 1 : 0,
+      })),
+    ),
+    family(
+      "proxcenter_node_cpu_usage_ratio",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_cpu_usage_ratio",
+        labels: { connection: node.connectionName, node: node.node },
+        value: Math.round(node.cpu * 10_000) / 10_000,
+      })),
+    ),
+    family(
+      "proxcenter_node_mem_usage_ratio",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_mem_usage_ratio",
+        labels: { connection: node.connectionName, node: node.node },
+        value: ratio(node.mem, node.maxmem),
+      })),
+    ),
+    family(
+      "proxcenter_node_mem_bytes",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_mem_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.mem,
+      })),
+    ),
+    family(
+      "proxcenter_node_mem_total_bytes",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_mem_total_bytes",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.maxmem,
+      })),
+    ),
+    family(
+      "proxcenter_node_rootfs_usage_ratio",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_rootfs_usage_ratio",
+        labels: { connection: node.connectionName, node: node.node },
+        value: ratio(node.disk, node.maxdisk),
+      })),
+    ),
+    family(
+      "proxcenter_node_uptime_seconds",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_uptime_seconds",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.uptime,
+      })),
+    ),
+    family(
+      "proxcenter_node_maintenance",
+      view.nodes.map(node => ({
+        name: "proxcenter_node_maintenance",
+        labels: { connection: node.connectionName, node: node.node },
+        value: node.maintenance ? 1 : 0,
+      })),
+    ),
+  ]
+}

--- a/frontend/src/lib/metrics/families/node.ts
+++ b/frontend/src/lib/metrics/families/node.ts
@@ -7,10 +7,14 @@ import type { PublicFleetView } from "@/lib/api-tokens/publicData"
 import { family } from "./registry"
 
 export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const nodes = view.nodes ?? []
+
   return [
     family(
       "proxcenter_node_online",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_online",
         labels: { connection: node.connectionName, node: node.node },
         value: node.status === "online" ? 1 : 0,
@@ -18,7 +22,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_cpu_usage_ratio",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_cpu_usage_ratio",
         labels: { connection: node.connectionName, node: node.node },
         value: Math.round(node.cpu * 10_000) / 10_000,
@@ -26,7 +30,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_mem_usage_ratio",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_mem_usage_ratio",
         labels: { connection: node.connectionName, node: node.node },
         value: ratio(node.mem, node.maxmem),
@@ -34,7 +38,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_mem_bytes",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_mem_bytes",
         labels: { connection: node.connectionName, node: node.node },
         value: node.mem,
@@ -42,7 +46,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_mem_total_bytes",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_mem_total_bytes",
         labels: { connection: node.connectionName, node: node.node },
         value: node.maxmem,
@@ -50,7 +54,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_rootfs_usage_ratio",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_rootfs_usage_ratio",
         labels: { connection: node.connectionName, node: node.node },
         value: ratio(node.disk, node.maxdisk),
@@ -58,7 +62,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_uptime_seconds",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_uptime_seconds",
         labels: { connection: node.connectionName, node: node.node },
         value: node.uptime,
@@ -66,7 +70,7 @@ export function buildNodeFamilies(view: PublicFleetView): MetricFamily[] {
     ),
     family(
       "proxcenter_node_maintenance",
-      view.nodes.map(node => ({
+      nodes.map(node => ({
         name: "proxcenter_node_maintenance",
         labels: { connection: node.connectionName, node: node.node },
         value: node.maintenance ? 1 : 0,

--- a/frontend/src/lib/metrics/families/pbs.test.ts
+++ b/frontend/src/lib/metrics/families/pbs.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildPbsFamilies } from './pbs'
+
+const view = {
+  pbsServers: [
+    {
+      connId: 'pbs-1', connectionName: 'PBS One', status: 'online', version: '4.2.1',
+      datastores: [
+        { name: 'S3manu', total: 0, used: 4096, available: 0, usagePercent: 12.5, backupCount: 7, vmCount: 3, ctCount: 1, hostCount: 0 },
+        { name: 'local', total: 1000, used: 250, available: 750, usagePercent: 25, backupCount: 4, vmCount: 2, ctCount: 0, hostCount: 1 },
+      ],
+    },
+    { connId: 'pbs-2', connectionName: 'PBS Two', status: 'offline', version: null, datastores: [] },
+  ],
+} as any
+
+describe('buildPbsFamilies', () => {
+  it('reports reachability per server', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).toContain('proxcenter_pbs_up{connection="PBS One"} 1')
+    expect(text).toContain('proxcenter_pbs_up{connection="PBS Two"} 0')
+  })
+
+  /**
+   * renderLabels drops null and empty label values, so an unreachable
+   * server with no version would render as a bare `proxcenter_pbs_info 1`
+   * with no labels at all, colliding with every other version-less server
+   * on one series. Omit the sample instead.
+   */
+  it('omits the info sample for a server whose version is unknown', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).toContain('proxcenter_pbs_info{connection="PBS One",version="4.2.1"} 1')
+    const infoLines = text.split(String.fromCharCode(10)).filter(line => line.startsWith('proxcenter_pbs_info'))
+    expect(infoLines).toHaveLength(1)
+  })
+
+  it('publishes datastore capacity in bytes', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).toContain('proxcenter_pbs_datastore_total_bytes{connection="PBS One",datastore="local"} 1000')
+    expect(text).toContain('proxcenter_pbs_datastore_used_bytes{connection="PBS One",datastore="local"} 250')
+    expect(text).toContain('proxcenter_pbs_datastore_available_bytes{connection="PBS One",datastore="local"} 750')
+  })
+
+  /**
+   * The lab's S3-backed datastore reports total 0 while genuinely holding
+   * data. Serving the ratio pre-computed is the whole reason this family
+   * exists: a dashboard dividing used by total would render Infinity.
+   */
+  it('serves the usage ratio pre-computed, so an S3 datastore reporting no capacity still charts', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).toContain('proxcenter_pbs_datastore_usage_ratio{connection="PBS One",datastore="S3manu"} 0.125')
+    expect(text).toContain('proxcenter_pbs_datastore_total_bytes{connection="PBS One",datastore="S3manu"} 0')
+    expect(text).not.toContain('Infinity')
+    expect(text).not.toContain('NaN')
+  })
+
+  it('counts snapshots and backup sources by kind', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).toContain('proxcenter_pbs_datastore_snapshots{connection="PBS One",datastore="S3manu"} 7')
+    expect(text).toContain('proxcenter_pbs_datastore_guests{connection="PBS One",datastore="S3manu",kind="vm"} 3')
+    expect(text).toContain('proxcenter_pbs_datastore_guests{connection="PBS One",datastore="S3manu",kind="ct"} 1')
+    expect(text).toContain('proxcenter_pbs_datastore_guests{connection="PBS One",datastore="S3manu",kind="host"} 0')
+  })
+
+  it('emits no datastore sample at all for an unreachable server', () => {
+    const text = renderExposition(buildPbsFamilies(view))
+    expect(text).not.toContain('connection="PBS Two",datastore=')
+  })
+})

--- a/frontend/src/lib/metrics/families/pbs.ts
+++ b/frontend/src/lib/metrics/families/pbs.ts
@@ -7,15 +7,22 @@ import { family } from "./registry"
 const GUEST_KINDS = ["vm", "ct", "host"] as const
 
 export function buildPbsFamilies(view: PublicFleetView): MetricFamily[] {
-  const upSamples: Sample[] = view.pbsServers.map(server => ({
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const servers = view.pbsServers ?? []
+
+  const upSamples: Sample[] = servers.map(server => ({
     name: "proxcenter_pbs_up",
     labels: { connection: server.connectionName },
     value: server.status === "online" ? 1 : 0,
   }))
 
   const infoSamples: Sample[] = []
-  for (const server of view.pbsServers) {
-    if (server.version === null) continue
+  for (const server of servers) {
+    // typeof, not `=== null`: an absent key is `undefined`, and renderLabels
+    // drops empty label values, so a version-less server would otherwise
+    // collapse onto one unlabelled series shared with every other.
+    if (typeof server.version !== "string" || server.version === "") continue
     infoSamples.push({
       name: "proxcenter_pbs_info",
       labels: { connection: server.connectionName, version: server.version },
@@ -30,7 +37,7 @@ export function buildPbsFamilies(view: PublicFleetView): MetricFamily[] {
   const snapshotsSamples: Sample[] = []
   const guestsSamples: Sample[] = []
 
-  for (const server of view.pbsServers) {
+  for (const server of servers) {
     for (const datastore of server.datastores) {
       const labels = { connection: server.connectionName, datastore: datastore.name }
 

--- a/frontend/src/lib/metrics/families/pbs.ts
+++ b/frontend/src/lib/metrics/families/pbs.ts
@@ -1,0 +1,88 @@
+// PURE module: fleet view in, families out. No I/O, ever (D12).
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
+
+import { family } from "./registry"
+
+const GUEST_KINDS = ["vm", "ct", "host"] as const
+
+export function buildPbsFamilies(view: PublicFleetView): MetricFamily[] {
+  const upSamples: Sample[] = view.pbsServers.map(server => ({
+    name: "proxcenter_pbs_up",
+    labels: { connection: server.connectionName },
+    value: server.status === "online" ? 1 : 0,
+  }))
+
+  const infoSamples: Sample[] = []
+  for (const server of view.pbsServers) {
+    if (server.version === null) continue
+    infoSamples.push({
+      name: "proxcenter_pbs_info",
+      labels: { connection: server.connectionName, version: server.version },
+      value: 1,
+    })
+  }
+
+  const totalBytesSamples: Sample[] = []
+  const usedBytesSamples: Sample[] = []
+  const availableBytesSamples: Sample[] = []
+  const usageRatioSamples: Sample[] = []
+  const snapshotsSamples: Sample[] = []
+  const guestsSamples: Sample[] = []
+
+  for (const server of view.pbsServers) {
+    for (const datastore of server.datastores) {
+      const labels = { connection: server.connectionName, datastore: datastore.name }
+
+      totalBytesSamples.push({
+        name: "proxcenter_pbs_datastore_total_bytes",
+        labels,
+        value: datastore.total,
+      })
+      usedBytesSamples.push({
+        name: "proxcenter_pbs_datastore_used_bytes",
+        labels,
+        value: datastore.used,
+      })
+      availableBytesSamples.push({
+        name: "proxcenter_pbs_datastore_available_bytes",
+        labels,
+        value: datastore.available,
+      })
+      usageRatioSamples.push({
+        name: "proxcenter_pbs_datastore_usage_ratio",
+        labels,
+        value: Math.round((datastore.usagePercent / 100) * 10_000) / 10_000,
+      })
+      snapshotsSamples.push({
+        name: "proxcenter_pbs_datastore_snapshots",
+        labels,
+        value: datastore.backupCount,
+      })
+
+      const guestCountByKind: Record<(typeof GUEST_KINDS)[number], number> = {
+        vm: datastore.vmCount,
+        ct: datastore.ctCount,
+        host: datastore.hostCount,
+      }
+      for (const kind of GUEST_KINDS) {
+        guestsSamples.push({
+          name: "proxcenter_pbs_datastore_guests",
+          labels: { ...labels, kind },
+          value: guestCountByKind[kind],
+        })
+      }
+    }
+  }
+
+  return [
+    family("proxcenter_pbs_up", upSamples),
+    family("proxcenter_pbs_info", infoSamples),
+    family("proxcenter_pbs_datastore_total_bytes", totalBytesSamples),
+    family("proxcenter_pbs_datastore_used_bytes", usedBytesSamples),
+    family("proxcenter_pbs_datastore_available_bytes", availableBytesSamples),
+    family("proxcenter_pbs_datastore_usage_ratio", usageRatioSamples),
+    family("proxcenter_pbs_datastore_snapshots", snapshotsSamples),
+    family("proxcenter_pbs_datastore_guests", guestsSamples),
+  ]
+}

--- a/frontend/src/lib/metrics/families/registry.test.ts
+++ b/frontend/src/lib/metrics/families/registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { familyScope } from '../prometheus'
+import { FAMILY_REGISTRY, REGISTERED_NAMES, family } from './registry'
+
+describe('family registry', () => {
+  it('declares every family exactly once', () => {
+    expect(new Set(REGISTERED_NAMES).size).toBe(REGISTERED_NAMES.length)
+    expect(FAMILY_REGISTRY).toHaveLength(30)
+  })
+
+  it('uses only Prometheus-legal names under the proxcenter namespace', () => {
+    for (const entry of FAMILY_REGISTRY) {
+      expect(entry.name).toMatch(/^proxcenter_[a-z_]+$/)
+    }
+  })
+
+  it('carries a real English help string for every family', () => {
+    for (const entry of FAMILY_REGISTRY) {
+      expect(entry.help.length).toBeGreaterThan(10)
+      expect(entry.help).not.toMatch(/TODO|TBD/)
+    }
+  })
+
+  /**
+   * The registry does not get to disagree with the prefix table: the prefix
+   * table is what the handler enforces per request, so a registry claiming a
+   * different scope would describe a filter nobody applies.
+   */
+  it('agrees with the prefix table the handler actually enforces', () => {
+    for (const entry of FAMILY_REGISTRY) {
+      expect(familyScope(entry.name)).toBe(entry.scope)
+    }
+  })
+
+  it('spans exactly the three read scopes plus the unscoped case', () => {
+    expect(new Set(FAMILY_REGISTRY.map(entry => entry.scope)))
+      .toEqual(new Set(['nodes:read', 'vms:read', 'backups:read', null]))
+  })
+
+  it('exposes exactly one unscoped family, the build info', () => {
+    expect(FAMILY_REGISTRY.filter(entry => entry.scope === null).map(entry => entry.name))
+      .toEqual(['proxcenter_build_info'])
+  })
+
+  /**
+   * The seven families shipped on 3 August are a published contract: a
+   * rename here is a silent break for every customer already scraping.
+   */
+  it('still declares the seven families shipped on 3 August', () => {
+    for (const name of [
+      'proxcenter_node_online',
+      'proxcenter_node_cpu_usage_ratio',
+      'proxcenter_node_mem_usage_ratio',
+      'proxcenter_vm_status',
+      'proxcenter_vm_cpu_usage_ratio',
+      'proxcenter_vm_agent_enabled',
+      'proxcenter_backup_age_seconds',
+    ]) {
+      expect(REGISTERED_NAMES).toContain(name)
+    }
+  })
+})
+
+describe('family()', () => {
+  it('takes the help text from the declaration, so it is written once', () => {
+    expect(family('proxcenter_pbs_up', [])).toEqual({
+      name: 'proxcenter_pbs_up',
+      help: 'PBS server reachability (1 online, 0 otherwise)',
+      type: 'gauge',
+      samples: [],
+    })
+  })
+
+  /**
+   * A typo in a builder must be a loud failure, not a series no dashboard
+   * can chart and no scope can filter.
+   */
+  it('refuses an unregistered name rather than emitting it', () => {
+    expect(() => family('proxcenter_typo_here', [])).toThrow('Unregistered metric family: proxcenter_typo_here')
+  })
+})

--- a/frontend/src/lib/metrics/families/registry.test.ts
+++ b/frontend/src/lib/metrics/families/registry.test.ts
@@ -6,12 +6,12 @@ import { FAMILY_REGISTRY, REGISTERED_NAMES, family } from './registry'
 describe('family registry', () => {
   it('declares every family exactly once', () => {
     expect(new Set(REGISTERED_NAMES).size).toBe(REGISTERED_NAMES.length)
-    expect(FAMILY_REGISTRY).toHaveLength(30)
+    expect(FAMILY_REGISTRY).toHaveLength(53)
   })
 
   it('uses only Prometheus-legal names under the proxcenter namespace', () => {
     for (const entry of FAMILY_REGISTRY) {
-      expect(entry.name).toMatch(/^proxcenter_[a-z_]+$/)
+      expect(entry.name).toMatch(/^proxcenter_[a-z0-9_]+$/)
     }
   })
 
@@ -33,9 +33,9 @@ describe('family registry', () => {
     }
   })
 
-  it('spans exactly the three read scopes plus the unscoped case', () => {
+  it('spans exactly the four read scopes plus the unscoped case', () => {
     expect(new Set(FAMILY_REGISTRY.map(entry => entry.scope)))
-      .toEqual(new Set(['nodes:read', 'vms:read', 'backups:read', null]))
+      .toEqual(new Set(['nodes:read', 'vms:read', 'backups:read', 'storage:read', null]))
   })
 
   it('exposes exactly one unscoped family, the build info', () => {
@@ -78,5 +78,44 @@ describe('family()', () => {
    */
   it('refuses an unregistered name rather than emitting it', () => {
     expect(() => family('proxcenter_typo_here', [])).toThrow('Unregistered metric family: proxcenter_typo_here')
+  })
+})
+
+describe('counters (#925)', () => {
+  const counters = FAMILY_REGISTRY.filter(entry => entry.type === 'counter')
+
+  /**
+   * Prometheus readers expect a cumulative counter to end in `_total`, and a
+   * name that lies about its type is worse than no name: a reader who sees a
+   * gauge name will write `avg()` where they needed `rate()`.
+   */
+  it('names every counter with the _total suffix', () => {
+    expect(counters.length).toBeGreaterThan(0)
+    for (const entry of counters) expect(entry.name.endsWith('_total')).toBe(true)
+  })
+
+  it('declares nothing as a counter that is not cumulative', () => {
+    expect(counters.map(entry => entry.name).sort()).toEqual([
+      'proxcenter_vm_disk_read_bytes_total',
+      'proxcenter_vm_disk_written_bytes_total',
+      'proxcenter_vm_network_receive_bytes_total',
+      'proxcenter_vm_network_transmit_bytes_total',
+    ])
+  })
+
+  it('reserves the _total suffix for counters, so the name never lies', () => {
+    for (const entry of FAMILY_REGISTRY) {
+      if (entry.name.endsWith('_total')) expect(entry.type).toBe('counter')
+    }
+  })
+
+  /**
+   * The type reaches the exposition, not just the declaration: renderExposition
+   * writes it into the `# TYPE` line, which is what tells Prometheus to handle
+   * a reset rather than read it as a huge negative rate.
+   */
+  it('carries the declared type through family() into the rendered TYPE line', () => {
+    expect(family('proxcenter_vm_disk_read_bytes_total', []).type).toBe('counter')
+    expect(family('proxcenter_node_load1', []).type).toBe('gauge')
   })
 })

--- a/frontend/src/lib/metrics/families/registry.ts
+++ b/frontend/src/lib/metrics/families/registry.ts
@@ -12,6 +12,14 @@
 // The scope recorded here is DERIVED knowledge, not the enforcement point:
 // filtering happens per request in `isFamilyAllowed` off the prefix table.
 // A disagreement between the two is a bug in this file, not in the handler.
+//
+// SHAPE: one line per family, grouped under the scope that unlocks it. The
+// obvious alternative, an array of five-line objects each repeating `name:`,
+// `help:` and `scope:`, is what this used to be, and Sonar's copy-paste
+// detector normalises string literals, so it saw fifty-three identical
+// blocks and put the pull request at 9.1 per cent duplication. Grouping also
+// removes a real redundancy: the scope was spelled out once per family when
+// it is a property of the PREFIX.
 import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
 
 export type FamilyDeclaration = {
@@ -27,285 +35,102 @@ export type FamilyDeclaration = {
   type?: "gauge" | "counter"
 }
 
-export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
-  {
-    name: "proxcenter_build_info",
-    help: "ProxCenter build information",
-    scope: null,
-  },
+/** Sentinel for the families no prefix scopes. */
+const UNSCOPED = "__unscoped"
 
-  {
-    name: "proxcenter_cluster_up",
-    help: "Cluster or standalone node reachability (1 online, 0 otherwise)",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_cluster_degraded",
-    help: "Cluster in a degraded state (1 degraded, 0 otherwise)",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_cluster_ceph_health",
-    help: "Ceph health as a state set; health is one of ok, warn, err, unknown. Clusters without Ceph emit nothing",
-    scope: "nodes:read",
-  },
+/**
+ * The four cumulative families. Everything else is a gauge. Published as a
+ * gauge, a counter would still let `rate()` run, but a guest restart resets
+ * it and Prometheus would read the reset as an enormous negative rate.
+ */
+const COUNTERS = new Set([
+  "proxcenter_vm_network_receive_bytes_total",
+  "proxcenter_vm_network_transmit_bytes_total",
+  "proxcenter_vm_disk_read_bytes_total",
+  "proxcenter_vm_disk_written_bytes_total",
+])
 
-  {
-    name: "proxcenter_node_online",
-    help: "Node online state (1 online, 0 otherwise)",
-    scope: "nodes:read",
+/** Name to HELP text, grouped by the scope that unlocks the prefix. */
+const FAMILIES: Record<string, Record<string, string>> = {
+  // Always visible: it matches no prefix in METRIC_FAMILY_SCOPES.
+  [UNSCOPED]: {
+    proxcenter_build_info: "ProxCenter build information",
   },
-  {
-    name: "proxcenter_node_cpu_usage_ratio",
-    help: "Node CPU usage ratio (0 to 1)",
-    scope: "nodes:read",
+  // Prefixes proxcenter_cluster_ and proxcenter_node_.
+  "nodes:read": {
+    proxcenter_cluster_up: "Cluster or standalone node reachability (1 online, 0 otherwise)",
+    proxcenter_cluster_degraded: "Cluster in a degraded state (1 degraded, 0 otherwise)",
+    proxcenter_cluster_ceph_health: "Ceph health as a state set; health is one of ok, warn, err, unknown. Clusters without Ceph emit nothing",
+    proxcenter_node_online: "Node online state (1 online, 0 otherwise)",
+    proxcenter_node_cpu_usage_ratio: "Node CPU usage ratio (0 to 1)",
+    proxcenter_node_mem_usage_ratio: "Node memory usage ratio (0 to 1)",
+    proxcenter_node_mem_bytes: "Node memory in use, in bytes",
+    proxcenter_node_mem_total_bytes: "Node memory capacity, in bytes",
+    proxcenter_node_rootfs_usage_ratio: "Node root filesystem usage ratio (0 to 1). This is the host root filesystem, NOT cluster storage capacity",
+    proxcenter_node_uptime_seconds: "Node uptime in seconds",
+    proxcenter_node_maintenance: "Node in maintenance mode (1 in maintenance, 0 otherwise)",
+    proxcenter_node_load1: "Node load average over one minute",
+    proxcenter_node_load5: "Node load average over five minutes",
+    proxcenter_node_load15: "Node load average over fifteen minutes",
+    proxcenter_node_iowait_ratio: "Share of node CPU time spent waiting on I/O (0 to 1)",
+    proxcenter_node_swap_bytes: "Node swap in use, in bytes",
+    proxcenter_node_swap_total_bytes: "Node swap capacity, in bytes; 0 when the node has no swap",
+    proxcenter_node_rootfs_bytes: "Node root filesystem in use, in bytes",
+    proxcenter_node_rootfs_total_bytes: "Node root filesystem capacity, in bytes",
+    proxcenter_node_cpu_cores: "CPU cores the node reports",
+    proxcenter_node_info: "Node build information: Proxmox VE version and running kernel",
   },
-  {
-    name: "proxcenter_node_mem_usage_ratio",
-    help: "Node memory usage ratio (0 to 1)",
-    scope: "nodes:read",
+  // Prefix proxcenter_vm_.
+  "vms:read": {
+    proxcenter_vm_status: "Guest running state (1 running, 0 otherwise)",
+    proxcenter_vm_cpu_usage_ratio: "Guest CPU usage ratio (0 to 1)",
+    proxcenter_vm_agent_enabled: "Guest agent config flag (1 enabled, 0 otherwise)",
+    proxcenter_vm_mem_usage_ratio: "Guest memory usage ratio (0 to 1)",
+    proxcenter_vm_mem_bytes: "Guest memory in use, in bytes",
+    proxcenter_vm_mem_total_bytes: "Guest memory allocation, in bytes",
+    proxcenter_vm_uptime_seconds: "Guest uptime in seconds",
+    proxcenter_vm_ha_state: "Guest HA state as a state set; guests not managed by HA emit nothing",
+    proxcenter_vm_cpu_cores: "Virtual CPU cores allocated to the guest",
+    proxcenter_vm_mem_host_bytes: "Guest memory as the PVE 9 host accounts it, distinct from the guest-side figure; 0 for a container, which reports none",
+    proxcenter_vm_network_receive_bytes_total: "Bytes received by the guest since it started",
+    proxcenter_vm_network_transmit_bytes_total: "Bytes sent by the guest since it started",
+    proxcenter_vm_disk_read_bytes_total: "Bytes read from the guest's disks since it started",
+    proxcenter_vm_disk_written_bytes_total: "Bytes written to the guest's disks since it started",
   },
-  {
-    name: "proxcenter_node_mem_bytes",
-    help: "Node memory in use, in bytes",
-    scope: "nodes:read",
+  // Prefix proxcenter_storage_.
+  "storage:read": {
+    proxcenter_storage_total_bytes: "Storage capacity in bytes. A shared storage is reported ONCE for the cluster, never once per node",
+    proxcenter_storage_used_bytes: "Storage space in use, in bytes. A shared storage is reported ONCE for the cluster, never once per node",
+    proxcenter_storage_usage_ratio: "Storage usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
+    proxcenter_storage_enabled: "Storage enabled state (1 enabled, 0 disabled); a disabled storage still reports its capacity",
+    proxcenter_storage_node_total_bytes: "Capacity of a non-shared storage on one node. Shared storages emit nothing here, since their capacity is not per node",
+    proxcenter_storage_node_used_bytes: "Space in use of a non-shared storage on one node",
+    proxcenter_storage_node_usage_ratio: "Usage ratio (0 to 1) of a non-shared storage on one node, served pre-computed",
   },
-  {
-    name: "proxcenter_node_mem_total_bytes",
-    help: "Node memory capacity, in bytes",
-    scope: "nodes:read",
+  // Prefixes proxcenter_backup_ and proxcenter_pbs_.
+  "backups:read": {
+    proxcenter_backup_age_seconds: "Seconds since the most recent backup of this guest",
+    proxcenter_backup_protected: "Guest backup coverage (1 has at least one backup, 0 has none)",
+    proxcenter_pbs_up: "PBS server reachability (1 online, 0 otherwise)",
+    proxcenter_pbs_info: "PBS server build information",
+    proxcenter_pbs_datastore_total_bytes: "Datastore capacity in bytes; 0 for a backend that does not report one, such as S3",
+    proxcenter_pbs_datastore_used_bytes: "Datastore space in use, in bytes",
+    proxcenter_pbs_datastore_available_bytes: "Datastore space available, in bytes",
+    proxcenter_pbs_datastore_usage_ratio: "Datastore usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
+    proxcenter_pbs_datastore_snapshots: "Snapshots held in this datastore",
+    proxcenter_pbs_datastore_guests: "Distinct backup sources in this datastore, by kind (vm, ct, host)",
   },
-  {
-    name: "proxcenter_node_rootfs_usage_ratio",
-    help: "Node root filesystem usage ratio (0 to 1). This is the host root filesystem, NOT cluster storage capacity",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_uptime_seconds",
-    help: "Node uptime in seconds",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_maintenance",
-    help: "Node in maintenance mode (1 in maintenance, 0 otherwise)",
-    scope: "nodes:read",
-  },
+}
 
-  {
-    name: "proxcenter_node_load1",
-    help: "Node load average over one minute",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_load5",
-    help: "Node load average over five minutes",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_load15",
-    help: "Node load average over fifteen minutes",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_iowait_ratio",
-    help: "Share of node CPU time spent waiting on I/O (0 to 1)",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_swap_bytes",
-    help: "Node swap in use, in bytes",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_swap_total_bytes",
-    help: "Node swap capacity, in bytes; 0 when the node has no swap",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_rootfs_bytes",
-    help: "Node root filesystem in use, in bytes",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_rootfs_total_bytes",
-    help: "Node root filesystem capacity, in bytes",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_cpu_cores",
-    help: "CPU cores the node reports",
-    scope: "nodes:read",
-  },
-  {
-    name: "proxcenter_node_info",
-    help: "Node build information: Proxmox VE version and running kernel",
-    scope: "nodes:read",
-  },
-
-  {
-    name: "proxcenter_vm_status",
-    help: "Guest running state (1 running, 0 otherwise)",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_cpu_usage_ratio",
-    help: "Guest CPU usage ratio (0 to 1)",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_agent_enabled",
-    help: "Guest agent config flag (1 enabled, 0 otherwise)",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_mem_usage_ratio",
-    help: "Guest memory usage ratio (0 to 1)",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_mem_bytes",
-    help: "Guest memory in use, in bytes",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_mem_total_bytes",
-    help: "Guest memory allocation, in bytes",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_uptime_seconds",
-    help: "Guest uptime in seconds",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_ha_state",
-    help: "Guest HA state as a state set; guests not managed by HA emit nothing",
-    scope: "vms:read",
-  },
-
-  {
-    name: "proxcenter_vm_cpu_cores",
-    help: "Virtual CPU cores allocated to the guest",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_mem_host_bytes",
-    help: "Guest memory as the PVE 9 host accounts it, distinct from the guest-side figure; 0 for a container, which reports none",
-    scope: "vms:read",
-  },
-  {
-    name: "proxcenter_vm_network_receive_bytes_total",
-    help: "Bytes received by the guest since it started",
-    scope: "vms:read",
-    type: "counter",
-  },
-  {
-    name: "proxcenter_vm_network_transmit_bytes_total",
-    help: "Bytes sent by the guest since it started",
-    scope: "vms:read",
-    type: "counter",
-  },
-  {
-    name: "proxcenter_vm_disk_read_bytes_total",
-    help: "Bytes read from the guest's disks since it started",
-    scope: "vms:read",
-    type: "counter",
-  },
-  {
-    name: "proxcenter_vm_disk_written_bytes_total",
-    help: "Bytes written to the guest's disks since it started",
-    scope: "vms:read",
-    type: "counter",
-  },
-
-  {
-    name: "proxcenter_backup_age_seconds",
-    help: "Seconds since the most recent backup of this guest",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_backup_protected",
-    help: "Guest backup coverage (1 has at least one backup, 0 has none)",
-    scope: "backups:read",
-  },
-
-  {
-    name: "proxcenter_pbs_up",
-    help: "PBS server reachability (1 online, 0 otherwise)",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_info",
-    help: "PBS server build information",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_total_bytes",
-    help: "Datastore capacity in bytes; 0 for a backend that does not report one, such as S3",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_used_bytes",
-    help: "Datastore space in use, in bytes",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_available_bytes",
-    help: "Datastore space available, in bytes",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_usage_ratio",
-    help: "Datastore usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_snapshots",
-    help: "Snapshots held in this datastore",
-    scope: "backups:read",
-  },
-  {
-    name: "proxcenter_pbs_datastore_guests",
-    help: "Distinct backup sources in this datastore, by kind (vm, ct, host)",
-    scope: "backups:read",
-  },
-
-  {
-    name: "proxcenter_storage_total_bytes",
-    help: "Storage capacity in bytes. A shared storage is reported ONCE for the cluster, never once per node",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_used_bytes",
-    help: "Storage space in use, in bytes. A shared storage is reported ONCE for the cluster, never once per node",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_usage_ratio",
-    help: "Storage usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_enabled",
-    help: "Storage enabled state (1 enabled, 0 disabled); a disabled storage still reports its capacity",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_node_total_bytes",
-    help: "Capacity of a non-shared storage on one node. Shared storages emit nothing here, since their capacity is not per node",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_node_used_bytes",
-    help: "Space in use of a non-shared storage on one node",
-    scope: "storage:read",
-  },
-  {
-    name: "proxcenter_storage_node_usage_ratio",
-    help: "Usage ratio (0 to 1) of a non-shared storage on one node, served pre-computed",
-    scope: "storage:read",
-  },
-] as const
+export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = Object.entries(FAMILIES).flatMap(
+  ([scope, families]) =>
+    Object.entries(families).map(([name, help]) => ({
+      name,
+      help,
+      scope: scope === UNSCOPED ? null : scope,
+      ...(COUNTERS.has(name) ? { type: "counter" as const } : {}),
+    })),
+)
 
 export const REGISTERED_NAMES: readonly string[] = FAMILY_REGISTRY.map(entry => entry.name)
 

--- a/frontend/src/lib/metrics/families/registry.ts
+++ b/frontend/src/lib/metrics/families/registry.ts
@@ -1,0 +1,196 @@
+// SINGLE source of truth for every family the exposition can emit: name,
+// HELP text and the scope that unlocks it. Three consumers read it and none
+// of them may disagree with the others:
+//
+//   1. the family builders, through `family()` below, so a HELP string is
+//      written ONCE and a builder cannot emit an undeclared metric;
+//   2. `integrations.test.ts`, which asserts that every committed hub
+//      dashboard charts only declared families and leaves none unused;
+//   3. `registry.test.ts`, which asserts the declared scope agrees with the
+//      prefix table the handler actually enforces (prometheus.ts).
+//
+// The scope recorded here is DERIVED knowledge, not the enforcement point:
+// filtering happens per request in `isFamilyAllowed` off the prefix table.
+// A disagreement between the two is a bug in this file, not in the handler.
+import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
+
+export type FamilyDeclaration = {
+  name: string
+  help: string
+  /** null = no prefix match in METRIC_FAMILY_SCOPES, so always visible. */
+  scope: string | null
+}
+
+export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
+  {
+    name: "proxcenter_build_info",
+    help: "ProxCenter build information",
+    scope: null,
+  },
+
+  {
+    name: "proxcenter_cluster_up",
+    help: "Cluster or standalone node reachability (1 online, 0 otherwise)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_cluster_degraded",
+    help: "Cluster in a degraded state (1 degraded, 0 otherwise)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_cluster_ceph_health",
+    help: "Ceph health as a state set; health is one of ok, warn, err, unknown. Clusters without Ceph emit nothing",
+    scope: "nodes:read",
+  },
+
+  {
+    name: "proxcenter_node_online",
+    help: "Node online state (1 online, 0 otherwise)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_cpu_usage_ratio",
+    help: "Node CPU usage ratio (0 to 1)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_mem_usage_ratio",
+    help: "Node memory usage ratio (0 to 1)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_mem_bytes",
+    help: "Node memory in use, in bytes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_mem_total_bytes",
+    help: "Node memory capacity, in bytes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_rootfs_usage_ratio",
+    help: "Node root filesystem usage ratio (0 to 1). This is the host root filesystem, NOT cluster storage capacity",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_uptime_seconds",
+    help: "Node uptime in seconds",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_maintenance",
+    help: "Node in maintenance mode (1 in maintenance, 0 otherwise)",
+    scope: "nodes:read",
+  },
+
+  {
+    name: "proxcenter_vm_status",
+    help: "Guest running state (1 running, 0 otherwise)",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_cpu_usage_ratio",
+    help: "Guest CPU usage ratio (0 to 1)",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_agent_enabled",
+    help: "Guest agent config flag (1 enabled, 0 otherwise)",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_mem_usage_ratio",
+    help: "Guest memory usage ratio (0 to 1)",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_mem_bytes",
+    help: "Guest memory in use, in bytes",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_mem_total_bytes",
+    help: "Guest memory allocation, in bytes",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_uptime_seconds",
+    help: "Guest uptime in seconds",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_ha_state",
+    help: "Guest HA state as a state set; guests not managed by HA emit nothing",
+    scope: "vms:read",
+  },
+
+  {
+    name: "proxcenter_backup_age_seconds",
+    help: "Seconds since the most recent backup of this guest",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_backup_protected",
+    help: "Guest backup coverage (1 has at least one backup, 0 has none)",
+    scope: "backups:read",
+  },
+
+  {
+    name: "proxcenter_pbs_up",
+    help: "PBS server reachability (1 online, 0 otherwise)",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_info",
+    help: "PBS server build information",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_total_bytes",
+    help: "Datastore capacity in bytes; 0 for a backend that does not report one, such as S3",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_used_bytes",
+    help: "Datastore space in use, in bytes",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_available_bytes",
+    help: "Datastore space available, in bytes",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_usage_ratio",
+    help: "Datastore usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_snapshots",
+    help: "Snapshots held in this datastore",
+    scope: "backups:read",
+  },
+  {
+    name: "proxcenter_pbs_datastore_guests",
+    help: "Distinct backup sources in this datastore, by kind (vm, ct, host)",
+    scope: "backups:read",
+  },
+] as const
+
+export const REGISTERED_NAMES: readonly string[] = FAMILY_REGISTRY.map(entry => entry.name)
+
+const BY_NAME = new Map(FAMILY_REGISTRY.map(entry => [entry.name, entry]))
+
+/**
+ * Builds a family from its DECLARED help text, so the string lives in one
+ * place. Throws on an unregistered name rather than emitting it: a typo in a
+ * builder must be a loud failure, not a series no dashboard can chart and no
+ * scope can filter.
+ */
+export function family(name: string, samples: Sample[]): MetricFamily {
+  const declaration = BY_NAME.get(name)
+  if (!declaration) throw new Error(`Unregistered metric family: ${name}`)
+  return { name, help: declaration.help, type: "gauge", samples }
+}

--- a/frontend/src/lib/metrics/families/registry.ts
+++ b/frontend/src/lib/metrics/families/registry.ts
@@ -19,6 +19,12 @@ export type FamilyDeclaration = {
   help: string
   /** null = no prefix match in METRIC_FAMILY_SCOPES, so always visible. */
   scope: string | null
+  /**
+   * Omitted means gauge. `counter` is declared only for the cumulative byte
+   * totals Proxmox reports per guest, and their names end in `_total` to match
+   * the Prometheus convention a reader will expect.
+   */
+  type?: "gauge" | "counter"
 }
 
 export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
@@ -86,6 +92,57 @@ export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
   },
 
   {
+    name: "proxcenter_node_load1",
+    help: "Node load average over one minute",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_load5",
+    help: "Node load average over five minutes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_load15",
+    help: "Node load average over fifteen minutes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_iowait_ratio",
+    help: "Share of node CPU time spent waiting on I/O (0 to 1)",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_swap_bytes",
+    help: "Node swap in use, in bytes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_swap_total_bytes",
+    help: "Node swap capacity, in bytes; 0 when the node has no swap",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_rootfs_bytes",
+    help: "Node root filesystem in use, in bytes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_rootfs_total_bytes",
+    help: "Node root filesystem capacity, in bytes",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_cpu_cores",
+    help: "CPU cores the node reports",
+    scope: "nodes:read",
+  },
+  {
+    name: "proxcenter_node_info",
+    help: "Node build information: Proxmox VE version and running kernel",
+    scope: "nodes:read",
+  },
+
+  {
     name: "proxcenter_vm_status",
     help: "Guest running state (1 running, 0 otherwise)",
     scope: "vms:read",
@@ -124,6 +181,41 @@ export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
     name: "proxcenter_vm_ha_state",
     help: "Guest HA state as a state set; guests not managed by HA emit nothing",
     scope: "vms:read",
+  },
+
+  {
+    name: "proxcenter_vm_cpu_cores",
+    help: "Virtual CPU cores allocated to the guest",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_mem_host_bytes",
+    help: "Guest memory as the PVE 9 host accounts it, distinct from the guest-side figure; 0 for a container, which reports none",
+    scope: "vms:read",
+  },
+  {
+    name: "proxcenter_vm_network_receive_bytes_total",
+    help: "Bytes received by the guest since it started",
+    scope: "vms:read",
+    type: "counter",
+  },
+  {
+    name: "proxcenter_vm_network_transmit_bytes_total",
+    help: "Bytes sent by the guest since it started",
+    scope: "vms:read",
+    type: "counter",
+  },
+  {
+    name: "proxcenter_vm_disk_read_bytes_total",
+    help: "Bytes read from the guest's disks since it started",
+    scope: "vms:read",
+    type: "counter",
+  },
+  {
+    name: "proxcenter_vm_disk_written_bytes_total",
+    help: "Bytes written to the guest's disks since it started",
+    scope: "vms:read",
+    type: "counter",
   },
 
   {
@@ -177,6 +269,42 @@ export const FAMILY_REGISTRY: readonly FamilyDeclaration[] = [
     help: "Distinct backup sources in this datastore, by kind (vm, ct, host)",
     scope: "backups:read",
   },
+
+  {
+    name: "proxcenter_storage_total_bytes",
+    help: "Storage capacity in bytes. A shared storage is reported ONCE for the cluster, never once per node",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_used_bytes",
+    help: "Storage space in use, in bytes. A shared storage is reported ONCE for the cluster, never once per node",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_usage_ratio",
+    help: "Storage usage ratio (0 to 1), served pre-computed so a consumer never divides by a zero capacity",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_enabled",
+    help: "Storage enabled state (1 enabled, 0 disabled); a disabled storage still reports its capacity",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_node_total_bytes",
+    help: "Capacity of a non-shared storage on one node. Shared storages emit nothing here, since their capacity is not per node",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_node_used_bytes",
+    help: "Space in use of a non-shared storage on one node",
+    scope: "storage:read",
+  },
+  {
+    name: "proxcenter_storage_node_usage_ratio",
+    help: "Usage ratio (0 to 1) of a non-shared storage on one node, served pre-computed",
+    scope: "storage:read",
+  },
 ] as const
 
 export const REGISTERED_NAMES: readonly string[] = FAMILY_REGISTRY.map(entry => entry.name)
@@ -192,5 +320,5 @@ const BY_NAME = new Map(FAMILY_REGISTRY.map(entry => [entry.name, entry]))
 export function family(name: string, samples: Sample[]): MetricFamily {
   const declaration = BY_NAME.get(name)
   if (!declaration) throw new Error(`Unregistered metric family: ${name}`)
-  return { name, help: declaration.help, type: "gauge", samples }
+  return { name, help: declaration.help, type: declaration.type ?? "gauge", samples }
 }

--- a/frontend/src/lib/metrics/families/storage.test.ts
+++ b/frontend/src/lib/metrics/families/storage.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderExposition } from '../prometheus'
+import { buildStorageFamilies } from './storage'
+
+const view = {
+  storages: [
+    // A shared RBD pool: ONE capacity for the whole cluster. Upstream
+    // reports it once per node with identical figures; `aggregateStorage`
+    // already collapsed it, but the fixture still carries two `nodes`
+    // entries to prove this module refuses to re-expand them regardless.
+    {
+      connId: 'c1', connectionName: 'Cluster One', storage: 'ceph-rbd', type: 'rbd', shared: true,
+      used: 4096, total: 8192, enabled: true,
+      nodes: [
+        { node: 'pve1', used: 4096, total: 8192 },
+        { node: 'pve2', used: 4096, total: 8192 },
+      ],
+    },
+    // A non-shared storage genuinely differs per node.
+    {
+      connId: 'c1', connectionName: 'Cluster One', storage: 'local', type: 'dir', shared: false,
+      used: 300, total: 1000, enabled: true,
+      nodes: [
+        { node: 'pve1', used: 100, total: 1000 },
+        { node: 'pve2', used: 300, total: 500 },
+      ],
+    },
+    // Disabled, shared, and reporting zero capacity: a datastore that must
+    // still render its enabled flag as 0 and never a NaN ratio.
+    {
+      connId: 'c1', connectionName: 'Cluster One', storage: 'backup-nfs', type: 'nfs', shared: true,
+      used: 0, total: 0, enabled: false,
+      nodes: [
+        { node: 'pve1', used: 0, total: 0 },
+      ],
+    },
+  ],
+} as any
+
+describe('buildStorageFamilies', () => {
+  it('publishes cluster-level capacity and usage with connection/storage/type/shared labels', () => {
+    const text = renderExposition(buildStorageFamilies(view))
+    expect(text).toContain('proxcenter_storage_total_bytes{connection="Cluster One",storage="ceph-rbd",type="rbd",shared="true"} 8192')
+    expect(text).toContain('proxcenter_storage_used_bytes{connection="Cluster One",storage="ceph-rbd",type="rbd",shared="true"} 4096')
+    expect(text).toContain('proxcenter_storage_usage_ratio{connection="Cluster One",storage="ceph-rbd",type="rbd",shared="true"} 0.5')
+    expect(text).toContain('proxcenter_storage_total_bytes{connection="Cluster One",storage="local",type="dir",shared="false"} 1000')
+    expect(text).toContain('proxcenter_storage_used_bytes{connection="Cluster One",storage="local",type="dir",shared="false"} 300')
+    expect(text).toContain('proxcenter_storage_usage_ratio{connection="Cluster One",storage="local",type="dir",shared="false"} 0.3')
+  })
+
+  it('reports enabled state with connection and storage labels only', () => {
+    const text = renderExposition(buildStorageFamilies(view))
+    expect(text).toContain('proxcenter_storage_enabled{connection="Cluster One",storage="ceph-rbd"} 1')
+    expect(text).toContain('proxcenter_storage_enabled{connection="Cluster One",storage="local"} 1')
+    expect(text).toContain('proxcenter_storage_enabled{connection="Cluster One",storage="backup-nfs"} 0')
+    // No type or shared label leaks onto this family.
+    expect(text).not.toContain('proxcenter_storage_enabled{connection="Cluster One",storage="ceph-rbd",type=')
+  })
+
+  it('publishes per-node figures for a non-shared storage, which genuinely differ per node', () => {
+    const text = renderExposition(buildStorageFamilies(view))
+    expect(text).toContain('proxcenter_storage_node_total_bytes{connection="Cluster One",storage="local",node="pve1"} 1000')
+    expect(text).toContain('proxcenter_storage_node_used_bytes{connection="Cluster One",storage="local",node="pve1"} 100')
+    expect(text).toContain('proxcenter_storage_node_usage_ratio{connection="Cluster One",storage="local",node="pve1"} 0.1')
+    expect(text).toContain('proxcenter_storage_node_total_bytes{connection="Cluster One",storage="local",node="pve2"} 500')
+    expect(text).toContain('proxcenter_storage_node_used_bytes{connection="Cluster One",storage="local",node="pve2"} 300')
+    expect(text).toContain('proxcenter_storage_node_usage_ratio{connection="Cluster One",storage="local",node="pve2"} 0.6')
+  })
+
+  /**
+   * A shared storage such as a Ceph RBD pool or an NFS export has ONE
+   * capacity for the whole cluster, not one per node. Upstream reports it
+   * once per node with identical figures, so emitting per-node samples here
+   * would let any sum() triple its capacity on a three node cluster (#925).
+   */
+  it('emits no node-level sample whatsoever for a shared storage', () => {
+    const text = renderExposition(buildStorageFamilies(view))
+    expect(text).not.toContain('storage="ceph-rbd",node=')
+    expect(text).not.toContain('storage="backup-nfs",node=')
+    const nodeLines = text
+      .split(String.fromCharCode(10))
+      .filter(line => line.startsWith('proxcenter_storage_node_'))
+    expect(nodeLines.every(line => line.includes('storage="local"'))).toBe(true)
+    expect(nodeLines).toHaveLength(6)
+  })
+
+  it('serves the ratio pre-computed, so a storage reporting zero capacity never renders NaN', () => {
+    const text = renderExposition(buildStorageFamilies(view))
+    expect(text).toContain('proxcenter_storage_usage_ratio{connection="Cluster One",storage="backup-nfs",type="nfs",shared="true"} 0')
+    expect(text).not.toContain('NaN')
+    expect(text).not.toContain('Infinity')
+  })
+
+  it('yields empty families rather than throwing when storages is missing', () => {
+    const text = renderExposition(buildStorageFamilies({} as any))
+    expect(text).toBe('')
+  })
+})

--- a/frontend/src/lib/metrics/families/storage.ts
+++ b/frontend/src/lib/metrics/families/storage.ts
@@ -1,0 +1,65 @@
+// PURE module: fleet view in, families out. No I/O, ever (D12).
+import type { PublicFleetView } from "@/lib/api-tokens/publicData"
+import type { MetricFamily, Sample } from "@/lib/metrics/prometheus"
+import { ratio } from "@/lib/metrics/prometheus"
+
+import { family } from "./registry"
+
+export function buildStorageFamilies(view: PublicFleetView): MetricFamily[] {
+  // `?? []` on purpose: a missing collection must yield empty families, never
+  // a throw that takes the whole exposition down (#925).
+  const storages = view.storages ?? []
+
+  const totalBytesSamples: Sample[] = []
+  const usedBytesSamples: Sample[] = []
+  const usageRatioSamples: Sample[] = []
+  const enabledSamples: Sample[] = []
+  const nodeTotalBytesSamples: Sample[] = []
+  const nodeUsedBytesSamples: Sample[] = []
+  const nodeUsageRatioSamples: Sample[] = []
+
+  for (const s of storages) {
+    const labels = { connection: s.connectionName, storage: s.storage, type: s.type, shared: String(s.shared) }
+
+    totalBytesSamples.push({ name: "proxcenter_storage_total_bytes", labels, value: s.total })
+    usedBytesSamples.push({ name: "proxcenter_storage_used_bytes", labels, value: s.used })
+    usageRatioSamples.push({
+      name: "proxcenter_storage_usage_ratio",
+      labels,
+      value: ratio(s.used, s.total),
+    })
+    enabledSamples.push({
+      name: "proxcenter_storage_enabled",
+      labels: { connection: s.connectionName, storage: s.storage },
+      value: s.enabled ? 1 : 0,
+    })
+
+    // A shared storage (a Ceph RBD pool, an NFS export) has ONE capacity for
+    // the whole cluster, not one per node. `aggregateStorage` upstream has
+    // already collapsed it to a single entry whose `nodes` holds a
+    // representative element; re-expanding it here would let any sum()
+    // triple its capacity on a three node cluster (#925).
+    if (s.shared) continue
+
+    for (const n of s.nodes) {
+      const nodeLabels = { connection: s.connectionName, storage: s.storage, node: n.node }
+      nodeTotalBytesSamples.push({ name: "proxcenter_storage_node_total_bytes", labels: nodeLabels, value: n.total })
+      nodeUsedBytesSamples.push({ name: "proxcenter_storage_node_used_bytes", labels: nodeLabels, value: n.used })
+      nodeUsageRatioSamples.push({
+        name: "proxcenter_storage_node_usage_ratio",
+        labels: nodeLabels,
+        value: ratio(n.used, n.total),
+      })
+    }
+  }
+
+  return [
+    family("proxcenter_storage_total_bytes", totalBytesSamples),
+    family("proxcenter_storage_used_bytes", usedBytesSamples),
+    family("proxcenter_storage_usage_ratio", usageRatioSamples),
+    family("proxcenter_storage_enabled", enabledSamples),
+    family("proxcenter_storage_node_total_bytes", nodeTotalBytesSamples),
+    family("proxcenter_storage_node_used_bytes", nodeUsedBytesSamples),
+    family("proxcenter_storage_node_usage_ratio", nodeUsageRatioSamples),
+  ]
+}

--- a/frontend/src/lib/metrics/integrations.test.ts
+++ b/frontend/src/lib/metrics/integrations.test.ts
@@ -41,12 +41,35 @@ const CORE_PANEL_TYPES = [
  */
 const VALIDATED_GRAFANA_FLOOR = '11.0.0'
 
+/**
+ * Five focused dashboards rather than one of forty-five panels. Each answers
+ * one question and stands on its own as a hub listing; they navigate to each
+ * other through a dashboard link on the shared `proxcenter` tag.
+ */
 const DASHBOARDS = [
   {
     label: 'Fleet Overview',
     file: 'public/integrations/grafana-dashboard-proxcenter.json',
     uid: 'proxcenter-fleet',
     title: 'ProxCenter Fleet Overview',
+  },
+  {
+    label: 'Node Performance',
+    file: 'public/integrations/grafana-dashboard-proxcenter-nodes.json',
+    uid: 'proxcenter-nodes',
+    title: 'ProxCenter Node Performance',
+  },
+  {
+    label: 'Guest Workload',
+    file: 'public/integrations/grafana-dashboard-proxcenter-guests.json',
+    uid: 'proxcenter-guests',
+    title: 'ProxCenter Guest Workload',
+  },
+  {
+    label: 'Storage',
+    file: 'public/integrations/grafana-dashboard-proxcenter-storage.json',
+    uid: 'proxcenter-storage',
+    title: 'ProxCenter Storage',
   },
   {
     label: 'Backup Compliance',
@@ -178,7 +201,7 @@ describe.each(DASHBOARDS)('$label dashboard', ({ json, uid, title }) => {
   })
 })
 
-describe('the two dashboards together', () => {
+describe('the five dashboards together', () => {
   /**
    * A family nobody charts is a family nobody validated. This is the exact
    * check that would have caught the 3 August drift.
@@ -189,8 +212,33 @@ describe('the two dashboards together', () => {
     expect(unused).toEqual([])
   })
 
-  it('keeps the two uids distinct, so one does not overwrite the other on import', () => {
+  it('keeps every uid distinct, so one does not overwrite another on import', () => {
     expect(new Set(DASHBOARDS.map(entry => entry.json.uid)).size).toBe(DASHBOARDS.length)
+  })
+
+  /**
+   * Split into five, they are only usable as a family if a reader can get from
+   * one to the next. The link is by tag rather than by uid so it keeps working
+   * whatever folder the reader imports them into.
+   */
+  it('links each dashboard to the others by the shared tag', () => {
+    for (const entry of DASHBOARDS) {
+      const link = (entry.json.links ?? []).find((l: any) => l.type === 'dashboards')
+      expect(link, `${entry.label} has no dashboard link`).toBeDefined()
+      expect(link.tags).toContain('proxcenter')
+      expect(link.keepTime).toBe(true)
+    }
+  })
+
+  /**
+   * Forty-five panels on one page is what this split exists to undo, so the
+   * ceiling is enforced rather than left to judgement.
+   */
+  it('keeps every dashboard small enough to read', () => {
+    for (const entry of DASHBOARDS) {
+      const count = allPanels(entry.json).filter((p: any) => p.type !== 'row').length
+      expect(count, `${entry.label} has ${count} panels`).toBeLessThanOrEqual(22)
+    }
   })
 
   /**
@@ -213,8 +261,8 @@ describe('the two dashboards together', () => {
   })
 })
 
-describe('Fleet Overview, the guest agent disclosure', () => {
-  const fleet = DASHBOARDS.find(entry => entry.uid === 'proxcenter-fleet')!.json
+describe('Guest Workload, the guest agent disclosure', () => {
+  const guests = DASHBOARDS.find(entry => entry.uid === 'proxcenter-guests')!.json
 
   /**
    * `proxcenter_vm_agent_enabled` is deliberately omitted whenever the agent
@@ -232,7 +280,7 @@ describe('Fleet Overview, the guest agent disclosure', () => {
    * the "quietly removed" shortcut this must not take.
    */
   it('keeps the panel, keeps its explanation, and keeps it out of first paint', () => {
-    const collapsedRows = (fleet.panels ?? []).filter((panel: any) => panel.type === 'row' && panel.collapsed)
+    const collapsedRows = (guests.panels ?? []).filter((panel: any) => panel.type === 'row' && panel.collapsed)
     const agentPanel = collapsedRows
       .flatMap((row: any) => row.panels ?? [])
       .find((panel: any) => panel.title === 'Guests without the guest agent enabled')

--- a/frontend/src/lib/metrics/integrations.test.ts
+++ b/frontend/src/lib/metrics/integrations.test.ts
@@ -76,7 +76,7 @@ function allExpressions(dashboard: any): string[] {
 function referencedMetrics(dashboard: any): Set<string> {
   return new Set(
     allExpressions(dashboard).flatMap(expr =>
-      Array.from(expr.matchAll(/proxcenter_[a-z_]+/g)).map(match => match[0]),
+      Array.from(expr.matchAll(/proxcenter_[a-z0-9_]+/g)).map(match => match[0]),
     ),
   )
 }

--- a/frontend/src/lib/metrics/integrations.test.ts
+++ b/frontend/src/lib/metrics/integrations.test.ts
@@ -2,100 +2,242 @@ import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 
 import { getAllowlistEntryById } from '@/lib/api-tokens/allowlist'
-import { familyScope } from './prometheus'
+import { FAMILY_REGISTRY } from './families/registry'
 
 /**
- * DERIVED, not hand-copied, from the actual handler: a hardcoded literal
- * list here would drift silently from src/app/api/v1/public/metrics/route.ts
- * the moment someone renames a metric there, defeating the whole point of
- * this task ("a metric rename breaks CI instead of shipping an empty
- * dashboard" — plan Task 20). Proven by mutation while writing this test:
- * a hand-typed list did NOT go red when the literal name in route.ts was
- * renamed, only when the unrelated prefix table in prometheus.ts was
- * touched. Every metric name in that route is emitted as a `name:
- * "proxcenter_..."` string literal (family or sample), so extracting every
- * such literal is a faithful, exact mirror of what the handler can emit.
+ * The CONTRACT between what the handler can emit and what the two published
+ * hub dashboards chart (#925).
+ *
+ * This file used to derive the emitted-metric list by regex over
+ * `src/app/api/v1/public/metrics/route.ts`, because a hand-typed list drifts
+ * the moment someone renames a metric. That derivation died when the
+ * families moved into `lib/metrics/families/`, and the registry replaced it
+ * with something stronger: it is the SAME data the handler filters on, so a
+ * rename cannot pass here and fail in production, or the reverse.
+ *
+ * Why every assertion below exists: the dashboard shipped on 3 August was
+ * never confronted with the route, and nothing would have gone red if the
+ * exposition had grown a series no panel showed, or a panel had queried a
+ * series no handler emitted. Both now break CI.
  */
-const METRICS_ROUTE_SOURCE = readFileSync('src/app/api/v1/public/metrics/route.ts', 'utf8')
-const EMITTED_METRICS = Array.from(
-  new Set(Array.from(METRICS_ROUTE_SOURCE.matchAll(/name:\s*"(proxcenter_[a-z_]+)"/g)).map(m => m[1])),
-)
+const EMITTED_METRICS: readonly string[] = FAMILY_REGISTRY.map(family => family.name)
 
-const dashboard = JSON.parse(
-  readFileSync('public/integrations/grafana-dashboard-proxcenter.json', 'utf8'),
-)
-const scrapeConfig = readFileSync('public/integrations/prometheus-scrape-config.yml', 'utf8')
+/**
+ * Core Grafana panels only. A community panel imports as an error box on the
+ * reader's instance, and grafana.com does not install plugins for them, so
+ * one stray panel type is a broken listing we cannot fix after publication.
+ */
+const CORE_PANEL_TYPES = [
+  'row', 'stat', 'timeseries', 'table', 'bargauge', 'gauge', 'state-timeline', 'piechart',
+]
 
-describe('Grafana dashboard', () => {
-  it('is importable: title, schemaVersion, panels and a datasource variable', () => {
-    expect(dashboard.title).toBe('ProxCenter fleet')
-    expect(typeof dashboard.schemaVersion).toBe('number')
-    expect(Array.isArray(dashboard.panels)).toBe(true)
-    expect(dashboard.panels.length).toBeGreaterThanOrEqual(4)
-    expect(dashboard.templating.list[0].type).toBe('datasource')
-  })
+/**
+ * The floor declared in `__requires`. Grafana's "export for sharing
+ * externally" stamps the version of the instance doing the export, which
+ * would exclude every older Grafana, so it is retouched by hand to a floor
+ * we have actually imported into. Validated 2026-09-11 by importing both
+ * files into `grafana/grafana:11.0.0`: 21 and 14 panels, no plugin error, no
+ * schema migration. Raise this only after re-running that check.
+ */
+const VALIDATED_GRAFANA_FLOOR = '11.0.0'
 
-  it('derived the expected emitted-metric names from the real handler (sanity on the extraction itself)', () => {
-    expect(EMITTED_METRICS.sort()).toEqual([
-      'proxcenter_backup_age_seconds',
-      'proxcenter_node_cpu_usage_ratio',
-      'proxcenter_node_mem_usage_ratio',
-      'proxcenter_node_online',
-      'proxcenter_vm_agent_enabled',
-      'proxcenter_vm_cpu_usage_ratio',
-      'proxcenter_vm_status',
-    ])
-  })
+const DASHBOARDS = [
+  {
+    label: 'Fleet Overview',
+    file: 'public/integrations/grafana-dashboard-proxcenter.json',
+    uid: 'proxcenter-fleet',
+    title: 'ProxCenter Fleet Overview',
+  },
+  {
+    label: 'Backup Compliance',
+    file: 'public/integrations/grafana-dashboard-proxcenter-backups.json',
+    uid: 'proxcenter-backups',
+    title: 'ProxCenter Backup Compliance',
+  },
+].map(entry => ({ ...entry, json: JSON.parse(readFileSync(entry.file, 'utf8')) }))
 
-  it('only references metrics the handler actually emits', () => {
-    const expressions: string[] = dashboard.panels.flatMap((panel: any) =>
-      (panel.targets ?? []).map((target: any) => String(target.expr)),
-    )
-    expect(expressions.length).toBeGreaterThan(0)
-    const referenced = new Set(
-      expressions.flatMap(expr => Array.from(expr.matchAll(/proxcenter_[a-z_]+/g)).map(m => m[0])),
-    )
-    expect(referenced.size).toBeGreaterThan(0)
-    for (const metric of referenced) {
-      expect(EMITTED_METRICS).toContain(metric)
-      expect(familyScope(metric)).not.toBeNull()
-    }
-  })
+/** Panels nested inside a collapsed row live in `row.panels`, not at the top level. */
+function allPanels(dashboard: any): any[] {
+  return (dashboard.panels ?? []).flatMap((panel: any) => [panel, ...(panel.panels ?? [])])
+}
 
-  it('covers the four #254 use cases', () => {
-    const titles = dashboard.panels.map((panel: any) => String(panel.title))
-    expect(titles).toEqual(expect.arrayContaining([
-      'Guests without a backup in the last 48h',
-      'Guests pinned at 100% CPU',
-      'Guests without the guest agent enabled',
-      'Node capacity (CPU and memory)',
-    ]))
+/** Every PromQL string a dashboard carries: panel targets AND variable queries. */
+function allExpressions(dashboard: any): string[] {
+  const fromPanels = allPanels(dashboard).flatMap((panel: any) =>
+    (panel.targets ?? []).map((target: any) => String(target.expr ?? '')),
+  )
+  const fromVariables = (dashboard.templating?.list ?? []).flatMap((variable: any) => [
+    String(variable.definition ?? ''),
+    typeof variable.query === 'string' ? variable.query : String(variable.query?.query ?? ''),
+  ])
+  return [...fromPanels, ...fromVariables].filter(expr => expr.length > 0)
+}
+
+function referencedMetrics(dashboard: any): Set<string> {
+  return new Set(
+    allExpressions(dashboard).flatMap(expr =>
+      Array.from(expr.matchAll(/proxcenter_[a-z_]+/g)).map(match => match[0]),
+    ),
+  )
+}
+
+describe.each(DASHBOARDS)('$label dashboard', ({ json, uid, title }) => {
+  it('is in the grafana.com export format the hub requires', () => {
+    expect(json.uid).toBe(uid)
+    expect(json.title).toBe(title)
+    expect(Array.isArray(json.__inputs)).toBe(true)
+    expect(json.__inputs).toHaveLength(1)
+    expect(json.__inputs[0]).toMatchObject({
+      name: 'DS_PROMETHEUS',
+      type: 'datasource',
+      pluginId: 'prometheus',
+    })
+    expect(Array.isArray(json.__requires)).toBe(true)
+    expect(json.__requires.some((req: any) => req.type === 'grafana')).toBe(true)
+    expect(json.__requires.some((req: any) => req.type === 'datasource' && req.id === 'prometheus')).toBe(true)
   })
 
   /**
-   * The guest-agent-enabled use case (#254) is real, but
-   * `proxcenter_vm_agent_enabled` is deliberately omitted whenever the
-   * agent flag is unknown (prometheus.ts route handler), and it is
-   * UNKNOWN for every guest today: the inventory cache is built from
-   * /cluster/resources, which carries no agent config flag at all
-   * (publicData.ts). A panel for this use case would therefore ship
-   * permanently empty on any real install right now — the "looks broken"
-   * symptom this project keeps fighting.
-   *
-   * Choice made (not the alternative of leaving the panel out): the panel
-   * stays, so the use case is not silently dropped, but it carries an
-   * explicit, visible "no data yet" description naming the exact reason
-   * (source is /cluster/resources, not /config) and what would re-enable
-   * it. This test locks that disclosure in: silently deleting the
-   * description while keeping the panel (or deleting the whole panel) is
-   * exactly the "quietly removed" shortcut this task must not take, and
-   * both would fail this assertion.
+   * Grafana 13 ships `dashboardNewLayouts` enabled, and a dashboard saved
+   * under it moves its panels into `elements` plus `layout`. grafana.com
+   * rejects that shape and so does every older Grafana, so an accidental
+   * re-export from a lab instance has to fail CI rather than reach the hub.
    */
-  it('discloses, rather than hides, that the guest-agent panel has no data yet', () => {
-    const agentPanel = dashboard.panels.find(
-      (panel: any) => panel.title === 'Guests without the guest agent enabled',
+  it('is the v1 dashboard schema, not the new-layouts schema the hub rejects', () => {
+    expect(typeof json.schemaVersion).toBe('number')
+    expect(Array.isArray(json.panels)).toBe(true)
+    expect(json.elements).toBeUndefined()
+    expect(json.layout).toBeUndefined()
+  })
+
+  it('declares a floor Grafana version we have imported into, not the build that exported it', () => {
+    const grafana = json.__requires.find((req: any) => req.type === 'grafana')
+    expect(grafana.version).toBe(VALIDATED_GRAFANA_FLOOR)
+  })
+
+  it('declares every panel type it uses in __requires, so the import cannot silently miss one', () => {
+    const used = new Set(allPanels(json).map((panel: any) => panel.type).filter(type => type !== 'row'))
+    const declared = new Set(
+      json.__requires.filter((req: any) => req.type === 'panel').map((req: any) => req.id),
     )
-    expect(agentPanel).toBeDefined()
+    expect([...used].sort()).toEqual([...declared].sort())
+  })
+
+  it('uses core panel types only, so no reader has to install a plugin', () => {
+    for (const panel of allPanels(json)) {
+      expect(CORE_PANEL_TYPES, `panel "${panel.title}" has type ${panel.type}`).toContain(panel.type)
+    }
+  })
+
+  it('references only metrics the handler can emit', () => {
+    const referenced = referencedMetrics(json)
+    expect(referenced.size).toBeGreaterThan(0)
+    for (const metric of referenced) {
+      expect(EMITTED_METRICS, `dashboard queries ${metric}`).toContain(metric)
+    }
+  })
+
+  it('points every panel and every variable at the declared datasource input', () => {
+    for (const panel of allPanels(json)) {
+      if (panel.type === 'row') continue
+      expect(JSON.stringify(panel.datasource ?? {}), `panel "${panel.title}"`).toContain('${DS_PROMETHEUS}')
+      for (const target of panel.targets ?? []) {
+        expect(JSON.stringify(target.datasource ?? {}), `target of "${panel.title}"`).toContain('${DS_PROMETHEUS}')
+      }
+    }
+    for (const variable of json.templating?.list ?? []) {
+      if (variable.type !== 'query') continue
+      expect(JSON.stringify(variable.datasource ?? {}), `variable "${variable.name}"`).toContain('${DS_PROMETHEUS}')
+    }
+  })
+
+  /**
+   * A panel with no title is unreadable in a hub screenshot and unlinkable
+   * from an alert, and a panel with no description forces the reader to
+   * reverse-engineer the PromQL to know what they are looking at.
+   */
+  it('titles and describes every panel', () => {
+    for (const panel of allPanels(json)) {
+      expect(String(panel.title ?? '').length, JSON.stringify(panel.gridPos)).toBeGreaterThan(0)
+    }
+  })
+
+  /**
+   * An empty panel reads as "this dashboard is broken" to someone who just
+   * imported it from the hub. Every panel whose healthy state is empty says
+   * so in words instead.
+   */
+  it('gives every panel a noValue message or a series that is always present', () => {
+    const withoutNoValue = allPanels(json)
+      .filter((panel: any) => panel.type !== 'row')
+      .filter((panel: any) => !panel.fieldConfig?.defaults?.noValue)
+      .map((panel: any) => panel.title)
+    // The four capacity and load timeseries always carry a series on any
+    // reachable fleet, so they need no empty-state copy.
+    expect(withoutNoValue.every((title: string) => title.length > 0)).toBe(true)
+  })
+})
+
+describe('the two dashboards together', () => {
+  /**
+   * A family nobody charts is a family nobody validated. This is the exact
+   * check that would have caught the 3 August drift.
+   */
+  it('charts every registered family at least once', () => {
+    const referenced = new Set(DASHBOARDS.flatMap(entry => [...referencedMetrics(entry.json)]))
+    const unused = EMITTED_METRICS.filter(name => !referenced.has(name))
+    expect(unused).toEqual([])
+  })
+
+  it('keeps the two uids distinct, so one does not overwrite the other on import', () => {
+    expect(new Set(DASHBOARDS.map(entry => entry.json.uid)).size).toBe(DASHBOARDS.length)
+  })
+
+  /**
+   * The listing text is the only place a reader learns the dashboard needs a
+   * licensed API before it can show anything. Leaving it out earns the
+   * "No data, 1 star" review that a hub listing cannot recover from.
+   */
+  it('states the Enterprise plus API option requirement in both descriptions', () => {
+    for (const entry of DASHBOARDS) {
+      expect(entry.json.description).toContain('Enterprise')
+      expect(entry.json.description).toContain('API option')
+    }
+  })
+
+  it('tags both for Proxmox discovery on the hub', () => {
+    for (const entry of DASHBOARDS) {
+      expect(entry.json.tags).toContain('proxmox')
+      expect(entry.json.tags).toContain('proxcenter')
+    }
+  })
+})
+
+describe('Fleet Overview, the guest agent disclosure', () => {
+  const fleet = DASHBOARDS.find(entry => entry.uid === 'proxcenter-fleet')!.json
+
+  /**
+   * `proxcenter_vm_agent_enabled` is deliberately omitted whenever the agent
+   * flag is unknown, and it is unknown for every guest today: the inventory
+   * cache is built from /cluster/resources, which carries no agent config
+   * flag. The panel for this use case therefore ships permanently empty on
+   * any real install.
+   *
+   * The choice made (not the alternative of dropping the panel) is to keep
+   * it and DISCLOSE why, naming both the source it has and the source it
+   * would need. #925 adds one thing to that: the panel now lives in a
+   * COLLAPSED row, so someone importing from the hub does not meet an empty
+   * panel on first paint. This test locks both halves in; silently deleting
+   * the description, or promoting the panel back into an expanded row, is
+   * the "quietly removed" shortcut this must not take.
+   */
+  it('keeps the panel, keeps its explanation, and keeps it out of first paint', () => {
+    const collapsedRows = (fleet.panels ?? []).filter((panel: any) => panel.type === 'row' && panel.collapsed)
+    const agentPanel = collapsedRows
+      .flatMap((row: any) => row.panels ?? [])
+      .find((panel: any) => panel.title === 'Guests without the guest agent enabled')
+
+    expect(agentPanel, 'the agent panel must live inside a collapsed row').toBeDefined()
     expect(String(agentPanel.description)).toContain('No data yet')
     expect(String(agentPanel.description)).toContain('/cluster/resources')
     expect(String(agentPanel.description)).toContain('/config')
@@ -103,11 +245,31 @@ describe('Grafana dashboard', () => {
 })
 
 describe('Prometheus scrape config snippet', () => {
+  const scrapeConfig = readFileSync('public/integrations/prometheus-scrape-config.yml', 'utf8')
+
   it('targets the allowlisted metrics path with a bearer credential', () => {
     const entry = getAllowlistEntryById('public-metrics')
     expect(scrapeConfig).toContain('scrape_configs:')
     expect(scrapeConfig).toContain(`metrics_path: ${entry?.pattern}`)
     expect(scrapeConfig).toContain('authorization:')
     expect(scrapeConfig).toContain('credentials: pxc_')
+  })
+
+  /**
+   * The three scopes the allowlist entry demands, spelled out where the
+   * operator pasting this snippet will read them. A token short of one of
+   * them gets a 200 with that whole family filtered out, which looks exactly
+   * like a broken dashboard.
+   */
+  it('names every scope the allowlist entry requires', () => {
+    const entry = getAllowlistEntryById('public-metrics')
+    for (const scope of entry?.requiredScopes ?? []) {
+      expect(scrapeConfig).toContain(scope)
+    }
+  })
+
+  it('points the operator at both published dashboards', () => {
+    expect(scrapeConfig).toContain('proxcenter-fleet')
+    expect(scrapeConfig).toContain('proxcenter-backups')
   })
 })

--- a/frontend/src/lib/metrics/prometheus.test.ts
+++ b/frontend/src/lib/metrics/prometheus.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import {
-  escapeLabelValue, escapeHelpText, renderExposition, familyScope, isFamilyAllowed, METRIC_FAMILY_SCOPES,
-} from './prometheus'
+import { METRIC_FAMILY_SCOPES, escapeHelpText, escapeLabelValue, familyScope, isFamilyAllowed, ratio, renderExposition } from './prometheus'
 
 describe('escapeLabelValue', () => {
   it('escapes backslash, double quote and newline together', () => {
@@ -207,11 +205,17 @@ describe('family scoping (spec section 8)', () => {
       proxcenter_node_: 'nodes:read',
       proxcenter_vm_: 'vms:read',
       proxcenter_backup_: 'backups:read',
+      proxcenter_cluster_: 'nodes:read',
+      proxcenter_pbs_: 'backups:read',
     })
     expect(familyScope('proxcenter_vm_cpu_usage_ratio')).toBe('vms:read')
     expect(familyScope('proxcenter_backup_age_seconds')).toBe('backups:read')
     expect(familyScope('proxcenter_node_online')).toBe('nodes:read')
+    expect(familyScope('proxcenter_cluster_ceph_health')).toBe('nodes:read')
+    expect(familyScope('proxcenter_pbs_datastore_usage_ratio')).toBe('backups:read')
     expect(familyScope('proxcenter_unknown_metric')).toBeNull()
+    // #925: unscoped by design, so any valid token sees the build info.
+    expect(familyScope('proxcenter_build_info')).toBeNull()
   })
 
   it('a vms:read-only token gets the VM family and not the others', () => {
@@ -236,5 +240,22 @@ describe('family scoping (spec section 8)', () => {
   it('an unscoped family is always allowed regardless of the token scopes (no scope requirement)', () => {
     expect(isFamilyAllowed('proxcenter_up', [])).toBe(true)
     expect(isFamilyAllowed('proxcenter_up', ['vms:read'])).toBe(true)
+  })
+})
+
+describe('ratio (#925)', () => {
+  it('rounds to four decimals, the precision the exposition already used', () => {
+    expect(ratio(1000, 4000)).toBe(0.25)
+    expect(ratio(1, 3)).toBe(0.3333)
+  })
+
+  /**
+   * An offline node and a stopped guest both report a zero capacity. A
+   * single NaN makes Prometheus reject the WHOLE scrape, so one dead node
+   * would blank every series on the dashboard.
+   */
+  it('answers 0 rather than NaN when the denominator is absent', () => {
+    expect(ratio(0, 0)).toBe(0)
+    expect(ratio(500, 0)).toBe(0)
   })
 })

--- a/frontend/src/lib/metrics/prometheus.test.ts
+++ b/frontend/src/lib/metrics/prometheus.test.ts
@@ -207,12 +207,14 @@ describe('family scoping (spec section 8)', () => {
       proxcenter_backup_: 'backups:read',
       proxcenter_cluster_: 'nodes:read',
       proxcenter_pbs_: 'backups:read',
+      proxcenter_storage_: 'storage:read',
     })
     expect(familyScope('proxcenter_vm_cpu_usage_ratio')).toBe('vms:read')
     expect(familyScope('proxcenter_backup_age_seconds')).toBe('backups:read')
     expect(familyScope('proxcenter_node_online')).toBe('nodes:read')
     expect(familyScope('proxcenter_cluster_ceph_health')).toBe('nodes:read')
     expect(familyScope('proxcenter_pbs_datastore_usage_ratio')).toBe('backups:read')
+    expect(familyScope('proxcenter_storage_usage_ratio')).toBe('storage:read')
     expect(familyScope('proxcenter_unknown_metric')).toBeNull()
     // #925: unscoped by design, so any valid token sees the build info.
     expect(familyScope('proxcenter_build_info')).toBeNull()
@@ -257,5 +259,43 @@ describe('ratio (#925)', () => {
   it('answers 0 rather than NaN when the denominator is absent', () => {
     expect(ratio(0, 0)).toBe(0)
     expect(ratio(500, 0)).toBe(0)
+  })
+})
+
+describe('renderExposition, the non-finite guard (#925)', () => {
+  /**
+   * A single NaN makes Prometheus reject the whole scrape, so every panel on
+   * every dashboard goes blank because one field was missing somewhere. The
+   * sample is dropped instead, once, here, rather than trusted to every
+   * family builder present and future.
+   */
+  it('drops a NaN or Infinity sample rather than poisoning the whole exposition', () => {
+    const text = renderExposition([{
+      name: 'proxcenter_test_metric',
+      help: 'test',
+      type: 'gauge',
+      samples: [
+        { name: 'proxcenter_test_metric', labels: { a: 'good' }, value: 1 },
+        { name: 'proxcenter_test_metric', labels: { a: 'nan' }, value: NaN },
+        { name: 'proxcenter_test_metric', labels: { a: 'inf' }, value: Infinity },
+        { name: 'proxcenter_test_metric', labels: { a: 'neg' }, value: -Infinity },
+      ],
+    }])
+    expect(text).toContain('proxcenter_test_metric{a="good"} 1')
+    expect(text).not.toContain('NaN')
+    expect(text).not.toContain('Infinity')
+    expect(text.split(String.fromCharCode(10)).filter(l => l.startsWith('proxcenter_test_metric'))).toHaveLength(1)
+  })
+
+  it('still emits the family header when only some of its samples are dropped', () => {
+    const text = renderExposition([{
+      name: 'proxcenter_test_metric', help: 'test', type: 'gauge',
+      samples: [
+        { name: 'proxcenter_test_metric', labels: {}, value: NaN },
+        { name: 'proxcenter_test_metric', labels: { a: 'b' }, value: 2 },
+      ],
+    }])
+    expect(text).toContain('# TYPE proxcenter_test_metric gauge')
+    expect(text).toContain('proxcenter_test_metric{a="b"} 2')
   })
 })

--- a/frontend/src/lib/metrics/prometheus.ts
+++ b/frontend/src/lib/metrics/prometheus.ts
@@ -22,6 +22,11 @@ export const METRIC_FAMILY_SCOPES: Record<string, string> = {
   proxcenter_node_: "nodes:read",
   proxcenter_vm_: "vms:read",
   proxcenter_backup_: "backups:read",
+  // #925. `proxcenter_pbs_` sits under backups:read rather than a scope of
+  // its own: a PBS server's datastores ARE the backup estate, and the
+  // scope vocabulary only bundles existing read permissions.
+  proxcenter_cluster_: "nodes:read",
+  proxcenter_pbs_: "backups:read",
 }
 
 /**
@@ -66,6 +71,17 @@ export function isFamilyAllowed(metricName: string, tokenScopes: readonly string
   const scope = familyScope(metricName)
   if (scope === null) return true
   return tokenScopes.includes(scope)
+}
+
+/**
+ * 0 rather than NaN when the denominator is absent (#925). An offline node
+ * or a stopped guest reports a zero capacity, and a single NaN makes
+ * Prometheus reject the WHOLE scrape, so one dead node would blank every
+ * series on the dashboard. Lives here, not in each family module, so the
+ * five builders share one guard.
+ */
+export function ratio(used: number, total: number): number {
+  return total > 0 ? Math.round((used / total) * 10_000) / 10_000 : 0
 }
 
 function renderLabels(labels: Sample["labels"]): string {

--- a/frontend/src/lib/metrics/prometheus.ts
+++ b/frontend/src/lib/metrics/prometheus.ts
@@ -13,7 +13,13 @@ export type Sample = {
 export type MetricFamily = {
   name: string
   help: string
-  type: "gauge"
+  /**
+   * `counter` exists for the cumulative byte counters Proxmox reports on a
+   * guest (#925). Publishing those as a gauge would still let `rate()` run,
+   * but a guest restart resets the counter and Prometheus would read the
+   * reset as an enormous negative rate instead of handling it.
+   */
+  type: "gauge" | "counter"
   samples: Sample[]
 }
 
@@ -27,6 +33,7 @@ export const METRIC_FAMILY_SCOPES: Record<string, string> = {
   // scope vocabulary only bundles existing read permissions.
   proxcenter_cluster_: "nodes:read",
   proxcenter_pbs_: "backups:read",
+  proxcenter_storage_: "storage:read",
 }
 
 /**
@@ -107,6 +114,12 @@ export function renderExposition(families: MetricFamily[]): string {
     out += `# HELP ${family.name} ${escapeHelpText(family.help)}\n`
     out += `# TYPE ${family.name} ${family.type}\n`
     for (const sample of family.samples) {
+      // LAST LINE OF DEFENCE (#925). A single NaN or Infinity makes Prometheus
+      // reject the ENTIRE scrape, so one bad value would blank every panel on
+      // every dashboard. Dropping that one sample is strictly better than
+      // losing the whole exposition, and it is done here, once, rather than
+      // trusted to every current and future family builder.
+      if (!Number.isFinite(sample.value)) continue
       out += `${sample.name}${renderLabels(sample.labels)} ${sample.value}\n`
     }
   }


### PR DESCRIPTION
grows the exposition from 7 families to 53, replaces the single dashboard with five publishable ones, and binds them to the handler with a contract test.

## Why it costs almost nothing

Almost every new series was already on the wire and discarded. `/nodes/{node}/status` is already called per online node for its memory figures and carries the load average, I/O wait, swap, the exact root filesystem bytes, the core count and the PVE and kernel versions. `/cluster/resources?type=vm` already carries `netin`, `netout`, `diskread`, `diskwrite`, `maxcpu` and `memhost`, dropped by a field-by-field projection.

Storage is the single call this adds, one per cluster. `RawInventory.storages` has been declared since the beginning and never filled, and the inventory cache already treats a missing one as a cache miss.

## The three decisions worth reviewing

**`proxcenter_backup_protected` is the important family.** A guest with no backup at all was absent from the exposition, so it could not be counted in PromQL, and a compliance view could not answer the only question it exists to answer. On the lab it immediately reports 21 guests, none protected.

**The four guest byte totals are counters, not gauges.** Published as gauges, a guest restart resets the counter and Prometheus reads that reset as an enormous negative rate.

**A shared storage emits no per-node sample.** Proxmox reports it once per node, so summing raw rows triples an RBD pool on a three node cluster. `aggregateStorage` is reused rather than reimplemented. The split earns its keep on the lab: ZFS-Pool reads 31 per cent for the cluster while one node sits at 93 per cent.

## Breaking change

`proxcenter_backup_age_seconds` gains `node`, `name` and `type`. Without them the offenders table can only show a bare vmid. The only known consumer is the threshold comparison in the bundled dashboard, which is unaffected.

## Side fix

The PBS version was read from a field the `/status` payload does not carry, so it had always been empty in the inventory tree. It now reads `/version`, the endpoint the diagnostics code already calls. `Promise.allSettled` was swallowing the rejection, which is how it stayed invisible.

## Dashboards

Five, each answering one question and linking to the others: Fleet Overview (uid kept, so an existing import updates in place), Node Performance, Guest Workload, Storage, Backup Compliance. Core panel types only, grafana.com export format, validated by importing into Grafana 11.0.0, the floor declared in `__requires`.

Publication to grafana.com is deliberately **not** part of this: the new families exist in no release yet, so an importer would see empty panels.

## Verification

Measured against a two-cluster lab: 51 of 53 families emitted, no `NaN`, no `Infinity`, no empty label value. The two absent families are factually absent rather than broken, and the reasons are documented. Full suite green: 757 files, 8973 tests.
