### PR TITLE
Stop a cut-off test failover cleanup from reading as a finished one

### DIFF
--- a/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
+++ b/frontend/src/app/(dashboard)/automation/site-recovery/page.tsx
@@ -358,12 +358,25 @@ export default function SiteRecoveryPage() {
     setCleanupLoading(true)
     try {
       const res = await fetch(`/api/v1/orchestrator/replication/plans/${failoverDialog.planId}/cleanup-test`, { method: 'POST' })
-      const data = await res.json()
-      setCleanupResult(data)
+      const data = await res.json().catch(() => ({}))
+
+      // A cleanup that never reached the orchestrator, or whose call was cut
+      // off on the way back, must never read as a finished one: the DR guests
+      // may still be running on the replica images. Feed the error through the
+      // same shape the dialog already renders, so the retry button stays.
+      // What travels here is the technical cause only; the dialog states the
+      // operator-facing consequence itself, in the operator's own language.
+      setCleanupResult(res.ok
+        ? data
+        : { vms_stopped: 0, disks_rolled: 0, jobs_resumed: 0, errors: data?.error ? [data.error] : [] })
       mutateJobs()
       mutatePlans()
     } catch (e) {
+      // A request that never came back leaves the DR guests up just the same,
+      // so it owes the operator a banner rather than a console line and a
+      // spinner that stops on its own.
       console.error('Failed to cleanup test:', e)
+      setCleanupResult({ vms_stopped: 0, disks_rolled: 0, jobs_resumed: 0, errors: [e instanceof Error ? e.message : String(e)] })
     } finally {
       setCleanupLoading(false)
     }

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.test.tsx
@@ -680,7 +680,7 @@ const cloneVM = {
 }
 
 it('describes clone cleanup using the execution manifest', () => {
-  renderDialog({ execution: execution({ vm_results: [cloneVM] }), cleanupResult: { vms_stopped: 1, disks_rolled: 1, jobs_resumed: 1, errors: [] } })
+  renderDialog({ execution: execution({ vm_results: [cloneVM] }), cleanupResult: { all_cleaned: true, vms_stopped: 1, disks_rolled: 1, jobs_resumed: 1, errors: [] } })
   expect(screen.getByText(/Clones destroyed, configuration restored/)).toBeInTheDocument()
   expect(screen.queryByText(/RBD disk\(s\) rolled back/)).not.toBeInTheDocument()
   expect(screen.getByText(/dr1/)).toBeInTheDocument()
@@ -694,6 +694,29 @@ it('keeps cleanup retry available for an interrupted clone test with partial cle
   expect(screen.getByText('clone still in use')).toBeInTheDocument()
   await userEvent.click(screen.getByRole('button', { name: 'Cleanup test' }))
   expect(onCleanup).toHaveBeenCalledOnce()
+})
+
+// Reported from the field: a cleanup whose call was aborted came back as an
+// error body, and the dialog read its missing `errors` key as "no errors" and
+// announced "Cleanup completed" with no detail line, while two DR guests were
+// still running on their replica images. Only all_cleaned may claim success.
+it.each([
+  ['an aborted call', { error: 'Orchestrator request timeout' }],
+  ['a payload without the verdict', { vms_stopped: 1, disks_rolled: 1, jobs_resumed: 1, errors: [] }],
+  ['an explicitly unfinished run', { all_cleaned: false, vms_stopped: 1, disks_rolled: 0, jobs_resumed: 0, errors: ['VM 2000102 is not stopped'] }],
+])('never announces a completed cleanup for %s', async (_label, cleanupResult) => {
+  const onCleanup = vi.fn()
+  renderDialog({ execution: execution(), onCleanup, cleanupResult: cleanupResult as never })
+  expect(screen.queryByText('Cleanup completed')).not.toBeInTheDocument()
+  expect(screen.getByText('Cleanup did not complete')).toBeInTheDocument()
+  await userEvent.click(screen.getByRole('button', { name: 'Cleanup test' }))
+  expect(onCleanup).toHaveBeenCalledOnce()
+})
+
+it('announces a completed cleanup only on the orchestrator verdict', () => {
+  renderDialog({ execution: execution(), onCleanup: vi.fn(), cleanupResult: { all_cleaned: true, vms_stopped: 2, disks_rolled: 3, jobs_resumed: 1, errors: [] } })
+  expect(screen.getByText('Cleanup completed')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: 'Cleanup test' })).not.toBeInTheDocument()
 })
 
 it('shows an explicit cleanup-first banner for a 409', () => {

--- a/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
+++ b/frontend/src/components/automation/site-recovery/FailoverDialog.tsx
@@ -39,7 +39,7 @@ interface FailoverDialogProps {
   onConfirm: (options?: TestFailoverOptions) => void
   onCleanup?: () => void
   cleanupLoading?: boolean
-  cleanupResult?: { vms_stopped: number; disks_rolled: number; jobs_resumed: number; errors: string[] } | null
+  cleanupResult?: { all_cleaned?: boolean; vms_stopped: number; disks_rolled: number; jobs_resumed: number; errors: string[] } | null
   execution: RecoveryExecution | null
   errorMessage?: string | null
   errorStatus?: number | null
@@ -395,14 +395,31 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
           {/* Cleanup result */}
           {cleanupResult && (() => {
             const errs = cleanupResult.errors || []
+
+            // all_cleaned is the orchestrator's own verdict, and the only
+            // field that says the run reached its end. Keying the banner on an
+            // empty error list instead would call any payload without one a
+            // success, including the error bodies an aborted or refused call
+            // returns, while the DR guests are still up on the replica images.
+            const done = cleanupResult.all_cleaned === true && errs.length === 0
             return (
-              <Alert severity={errs.length > 0 ? 'warning' : 'success'}>
+              <Alert severity={done ? 'success' : 'warning'}>
                 <Typography variant='body2' sx={{ fontWeight: 600, mb: 0.5 }}>
-                  {t(errs.length > 0 ? 'siteRecovery.failover.cleanup' : 'siteRecovery.failover.cleanupDone')}
+                  {t(done ? 'siteRecovery.failover.cleanupDone' : 'siteRecovery.failover.cleanupIncomplete')}
                 </Typography>
+                {/* What an unfinished cleanup means for the operator, said in
+                    their own language. The route's message follows below as
+                    the technical cause: on its own, a string like
+                    "Orchestrator request timeout" is untranslated and says
+                    nothing about the DR guests left running on the replicas. */}
+                {!done && (
+                  <Typography variant='caption' component='div' sx={{ mb: 0.5 }}>
+                    {t('siteRecovery.failover.cleanupFailed')}
+                  </Typography>
+                )}
                 <Typography variant='caption' component='div'>
                   {cleanupResult.vms_stopped > 0 && <>{cleanupResult.vms_stopped} VM(s) {t('siteRecovery.failover.stopped')}<br /></>}
-                  {hasTestClones && errs.length === 0 && <>{t('siteRecovery.failover.clonesDestroyed')}<br /></>}
+                  {hasTestClones && done && <>{t('siteRecovery.failover.clonesDestroyed')}<br /></>}
                   {(!hasTestClones || hasRollbackVMs) && cleanupResult.disks_rolled > 0 && <>{cleanupResult.disks_rolled} {t('siteRecovery.failover.disksRolledBack')}<br /></>}
                   {cleanupResult.jobs_resumed > 0 && <>{cleanupResult.jobs_resumed} {t('siteRecovery.failover.jobsResumed')}</>}
                 </Typography>
@@ -697,7 +714,7 @@ export default function FailoverDialog({ open, onClose, plan, type, onConfirm, o
         )}
         {execution && execution.status !== 'running' && (
           <>
-            {type === 'test' && onCleanup && (!cleanupResult || cleanupResult.errors?.length > 0) && (
+            {type === 'test' && onCleanup && cleanupResult?.all_cleaned !== true && (
               <Button
                 variant='outlined'
                 color='warning'

--- a/frontend/src/lib/cache/inventoryPoller.test.ts
+++ b/frontend/src/lib/cache/inventoryPoller.test.ts
@@ -133,3 +133,40 @@ describe("inventoryPoller tag threading", () => {
     expect(events[0]).not.toHaveProperty("tags")
   })
 })
+
+/**
+ * A DR replica lands on its target cluster as a brand new guest, so Auto-HA
+ * handed it to the CRM with state "started". That overrides the onboot: 0 the
+ * replica config carries on purpose and undoes every `qm stop` a test failover
+ * cleanup issues, leaving a second writer on an image the next incremental
+ * sync imports into. The orchestrator tags replicas; Auto-HA must skip them.
+ */
+describe("inventoryPoller Auto-HA", () => {
+  async function haCallsFor(guest: any) {
+    const { getSetting } = await import("@/lib/db/settings")
+
+    ;(getSetting as any).mockResolvedValue({ enabled: true, state: "started" })
+    await pollTwice([], [guest])
+
+    return pveFetchMock.mock.calls.filter(call => call[1] === "/cluster/ha/resources")
+  }
+
+  it("enables HA on a guest somebody really did add", async () => {
+    const calls = await haCallsFor({ type: "qemu", vmid: 100, node: "n1", status: "running", tags: "prod" })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0][2].body).toContain("sid=vm%3A100")
+  })
+
+  it("never enables HA on a DR replica", async () => {
+    const calls = await haCallsFor({ type: "qemu", vmid: 9100, node: "n1", status: "stopped", tags: "prod;proxcenter-replica" })
+
+    expect(calls).toEqual([])
+  })
+
+  it("matches the tag exactly, not as a substring", async () => {
+    const calls = await haCallsFor({ type: "qemu", vmid: 101, node: "n1", status: "running", tags: "proxcenter-replicated" })
+
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/frontend/src/lib/cache/inventoryPoller.ts
+++ b/frontend/src/lib/cache/inventoryPoller.ts
@@ -335,6 +335,20 @@ async function pollAll() {
 
 // ---------- Auto-HA Handler ----------
 
+// The tag the orchestrator writes into every replica config it transfers.
+const REPLICA_TAG = 'proxcenter-replica'
+
+// A DR replica reaches its target cluster as a brand new guest, so Auto-HA saw
+// one every time a replication job seeded a VM and handed it to the CRM with
+// state "started". That overrides the onboot: 0 the replica config carries on
+// purpose, and it also undoes every `qm stop` a test failover cleanup issues:
+// the replica comes back up and writes to the image the next incremental sync
+// imports into, which silently tears it. A replica is only ever started by a
+// failover, never by us.
+function isReplica(e: InventoryEvent & { tags?: string }): boolean {
+  return (e.tags || '').split(';').some(tag => tag.trim() === REPLICA_TAG)
+}
+
 async function handleAutoHaEvents(events: InventoryEvent[]) {
   // Relocations emit a remove+add pair in the same batch (see pollConnection).
   // Skip Auto-HA for those: the VM is already an HA resource, just moved.
@@ -351,6 +365,7 @@ async function handleAutoHaEvents(events: InventoryEvent[]) {
     (e): e is Extract<InventoryEvent, { event: 'vm:added' }> =>
       e.event === 'vm:added' &&
       (e as any).template !== 1 &&
+      !isReplica(e) &&
       !relocatedKeys.has(`${e.connId}:${e.type}/${e.vmid}`)
   )
 

--- a/frontend/src/lib/orchestrator/client.ts
+++ b/frontend/src/lib/orchestrator/client.ts
@@ -347,10 +347,10 @@ return { data, status: 200 }
   /**
    * POST request - retourne { data: T }
    */
-  async post<T = any>(path: string, body?: any): Promise<OrchestratorResponse<T>> {
-    const data = await orchestratorFetch<T>(path, { method: 'POST', body })
+  async post<T = any>(path: string, body?: any, timeout?: number): Promise<OrchestratorResponse<T>> {
+    const data = await orchestratorFetch<T>(path, { method: 'POST', body, timeout })
 
-    
+
 return { data, status: 200 }
   }
 
@@ -648,7 +648,13 @@ return this.get<ClusterMetrics[]>(`/metrics/${connectionId}/history${query ? `?$
   }
 
   cleanupTestFailover(planId: string) {
-    return this.post<any>(`/replication/plans/${planId}/cleanup-test`)
+    // A test failover cleanup stops each DR VM, waits for it to report
+    // stopped, reconnects its NICs and rolls every replica image back, one VM
+    // after another: measured at ~20s for a single-disk VM on a local cluster,
+    // so the 30s default expires on any plan with more than one guest. Kept
+    // under the 60s nginx read timeout of a packaged install, so the abort
+    // comes back as our own JSON error rather than an nginx 504 page.
+    return this.post<any>(`/replication/plans/${planId}/cleanup-test`, undefined, 55_000)
   }
 
   startDRVM(body: { vm_id: number; target_cluster: string; replication_job_id: string }) {

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -4540,6 +4540,8 @@
       "openConsole": "Konsole öffnen",
       "cleanup": "Test bereinigen",
       "cleanupDone": "Cleanup abgeschlossen",
+      "cleanupIncomplete": "Bereinigung nicht abgeschlossen",
+      "cleanupFailed": "Die Bereinigung konnte nicht abgeschlossen werden, die DR-Gäste laufen möglicherweise noch auf den replizierten Images",
       "stopped": "Gestoppt",
       "disksRolledBack": "RBD-Festplatte(n) zurückgesetzt",
       "jobsResumed": "Replikation job(s) resumed",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4561,6 +4561,8 @@
       "openConsole": "Open Console",
       "cleanup": "Cleanup test",
       "cleanupDone": "Cleanup completed",
+      "cleanupIncomplete": "Cleanup did not complete",
+      "cleanupFailed": "The cleanup could not be completed, the DR guests may still be running on the replica images",
       "stopped": "stopped",
       "disksRolledBack": "RBD disk(s) rolled back",
       "jobsResumed": "replication job(s) resumed",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -4561,6 +4561,8 @@
       "openConsole": "Abrir consola",
       "cleanup": "Limpiar prueba",
       "cleanupDone": "Limpieza completada",
+      "cleanupIncomplete": "La limpieza no se completó",
+      "cleanupFailed": "La limpieza no pudo completarse, los invitados de DR podrían seguir ejecutándose en las imágenes replicadas",
       "stopped": "detenida",
       "disksRolledBack": "disco(s) RBD revertido(s)",
       "jobsResumed": "trabajo(s) de replicación reanudado(s)",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -4561,6 +4561,8 @@
       "openConsole": "Ouvrir la console",
       "cleanup": "Nettoyer le test",
       "cleanupDone": "Nettoyage terminé",
+      "cleanupIncomplete": "Nettoyage non terminé",
+      "cleanupFailed": "Le nettoyage n'a pas pu aboutir, les invités DR tournent peut-être encore sur les images répliquées",
       "stopped": "arrêtée(s)",
       "disksRolledBack": "disque(s) RBD restauré(s)",
       "jobsResumed": "job(s) de réplication repris",

--- a/frontend/src/messages/ko.json
+++ b/frontend/src/messages/ko.json
@@ -4561,6 +4561,8 @@
       "openConsole": "콘솔 열기",
       "cleanup": "테스트 정리",
       "cleanupDone": "정리 완료",
+      "cleanupIncomplete": "정리가 완료되지 않았습니다",
+      "cleanupFailed": "정리를 완료하지 못했습니다. DR 게스트가 복제 이미지에서 계속 실행 중일 수 있습니다",
       "stopped": "중지됨",
       "disksRolledBack": "RBD 디스크 롤백됨",
       "jobsResumed": "복제 작업 재개됨",

--- a/frontend/src/messages/zh-CN.json
+++ b/frontend/src/messages/zh-CN.json
@@ -4565,6 +4565,8 @@
       "openConsole": "打开控制台",
       "cleanup": "清理测试",
       "cleanupDone": "清理完成",
+      "cleanupIncomplete": "清理未完成",
+      "cleanupFailed": "清理未能完成，DR 客户机可能仍在副本镜像上运行",
       "stopped": "已停止",
       "disksRolledBack": "RBD 磁盘已回滚",
       "jobsResumed": "复制任务已恢复",


### PR DESCRIPTION
A customer reported that after a test failover, two of three DR VMs no longer booted from any restore point. Their screenshot showed a green "Cleanup completed" banner with no detail lines under it and no retry button, so they moved on believing the lab was clean. The cleanup had in fact done nothing, the DR guests were still running on the replicated images, and replication resumed on top of them.

## What breaks without this

Three defects stacked up.

The dialog keyed its banner on an empty error list, so any payload without one read as a success, including the error body an aborted call returns. It now keys on `all_cleaned`, the orchestrator's own verdict, and keeps the retry button until that is true. The banner also states what an unfinished cleanup means for the operator, in their own language, rather than passing an untranslated timeout string through as the only detail.

The client budget was 30s. A cleanup was measured at 20s for a single-disk guest and handles them one after another, so any plan with more than one guest expired mid-run, and the customer's three did. It gets 55s, which stays under the 60s nginx read timeout of a packaged install so the abort comes back as our own JSON error rather than an nginx error page.

Auto-HA enrolled DR replicas. A replica reaches its target cluster as a brand new guest, so nothing distinguished it: the CRM started it, overriding the `onboot: 0` its config carries on purpose and undoing every stop the cleanup issued. Replicas are now tagged at the source and skipped.

## Verified in the lab

Both paths were driven end to end against a real DR cluster. The nominal cleanup shows green with its detail lines, and all four operations were confirmed on the cluster. For the failure path, the orchestrator was frozen the instant the cleanup started and released after the client gave up: the banner came back amber with the cause and the retry button, while three of the four operations had indeed not happened and the replica still carried the test writes.

Depends on a separate backend fix, in review, that refuses to stream an incremental sync onto a replica image written to since its last snapshot.